### PR TITLE
chore: Adjust startupProbe in production

### DIFF
--- a/deploy/prod/common-values-iris-mpc.yaml
+++ b/deploy/prod/common-values-iris-mpc.yaml
@@ -34,7 +34,7 @@ readinessProbe:
 startupProbe:
   enabled: true
   initialDelaySeconds: 900
-  failureThreshold: 10
+  failureThreshold: 20
   periodSeconds: 30
   httpGet:
     path: /health


### PR DESCRIPTION
When the Aurora is scaled-down, the application can take as long as ~22 minutes to load the DB.
I wanted to avoid setting the `startupProbe` initialDelay any higher, but rather bumped the amount of accepted failures.

Right now the star threshold is set to 25 minutes, this should prevent us from killing the app immediately after a cold Aurora start.