### PR TITLE
deploy values for upgrade server in all stage accts

### DIFF
--- a/deploy/stage/common-values-upgrade-server-left.yaml
+++ b/deploy/stage/common-values-upgrade-server-left.yaml
@@ -1,0 +1,73 @@
+image: "ghcr.io/worldcoin/iris-mpc:v0.4.3"
+
+environment: stage
+replicaCount: 1
+
+strategy:
+  type: Recreate
+
+datadog:
+  enabled: true
+
+ports:
+  - containerPort: 8000
+    name: http
+    protocol: TCP
+    port: 8000
+
+livenessProbe:
+  initialDelaySeconds: 300
+  httpGet:
+    path: /health
+    port: health
+
+readinessProbe:
+  initialDelaySeconds: 300
+  periodSeconds: 30
+  failureThreshold: 10
+  httpGet:
+    path: /health
+    port: health
+
+resources:
+  limits:
+    cpu: 4
+    memory: 1Gi
+  requests:
+    cpu: 4
+    memory: 1Gi
+
+imagePullSecrets:
+  - name: github-secret
+
+nodeSelector:
+  kubernetes.io/arch: amd64
+
+hostNetwork: true
+
+podSecurityContext:
+  runAsUser: 65534
+  runAsGroup: 65534
+
+tolerations:
+  - key: "dedicated"
+    operator: "Equal"
+    value: "gpuGroup"
+    effect: "NoSchedule"
+
+serviceAccount:
+  create: true
+
+command: ["/bin/upgrade-server"]
+
+env:
+  - name: SMPC__DATABASE__URL
+    valueFrom:
+      secretKeyRef:
+        key: DATABASE_URL
+        name: application
+
+
+keelPolling:
+  # -- Specifies whether keel should poll for container updates
+  enabled: true

--- a/deploy/stage/common-values-upgrade-server-right.yaml
+++ b/deploy/stage/common-values-upgrade-server-right.yaml
@@ -1,0 +1,73 @@
+image: "ghcr.io/worldcoin/iris-mpc:v0.4.3"
+
+environment: stage
+replicaCount: 1
+
+strategy:
+  type: Recreate
+
+datadog:
+  enabled: true
+
+ports:
+  - containerPort: 8000
+    name: http
+    protocol: TCP
+    port: 8000
+
+livenessProbe:
+  initialDelaySeconds: 300
+  httpGet:
+    path: /health
+    port: health
+
+readinessProbe:
+  initialDelaySeconds: 300
+  periodSeconds: 30
+  failureThreshold: 10
+  httpGet:
+    path: /health
+    port: health
+
+resources:
+  limits:
+    cpu: 4
+    memory: 1Gi
+  requests:
+    cpu: 4
+    memory: 1Gi
+
+imagePullSecrets:
+  - name: github-secret
+
+nodeSelector:
+  kubernetes.io/arch: amd64
+
+hostNetwork: true
+
+podSecurityContext:
+  runAsUser: 65534
+  runAsGroup: 65534
+
+tolerations:
+  - key: "dedicated"
+    operator: "Equal"
+    value: "gpuGroup"
+    effect: "NoSchedule"
+
+serviceAccount:
+  create: true
+
+command: ["/bin/upgrade-server"]
+
+env:
+  - name: SMPC__DATABASE__URL
+    valueFrom:
+      secretKeyRef:
+        key: DATABASE_URL
+        name: application
+
+
+keelPolling:
+  # -- Specifies whether keel should poll for container updates
+  enabled: true

--- a/deploy/stage/mpc1-stage/values-upgrade-server-left.yaml
+++ b/deploy/stage/mpc1-stage/values-upgrade-server-left.yaml
@@ -1,0 +1,9 @@
+args:
+  - "--bind-addr"
+  - "127.0.0.1:8000"
+  - "--db-url"
+  - "$(SMPC__DATABASE__URL)"
+  - "--party-id"
+  - "0"
+  - "--eye"
+  - "left"

--- a/deploy/stage/mpc1-stage/values-upgrade-server-right.yaml
+++ b/deploy/stage/mpc1-stage/values-upgrade-server-right.yaml
@@ -1,0 +1,9 @@
+args:
+  - "--bind-addr"
+  - "127.0.0.1:8000"
+  - "--db-url"
+  - "$(SMPC__DATABASE__URL)"
+  - "--party-id"
+  - "0"
+  - "--eye"
+  - "right"

--- a/deploy/stage/mpc2-stage/values-upgrade-server-left.yaml
+++ b/deploy/stage/mpc2-stage/values-upgrade-server-left.yaml
@@ -1,0 +1,9 @@
+args:
+  - "--bind-addr"
+  - "127.0.0.1:8000"
+  - "--db-url"
+  - "$(SMPC__DATABASE__URL)"
+  - "--party-id"
+  - "1"
+  - "--eye"
+  - "left"

--- a/deploy/stage/mpc2-stage/values-upgrade-server-right.yaml
+++ b/deploy/stage/mpc2-stage/values-upgrade-server-right.yaml
@@ -1,0 +1,9 @@
+args:
+  - "--bind-addr"
+  - "127.0.0.1:8000"
+  - "--db-url"
+  - "$(SMPC__DATABASE__URL)"
+  - "--party-id"
+  - "1"
+  - "--eye"
+  - "right"

--- a/deploy/stage/mpc3-stage/values-upgrade-server-left.yaml
+++ b/deploy/stage/mpc3-stage/values-upgrade-server-left.yaml
@@ -1,0 +1,9 @@
+args:
+  - "--bind-addr"
+  - "127.0.0.1:8000"
+  - "--db-url"
+  - "$(SMPC__DATABASE__URL)"
+  - "--party-id"
+  - "2"
+  - "--eye"
+  - "left"

--- a/deploy/stage/mpc3-stage/values-upgrade-server-right.yaml
+++ b/deploy/stage/mpc3-stage/values-upgrade-server-right.yaml
@@ -1,0 +1,9 @@
+args:
+  - "--bind-addr"
+  - "127.0.0.1:8000"
+  - "--db-url"
+  - "$(SMPC__DATABASE__URL)"
+  - "--party-id"
+  - "2"
+  - "--eye"
+  - "right"

--- a/deploy/stage/smpc0-stage-eu-north-1/values-upgrade-server-left.yaml
+++ b/deploy/stage/smpc0-stage-eu-north-1/values-upgrade-server-left.yaml
@@ -1,0 +1,9 @@
+args:
+  - "--bind-addr"
+  - "127.0.0.1:8000"
+  - "--db-url"
+  - "$(SMPC__DATABASE__URL)"
+  - "--party-id"
+  - "0"
+  - "--eye"
+  - "left"

--- a/deploy/stage/smpc0-stage-eu-north-1/values-upgrade-server-right.yaml
+++ b/deploy/stage/smpc0-stage-eu-north-1/values-upgrade-server-right.yaml
@@ -1,0 +1,9 @@
+args:
+  - "--bind-addr"
+  - "127.0.0.1:8000"
+  - "--db-url"
+  - "$(SMPC__DATABASE__URL)"
+  - "--party-id"
+  - "0"
+  - "--eye"
+  - "right"

--- a/deploy/stage/smpc1-stage-eu-north-1/values-upgrade-server-left.yaml
+++ b/deploy/stage/smpc1-stage-eu-north-1/values-upgrade-server-left.yaml
@@ -1,0 +1,9 @@
+args:
+  - "--bind-addr"
+  - "127.0.0.1:8000"
+  - "--db-url"
+  - "$(SMPC__DATABASE__URL)"
+  - "--party-id"
+  - "1"
+  - "--eye"
+  - "left"

--- a/deploy/stage/smpc1-stage-eu-north-1/values-upgrade-server-right.yaml
+++ b/deploy/stage/smpc1-stage-eu-north-1/values-upgrade-server-right.yaml
@@ -1,0 +1,9 @@
+args:
+  - "--bind-addr"
+  - "127.0.0.1:8000"
+  - "--db-url"
+  - "$(SMPC__DATABASE__URL)"
+  - "--party-id"
+  - "1"
+  - "--eye"
+  - "right"

--- a/deploy/stage/smpc2-stage-eu-north-1/values-upgrade-server-left.yaml
+++ b/deploy/stage/smpc2-stage-eu-north-1/values-upgrade-server-left.yaml
@@ -1,0 +1,9 @@
+args:
+  - "--bind-addr"
+  - "127.0.0.1:8000"
+  - "--db-url"
+  - "$(SMPC__DATABASE__URL)"
+  - "--party-id"
+  - "2"
+  - "--eye"
+  - "left"

--- a/deploy/stage/smpc2-stage-eu-north-1/values-upgrade-server-right.yaml
+++ b/deploy/stage/smpc2-stage-eu-north-1/values-upgrade-server-right.yaml
@@ -1,0 +1,9 @@
+args:
+  - "--bind-addr"
+  - "127.0.0.1:8000"
+  - "--db-url"
+  - "$(SMPC__DATABASE__URL)"
+  - "--party-id"
+  - "2"
+  - "--eye"
+  - "right"


### PR DESCRIPTION
We moved the values here instead of using the ones in cluster-apps. This is because we want to be able to pass the specific image to it instead of relying on the default defined in cluster-apps

See: https://github.com/worldcoin-foundation/cluster-apps/pull/39