### PR TITLE
use correct url for pub key, add upgrade-checker binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN cargo install cargo-build-deps \
 FROM --platform=linux/amd64 build-image as build-app
 WORKDIR /src/gpu-iris-mpc
 COPY . .
-RUN cargo build --release --target x86_64-unknown-linux-gnu --bin server --bin client --bin key-manager --bin upgrade-server --bin upgrade-client
+RUN cargo build --release --target x86_64-unknown-linux-gnu --bin server --bin client --bin key-manager --bin upgrade-server --bin upgrade-client --bin upgrade-checker
 
 FROM --platform=linux/amd64 ghcr.io/worldcoin/iris-mpc-base:cuda12_6-nccl2_22_3_1
 ENV DEBIAN_FRONTEND=noninteractive
@@ -38,6 +38,7 @@ COPY --from=build-app /src/gpu-iris-mpc/target/x86_64-unknown-linux-gnu/release/
 COPY --from=build-app /src/gpu-iris-mpc/target/x86_64-unknown-linux-gnu/release/key-manager /bin/key-manager
 COPY --from=build-app /src/gpu-iris-mpc/target/x86_64-unknown-linux-gnu/release/upgrade-server /bin/upgrade-server
 COPY --from=build-app /src/gpu-iris-mpc/target/x86_64-unknown-linux-gnu/release/upgrade-client /bin/upgrade-client
+COPY --from=build-app /src/gpu-iris-mpc/target/x86_64-unknown-linux-gnu/release/upgrade-client /bin/upgrade-checker
 
 USER 65534
 ENTRYPOINT ["/bin/server"]

--- a/deploy/stage/mpc1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/mpc1-stage/values-iris-mpc.yaml
@@ -63,7 +63,7 @@ env:
     value: "0"
 
   - name: SMPC__PUBLIC_KEY_BASE_URL
-    value: "https://d24uxaabh702ht.cloudfront.net"
+    value: "https://pki-smpc-stage.worldcoin.org"
 
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"

--- a/deploy/stage/mpc2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/mpc2-stage/values-iris-mpc.yaml
@@ -63,7 +63,7 @@ env:
     value: "1"
 
   - name: SMPC__PUBLIC_KEY_BASE_URL
-    value: "https://d24uxaabh702ht.cloudfront.net"
+    value: "https://pki-smpc-stage.worldcoin.org"
 
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"

--- a/deploy/stage/mpc3-stage/values-iris-mpc.yaml
+++ b/deploy/stage/mpc3-stage/values-iris-mpc.yaml
@@ -63,7 +63,7 @@ env:
     value: "2"
 
   - name: SMPC__PUBLIC_KEY_BASE_URL
-    value: "https://d24uxaabh702ht.cloudfront.net"
+    value: "https://pki-smpc-stage.worldcoin.org"
 
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"


### PR DESCRIPTION
Part of: https://linear.app/worldcoin/issue/POP-1863/run-upgrade-checker-in-staging

Also includes a fix to using the correct urls for the pubkeys