### PR TITLE
Rename KMS key folder in s3 bucket

### DIFF
--- a/iris-mpc-common/src/bin/key_manager.rs
+++ b/iris-mpc-common/src/bin/key_manager.rs
@@ -75,10 +75,8 @@ async fn main() -> eyre::Result<()> {
     let shared_config = aws_config::from_env().region(region_provider).load().await;
 
     let bucket_key_name = format!("{}-{}", PUBLIC_KEY_S3_KEY_NAME_PREFIX, args.node_id);
-    let private_key_secret_id: String = format!(
-        "{}/iris-mpc/ecdh-private-key-{}",
-        args.env, args.node_id
-    );
+    let private_key_secret_id: String =
+        format!("{}/iris-mpc/ecdh-private-key-{}", args.env, args.node_id);
 
     match args.command {
         Commands::Rotate {

--- a/iris-mpc-common/src/helpers/key_pair.rs
+++ b/iris-mpc-common/src/helpers/key_pair.rs
@@ -191,8 +191,7 @@ async fn download_private_key_from_asm(
     node_id: &str,
     version_stage: &str,
 ) -> Result<String, SharesDecodingError> {
-    let private_key_secret_id: String =
-        format!("{}/iris-mpc/ecdh-private-key-{}", env, node_id);
+    let private_key_secret_id: String = format!("{}/iris-mpc/ecdh-private-key-{}", env, node_id);
     match client
         .get_secret_value()
         .secret_id(private_key_secret_id)


### PR DESCRIPTION
After having renamed the github repo and all infra resources from `gpu-iris-mpc` to `iris-mpc`, we would like to also rename the folder used to store KMS private keys in S3, so to have consistency.