### PR TITLE
chore: Set eth0 as NCCL socket, use new NCCL version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update && apt-get install -y pkg-config wget libssl-dev ca-certifica
 RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb \
     && dpkg -i cuda-keyring_1.1-1_all.deb \
     && apt-get update \
-    && apt-get install -y cuda-toolkit-12-2 libnccl2 libnccl-dev
+    && apt-get install -y cuda-toolkit-12-2 libnccl2=2.22.3-1+cuda12.2 libnccl-dev=2.22.3-1+cuda12.2
 
 USER 65534
 ENTRYPOINT ["/bin/server"]

--- a/deploy/stage/mpc1-stage/values-gpu-iris-mpc.yaml
+++ b/deploy/stage/mpc1-stage/values-gpu-iris-mpc.yaml
@@ -1,4 +1,7 @@
 env:
+  - name: NCCL_SOCKET_IFNAME
+    value: "eth0"
+
   - name: RUST_BACKTRACE
     value: "full"
 

--- a/deploy/stage/mpc2-stage/values-gpu-iris-mpc.yaml
+++ b/deploy/stage/mpc2-stage/values-gpu-iris-mpc.yaml
@@ -2,6 +2,9 @@ env:
   - name: RUST_BACKTRACE
     value: "full"
 
+  - name: NCCL_SOCKET_IFNAME
+    value: "eth0"
+
   - name: SMPC__ENVIRONMENT
     value: "stage"
 

--- a/deploy/stage/mpc3-stage/values-gpu-iris-mpc.yaml
+++ b/deploy/stage/mpc3-stage/values-gpu-iris-mpc.yaml
@@ -2,6 +2,9 @@ env:
   - name: RUST_BACKTRACE
     value: "full"
 
+  - name: NCCL_SOCKET_IFNAME
+    value: "eth0"
+
   - name: SMPC__ENVIRONMENT
     value: "stage"
 


### PR DESCRIPTION
Work done:
- install newest NCCL library,
- force set EFA interface for NCCL