### PR TITLE
preprocess limbs earlier

### DIFF
--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -499,7 +499,11 @@ impl ServerActor {
                 && batch_size * ROTATIONS == batch.db_left.code.len()
                 && batch_size * ROTATIONS == batch.db_left.mask.len()
                 && batch_size * ROTATIONS == batch.db_right.code.len()
-                && batch_size * ROTATIONS == batch.db_right.mask.len(),
+                && batch_size * ROTATIONS == batch.db_right.mask.len()
+                && batch_size * ROTATIONS == batch.query_left_preprocessed.len()
+                && batch_size * ROTATIONS == batch.query_right_preprocessed.len()
+                && batch_size * ROTATIONS == batch.db_left_preprocessed.len()
+                && batch_size * ROTATIONS == batch.db_right_preprocessed.len(),
             "Query batch sizes mismatch"
         );
 
@@ -559,47 +563,11 @@ impl ServerActor {
         ///////////////////////////////////////////////////////////////////
         tracing::info!("Comparing left eye queries");
         // *Query* variant including Lagrange interpolation.
-        let compact_query_left = {
-            let code_query = preprocess_query(
-                &batch
-                    .query_left
-                    .code
-                    .into_iter()
-                    .flat_map(|e| e.coefs)
-                    .collect::<Vec<_>>(),
-            );
-
-            let mask_query = preprocess_query(
-                &batch
-                    .query_left
-                    .mask
-                    .into_iter()
-                    .flat_map(|e| e.coefs)
-                    .collect::<Vec<_>>(),
-            );
-            // *Storage* variant (no interpolation).
-            let code_query_insert = preprocess_query(
-                &batch
-                    .db_left
-                    .code
-                    .into_iter()
-                    .flat_map(|e| e.coefs)
-                    .collect::<Vec<_>>(),
-            );
-            let mask_query_insert = preprocess_query(
-                &batch
-                    .db_left
-                    .mask
-                    .into_iter()
-                    .flat_map(|e| e.coefs)
-                    .collect::<Vec<_>>(),
-            );
-            CompactQuery {
-                code_query,
-                mask_query,
-                code_query_insert,
-                mask_query_insert,
-            }
+        let compact_query_left = CompactQuery {
+            code_query:        batch.query_left_preprocessed.code.clone(),
+            mask_query:        batch.query_left_preprocessed.mask.clone(),
+            code_query_insert: batch.db_left_preprocessed.code.clone(),
+            mask_query_insert: batch.db_left_preprocessed.mask.clone(),
         };
         let query_store_left = batch.store_left;
 
@@ -631,47 +599,11 @@ impl ServerActor {
         ///////////////////////////////////////////////////////////////////
         tracing::info!("Comparing right eye queries");
         // *Query* variant including Lagrange interpolation.
-        let compact_query_right = {
-            let code_query = preprocess_query(
-                &batch
-                    .query_right
-                    .code
-                    .into_iter()
-                    .flat_map(|e| e.coefs)
-                    .collect::<Vec<_>>(),
-            );
-
-            let mask_query = preprocess_query(
-                &batch
-                    .query_right
-                    .mask
-                    .into_iter()
-                    .flat_map(|e| e.coefs)
-                    .collect::<Vec<_>>(),
-            );
-            // *Storage* variant (no interpolation).
-            let code_query_insert = preprocess_query(
-                &batch
-                    .db_right
-                    .code
-                    .into_iter()
-                    .flat_map(|e| e.coefs)
-                    .collect::<Vec<_>>(),
-            );
-            let mask_query_insert = preprocess_query(
-                &batch
-                    .db_right
-                    .mask
-                    .into_iter()
-                    .flat_map(|e| e.coefs)
-                    .collect::<Vec<_>>(),
-            );
-            CompactQuery {
-                code_query,
-                mask_query,
-                code_query_insert,
-                mask_query_insert,
-            }
+        let compact_query_right = CompactQuery {
+            code_query:        batch.query_right_preprocessed.code.clone(),
+            mask_query:        batch.query_right_preprocessed.mask.clone(),
+            code_query_insert: batch.db_right_preprocessed.code.clone(),
+            mask_query_insert: batch.db_right_preprocessed.mask.clone(),
         };
         let query_store_right = batch.store_right;
 

--- a/iris-mpc-gpu/src/server/mod.rs
+++ b/iris-mpc-gpu/src/server/mod.rs
@@ -37,6 +37,10 @@ impl BatchQueryEntriesPreprocessed {
         assert!(codes == masks);
         codes
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]

--- a/iris-mpc-gpu/tests/e2e.rs
+++ b/iris-mpc-gpu/tests/e2e.rs
@@ -8,7 +8,7 @@ mod e2e_test {
     };
     use iris_mpc_gpu::{
         helpers::device_manager::DeviceManager,
-        server::{BatchQuery, ServerActor, ServerJobResult},
+        server::{BatchQuery, BatchQueryEntriesPreprocessed, ServerActor, ServerJobResult},
     };
     use rand::{rngs::StdRng, Rng, SeedableRng};
     use std::{collections::HashMap, env, sync::Arc};
@@ -378,6 +378,11 @@ mod e2e_test {
             batch1.store_right = batch1.store_left.clone();
             batch2.store_right = batch2.store_left.clone();
 
+            // Preprocess the batches
+            preprocess_batch(&mut batch0)?;
+            preprocess_batch(&mut batch1)?;
+            preprocess_batch(&mut batch2)?;
+
             // send batches to servers
             let res0_fut = handle0.submit_batch_query(batch0).await;
             let res1_fut = handle1.submit_batch_query(batch1).await;
@@ -438,6 +443,16 @@ mod e2e_test {
         actor1_task.await.unwrap();
         actor2_task.await.unwrap();
 
+        Ok(())
+    }
+
+    fn preprocess_batch(batch: &mut BatchQuery) -> Result<()> {
+        batch.query_left_preprocessed =
+            BatchQueryEntriesPreprocessed::from(batch.query_left.clone());
+        batch.query_right_preprocessed =
+            BatchQueryEntriesPreprocessed::from(batch.query_right.clone());
+        batch.db_left_preprocessed = BatchQueryEntriesPreprocessed::from(batch.db_left.clone());
+        batch.db_right_preprocessed = BatchQueryEntriesPreprocessed::from(batch.db_right.clone());
         Ok(())
     }
 }

--- a/iris-mpc/src/bin/server.rs
+++ b/iris-mpc/src/bin/server.rs
@@ -29,8 +29,8 @@ use iris_mpc_common::{
 use iris_mpc_gpu::{
     helpers::device_manager::DeviceManager,
     server::{
-        get_dummy_shares_for_deletion, sync_nccl, BatchMetadata, BatchQuery, ServerActor,
-        ServerJobResult,
+        get_dummy_shares_for_deletion, sync_nccl, BatchMetadata, BatchQuery,
+        BatchQueryEntriesPreprocessed, ServerActor, ServerJobResult,
     },
 };
 use iris_mpc_store::{Store, StoredIrisRef};
@@ -408,6 +408,16 @@ async fn receive_batch(
         batch_query.query_right.code.extend(iris_shares_right);
         batch_query.query_right.mask.extend(mask_shares_right);
     }
+
+    // Preprocess query shares here already to avoid blocking the actor
+    batch_query.query_left_preprocessed =
+        BatchQueryEntriesPreprocessed::from(batch_query.query_left.clone());
+    batch_query.query_right_preprocessed =
+        BatchQueryEntriesPreprocessed::from(batch_query.query_right.clone());
+    batch_query.db_left_preprocessed =
+        BatchQueryEntriesPreprocessed::from(batch_query.db_left.clone());
+    batch_query.db_right_preprocessed =
+        BatchQueryEntriesPreprocessed::from(batch_query.db_right.clone());
 
     Ok(batch_query)
 }


### PR DESCRIPTION
During production usage we saw the performance dropping during larger batches. This seems to be due to the preprocessing that is linear in terms of elements in the batch. This PR moves *most* preprocessing out of the main worker. 
Preprocessing that is still left in the main worker and could be addressed in the future:
1. sum calculation of queries
2. htod transfer

Both are GPU operations and therefore not trivial to move out, but we can make 1 a CPU operation again. 


<img width="736" alt="image" src="https://github.com/user-attachments/assets/51f04d9c-fe9f-44ce-9604-f7d4b5903432">
