### PR TITLE
Add backtrace to be 1

### DIFF
--- a/deploy/prod/smpcv2-0-prod/values-iris-mpc.yaml
+++ b/deploy/prod/smpcv2-0-prod/values-iris-mpc.yaml
@@ -9,7 +9,7 @@ env:
     value: "iris-mpc-node.1.smpcv2.worldcoin.org:4000"
 
   - name: RUST_BACKTRACE
-    value: "full"
+    value: "1"
 
   - name: SMPC__ENVIRONMENT
     value: "prod"

--- a/deploy/prod/smpcv2-1-prod/values-iris-mpc.yaml
+++ b/deploy/prod/smpcv2-1-prod/values-iris-mpc.yaml
@@ -3,7 +3,7 @@ env:
     value: "info"
 
   - name: RUST_BACKTRACE
-    value: "full"
+    value: "1"
 
   - name: NCCL_SOCKET_IFNAME
     value: "eth0"

--- a/deploy/prod/smpcv2-2-prod/values-iris-mpc.yaml
+++ b/deploy/prod/smpcv2-2-prod/values-iris-mpc.yaml
@@ -3,7 +3,7 @@ env:
     value: "info"
 
   - name: RUST_BACKTRACE
-    value: "full"
+    value: "1"
 
   - name: NCCL_SOCKET_IFNAME
     value: "eth0"


### PR DESCRIPTION
### Notes
* add backtrace to be 1 - this prevents the panics from forming on multiple lines. 
* this will allow us to create alarms on errors and have not one error create an alarm everytime
