### PR TITLE
increase pod's terminationGracePeriodSeconds

### DIFF
--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -78,3 +78,7 @@ libsDir:
       file: "libcublasLt.so.12.2.5.6"
     - path: "/usr/local/cuda-12.2/targets/x86_64-linux/lib/libcublas.so.12.2.5.6"
       file: "libcublas.so.12.2.5.6"
+
+preStop:
+  # sleepPeriod is a variable in common-app to specify k8s terminationGracePeriodSeconds
+  sleepPeriod: 180 # 3x SMPC__PROCESSING_TIMEOUT_SECS


### PR DESCRIPTION
**Change**
- Our `terminationGracePeriodSeconds` is set to 20 seconds by default ([here](https://github.com/worldcoin-foundation/common-app/blob/main/templates/deployment.yaml#L261))
- To gracefully shutdown we need to give pod enough space to complete current batch + next batch + send results.
- Hence, this PR sets the grace period to `3 * SMPC__PROCESSING_TIMEOUT_SECS`