### PR TITLE
build: enable debug info for release builds during development

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ uuid = { version = "1", features = ["v4"] }
 # bench gets its setting from release, and test from dev.
 [profile.release]
 panic = 'abort'
+debug = 1
 
 [profile.dev]
 panic = 'abort'


### PR DESCRIPTION
only downside is that the images should be larger due to the debug info