### PR TITLE
INFRA-3475 Update startup probe values in iris-mpc

### DIFF
--- a/deploy/prod/common-values-iris-mpc.yaml
+++ b/deploy/prod/common-values-iris-mpc.yaml
@@ -33,7 +33,7 @@ readinessProbe:
 
 startupProbe:
   initialDelaySeconds: 900
-  failureThreshold: 10
+  failureThreshold: 20
   periodSeconds: 30
   httpGet:
     path: /health

--- a/deploy/prod/common-values-iris-mpc.yaml
+++ b/deploy/prod/common-values-iris-mpc.yaml
@@ -32,7 +32,6 @@ readinessProbe:
     port: health
 
 startupProbe:
-  enabled: true
   initialDelaySeconds: 900
   failureThreshold: 10
   periodSeconds: 30

--- a/deploy/prod/common-values-upgrade-server-left.yaml
+++ b/deploy/prod/common-values-upgrade-server-left.yaml
@@ -18,7 +18,6 @@ ports:
     protocol: TCP
 
 startupProbe:
-  enabled: true
   httpGet:
     path: /health
     port: health

--- a/deploy/prod/common-values-upgrade-server-right.yaml
+++ b/deploy/prod/common-values-upgrade-server-right.yaml
@@ -18,7 +18,6 @@ ports:
     protocol: TCP
 
 startupProbe:
-  enabled: true
   httpGet:
     path: /health
     port: health

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -29,7 +29,6 @@ readinessProbe:
     port: health
 
 startupProbe:
-  enabled: true
   initialDelaySeconds: 300
   httpGet:
     path: /health

--- a/deploy/stage/common-values-upgrade-server-left.yaml
+++ b/deploy/stage/common-values-upgrade-server-left.yaml
@@ -16,7 +16,6 @@ ports:
     protocol: TCP
 
 startupProbe:
-  enabled: true
   httpGet:
     path: /health
     port: health

--- a/deploy/stage/common-values-upgrade-server-right.yaml
+++ b/deploy/stage/common-values-upgrade-server-right.yaml
@@ -16,7 +16,6 @@ ports:
     protocol: TCP
 
 startupProbe:
-  enabled: true
   httpGet:
     path: /health
     port: health


### PR DESCRIPTION
https://linear.app/worldcoin/issue/INFRA-3475/update-startupprobe-values-for-iris-mpc-to-fix-warnings

In order to fix these warnings: [datadog](https://app.datadoghq.com/logs?query=-%28status%3Ainfo%20OR%20status%3Anotice%29%20service%3Aargocd%20status%3Awarn%20%22unknown%20field%20spec.template.spec.containers%200%20startupprobe.enabled%22&agg_m=count&agg_m_source=base&agg_q=status%2Cservice&agg_q_source=base%2Cbase&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&sort_m=%2C&sort_m_source=%2C&sort_t=%2C&storage=hot&stream_sort=desc&top_n=10%2C10&top_o=top%2Ctop&viz=stream&x_missing=true%2Ctrue&from_ts=1731323916327&to_ts=1731410316327&live=true)

![image](https://github.com/user-attachments/assets/8349c082-e9d3-4c3c-8a65-fb15b6eff2fd)
