### PR TITLE
Configure automatic Rust & GitHub Actions dependency update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
       # TODO: change to weekly, and delete the detailed schedule
       interval: "daily"
       # Used to get an immediate test
-      time: "05:00"
+      time: "05:10"
       timezone: "Etc/UTC"
       
   - package-ecosystem: "github-actions" # See documentation for possible values
@@ -20,5 +20,5 @@ updates:
       # TODO: change to weekly, and delete the detailed schedule
       interval: "daily"
       # Used to get an immediate test
-      time: "05:00"
+      time: "05:10"
       timezone: "Etc/UTC"


### PR DESCRIPTION
This PR configures automatic dependency update PRs. 

#### Merge Timing

PRs #67 and #68 should be merged first, to detect dependency updates that break the build (or more rarely, docs).

We might want to wait until we have some spare review and testing cycles before merging this PR. Or we could do a manual bulk update and test PR using `cargo upgrade`, then merge this PR.

#### What it does

When it is merged, GitHub will open up to 10 dependency update PRs, one per outdated dependency. Then after the first upgrades are all done, it will open any new upgrade PRs once a week.

Close #40

### Next Steps

Admins might also want to enable dependabot security alerts:
https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide#viewing-dependabot-alerts-for-your-repository

Switch to weekly, and remove the fixed time configs.

Admin: Update the actions that are required to pass before merging.