### PR TITLE
update db purge scripts

### DIFF
--- a/scripts/db-cleaner-helper-pod.yaml
+++ b/scripts/db-cleaner-helper-pod.yaml
@@ -4,13 +4,13 @@ metadata:
   name: db-cleaner
   namespace: iris-mpc
 spec:
-  hostNetwork: true
-  serviceAccountName: iris-mpc  # Add this line
+  nodeSelector:
+    beta.kubernetes.io/instance-type: t3.2xlarge # Use migration node for db-cleaner
   securityContext:
     runAsUser: 0
   containers:
     - name: db-cleaner
-      image: ubuntu
+      image: postgres
       imagePullPolicy: Always
       command: [ "/bin/bash" ]
       args: [ "-c", "while true; do ping localhost; sleep 60; done" ]

--- a/scripts/purge_stage_dbs.sh
+++ b/scripts/purge_stage_dbs.sh
@@ -40,7 +40,6 @@ kubens iris-mpc
 kubectl apply -f db-cleaner-helper-pod.yaml
 echo "Waiting 10s for db-cleaner pod to be ready..."
 sleep 10
-kubectl exec -it db-cleaner -- bash -c "apt update && apt install -y postgresql-client"
 kubectl exec -it db-cleaner -- bash -c "psql -H $MPC_1_DATABASE_URL -c 'SET search_path TO \"SMPC_stage_0\"; TRUNCATE irises RESTART IDENTITY;'"
 kubectl exec -it db-cleaner -- bash -c "psql -H $MPC_1_DATABASE_URL -c 'SET search_path TO \"SMPC_stage_0\"; TRUNCATE sync RESTART IDENTITY;'"
 kubectl exec -it db-cleaner -- bash -c "psql -H $MPC_1_DATABASE_URL -c 'SET search_path TO \"SMPC_stage_0\"; TRUNCATE results;'"
@@ -51,7 +50,6 @@ kubens iris-mpc
 kubectl apply -f db-cleaner-helper-pod.yaml
 echo "Waiting 10s for db-cleaner pod to be ready..."
 sleep 10
-kubectl exec -it db-cleaner -- bash -c "apt update && apt install -y postgresql-client"
 kubectl exec -it db-cleaner -- bash -c "psql -H $MPC_2_DATABASE_URL -c 'SET search_path TO \"SMPC_stage_1\"; TRUNCATE irises RESTART IDENTITY;'"
 kubectl exec -it db-cleaner -- bash -c "psql -H $MPC_2_DATABASE_URL -c 'SET search_path TO \"SMPC_stage_1\"; TRUNCATE sync RESTART IDENTITY;'"
 kubectl exec -it db-cleaner -- bash -c "psql -H $MPC_2_DATABASE_URL -c 'SET search_path TO \"SMPC_stage_1\"; TRUNCATE results;'"
@@ -62,7 +60,6 @@ kubens iris-mpc
 kubectl apply -f db-cleaner-helper-pod.yaml
 echo "Waiting 10s for db-cleaner pod to be ready..."
 sleep 10
-kubectl exec -it db-cleaner -- bash -c "apt update && apt install -y postgresql-client"
 kubectl exec -it db-cleaner -- bash -c "psql -H $MPC_3_DATABASE_URL -c 'SET search_path TO \"SMPC_stage_2\"; TRUNCATE irises RESTART IDENTITY;'"
 kubectl exec -it db-cleaner -- bash -c "psql -H $MPC_3_DATABASE_URL -c 'SET search_path TO \"SMPC_stage_2\"; TRUNCATE sync RESTART IDENTITY;'"
 kubectl exec -it db-cleaner -- bash -c "psql -H $MPC_3_DATABASE_URL -c 'SET search_path TO \"SMPC_stage_2\"; TRUNCATE results;'"


### PR DESCRIPTION
**Change**
- Since RDS security group is no more the default one, we need to run the cleaner from a node with correct security group attached.
- In this PR, we use migration node for db-cleaner pod.