### PR TITLE
chore: Use SDK to get derived shared secret of KMS keys

### DIFF
--- a/src/helpers/kms_dh.rs
+++ b/src/helpers/kms_dh.rs
@@ -1,6 +1,4 @@
 use aws_sdk_kms::{types::KeyAgreementAlgorithmSpec, Client};
-use base64::{prelude::BASE64_STANDARD, Engine};
-use eyre::ContextCompat;
 
 /// Derive a shared secret from two KMS keys
 pub async fn derive_shared_secret(own_key_id: &str, other_key_id: &str) -> eyre::Result<[u8; 32]> {


### PR DESCRIPTION
With KMS SDK 1.35.0 it now works :)