### PR TITLE
Add binaries for upgrade server and client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,15 +27,17 @@ RUN cargo install cargo-build-deps \
 FROM --platform=linux/amd64 build-image as build-app
 WORKDIR /src/gpu-iris-mpc
 COPY . .
-RUN cargo build --release --target x86_64-unknown-linux-gnu --bin server --bin client --bin key-manager
+RUN cargo build --release --target x86_64-unknown-linux-gnu --bin server --bin client --bin key-manager --bin upgrade-server --bin upgrade-client
 
 FROM --platform=linux/amd64 ghcr.io/worldcoin/gpu-iris-mpc-base:cuda12_2-nccl2_22_3_1
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Include client, server and key-manager
+# Include client, server and key-manager, upgrade-client and upgrade-server binaries
 COPY --from=build-app /src/gpu-iris-mpc/target/x86_64-unknown-linux-gnu/release/server /bin/server
 COPY --from=build-app /src/gpu-iris-mpc/target/x86_64-unknown-linux-gnu/release/client /bin/client
 COPY --from=build-app /src/gpu-iris-mpc/target/x86_64-unknown-linux-gnu/release/key-manager /bin/key-manager
+COPY --from=build-app /src/gpu-iris-mpc/target/x86_64-unknown-linux-gnu/release/upgrade-server /bin/upgrade-server
+COPY --from=build-app /src/gpu-iris-mpc/target/x86_64-unknown-linux-gnu/release/upgrade-client /bin/upgrade-client
 
 USER 65534
 ENTRYPOINT ["/bin/server"]

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -10,7 +10,7 @@ apt update && apt install -y postgresql-client && psql -H <DB_URL> -c 'SET searc
 
 # Application Upgrade Documentation
 
-This document provides a step-by-step guide on how to upgrade the application deployed using ArgoCD. The application configuration is located in the `deploy/stage/mpc1-stage`, `deploy/stage/mpc2-stage`, and `deploy/stage/mpc3-stage` directories. Each directory contains a `values-gpu-iris-mpc.yaml` file, which includes the deployment configuration for the respective clusters: `mpc1-stage`, `mpc2-stage`, and `mpc3-stage`, and common value file placed in `deploy/stage/values-common-gpu-iris-mpc.yaml`
+This document provides a step-by-step guide on how to upgrade the application deployed using ArgoCD. The application configuration is located in the `deploy/stage/mpc1-stage`, `deploy/stage/mpc2-stage`, and `deploy/stage/mpc3-stage` directories. Each directory contains a `values-iris-mpc.yaml` file, which includes the deployment configuration for the respective clusters: `mpc1-stage`, `mpc2-stage`, and `mpc3-stage`, and common value file placed in `deploy/stage/values-common-gpu-iris-mpc.yaml`
 
 ## Prerequisites
 


### PR DESCRIPTION
### Notes
* add binaries for server and client. The command of the docker file can be overriden to run the services. 