### PR TITLE
set sequence id to current db size with increment on nextval

### DIFF
--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:v0.9.2"
+image: "ghcr.io/worldcoin/iris-mpc:v0.9.3"
 
 environment: stage
 replicaCount: 1

--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -295,7 +295,7 @@ DO UPDATE SET right_code = EXCLUDED.right_code, right_mask = EXCLUDED.right_mask
         id: usize,
         executor: impl sqlx::Executor<'_, Database = Postgres>,
     ) -> Result<()> {
-        sqlx::query("SELECT setval(pg_get_serial_sequence('irises', 'id'), $1 + 1, false)")
+        sqlx::query("SELECT setval(pg_get_serial_sequence('irises', 'id'), $1, true)")
             .bind(id as i64)
             .execute(executor)
             .await?;

--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -295,10 +295,19 @@ DO UPDATE SET right_code = EXCLUDED.right_code, right_mask = EXCLUDED.right_mask
         id: usize,
         executor: impl sqlx::Executor<'_, Database = Postgres>,
     ) -> Result<()> {
-        sqlx::query("SELECT setval(pg_get_serial_sequence('irises', 'id'), $1, true)")
-            .bind(id as i64)
-            .execute(executor)
-            .await?;
+        if id == 0 {
+            // If requested id is 0 (only used in tests), reset the sequence to 1 with
+            // advance_nextval set to false. This is because serial id starts from 1.
+            sqlx::query("SELECT setval(pg_get_serial_sequence('irises', 'id'), 1, false)")
+                .execute(executor)
+                .await?;
+        } else {
+            sqlx::query("SELECT setval(pg_get_serial_sequence('irises', 'id'), $1, true)")
+                .bind(id as i64)
+                .execute(executor)
+                .await?;
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
**Change**
- When we set next sequence id to `db_size + 1` with `advance_nextval` flag set to `false`, we can not assert db size and `lastval`
- The issue is fixed when we set the next sequence id into `db_size` with `advance_nextval` flag set to `true`

**Note**
- Tested manually in stage and the next signup was inserted with correctly advanced serial id