### PR TITLE
Reduce memory usage of plaintext HNSW indexes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ aws-sdk-secretsmanager = { version = "1.47.0" }
 axum = "0.7"
 clap = { version = "4", features = ["derive", "env"] }
 base64 = "0.22.1"
-bytemuck = "1.17"
+bytemuck = { version = "1.17", features = ["derive"] }
 dotenvy = "0.15"
 eyre = "0.6"
 futures = "0.3.30"

--- a/iris-mpc-cpu/src/protocol/ops.rs
+++ b/iris-mpc-cpu/src/protocol/ops.rs
@@ -281,7 +281,7 @@ mod tests {
     use crate::{
         database_generators::generate_galois_iris_shares,
         execution::{local::LocalRuntime, player::Identity},
-        hawkers::plaintext_store::FormattedIris,
+        hawkers::plaintext_store::PlaintextIris,
         protocol::ops::NetworkValue::RingElement32,
         shares::{int_ring::IntRing2k, ring_impl::RingElement},
     };
@@ -570,9 +570,9 @@ mod tests {
         assert_eq!(output0, output1);
         assert_eq!(output0, output2);
 
-        let formatted_first = FormattedIris::from(iris_db[0].clone());
-        let formatted_second = FormattedIris::from(iris_db[1].clone());
-        let (plain_d1, plain_d2) = formatted_first.compute_distance(&formatted_second);
+        let plaintext_first = PlaintextIris(iris_db[0].clone());
+        let plaintext_second = PlaintextIris(iris_db[1].clone());
+        let (plain_d1, plain_d2) = plaintext_first.dot_distance_fraction(&plaintext_second);
         assert_eq!(output0.0[0], plain_d1 as u16);
         assert_eq!(output0.0[1], plain_d2 as u16);
 


### PR DESCRIPTION
Previous implementation had some inefficiencies in the data representations used for a plaintext HNSW index:
- `PointId` used `usize` which is usually 64 bits, but only 32 bits are needed for a (4-)billion entry database; type is changed to use `u32` instead
- `FormattedIris` represented the "dot product" encoding of masked iris bits directly using `i8` values, plus an extra copy of the binary iris code mask, meaning iris codes represented in this way used 9 bits per geometric index instead of the necessary 2 from using a standard `IrisCode` object; `FormattedIris` is now `PlaintextIris`, a tuple struct wrapper for `IrisCode`
- `DistanceRef` used `(PointId, PointId)` to represent a lazy distance, which previously was 128 bits (64 bits using new `PointId`s), but only requires a `(u16, u16)` to represent a non-lazy distance as a numerator and denominator; implementation is changed to compute and store the plaintext distances directly

Overall reduction in space I believe should be around 4.5x for the iris code storage, and around 3x for the HNSW graph storage.