### PR TITLE
Build Binaries & Tests in CI, but don’t run them

### DIFF
--- a/.github/workflows/build-all-targets.yml
+++ b/.github/workflows/build-all-targets.yml
@@ -4,7 +4,7 @@ on:
   push:
 
 jobs:
-  lint:
+  build-all:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
This PR adds a `cargo` binary and test build to CI.

This covers more than the Dockerfile build, which only builds binaries in release mode.