### PR TITLE
handle pod restarts gracefully

### DIFF
--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:v0.9.1"
+image: "ghcr.io/worldcoin/iris-mpc:v0.9.2"
 
 environment: stage
 replicaCount: 1

--- a/iris-mpc-common/src/config/mod.rs
+++ b/iris-mpc-common/src/config/mod.rs
@@ -78,6 +78,9 @@ pub struct Config {
 
     #[serde(default, deserialize_with = "deserialize_yaml_json_string")]
     pub node_hostnames: Vec<String>,
+
+    #[serde(default = "default_shutdown_last_results_sync_timeout_secs")]
+    pub shutdown_last_results_sync_timeout_secs: u64,
 }
 
 fn default_processing_timeout_secs() -> u64 {
@@ -93,6 +96,10 @@ fn default_heartbeat_interval_secs() -> u64 {
 }
 
 fn default_heartbeat_initial_retries() -> u64 {
+    10
+}
+
+fn default_shutdown_last_results_sync_timeout_secs() -> u64 {
     10
 }
 

--- a/iris-mpc-common/src/helpers/mod.rs
+++ b/iris-mpc-common/src/helpers/mod.rs
@@ -3,6 +3,7 @@ pub mod aws_sigv4;
 pub mod key_pair;
 pub mod kms_dh;
 pub mod sha256;
+pub mod shutdown_handler;
 pub mod smpc_request;
 pub mod sqs_s3_helper;
 pub mod sync;

--- a/iris-mpc-common/src/helpers/shutdown_handler.rs
+++ b/iris-mpc-common/src/helpers/shutdown_handler.rs
@@ -1,0 +1,94 @@
+use std::{
+    sync::{
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        Arc,
+    },
+    time::{Duration, Instant},
+};
+use tokio::signal;
+
+#[derive(Clone, Debug)]
+pub struct ShutdownHandler {
+    shutdown_received:            Arc<AtomicBool>,
+    n_batches_pending_completion: Arc<AtomicUsize>,
+    last_results_sync_timeout:    Duration,
+}
+
+impl ShutdownHandler {
+    pub fn new(shutdown_last_results_sync_timeout_secs: u64) -> Self {
+        Self {
+            shutdown_received:            Arc::new(AtomicBool::new(false)),
+            n_batches_pending_completion: Arc::new(AtomicUsize::new(0)),
+            last_results_sync_timeout:    Duration::from_secs(
+                shutdown_last_results_sync_timeout_secs,
+            ),
+        }
+    }
+
+    pub fn is_shutting_down(&self) -> bool {
+        self.shutdown_received.load(Ordering::Relaxed)
+    }
+
+    pub async fn wait_for_shutdown_signal(&self) {
+        let shutdown_flag = self.shutdown_received.clone();
+        tokio::spawn(async move {
+            shutdown_signal().await;
+            shutdown_flag.store(true, Ordering::Relaxed);
+            tracing::info!("Shutdown signal received.");
+        });
+    }
+
+    pub fn increment_batches_pending_completion(&self) {
+        tracing::debug!("Incrementing pending batches count");
+        self.n_batches_pending_completion
+            .fetch_add(1, Ordering::SeqCst);
+    }
+
+    pub fn decrement_batches_pending_completion(&self) {
+        tracing::debug!("Decrementing pending batches count");
+        self.n_batches_pending_completion
+            .fetch_sub(1, Ordering::SeqCst);
+    }
+
+    pub async fn wait_for_pending_batches_completion(&self) {
+        let check_interval = Duration::from_millis(100);
+        let start = Instant::now();
+
+        while self.n_batches_pending_completion.load(Ordering::SeqCst) > 0 {
+            // Check if the timeout has been exceeded
+            if start.elapsed() >= self.last_results_sync_timeout {
+                tracing::error!("Timed out waiting for pending batches to complete.");
+                return;
+            }
+
+            // Wait before checking again
+            tokio::time::sleep(check_interval).await;
+        }
+
+        tracing::info!("Pending batches count reached zero.");
+    }
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        signal::unix::signal(signal::unix::SignalKind::terminate())
+            .expect("failed to install signal handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = terminate => {},
+    }
+}


### PR DESCRIPTION
**Change**
- This PR captures pod restart signals and shuts down the service gracefully by waiting for last batch to be completed
- It also waits for all pending batch results to be reported