### PR TITLE
Don't use default stream for heartbeat

### DIFF
--- a/iris-mpc-gpu/src/helpers/device_manager.rs
+++ b/iris-mpc-gpu/src/helpers/device_manager.rs
@@ -37,6 +37,17 @@ impl DeviceManager {
         Self { devices }
     }
 
+    pub fn init_with_streams() -> Self {
+        let mut devices = vec![];
+        for i in 0..CudaDevice::count().unwrap() {
+            devices.push(CudaDevice::new_with_stream(i as usize).unwrap());
+        }
+
+        tracing::info!("Found {} devices", devices.len());
+
+        Self { devices }
+    }
+
     /// Splits the devices into n chunks, returning a device manager for each
     /// chunk.
     /// If too few devices are present, returns the original device manager.

--- a/iris-mpc-gpu/src/server/heartbeat_nccl.rs
+++ b/iris-mpc-gpu/src/server/heartbeat_nccl.rs
@@ -16,7 +16,7 @@ pub async fn start_heartbeat(
     let (tx, mut rx) = mpsc::channel(1);
 
     let heartbeat_handle: JoinHandle<eyre::Result<()>> = spawn_blocking(move || {
-        let device_manager = Arc::new(DeviceManager::init());
+        let device_manager = Arc::new(DeviceManager::init_with_streams());
         let ids = device_manager.get_ids_from_magic(0xdead);
 
         let comms = device_manager.instantiate_network_from_ids(party_id, &ids)?;


### PR DESCRIPTION
This makes sure that the heartbeat is not interfering with the normal operations (based on suggestion from @dkales). Currently, the processing fails because of this sporadically.