### PR TITLE
INF-242 Add initContainer managing iris-mpc-node.* record with NCCL_C…

### DIFF
--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -76,3 +76,45 @@ env:
 
   - name: SMPC__MAX_BATCH_SIZE
     value: "64"
+
+initContainer:
+  enabled: true
+  image: "amazon/aws-cli:2.17.62"
+  name: "iri-mpc-dns-records-updater"
+  env:
+    - name: PARTY_ID
+      value: "1"
+    - name: MY_NODE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.hostIP
+  configMap:
+    init.sh: |
+      #!/usr/bin/env bash
+
+      # Set up environment variables
+      HOSTED_ZONE_ID=$(aws route53 list-hosted-zones-by-name --dns-name "$PARTY_ID".stage.smpcv2.worldcoin.dev --query "HostedZones[].Id" --output text)
+      
+      # Generate the JSON content in memory
+      BATCH_JSON=$(cat <<EOF
+      {
+        "Comment": "Upsert the A record for upgrade-server",
+        "Changes": [
+          {
+            "Action": "UPSERT",
+            "ResourceRecordSet": {
+              "Name": "iris-mpc-node.$PARTY_ID.stage.smpcv2.worldcoin.dev",
+              "TTL": 5,
+              "Type": "A",
+              "ResourceRecords": [{
+                "Value": "$MY_NODE_IP"
+              }]
+            }
+          }
+        ]
+      }
+      EOF
+      )
+      
+      # Execute AWS CLI command with the generated JSON
+      aws route53 change-resource-record-sets --hosted-zone-id "$HOSTED_ZONE_ID" --change-batch "$BATCH_JSON"


### PR DESCRIPTION
…OMM_ID on r53

In order to avoid issues when efa nodes ip is changed due to restart

Permissions to be able to manage r53 zone: https://github.com/worldcoin-foundation/smpc-setup/pull/41
