### PR TITLE
Return in-batch matching request ids

### DIFF
--- a/iris-mpc-common/src/helpers/smpc_request.rs
+++ b/iris-mpc-common/src/helpers/smpc_request.rs
@@ -302,13 +302,14 @@ impl UniquenessRequest {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct UniquenessResult {
-    pub node_id:                  usize,
-    pub serial_id:                Option<u32>,
-    pub is_match:                 bool,
-    pub signup_id:                String,
-    pub matched_serial_ids:       Option<Vec<u32>>,
-    pub matched_serial_ids_left:  Option<Vec<u32>>,
-    pub matched_serial_ids_right: Option<Vec<u32>>,
+    pub node_id:                   usize,
+    pub serial_id:                 Option<u32>,
+    pub is_match:                  bool,
+    pub signup_id:                 String,
+    pub matched_serial_ids:        Option<Vec<u32>>,
+    pub matched_serial_ids_left:   Option<Vec<u32>>,
+    pub matched_serial_ids_right:  Option<Vec<u32>>,
+    pub matched_batch_request_ids: Option<Vec<String>>,
 }
 
 impl UniquenessResult {
@@ -320,6 +321,7 @@ impl UniquenessResult {
         matched_serial_ids: Option<Vec<u32>>,
         matched_serial_ids_left: Option<Vec<u32>>,
         matched_serial_ids_right: Option<Vec<u32>>,
+        matched_batch_request_ids: Option<Vec<String>>,
     ) -> Self {
         Self {
             node_id,
@@ -329,6 +331,7 @@ impl UniquenessResult {
             matched_serial_ids,
             matched_serial_ids_left,
             matched_serial_ids_right,
+            matched_batch_request_ids,
         }
     }
 }

--- a/iris-mpc-common/src/helpers/smpc_request.rs
+++ b/iris-mpc-common/src/helpers/smpc_request.rs
@@ -313,6 +313,7 @@ pub struct UniquenessResult {
 }
 
 impl UniquenessResult {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         node_id: usize,
         serial_id: Option<u32>,

--- a/iris-mpc-gpu/src/dot/kernel.cu
+++ b/iris-mpc-gpu/src/dot/kernel.cu
@@ -93,7 +93,7 @@ extern "C" __global__ void mergeDbResults(unsigned long long *matchResultsLeft, 
     }
 }
 
-extern "C" __global__ void mergeBatchResults(unsigned long long *matchResultsSelfLeft, unsigned long long *matchResultsSelfRight, unsigned int *finalResults, size_t queryLength, size_t dbLength, size_t numElements, unsigned int *__matchCounter, unsigned int *__allMatches, unsigned int *__matchCounterLeft, unsigned int *__matchCounterRight, unsigned int *__partialResultsLeft, unsigned int *__partialResultsRight)
+extern "C" __global__ void mergeBatchResults(unsigned long long *matchResultsSelfLeft, unsigned long long *matchResultsSelfRight, unsigned int *finalResults, size_t queryLength, size_t dbLength, size_t numElements, unsigned int *matchCounter, unsigned int *allMatches, unsigned int *__matchCounterLeft, unsigned int *__matchCounterRight, unsigned int *__partialResultsLeft, unsigned int *__partialResultsRight)
 {
     size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx < numElements)
@@ -120,7 +120,12 @@ extern "C" __global__ void mergeBatchResults(unsigned long long *matchResultsSel
 
             // Current *AND* policy: only match if both eyes match
             if (matchLeft && matchRight)
+            {
                 atomicMin(&finalResults[queryIdx], UINT_MAX - 1);
+                unsigned int queryMatchCounter = atomicAdd(&matchCounter[queryIdx], 1);
+                if (queryMatchCounter < MAX_MATCHES_LEN)
+                    allMatches[MAX_MATCHES_LEN * queryIdx + queryMatchCounter] = UINT_MAX - dbIdx / ALL_ROTATIONS;
+            }
         }
     }
 }

--- a/iris-mpc-gpu/src/server/mod.rs
+++ b/iris-mpc-gpu/src/server/mod.rs
@@ -166,16 +166,17 @@ pub struct ServerJob {
 
 #[derive(Debug, Clone)]
 pub struct ServerJobResult {
-    pub merged_results:          Vec<u32>,
-    pub request_ids:             Vec<String>,
-    pub metadata:                Vec<BatchMetadata>,
-    pub matches:                 Vec<bool>,
-    pub match_ids:               Vec<Vec<u32>>,
-    pub partial_match_ids_left:  Vec<Vec<u32>>,
-    pub partial_match_ids_right: Vec<Vec<u32>>,
-    pub store_left:              BatchQueryEntries,
-    pub store_right:             BatchQueryEntries,
-    pub deleted_ids:             Vec<u32>,
+    pub merged_results:            Vec<u32>,
+    pub request_ids:               Vec<String>,
+    pub metadata:                  Vec<BatchMetadata>,
+    pub matches:                   Vec<bool>,
+    pub match_ids:                 Vec<Vec<u32>>,
+    pub partial_match_ids_left:    Vec<Vec<u32>>,
+    pub partial_match_ids_right:   Vec<Vec<u32>>,
+    pub store_left:                BatchQueryEntries,
+    pub store_right:               BatchQueryEntries,
+    pub deleted_ids:               Vec<u32>,
+    pub matched_batch_request_ids: Vec<Vec<String>>,
 }
 
 enum Eye {

--- a/iris-mpc-gpu/tests/e2e.rs
+++ b/iris-mpc-gpu/tests/e2e.rs
@@ -239,7 +239,7 @@ mod e2e_test {
                 };
 
                 let pick_from_batch = rng.gen_range(0..10);
-                let template = if pick_from_batch == 0 && new_templates_in_batch.len() > 0 {
+                let template = if pick_from_batch == 0 && !new_templates_in_batch.is_empty() {
                     let random_idx = rng.gen_range(0..new_templates_in_batch.len());
                     let (batch_idx, duplicate_request_id, template) =
                         new_templates_in_batch[random_idx].clone();

--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -589,6 +589,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         ))?;
         let result_events = vec![result_event; count];
 

--- a/iris-mpc/src/bin/server.rs
+++ b/iris-mpc/src/bin/server.rs
@@ -860,6 +860,7 @@ async fn server_main(config: Config) -> eyre::Result<()> {
             store_left,
             store_right,
             deleted_ids,
+            matched_batch_request_ids,
         }) = rx.recv().await
         {
             // returned serial_ids are 0 indexed, but we want them to be 1 indexed
@@ -897,6 +898,7 @@ async fn server_main(config: Config) -> eyre::Result<()> {
                             ),
                             true => None,
                         },
+                        Some(matched_batch_request_ids[i].clone()),
                     );
 
                     serde_json::to_string(&result_event).wrap_err("failed to serialize result")


### PR DESCRIPTION
In case the request matches another one in the batch, this now returns the `request_id`s of matching entries in the batch. 

For a follow up: We really need to refactor this e2e test.