### PR TITLE
INFRA-3307: Add `libsDir` volume

### DIFF
--- a/deploy/prod/common-values-iris-mpc.yaml
+++ b/deploy/prod/common-values-iris-mpc.yaml
@@ -63,3 +63,13 @@ tolerations:
 keelPolling:
   # -- Specifies whether keel should poll for container updates
   enabled: true
+
+libsDir:
+  enabled: true
+  path: "/libs"
+  size: 2Gi
+  files:
+    - path: "/usr/local/cuda-12.2/targets/x86_64-linux/lib/libcublasLt.so.12.2.5.6"
+      file: "libcublasLt.so.12.2.5.6"
+    - path: "/usr/local/cuda-12.2/targets/x86_64-linux/lib/libcublas.so.12.2.5.6"
+      file: "libcublas.so.12.2.5.6"

--- a/deploy/prod/smpcv2-0-prod/values-iris-mpc.yaml
+++ b/deploy/prod/smpcv2-0-prod/values-iris-mpc.yaml
@@ -83,16 +83,6 @@ env:
   - name: SMPC__DISABLE_PERSISTENCE
     value: "true"
 
-libsDir:
-  enabled: true
-  path: "/libs"
-  size: 2Gi
-  files:
-    - path: "/usr/local/cuda-12.2/targets/x86_64-linux/lib/libcublasLt.so.12.2.5.6"
-      file: "libcublasLt.so.12.2.5.6"
-    - path: "/usr/local/cuda-12.2/targets/x86_64-linux/lib/libcublas.so.12.2.5.6"
-      file: "libcublas.so.12.2.5.6"
-
 initContainer:
   enabled: true
   image: "amazon/aws-cli:2.17.62"

--- a/deploy/prod/smpcv2-1-prod/values-iris-mpc.yaml
+++ b/deploy/prod/smpcv2-1-prod/values-iris-mpc.yaml
@@ -83,16 +83,6 @@ env:
   - name: SMPC__DISABLE_PERSISTENCE
     value: "true"
 
-libsDir:
-  enabled: true
-  path: "/libs"
-  size: 2Gi
-  files:
-    - path: "/usr/local/cuda-12.2/targets/x86_64-linux/lib/libcublasLt.so.12.2.5.6"
-      file: "libcublasLt.so.12.2.5.6"
-    - path: "/usr/local/cuda-12.2/targets/x86_64-linux/lib/libcublas.so.12.2.5.6"
-      file: "libcublas.so.12.2.5.6"
-
 initContainer:
   enabled: true
   image: "amazon/aws-cli:2.17.62"

--- a/deploy/prod/smpcv2-2-prod/values-iris-mpc.yaml
+++ b/deploy/prod/smpcv2-2-prod/values-iris-mpc.yaml
@@ -83,16 +83,6 @@ env:
   - name: SMPC__DISABLE_PERSISTENCE
     value: "true"
 
-libsDir:
-  enabled: true
-  path: "/libs"
-  size: 2Gi
-  files:
-    - path: "/usr/local/cuda-12.2/targets/x86_64-linux/lib/libcublasLt.so.12.2.5.6"
-      file: "libcublasLt.so.12.2.5.6"
-    - path: "/usr/local/cuda-12.2/targets/x86_64-linux/lib/libcublas.so.12.2.5.6"
-      file: "libcublas.so.12.2.5.6"
-
 initContainer:
   enabled: true
   image: "amazon/aws-cli:2.17.62"

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -61,3 +61,13 @@ tolerations:
 keelPolling:
   # -- Specifies whether keel should poll for container updates
   enabled: true
+
+libsDir:
+  enabled: true
+  path: "/libs"
+  size: 2Gi
+  files:
+    - path: "/usr/local/cuda-12.2/targets/x86_64-linux/lib/libcublasLt.so.12.2.5.6"
+      file: "libcublasLt.so.12.2.5.6"
+    - path: "/usr/local/cuda-12.2/targets/x86_64-linux/lib/libcublas.so.12.2.5.6"
+      file: "libcublas.so.12.2.5.6"

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -77,16 +77,6 @@ env:
   - name: SMPC__MAX_BATCH_SIZE
     value: "64"
 
-libsDir:
-  enabled: true
-  path: "/libs"
-  size: 2Gi
-  files:
-    - path: "/usr/local/cuda-12.2/targets/x86_64-linux/lib/libcublasLt.so.12.2.5.6"
-      file: "libcublasLt.so.12.2.5.6"
-    - path: "/usr/local/cuda-12.2/targets/x86_64-linux/lib/libcublas.so.12.2.5.6"
-      file: "libcublas.so.12.2.5.6"
-
 initContainer:
   enabled: true
   image: "amazon/aws-cli:2.17.62"

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -77,16 +77,6 @@ env:
   - name: SMPC__MAX_BATCH_SIZE
     value: "64"
 
-libsDir:
-  enabled: true
-  path: "/libs"
-  size: 2Gi
-  files:
-    - path: "/usr/local/cuda-12.2/targets/x86_64-linux/lib/libcublasLt.so.12.2.5.6"
-      file: "libcublasLt.so.12.2.5.6"
-    - path: "/usr/local/cuda-12.2/targets/x86_64-linux/lib/libcublas.so.12.2.5.6"
-      file: "libcublas.so.12.2.5.6"
-
 initContainer:
   enabled: true
   image: "amazon/aws-cli:2.17.62"

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -77,16 +77,6 @@ env:
   - name: SMPC__MAX_BATCH_SIZE
     value: "64"
 
-libsDir:
-  enabled: true
-  path: "/libs"
-  size: 2Gi
-  files:
-    - path: "/usr/local/cuda-12.2/targets/x86_64-linux/lib/libcublasLt.so.12.2.5.6"
-      file: "libcublasLt.so.12.2.5.6"
-    - path: "/usr/local/cuda-12.2/targets/x86_64-linux/lib/libcublas.so.12.2.5.6"
-      file: "libcublas.so.12.2.5.6"
-
 initContainer:
   enabled: true
   image: "amazon/aws-cli:2.17.62"


### PR DESCRIPTION
Requestor/Issue: https://linear.app/worldcoin/issue/INFRA-3307/add-ability-to-get-additional-libs-from-s3 
Tested (yes/no): no
Description/Why: to be able to use patched libs



