### PR TITLE
fix: Rename KMS IDs to ARNs

### DIFF
--- a/.env.mpc1.dist
+++ b/.env.mpc1.dist
@@ -29,4 +29,6 @@ SMPC__PARTY_ID=0
 SMPC__REQUESTS_QUEUE_URL=https://sqs.eu-north-1.amazonaws.com/654654380399/mpc1.fifo
 SMPC__RESULTS_TOPIC_ARN=arn:aws:sns:eu-north-1:654654380399:mpc-results-topic
 SMPC__PATH=/opt/dlami/nvme/
-SMPC__KMS_KEY_IDS='["077788e2-9eeb-4044-859b-34496cfd500b", "896353dc-5ea5-42d4-9e4e-f65dd8169dee", "42bb01f5-8380-48b4-b1f1-929463a587fb"]'
+
+# These can be either ARNs or IDs, in production multi account setup they are ARNs
+SMPC__KMS_KEY_ARNS='["077788e2-9eeb-4044-859b-34496cfd500b", "896353dc-5ea5-42d4-9e4e-f65dd8169dee", "42bb01f5-8380-48b4-b1f1-929463a587fb"]'

--- a/.env.mpc2.dist
+++ b/.env.mpc2.dist
@@ -30,4 +30,6 @@ SMPC__PARTY_ID=1
 SMPC__REQUESTS_QUEUE_URL=https://sqs.eu-north-1.amazonaws.com/654654380399/mpc2.fifo
 SMPC__RESULTS_TOPIC_ARN=arn:aws:sns:eu-north-1:654654380399:mpc-results-topic
 SMPC__PATH=/opt/dlami/nvme/
-SMPC__KMS_KEY_IDS='["077788e2-9eeb-4044-859b-34496cfd500b", "896353dc-5ea5-42d4-9e4e-f65dd8169dee", "42bb01f5-8380-48b4-b1f1-929463a587fb"]'
+
+# These can be either ARNs or IDs, in production multi account setup they are ARNs
+SMPC__KMS_KEY_ARNS='["077788e2-9eeb-4044-859b-34496cfd500b", "896353dc-5ea5-42d4-9e4e-f65dd8169dee", "42bb01f5-8380-48b4-b1f1-929463a587fb"]'

--- a/.env.mpc3.dist
+++ b/.env.mpc3.dist
@@ -31,4 +31,6 @@ SMPC__REQUESTS_QUEUE_URL=https://sqs.eu-north-1.amazonaws.com/654654380399/mpc3.
 SMPC__RESULTS_TOPIC_ARN=arn:aws:sns:eu-north-1:654654380399:mpc-results-topic
 SMPC__PATH=/opt/dlami/nvme/
 SMPC__BOOTSTRAP_URL=10.15.32.27
-SMPC__KMS_KEY_IDS='["077788e2-9eeb-4044-859b-34496cfd500b", "896353dc-5ea5-42d4-9e4e-f65dd8169dee", "42bb01f5-8380-48b4-b1f1-929463a587fb"]'
+
+# These can be either ARNs or IDs, in production multi account setup they are ARNs
+SMPC__KMS_KEY_ARNS='["077788e2-9eeb-4044-859b-34496cfd500b", "896353dc-5ea5-42d4-9e4e-f65dd8169dee", "42bb01f5-8380-48b4-b1f1-929463a587fb"]'

--- a/deploy/stage/mpc1-stage/values-gpu-iris-mpc.yaml
+++ b/deploy/stage/mpc1-stage/values-gpu-iris-mpc.yaml
@@ -53,7 +53,7 @@ env:
   - name: SMPC__PATH
     value: "/data/"
 
-  - name: SMPC__KMS_KEY_IDS
+  - name: SMPC__KMS_KEY_ARNS
     valueFrom:
       secretKeyRef:
         key: KMS_KEYS

--- a/deploy/stage/mpc2-stage/values-gpu-iris-mpc.yaml
+++ b/deploy/stage/mpc2-stage/values-gpu-iris-mpc.yaml
@@ -53,7 +53,7 @@ env:
   - name: SMPC__PATH
     value: "/data/"
 
-  - name: SMPC__KMS_KEY_IDS
+  - name: SMPC__KMS_KEY_ARNS
     valueFrom:
       secretKeyRef:
         key: KMS_KEYS

--- a/deploy/stage/mpc3-stage/values-gpu-iris-mpc.yaml
+++ b/deploy/stage/mpc3-stage/values-gpu-iris-mpc.yaml
@@ -53,7 +53,7 @@ env:
   - name: SMPC__PATH
     value: "/data/"
 
-  - name: SMPC__KMS_KEY_IDS
+  - name: SMPC__KMS_KEY_ARNS
     valueFrom:
       secretKeyRef:
         key: KMS_KEYS

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -182,7 +182,7 @@ async fn main() -> eyre::Result<()> {
         party_id,
         results_topic_arn,
         requests_queue_url,
-        kms_key_ids,
+        kms_key_arns,
         ..
     } = config.clone();
 
@@ -195,10 +195,10 @@ async fn main() -> eyre::Result<()> {
     let sns_client = SNSClient::new(&shared_config);
 
     // Init RNGs
-    let own_key_id = kms_key_ids
+    let own_key_arn = kms_key_arns
         .0
         .get(party_id)
-        .expect("Expected value not found in kms_key_ids");
+        .expect("Expected value not found in kms_key_arns");
     let dh_pairs = match party_id {
         0 => (1usize, 2usize),
         1 => (2usize, 0usize),
@@ -206,18 +206,18 @@ async fn main() -> eyre::Result<()> {
         _ => unimplemented!(),
     };
 
-    let dh_pair_0: &str = kms_key_ids
+    let dh_pair_0: &str = kms_key_arns
         .0
         .get(dh_pairs.0)
-        .expect("Expected value not found in kms_key_ids");
-    let dh_pair_1: &str = kms_key_ids
+        .expect("Expected value not found in kms_key_arns");
+    let dh_pair_1: &str = kms_key_arns
         .0
         .get(dh_pairs.1)
-        .expect("Expected value not found in kms_key_ids");
+        .expect("Expected value not found in kms_key_arns");
 
     let chacha_seeds = (
-        bytemuck::cast(derive_shared_secret(own_key_id, dh_pair_0).await?),
-        bytemuck::cast(derive_shared_secret(own_key_id, dh_pair_1).await?),
+        bytemuck::cast(derive_shared_secret(own_key_arn, dh_pair_0).await?),
+        bytemuck::cast(derive_shared_secret(own_key_arn, dh_pair_1).await?),
     );
 
     // Generate or load DB

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -41,7 +41,7 @@ pub struct Config {
     pub path: String,
 
     #[serde(default)]
-    pub kms_key_ids: JsonStrWrapper<Vec<String>>,
+    pub kms_key_arns: JsonStrWrapper<Vec<String>>,
 
     #[serde(default)]
     pub servers: ServersConfig,

--- a/src/helpers/kms_dh.rs
+++ b/src/helpers/kms_dh.rs
@@ -1,16 +1,19 @@
 use aws_sdk_kms::{types::KeyAgreementAlgorithmSpec, Client};
 
 /// Derive a shared secret from two KMS keys
-pub async fn derive_shared_secret(own_key_id: &str, other_key_id: &str) -> eyre::Result<[u8; 32]> {
+pub async fn derive_shared_secret(
+    own_key_arn: &str,
+    other_key_arn: &str,
+) -> eyre::Result<[u8; 32]> {
     let shared_config = aws_config::from_env().load().await;
 
     let client = Client::new(&shared_config);
-    let other_public_key = client.get_public_key().key_id(other_key_id).send().await?;
+    let other_public_key = client.get_public_key().key_id(other_key_arn).send().await?;
     let public_key = other_public_key.public_key.unwrap();
 
     let res = client
         .derive_shared_secret()
-        .key_id(own_key_id)
+        .key_id(own_key_arn)
         .public_key(public_key)
         .key_agreement_algorithm(KeyAgreementAlgorithmSpec::Ecdh)
         .send()


### PR DESCRIPTION
In the multi-account setup we cannot use only ids of the KMS keys, we need to use full ARNs. Altered the variable names to reflect that fact.