### PR TITLE
Put clippy warnings in the PR diff view, cancel previous jobs on a new push

### DIFF
--- a/.github/workflows/lint-clippy.yaml
+++ b/.github/workflows/lint-clippy.yaml
@@ -3,6 +3,10 @@ name: Lint Clippy
 on:
   push:
 
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
 permissions:
   # Leaving clippy annotations on commits...
   contents: write


### PR DESCRIPTION
This PR puts clippy warnings inline next to the code they're about, rather than having to look in the clippy logs when it fails.

It also puts a concurrency limit on this CI job. If there are unfinished clippy CI runs on a PR, they will be cancelled when a new run starts.