### PR TITLE
chore: Provide a read store

### DIFF
--- a/deploy/prod/common-values-iris-mpc.yaml
+++ b/deploy/prod/common-values-iris-mpc.yaml
@@ -1,7 +1,7 @@
 image: "ghcr.io/worldcoin/iris-mpc:v0.8.27"
 
 environment: prod
-replicaCount: 1
+replicaCount: 0
 
 strategy:
   type: Recreate

--- a/deploy/prod/common-values-iris-mpc.yaml
+++ b/deploy/prod/common-values-iris-mpc.yaml
@@ -1,7 +1,7 @@
 image: "ghcr.io/worldcoin/iris-mpc:v0.8.27"
 
 environment: prod
-replicaCount: 0
+replicaCount: 1
 
 strategy:
   type: Recreate

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -17,19 +17,28 @@ env:
   - name: SMPC__SERVICE__SERVICE_NAME
     value: "smpcv2-server-stage"
 
-  - name: SMPC__DATABASE__URL
+  - name: SMPC__WRITE_DATABASE__URL
     valueFrom:
       secretKeyRef:
         key: DATABASE_AURORA_URL
         name: application
 
-  - name: SMPC__DATABASE__MIGRATE
+  - name: SMPC__WRITE_DATABASE__MIGRATE
     value: "true"
 
-  - name: SMPC__DATABASE__CREATE
+  - name: SMPC__WRITE_DATABASE__CREATE
     value: "true"
 
-  - name: SMPC__DATABASE__LOAD_PARALLELISM
+  - name: SMPC__WRITE_DATABASE__LOAD_PARALLELISM
+    value: "8"
+    
+  - name: SMPC__READ_DATABASE__URL
+    valueFrom:
+      secretKeyRef:
+        key: DATABASE_AURORA_RO_URL
+        name: application
+
+  - name: SMPC__READ_DATABASE__LOAD_PARALLELISM
     value: "8"
 
   - name: SMPC__AWS__REGION

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -17,19 +17,28 @@ env:
   - name: SMPC__SERVICE__SERVICE_NAME
     value: "smpcv2-server-stage"
 
-  - name: SMPC__DATABASE__URL
+  - name: SMPC__WRITE_DATABASE__URL
     valueFrom:
       secretKeyRef:
         key: DATABASE_AURORA_URL
         name: application
 
-  - name: SMPC__DATABASE__MIGRATE
+  - name: SMPC__WRITE_DATABASE__MIGRATE
     value: "true"
 
-  - name: SMPC__DATABASE__CREATE
+  - name: SMPC__WRITE_DATABASE__CREATE
     value: "true"
 
-  - name: SMPC__DATABASE__LOAD_PARALLELISM
+  - name: SMPC__WRITE_DATABASE__LOAD_PARALLELISM
+    value: "8"
+
+  - name: SMPC__READ_DATABASE__URL
+    valueFrom:
+      secretKeyRef:
+        key: DATABASE_AURORA_RO_URL
+        name: application
+
+  - name: SMPC__READ_DATABASE__LOAD_PARALLELISM
     value: "8"
 
   - name: SMPC__AWS__REGION

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -17,19 +17,28 @@ env:
   - name: SMPC__SERVICE__SERVICE_NAME
     value: "smpcv2-server-stage"
 
-  - name: SMPC__DATABASE__URL
+  - name: SMPC__WRITE_DATABASE__URL
     valueFrom:
       secretKeyRef:
         key: DATABASE_AURORA_URL
         name: application
 
-  - name: SMPC__DATABASE__MIGRATE
+  - name: SMPC__WRITE_DATABASE__MIGRATE
     value: "true"
 
-  - name: SMPC__DATABASE__CREATE
+  - name: SMPC__WRITE_DATABASE__CREATE
     value: "true"
 
-  - name: SMPC__DATABASE__LOAD_PARALLELISM
+  - name: SMPC__WRITE_DATABASE__LOAD_PARALLELISM
+    value: "8"
+
+  - name: SMPC__READ_DATABASE__URL
+    valueFrom:
+      secretKeyRef:
+        key: DATABASE_AURORA_RO_URL
+        name: application
+
+  - name: SMPC__READ_DATABASE__LOAD_PARALLELISM
     value: "8"
 
   - name: SMPC__AWS__REGION

--- a/iris-mpc-common/src/config/mod.rs
+++ b/iris-mpc-common/src/config/mod.rs
@@ -38,7 +38,10 @@ pub struct Config {
     pub service: Option<ServiceConfig>,
 
     #[serde(default)]
-    pub database: Option<DbConfig>,
+    pub read_database: Option<ReadDbConfig>,
+
+    #[serde(default)]
+    pub write_database: Option<WriteDbConfig>,
 
     #[serde(default)]
     pub aws: Option<AwsConfig>,
@@ -115,7 +118,15 @@ impl Config {
 }
 
 #[derive(Clone, Serialize, Deserialize, Default)]
-pub struct DbConfig {
+pub struct ReadDbConfig {
+    pub url: String,
+
+    #[serde(default = "default_load_parallelism")]
+    pub load_parallelism: usize,
+}
+
+#[derive(Clone, Serialize, Deserialize, Default)]
+pub struct WriteDbConfig {
     pub url: String,
 
     #[serde(default)]
@@ -132,12 +143,21 @@ fn default_load_parallelism() -> usize {
     8
 }
 
-impl fmt::Debug for DbConfig {
+impl fmt::Debug for WriteDbConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("DbConfig")
             .field("url", &"********") // Mask the URL
             .field("migrate", &self.migrate)
             .field("create", &self.create)
+            .finish()
+    }
+}
+
+impl fmt::Debug for ReadDbConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ReadDbConfig")
+            .field("url", &"********") // Mask the URL
+            .field("parallelism", &self.load_parallelism)
             .finish()
     }
 }


### PR DESCRIPTION
The current Aurora setup does not read from "reader" instance. We need to force it to do so, so that we can save on cross-AZ traffic.