### PR TITLE
Make local vector store independent of networking

### DIFF
--- a/iris-mpc-cpu/benches/hnsw.rs
+++ b/iris-mpc-cpu/benches/hnsw.rs
@@ -89,8 +89,7 @@ fn bench_hnsw_primitives(c: &mut Criterion) {
             let t1 = create_random_sharing(&mut rng, 10_u16);
             let t2 = create_random_sharing(&mut rng, 10_u16);
 
-            let runtime = LocalRuntime::replicated_test_config();
-            let ready_sessions = runtime.create_player_sessions().await.unwrap();
+            let runtime = LocalRuntime::replicated_test_config().await.unwrap();
 
             let mut jobs = JoinSet::new();
             for (index, player) in runtime.identities.iter().enumerate() {
@@ -98,7 +97,7 @@ fn bench_hnsw_primitives(c: &mut Criterion) {
                 let d2i = d2[index].clone();
                 let t1i = t1[index].clone();
                 let t2i = t2[index].clone();
-                let mut player_session = ready_sessions.get(player).unwrap().clone();
+                let mut player_session = runtime.sessions.get(player).unwrap().clone();
                 jobs.spawn(async move {
                     cross_compare(&mut player_session, d1i, t1i, d2i, t2i)
                         .await
@@ -117,8 +116,7 @@ fn bench_gr_primitives(c: &mut Criterion) {
             .build()
             .unwrap();
         b.to_async(&rt).iter(|| async move {
-            let runtime = LocalRuntime::replicated_test_config();
-            let ready_sessions = runtime.create_player_sessions().await.unwrap();
+            let runtime = LocalRuntime::replicated_test_config().await.unwrap();
             let mut rng = AesRng::seed_from_u64(0);
             let iris_db = IrisDB::new_random_rng(4, &mut rng).db;
 
@@ -135,7 +133,7 @@ fn bench_gr_primitives(c: &mut Criterion) {
                 let x2 = x2[index].clone();
                 let mut y2 = y2[index].clone();
 
-                let mut player_session = ready_sessions.get(player).unwrap().clone();
+                let mut player_session = runtime.sessions.get(player).unwrap().clone();
                 jobs.spawn(async move {
                     y1.code.preprocess_iris_code_query_share();
                     y1.mask.preprocess_mask_code_query_share();
@@ -186,25 +184,39 @@ fn bench_gr_ready_made_hnsw(c: &mut Criterion) {
             |b| {
                 b.to_async(&rt).iter_batched(
                     || secret_searcher.clone(),
-                    |(mut db_vectors, mut db_graph)| async move {
+                    |vectors_graphs| async move {
                         let searcher = HawkSearcher::default();
                         let mut rng = AesRng::seed_from_u64(0_u64);
                         let on_the_fly_query = IrisDB::new_random_rng(1, &mut rng).db[0].clone();
                         let raw_query = generate_galois_iris_shares(&mut rng, on_the_fly_query);
 
-                        let query = db_vectors.prepare_query(raw_query);
-                        let neighbors = searcher
-                            .search_to_insert(&mut db_vectors, &mut db_graph, &query)
-                            .await;
-                        searcher
-                            .insert_from_search_results(
-                                &mut db_vectors,
-                                &mut db_graph,
-                                &mut rng,
-                                query,
-                                neighbors,
-                            )
-                            .await;
+                        let mut jobs = JoinSet::new();
+
+                        for (vector_store, graph_store) in vectors_graphs.into_iter() {
+                            let mut vector_store = vector_store;
+                            let mut graph_store = graph_store;
+
+                            let player_index = vector_store.get_owner_index();
+                            let query = vector_store.prepare_query(raw_query[player_index].clone());
+                            let searcher = searcher.clone();
+                            let mut rng = rng.clone();
+                            jobs.spawn(async move {
+                                let neighbors = searcher
+                                    .search_to_insert(&mut vector_store, &mut graph_store, &query)
+                                    .await;
+                                searcher
+                                    .insert_from_search_results(
+                                        &mut vector_store,
+                                        &mut graph_store,
+                                        &mut rng,
+                                        query,
+                                        neighbors,
+                                    )
+                                    .await;
+                            });
+                        }
+
+                        jobs.join_all().await;
                     },
                     criterion::BatchSize::SmallInput,
                 )
@@ -216,17 +228,27 @@ fn bench_gr_ready_made_hnsw(c: &mut Criterion) {
             |b| {
                 b.to_async(&rt).iter_batched(
                     || secret_searcher.clone(),
-                    |(mut db_vectors, mut db_graph)| async move {
+                    |vectors_graphs| async move {
                         let searcher = HawkSearcher::default();
                         let mut rng = AesRng::seed_from_u64(0_u64);
                         let on_the_fly_query = IrisDB::new_random_rng(1, &mut rng).db[0].clone();
                         let raw_query = generate_galois_iris_shares(&mut rng, on_the_fly_query);
 
-                        let query = db_vectors.prepare_query(raw_query);
-                        let neighbors = searcher
-                            .search_to_insert(&mut db_vectors, &mut db_graph, &query)
-                            .await;
-                        searcher.is_match(&mut db_vectors, &neighbors).await;
+                        let mut jobs = JoinSet::new();
+                        for (vector_store, graph_store) in vectors_graphs.into_iter() {
+                            let mut vector_store = vector_store;
+                            let mut graph_store = graph_store;
+                            let player_index = vector_store.get_owner_index();
+                            let query = vector_store.prepare_query(raw_query[player_index].clone());
+                            let searcher = searcher.clone();
+                            jobs.spawn(async move {
+                                let neighbors = searcher
+                                    .search_to_insert(&mut vector_store, &mut graph_store, &query)
+                                    .await;
+                                searcher.is_match(&mut vector_store, &neighbors).await;
+                            });
+                        }
+                        jobs.join_all().await;
                     },
                     criterion::BatchSize::SmallInput,
                 )

--- a/iris-mpc-cpu/src/execution/player.rs
+++ b/iris-mpc-cpu/src/execution/player.rs
@@ -40,7 +40,7 @@ impl Role {
     }
 
     /// Retrieve index of Role (zero indexed)
-    pub fn zero_based(&self) -> usize {
+    pub fn index(&self) -> usize {
         self.0 as usize
     }
 

--- a/iris-mpc-cpu/src/execution/session.rs
+++ b/iris-mpc-cpu/src/execution/session.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use eyre::eyre;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, fmt::Debug, sync::Arc};
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct SessionId(pub u128);
@@ -18,7 +18,7 @@ impl From<u128> for SessionId {
 
 pub type NetworkingImpl = Arc<dyn Networking + Send + Sync>;
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Session {
     pub boot_session: BootSession,
     pub setup:        Prf,
@@ -30,6 +30,17 @@ pub struct BootSession {
     pub role_assignments: Arc<HashMap<Role, Identity>>,
     pub networking:       NetworkingImpl,
     pub own_identity:     Identity,
+}
+
+impl Debug for BootSession {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // TODO: incorporate networking into debug output
+        f.debug_struct("BootSession")
+            .field("session_id", &self.session_id)
+            .field("role_assignments", &self.role_assignments)
+            .field("own_identity", &self.own_identity)
+            .finish()
+    }
 }
 
 pub trait SessionHandles {

--- a/iris-mpc-cpu/src/network/local.rs
+++ b/iris-mpc-cpu/src/network/local.rs
@@ -51,6 +51,7 @@ impl LocalNetworkingStore {
     }
 }
 
+#[derive(Debug)]
 pub struct LocalNetworking {
     p2p_channels: P2PChannels,
     pub owner:    Identity,

--- a/iris-mpc-cpu/src/protocol/binary.rs
+++ b/iris-mpc-cpu/src/protocol/binary.rs
@@ -29,7 +29,7 @@ pub(crate) fn a2b_pre<T: IntRing2k>(
     let mut x2 = Share::zero();
     let mut x3 = Share::zero();
 
-    match session.own_role()?.zero_based() {
+    match session.own_role()?.index() {
         0 => {
             x1.a = a;
             x3.b = b;
@@ -384,7 +384,7 @@ pub(crate) async fn bit_inject_ot_2round(
     session: &mut Session,
     input: VecShare<Bit>,
 ) -> Result<VecShare<u16>, Error> {
-    let res = match session.own_role()?.zero_based() {
+    let res = match session.own_role()?.index() {
         0 => {
             // OT Helper
             bit_inject_ot_2round_helper(session, input).await?

--- a/iris-mpc-cpu/src/shares/share.rs
+++ b/iris-mpc-cpu/src/shares/share.rs
@@ -29,7 +29,7 @@ impl<T: IntRing2k> Share<T> {
     }
 
     pub fn add_assign_const_role(&mut self, other: T, role: Role) {
-        match role.zero_based() {
+        match role.index() {
             0 => self.a += RingElement(other),
             1 => self.b += RingElement(other),
             2 => {}
@@ -317,5 +317,22 @@ impl<T: IntRing2k> Shl<u32> for Share<T> {
             a: self.a << rhs,
             b: self.b << rhs,
         }
+    }
+}
+
+// Additive share of a Hamming distance value
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(bound = "")]
+pub struct DistanceShare<T: IntRing2k> {
+    pub code_dot: Share<T>,
+    pub mask_dot: Share<T>,
+}
+
+impl<T> DistanceShare<T>
+where
+    T: IntRing2k,
+{
+    pub fn new(code_dot: Share<T>, mask_dot: Share<T>) -> Self {
+        DistanceShare { code_dot, mask_dot }
     }
 }


### PR DESCRIPTION
This turns `LocalNetAby3NgStoreProtocol` into a more abstract structure that describes SMPC logic while all networking details are contained in `LocalRuntime`. The downside is that we have to create several instances of `LocalNetAby3NgStoreProtocol`, i.e., each per player, which downgrades performance in benchmarks. For example, insertions and searches in a 100000-vector graph are about 3 times slower.

```bash
gr_ready_made_hnsw/gr-big-hnsw-insertions/1
                        time:   [678.35 µs 682.97 µs 688.42 µs]
gr_ready_made_hnsw/gr-big-hnsw-searches/1
                        time:   [1.0140 ms 1.0203 ms 1.0322 ms]
gr_ready_made_hnsw/gr-big-hnsw-insertions/10
                        time:   [29.762 ms 30.011 ms 30.482 ms]
gr_ready_made_hnsw/gr-big-hnsw-searches/10
                        time:   [18.394 ms 18.489 ms 18.630 ms]
gr_ready_made_hnsw/gr-big-hnsw-insertions/100
                        time:   [302.67 ms 305.12 ms 307.85 ms]
gr_ready_made_hnsw/gr-big-hnsw-searches/100
                        time:   [246.78 ms 248.68 ms 250.88 ms]
gr_ready_made_hnsw/gr-big-hnsw-insertions/1000
                        time:   [747.22 ms 752.83 ms 758.39 ms]
gr_ready_made_hnsw/gr-big-hnsw-searches/1000
                        time:   [713.60 ms 727.21 ms 743.23 ms]
gr_ready_made_hnsw/gr-big-hnsw-insertions/10000
                        time:   [1.6913 s 1.7157 s 1.7440 s]
gr_ready_made_hnsw/gr-big-hnsw-searches/10000
                        time:   [1.6341 s 1.6659 s 1.7006 s]
gr_ready_made_hnsw/gr-big-hnsw-insertions/100000
                        time:   [6.2001 s 6.3299 s 6.4945 s]
gr_ready_made_hnsw/gr-big-hnsw-searches/100000
                        time:   [6.1615 s 6.2195 s 6.2884 s]
```

UPDATE
Removing some excessive clones helped to improve timings back to normal

```bash
gr_ready_made_hnsw/gr-big-hnsw-insertions/1
                        time:   [658.23 µs 677.93 µs 698.54 µs]
gr_ready_made_hnsw/gr-big-hnsw-searches/1
                        time:   [1.0116 ms 1.0268 ms 1.0407 ms]
gr_ready_made_hnsw/gr-big-hnsw-insertions/10
                        time:   [30.334 ms 30.524 ms 30.753 ms]
gr_ready_made_hnsw/gr-big-hnsw-searches/10
                        time:   [18.433 ms 18.615 ms 18.726 ms]
gr_ready_made_hnsw/gr-big-hnsw-insertions/100
                        time:   [315.49 ms 317.59 ms 320.00 ms]
gr_ready_made_hnsw/gr-big-hnsw-searches/100
                        time:   [254.14 ms 256.04 ms 258.52 ms]
gr_ready_made_hnsw/gr-big-hnsw-insertions/1000
                        time:   [710.88 ms 715.03 ms 719.04 ms]
gr_ready_made_hnsw/gr-big-hnsw-searches/1000
                        time:   [651.24 ms 656.83 ms 663.22 ms]
gr_ready_made_hnsw/gr-big-hnsw-insertions/10000
                        time:   [1.2751 s 1.2823 s 1.2894 s]
gr_ready_made_hnsw/gr-big-hnsw-searches/10000
                        time:   [1.2096 s 1.2171 s 1.2248 s]
gr_ready_made_hnsw/gr-big-hnsw-insertions/100000
                        time:   [2.1209 s 2.1344 s 2.1493 s]
gr_ready_made_hnsw/gr-big-hnsw-searches/100000
                        time:   [2.0763 s 2.0895 s 2.1057 s]
```

This effectively makes #618 obsolete.

TODO: 
- make `LocalRuntime` more generic such that it can encapsulate both local and gRPC networking,
- make this generic runtime structure a mutable argument in evaluation functions of `VectorStore`.
