### PR TITLE
update the pg serial after all insertions

### DIFF
--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -293,6 +293,7 @@ DO UPDATE SET right_code = EXCLUDED.right_code, right_mask = EXCLUDED.right_mask
 
         Ok(())
     }
+
     pub async fn insert_results(
         &self,
         tx: &mut Transaction<'_, Postgres>,
@@ -307,6 +308,16 @@ DO UPDATE SET right_code = EXCLUDED.right_code, right_mask = EXCLUDED.right_mask
         });
 
         query.build().execute(tx.deref_mut()).await?;
+        Ok(())
+    }
+
+    pub async fn update_iris_id_sequence(&self) -> Result<()> {
+        sqlx::query(
+            "SELECT setval(pg_get_serial_sequence('irises', 'id'), COALESCE(MAX(id), 0), false) \
+             FROM irises",
+        )
+        .execute(&self.pool)
+        .await?;
         Ok(())
     }
 

--- a/iris-mpc-upgrade/src/bin/tcp_upgrade_server.rs
+++ b/iris-mpc-upgrade/src/bin/tcp_upgrade_server.rs
@@ -61,7 +61,7 @@ async fn main() -> eyre::Result<()> {
     background_tasks.check_tasks();
     tracing::info!("Healthcheck server running on port 3000.");
 
-    let upgrader = IrisCodeUpgrader::new(args.party_id, sink);
+    let upgrader = IrisCodeUpgrader::new(args.party_id, sink.clone());
 
     // listen for incoming connections from clients
     let client_listener = tokio::net::TcpListener::bind(args.bind_addr).await?;
@@ -191,6 +191,9 @@ async fn main() -> eyre::Result<()> {
     }
     client_stream2.write_u8(FINAL_BATCH_SUCCESSFUL_ACK).await?;
     client_stream1.write_u8(FINAL_BATCH_SUCCESSFUL_ACK).await?;
+
+    sink.update_iris_id_sequence().await?;
+
     Ok(())
 }
 
@@ -226,5 +229,9 @@ impl NewIrisShareSink for IrisShareDbSink {
                     .await
             }
         }
+    }
+
+    async fn update_iris_id_sequence(&self) -> eyre::Result<()> {
+        self.store.update_iris_id_sequence().await
     }
 }

--- a/iris-mpc-upgrade/src/lib.rs
+++ b/iris-mpc-upgrade/src/lib.rs
@@ -41,6 +41,8 @@ pub trait NewIrisShareSink {
         code_share: &[u16; IRIS_CODE_LENGTH],
         mask_share: &[u16; MASK_CODE_LENGTH],
     ) -> eyre::Result<()>;
+
+    async fn update_iris_id_sequence(&self) -> eyre::Result<()>;
 }
 
 #[derive(Debug, Clone)]
@@ -78,6 +80,10 @@ impl NewIrisShareSink for IrisShareTestFileSink {
             writeln!(file, "{}", s)?;
         }
         file.flush()?;
+        Ok(())
+    }
+
+    async fn update_iris_id_sequence(&self) -> eyre::Result<()> {
         Ok(())
     }
 }


### PR DESCRIPTION
Currently, we insert a bunch of entries in the db during the upgrade protocol directly with a specified id, but later during normal operations we only insert by relying on the postgres serial. The serial is however starting freshly at 1 at this point (AFAIK the serial is not incremented automatically when specifying it). 