### PR TITLE
Add panic logging configuration

### DIFF
--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:v0.8.28"
+image: "ghcr.io/worldcoin/iris-mpc:v0.8.30"
 
 environment: stage
 replicaCount: 1


### PR DESCRIPTION
### Notes
* add panic hook to control backtraces not being printed on multi-line
* this prevents alarms being fired for one error in the case of heartbeat restart