### PR TITLE
more robust handling of sequence id 

### DIFF
--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:v0.8.34"
+image: "ghcr.io/worldcoin/iris-mpc:v0.9.1"
 
 environment: stage
 replicaCount: 1

--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -296,13 +296,22 @@ DO UPDATE SET right_code = EXCLUDED.right_code, right_mask = EXCLUDED.right_mask
             .execute(&self.pool)
             .await?;
 
-        // We also need to reset the sequence to avoid gaps in the IDs.
+        Ok(())
+    }
+
+    pub async fn set_irises_sequence_id(&self, id: usize) -> Result<()> {
         sqlx::query("SELECT setval(pg_get_serial_sequence('irises', 'id'), $1 + 1, false)")
-            .bind(db_len as i64)
+            .bind(id as i64)
             .execute(&self.pool)
             .await?;
-
         Ok(())
+    }
+
+    pub async fn get_irises_sequence_id(&self) -> Result<usize> {
+        let id: (i64,) = sqlx::query_as("SELECT currval(pg_get_serial_sequence('irises', 'id'))")
+            .fetch_one(&self.pool)
+            .await?;
+        Ok(id.0 as usize)
     }
 
     pub async fn insert_results(

--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -321,7 +321,7 @@ DO UPDATE SET right_code = EXCLUDED.right_code, right_mask = EXCLUDED.right_mask
     }
 
     pub async fn get_irises_sequence_id(&self) -> Result<usize> {
-        let id: (i64,) = sqlx::query_as("SELECT currval(pg_get_serial_sequence('irises', 'id'))")
+        let id: (i64,) = sqlx::query_as("SELECT last_value FROM irises_id_seq")
             .fetch_one(&self.pool)
             .await?;
         Ok(id.0 as usize)

--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -290,21 +290,34 @@ DO UPDATE SET right_code = EXCLUDED.right_code, right_mask = EXCLUDED.right_mask
         Ok(())
     }
 
+    async fn set_sequence_id(
+        &self,
+        id: usize,
+        executor: impl sqlx::Executor<'_, Database = Postgres>,
+    ) -> Result<()> {
+        sqlx::query("SELECT setval(pg_get_serial_sequence('irises', 'id'), $1 + 1, false)")
+            .bind(id as i64)
+            .execute(executor)
+            .await?;
+        Ok(())
+    }
+
     pub async fn rollback(&self, db_len: usize) -> Result<()> {
+        let mut tx = self.pool.begin().await?;
+
         sqlx::query("DELETE FROM irises WHERE id > $1")
             .bind(db_len as i64)
-            .execute(&self.pool)
+            .execute(&mut *tx)
             .await?;
 
+        self.set_sequence_id(db_len, &mut *tx).await?;
+
+        tx.commit().await?;
         Ok(())
     }
 
     pub async fn set_irises_sequence_id(&self, id: usize) -> Result<()> {
-        sqlx::query("SELECT setval(pg_get_serial_sequence('irises', 'id'), $1 + 1, false)")
-            .bind(id as i64)
-            .execute(&self.pool)
-            .await?;
-        Ok(())
+        self.set_sequence_id(id, &self.pool).await
     }
 
     pub async fn get_irises_sequence_id(&self) -> Result<usize> {


### PR DESCRIPTION
- merge delete and reset of id into a single db transaction
- try to recover from a state with out-of-sync sequence id