### PR TITLE
don't count dropped message in batch

### DIFF
--- a/iris-mpc/src/bin/server.rs
+++ b/iris-mpc/src/bin/server.rs
@@ -235,7 +235,8 @@ async fn receive_batch(
 
                         if skip_request_ids.contains(&smpc_request.signup_id) {
                             // Some party (maybe us) already meant to delete this request, so we
-                            // skip it.
+                            // skip it. Ignore this message when calculating the batch size.
+                            msg_counter -= 1;
                             continue;
                         }
 


### PR DESCRIPTION
This can cause the batches to go out of sync. The nodes that still have this "to be dropped" message in the queue will produce a smaller batch than the other nodes that don't have it. 