### PR TITLE
load-with-capacity

### DIFF
--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -263,6 +263,10 @@ async fn initialize_iris_dbs(
         (codes_db, masks_db)
     };
 
+    let count_irises = store.count_irises().await?;
+    codes_db.reserve(count_irises * IRIS_CODE_LENGTH);
+    masks_db.reserve(count_irises * IRIS_CODE_LENGTH);
+
     tracing::info!("Initialize iris db: Loading from DB");
     // Load DB from persistent storage.
     let mut store_len = 0;

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -111,6 +111,13 @@ impl Store {
         Ok(self.pool.begin().await?)
     }
 
+    pub async fn count_irises(&self) -> Result<usize> {
+        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM irises")
+            .fetch_one(&self.pool)
+            .await?;
+        Ok(count.0 as usize)
+    }
+
     pub async fn stream_irises(&self) -> impl Stream<Item = Result<StoredIris, sqlx::Error>> + '_ {
         sqlx::query_as::<_, StoredIris>("SELECT * FROM irises ORDER BY id").fetch(&self.pool)
     }
@@ -295,8 +302,10 @@ mod tests {
         store.insert_irises(&mut tx, &codes_and_masks[2..3]).await?;
         tx.commit().await?;
 
+        let got_len = store.count_irises().await?;
         let got: Vec<StoredIris> = store.stream_irises().await.try_collect().await?;
 
+        assert_eq!(got_len, 3);
         assert_eq!(got.len(), 3);
         for i in 0..3 {
             assert_eq!(got[i].id, i as i64);


### PR DESCRIPTION
Reduce memory copies during db load, which should make it a little faster.