### PR TITLE
restart counter while truncating the db

### DIFF
--- a/scripts/purge_stage_dbs.sh
+++ b/scripts/purge_stage_dbs.sh
@@ -35,7 +35,7 @@ MPC_1_DATABASE_URL=$(get_aws_secret "$SECRET_NAME" "$REGION" "DATABASE_URL" "wor
 MPC_2_DATABASE_URL=$(get_aws_secret "$SECRET_NAME" "$REGION" "DATABASE_URL" "worldcoin-smpcv2-2")
 MPC_3_DATABASE_URL=$(get_aws_secret "$SECRET_NAME" "$REGION" "DATABASE_URL" "worldcoin-smpcv2-3")
 
-kubectx arn:aws:eks:eu-north-1:767397983205:cluster/mpc1-stage
+kubectx arn:aws:eks:eu-north-1:767397983205:cluster/mpc1-stage || kubectx smpcv2-stage-1
 kubens iris-mpc
 kubectl apply -f db-cleaner-helper-pod.yaml
 echo "Waiting 10s for db-cleaner pod to be ready..."
@@ -45,7 +45,7 @@ kubectl exec -it db-cleaner -- bash -c "psql -H $MPC_1_DATABASE_URL -c 'SET sear
 kubectl exec -it db-cleaner -- bash -c "psql -H $MPC_1_DATABASE_URL -c 'SET search_path TO \"SMPC_stage_0\"; TRUNCATE results, sync;'"
 kubectl delete pod --force db-cleaner
 
-kubectx arn:aws:eks:eu-north-1:381492197851:cluster/mpc2-stage
+kubectx arn:aws:eks:eu-north-1:381492197851:cluster/mpc2-stage || kubectx smpcv2-stage-2
 kubens iris-mpc
 kubectl apply -f db-cleaner-helper-pod.yaml
 echo "Waiting 10s for db-cleaner pod to be ready..."
@@ -55,7 +55,7 @@ kubectl exec -it db-cleaner -- bash -c "psql -H $MPC_2_DATABASE_URL -c 'SET sear
 kubectl exec -it db-cleaner -- bash -c "psql -H $MPC_2_DATABASE_URL -c 'SET search_path TO \"SMPC_stage_1\"; TRUNCATE results, sync;'"
 kubectl delete pod --force db-cleaner
 
-kubectx arn:aws:eks:eu-north-1:590184084615:cluster/mpc3-stage
+kubectx arn:aws:eks:eu-north-1:590184084615:cluster/mpc3-stage || kubectx smpcv2-stage-3
 kubens iris-mpc
 kubectl apply -f db-cleaner-helper-pod.yaml
 echo "Waiting 10s for db-cleaner pod to be ready..."


### PR DESCRIPTION
**Change**
- When purging db, we do not restart the counter and the new iris entries start from the latest counter. This PR fixes this problem
- Old db state:
<img src="https://github.com/user-attachments/assets/fd1a9cbd-7538-43da-a73d-4fc7775992ad" alt="image" width="400"/>

- New db state after this fix:
<img src="https://github.com/user-attachments/assets/3efc42e3-b87d-42b7-989f-bb29eec9b749" alt="image" width="400"/>
