### PR TITLE
increment serial_id to match v1

### DIFF
--- a/iris-mpc/src/bin/client.rs
+++ b/iris-mpc/src/bin/client.rs
@@ -188,7 +188,7 @@ async fn main() -> eyre::Result<()> {
                     assert!(result.matched_serial_ids.is_some());
                     let matched_ids = result.matched_serial_ids.unwrap();
                     assert!(matched_ids.len() == 1);
-                    assert_eq!(expected_result.unwrap(), matched_ids[0]);
+                    assert_eq!(expected_result.unwrap() + 1, matched_ids[0]);
                 }
 
                 results_sqs_client

--- a/iris-mpc/src/bin/server.rs
+++ b/iris-mpc/src/bin/server.rs
@@ -610,6 +610,7 @@ async fn server_main(config: Config) -> eyre::Result<()> {
             store_right,
         }) = rx.recv().await
         {
+            // returned serial_ids are 0 indexed, but we want them to be 1 indexed
             let result_events = merged_results
                 .iter()
                 .enumerate()
@@ -618,12 +619,12 @@ async fn server_main(config: Config) -> eyre::Result<()> {
                         party_id,
                         match matches[i] {
                             true => None,
-                            false => Some(idx_result),
+                            false => Some(idx_result + 1),
                         },
                         matches[i],
                         request_ids[i].clone(),
                         match matches[i] {
-                            true => Some(match_ids[i].clone()),
+                            true => Some(match_ids[i].iter().map(|x| x + 1).collect::<Vec<_>>()),
                             false => None,
                         },
                     );


### PR DESCRIPTION
Serial_ids started with 1 in v1 instead of 0. This PR just increments the returned ids from the **server** by 1.