### PR TITLE
Abort on panics rather than unwinding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,3 +57,17 @@ harness = false
 [[bench]]
 name = "transpose"
 harness = false
+
+# Abort on panics rather than unwinding.
+# This improves performance and makes panic propagation more reliable.
+[profile.release]
+panic = 'abort'
+
+[profile.bench]
+panic = 'abort'
+
+[profile.dev]
+panic = 'abort'
+
+[profile.test]
+panic = 'abort'


### PR DESCRIPTION
Setting `panic = abort` makes panic handling code more reliable, and it improves performance by decreasing code size.

Part of #39.