### PR TITLE
fix: build nccl in separate workflow

### DIFF
--- a/.github/workflows/build-and-push-nccl.yaml
+++ b/.github/workflows/build-and-push-nccl.yaml
@@ -6,7 +6,7 @@ on:
       - "main"
     paths:
       - Dockerfile.nccl
-      - .github/workkflows/build-and-push-nccl.yaml
+      - .github/workflows/build-and-push-nccl.yaml
 
   workflow_dispatch:
 


### PR DESCRIPTION
Some fixes to build in separate workflow nccl. We want to keep it in a separate workflow because this is time-consuming.