### PR TITLE
Fix iris shares JSON to match orb output

### DIFF
--- a/iris-mpc-common/src/bin/shares_encoding.rs
+++ b/iris-mpc-common/src/bin/shares_encoding.rs
@@ -31,13 +31,13 @@ fn sorted_keys<T: Serialize, S: Serializer>(value: &T, serializer: S) -> Result<
 #[derive(Serialize, Debug, Clone, PartialEq)]
 struct IrisCodeSharesJson {
     #[serde(rename = "IRIS_version")]
-    iris_version:          String,
+    iris_version:           String,
     #[serde(rename = "IRIS_shares_version")]
-    iris_shares_version:   String,
-    left_iris_code_share:  String,
-    left_mask_code_share:  String,
-    right_iris_code_share: String,
-    right_mask_code_share: String,
+    iris_shares_version:    String,
+    left_iris_code_shares:  String,
+    left_mask_code_shares:  String,
+    right_iris_code_shares: String,
+    right_mask_code_shares: String,
 }
 
 /// Iris code shares.
@@ -109,12 +109,12 @@ fn main() {
         .enumerate()
     {
         let iris_code_shares = IrisCodeSharesJson {
-            iris_version:          IRIS_VERSION.to_string(),
-            iris_shares_version:   IRIS_MPC_VERSION.to_string(),
-            left_iris_code_share:  li.clone(),
-            left_mask_code_share:  lm.clone(),
-            right_iris_code_share: ri.clone(),
-            right_mask_code_share: rm.clone(),
+            iris_version:           IRIS_VERSION.to_string(),
+            iris_shares_version:    IRIS_MPC_VERSION.to_string(),
+            left_iris_code_shares:  li.clone(),
+            left_mask_code_shares:  lm.clone(),
+            right_iris_code_shares: ri.clone(),
+            right_mask_code_shares: rm.clone(),
         };
         let json_u8 = serde_json::to_string(&SerializeWithSortedKeys(&iris_code_shares))
             .unwrap()
@@ -144,15 +144,15 @@ mod tests {
     #[test]
     fn test_iris_code_shares_json() {
         let iris_code_shares = IrisCodeSharesJson {
-            iris_version:          IRIS_VERSION.to_string(),
-            iris_shares_version:   IRIS_MPC_VERSION.to_string(),
-            left_iris_code_share:  "left_iris_code_share".to_string(),
-            left_mask_code_share:  "left_mask_code_share".to_string(),
-            right_iris_code_share: "right_iris_code_share".to_string(),
-            right_mask_code_share: "right_mask_code_share".to_string(),
+            iris_version:           IRIS_VERSION.to_string(),
+            iris_shares_version:    IRIS_MPC_VERSION.to_string(),
+            left_iris_code_shares:  "left_iris_code_shares".to_string(),
+            left_mask_code_shares:  "left_mask_code_shares".to_string(),
+            right_iris_code_shares: "right_iris_code_shares".to_string(),
+            right_mask_code_shares: "right_mask_code_shares".to_string(),
         };
 
-        let expected = r#"{"IRIS_shares_version":"1.0","IRIS_version":"1.1","left_iris_code_share":"left_iris_code_share","left_mask_code_share":"left_mask_code_share","right_iris_code_share":"right_iris_code_share","right_mask_code_share":"right_mask_code_share"}"#;
+        let expected = r#"{"IRIS_shares_version":"1.0","IRIS_version":"1.1","left_iris_code_shares":"left_iris_code_shares","left_mask_code_shares":"left_mask_code_shares","right_iris_code_shares":"right_iris_code_shares","right_mask_code_shares":"right_mask_code_shares"}"#;
         assert_eq!(
             serde_json::to_string(&SerializeWithSortedKeys(&iris_code_shares)).unwrap(),
             expected

--- a/iris-mpc-common/src/helpers/smpc_request.rs
+++ b/iris-mpc-common/src/helpers/smpc_request.rs
@@ -171,13 +171,13 @@ pub struct SharesS3Object {
 #[derive(PartialEq, Serialize, Deserialize, Debug, Clone)]
 pub struct IrisCodesJSON {
     #[serde(rename = "IRIS_version")]
-    pub iris_version:          String,
+    pub iris_version:           String,
     #[serde(rename = "IRIS_shares_version")]
-    pub iris_shares_version:   String,
-    pub left_iris_code_share:  String, // these are base64 encoded strings
-    pub right_iris_code_share: String, // these are base64 encoded strings
-    pub left_mask_code_share:  String, // these are base64 encoded strings
-    pub right_mask_code_share: String, // these are base64 encoded strings
+    pub iris_shares_version:    String,
+    pub left_iris_code_shares:  String, // these are base64 encoded strings
+    pub right_iris_code_shares: String, // these are base64 encoded strings
+    pub left_mask_code_shares:  String, // these are base64 encoded strings
+    pub right_mask_code_shares: String, // these are base64 encoded strings
 }
 
 impl SharesS3Object {

--- a/iris-mpc-common/tests/smpc_request.rs
+++ b/iris-mpc-common/tests/smpc_request.rs
@@ -32,12 +32,12 @@ mod tests {
 
     fn mock_iris_codes_json() -> IrisCodesJSON {
         IrisCodesJSON {
-            iris_version:          "1.0".to_string(),
-            iris_shares_version:   "1.3".to_string(),
-            left_iris_code_share:  STANDARD.encode("left_iris_code_mock"),
-            right_iris_code_share: STANDARD.encode("right_iris_code_mock"),
-            left_mask_code_share:  STANDARD.encode("left_iris_mask_mock"),
-            right_mask_code_share: STANDARD.encode("right_iris_mask_mock"),
+            iris_version:           "1.0".to_string(),
+            iris_shares_version:    "1.3".to_string(),
+            left_iris_code_shares:  STANDARD.encode("left_iris_code_mock"),
+            right_iris_code_shares: STANDARD.encode("right_iris_code_mock"),
+            left_mask_code_shares:  STANDARD.encode("left_iris_mask_mock"),
+            right_mask_code_shares: STANDARD.encode("right_iris_mask_mock"),
         }
     }
 
@@ -103,12 +103,12 @@ mod tests {
     async fn test_decrypt_iris_share_success() {
         // Mocked base64 encoded JSON string
         let iris_codes_json = IrisCodesJSON {
-            iris_version:          "1.0".to_string(),
-            iris_shares_version:   "1.3".to_string(),
-            left_iris_code_share:  "left_code".to_string(),
-            right_iris_code_share: "right_code".to_string(),
-            left_mask_code_share:  "left_mask".to_string(),
-            right_mask_code_share: "right_mask".to_string(),
+            iris_version:           "1.0".to_string(),
+            iris_shares_version:    "1.3".to_string(),
+            left_iris_code_shares:  "left_code".to_string(),
+            right_iris_code_shares: "right_code".to_string(),
+            left_mask_code_shares:  "left_mask".to_string(),
+            right_mask_code_shares: "right_mask".to_string(),
         };
 
         let decoded_public_key = STANDARD.decode(CURRENT_PUBLIC_KEY.as_bytes()).unwrap();

--- a/iris-mpc/src/bin/client.rs
+++ b/iris-mpc/src/bin/client.rs
@@ -329,12 +329,12 @@ async fn main() -> eyre::Result<()> {
 
                 for i in 0..3 {
                     let iris_codes_json = IrisCodesJSON {
-                        iris_version:          "1.0".to_string(),
-                        iris_shares_version:   "1.3".to_string(),
-                        right_iris_code_share: shared_code[i].to_base64(),
-                        right_mask_code_share: shared_mask[i].to_base64(),
-                        left_iris_code_share:  shared_code[i].to_base64(),
-                        left_mask_code_share:  shared_mask[i].to_base64(),
+                        iris_version:           "1.0".to_string(),
+                        iris_shares_version:    "1.3".to_string(),
+                        right_iris_code_shares: shared_code[i].to_base64(),
+                        right_mask_code_shares: shared_mask[i].to_base64(),
+                        left_iris_code_shares:  shared_code[i].to_base64(),
+                        left_mask_code_shares:  shared_mask[i].to_base64(),
                     };
                     let serialized_iris_codes_json = to_string(&iris_codes_json)
                         .expect("Serialization failed")

--- a/iris-mpc/src/bin/server.rs
+++ b/iris-mpc/src/bin/server.rs
@@ -260,13 +260,13 @@ async fn receive_batch(
                             }
 
                             let (left_code, left_mask) = decode_iris_message_shares(
-                                iris_message_share.left_iris_code_share,
-                                iris_message_share.left_mask_code_share,
+                                iris_message_share.left_iris_code_shares,
+                                iris_message_share.left_mask_code_shares,
                             )?;
 
                             let (right_code, right_mask) = decode_iris_message_shares(
-                                iris_message_share.right_iris_code_share,
-                                iris_message_share.right_mask_code_share,
+                                iris_message_share.right_iris_code_shares,
+                                iris_message_share.right_mask_code_shares,
                             )?;
 
                             // Preprocess shares for left eye.


### PR DESCRIPTION
### Notes
* adding plural -->  orb sends plural :( https://github.com/worldcoin/priv-orb-core/blob/368be77d88052b371228f8ae05930e429c99c059/src/plans/personal_custody_package.rs#L164-L173
* updated the notion doc and agreed with Mehmet to use plural from now on 