### PR TITLE
INFRA-3305: Add `aws-efa-installer` and `aws-ofi-nccl` to base image

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y pkg-config wget libssl-dev ca-certifica
 RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb \
     && dpkg -i cuda-keyring_1.1-1_all.deb \
     && apt-get update \
-    && apt-get install -y cuda-toolkit-12-2 libnccl2=2.22.3-1+cuda12.2 libnccl-dev=2.22.3-1+cuda12.2 git curl build-essential
+    && apt-get install -y cuda-toolkit-12-2 libnccl2=2.22.3-1+cuda12.2 libnccl-dev=2.22.3-1+cuda12.2 git curl build-essential debhelper
 
 ARG GDRCOPY_VERSION=v2.4.1
 ARG EFA_INSTALLER_VERSION=1.34.0


### PR DESCRIPTION
Requestor/Issue: https://linear.app/worldcoin/issue/INFRA-3305/add-aws-efa-installer-and-aws-ofi-nccl-to-base-image
Tested (yes/no): no
Description/Why: after testing we need to install everything in the base image
