### PR TITLE
bump max db size

### DIFF
--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:v0.8.7"
+image: "ghcr.io/worldcoin/iris-mpc:v0.8.8"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/mpc1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/mpc1-stage/values-iris-mpc.yaml
@@ -74,5 +74,8 @@ env:
   - name: SMPC__INIT_DB_SIZE
     value: "100"
 
+  - name: SMPC__MAX_DB_SIZE
+    value: "200000"
+
   - name: SMPC__MAX_BATCH_SIZE
     value: "64"

--- a/deploy/stage/mpc2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/mpc2-stage/values-iris-mpc.yaml
@@ -74,5 +74,8 @@ env:
   - name: SMPC__INIT_DB_SIZE
     value: "100"
 
+  - name: SMPC__MAX_DB_SIZE
+    value: "200000"
+    
   - name: SMPC__MAX_BATCH_SIZE
     value: "64"

--- a/deploy/stage/mpc3-stage/values-iris-mpc.yaml
+++ b/deploy/stage/mpc3-stage/values-iris-mpc.yaml
@@ -74,5 +74,8 @@ env:
   - name: SMPC__INIT_DB_SIZE
     value: "100"
 
+  - name: SMPC__MAX_DB_SIZE
+    value: "200000"
+    
   - name: SMPC__MAX_BATCH_SIZE
     value: "64"

--- a/iris-mpc-common/src/config/mod.rs
+++ b/iris-mpc-common/src/config/mod.rs
@@ -55,6 +55,9 @@ pub struct Config {
     #[serde(default)]
     pub init_db_size: usize,
 
+    #[serde(default)]
+    pub max_db_size: usize,
+
     #[serde(default = "default_max_batch_size")]
     pub max_batch_size: usize,
 }

--- a/iris-mpc/src/bin/server.rs
+++ b/iris-mpc/src/bin/server.rs
@@ -48,7 +48,6 @@ use tokio::{
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 const REGION: &str = "eu-north-1";
-const MAX_DB_SIZE: usize = 8 * 2_000;
 const RNG_SEED_INIT_DB: u64 = 42;
 const SQS_POLLING_INTERVAL: Duration = Duration::from_secs(1);
 const MAX_CONCURRENT_REQUESTS: usize = 32;
@@ -565,7 +564,7 @@ async fn server_main(config: Config) -> eyre::Result<()> {
 
     tracing::info!("Size of the database after init: {}", store_len);
 
-    if store_len > MAX_DB_SIZE {
+    if store_len > config.max_db_size {
         tracing::error!("Database size exceeds maximum allowed size: {}", store_len);
         eyre::bail!("Database size exceeds maximum allowed size: {}", store_len);
     }
@@ -635,7 +634,7 @@ async fn server_main(config: Config) -> eyre::Result<()> {
             device_manager,
             comms,
             8,
-            MAX_DB_SIZE,
+            config.max_db_size,
             config.max_batch_size,
         ) {
             Ok((mut actor, handle)) => {


### PR DESCRIPTION
**Change**
- We were getting errors like `Server exited with error: Database size exceeds maximum allowed size: 35791`. 
- Moving the max db size into config and making it 200k for stage