### PR TITLE
switch to official sodiumoxide

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2447,7 +2447,8 @@ dependencies = [
 [[package]]
 name = "libsodium-sys"
 version = "0.2.7"
-source = "git+https://github.com/worldcoin/sodiumoxide.git#1b007a8c2a94445c080440b0341389953ba53e45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b779387cd56adfbc02ea4a668e704f729be8d6a6abd2c27ca5ee537849a92fd"
 dependencies = [
  "cc",
  "libc",
@@ -4140,13 +4141,13 @@ dependencies = [
 [[package]]
 name = "sodiumoxide"
 version = "0.2.7"
-source = "git+https://github.com/worldcoin/sodiumoxide.git#1b007a8c2a94445c080440b0341389953ba53e45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e26be3acb6c2d9a7aac28482586a7856436af4cfe7100031d219de2d2ecb0028"
 dependencies = [
  "ed25519",
  "libc",
  "libsodium-sys",
  "serde",
- "zeroize",
 ]
 
 [[package]]

--- a/iris-mpc-common/Cargo.toml
+++ b/iris-mpc-common/Cargo.toml
@@ -26,7 +26,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 reqwest.workspace = true
 
-sodiumoxide = { git = "https://github.com/worldcoin/sodiumoxide.git" }
+sodiumoxide = "0.2.7"
 hmac = "0.12"
 http = "1.1.0"
 opentelemetry = "0.21.0"


### PR DESCRIPTION
there is no need to use our fork I think and it otherwise creates a conflict on the orb:

```
error: failed to select a version for `libsodium-sys`.
    ... required by package `sodiumoxide v0.2.7 (https://github.com/worldcoin/sodiumoxide.git#1b007a8c)`
    ... which satisfies git dependency `sodiumoxide` of package `iris-mpc-common v0.1.0 (https://github.com/worldcoin/gpu-iris-mpc.git?rev=4f799d2c247bf99a835e70f290b2047ed8cb67a3#4f799d2c)`
    ... which satisfies git dependency `iris-mpc-common` of package `iris-mpc v0.1.0 (https://github.com/worldcoin/gpu-iris-mpc.git?rev=4f799d2c247bf99a835e70f290b2047ed8cb67a3#4f799d2c)`
    ... which satisfies git dependency `iris-mpc` of package `orb v0.1.0 (/workspaces/orb-core)`
    ... which satisfies path dependency `orb` (locked to 0.1.0) of package `orb-backend-connect v0.1.0 (/workspaces/orb-core/orb-backend-connect)`
versions that meet the requirements `^0.2.7` are: 0.2.7

the package `libsodium-sys` links to the native library `sodium`, but it conflicts with a previous package which links to `sodium` as well:
package `libsodium-sys v0.2.7`
    ... which satisfies dependency `libsodium-sys = "^0.2.7"` of package `sodiumoxide v0.2.7`
    ... which satisfies dependency `sodiumoxide = "^0.2.7"` of package `orb v0.1.0 (/workspaces/orb-core)`
    ... which satisfies path dependency `orb` (locked to 0.1.0) of package `orb-backend-connect v0.1.0 (/workspaces/orb-core/orb-backend-connect)`
Only one package in the dependency graph may specify the same links value. This helps ensure that only one copy of a native library is linked in the final binary. Try to adjust your dependencies so that only one package uses the `links = "sodium"` value. For more information, see https://doc.rust-lang.org/cargo/reference/resolver.html#links.

failed to select a version for `libsodium-sys` which could resolve this conflict
```