### PR TITLE
separate live and health check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,13 +183,34 @@ dependencies = [
 
 [[package]]
 name = "async-stream"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22068c0c19514942eefcfd4daf8976ef1aad84e61539f95cd200c35202f80af5"
+dependencies = [
+ "async-stream-impl 0.2.1",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
 dependencies = [
- "async-stream-impl",
+ "async-stream-impl 0.3.6",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -868,7 +889,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "lazy_static",
  "lazycell",
  "log",
@@ -2418,7 +2439,7 @@ dependencies = [
  "hyper 1.5.0",
  "hyper-util",
  "log",
- "rustls 0.23.16",
+ "rustls 0.23.18",
  "rustls-native-certs 0.8.0",
  "rustls-pki-types",
  "tokio",
@@ -4426,9 +4447,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.16"
+version = "0.23.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e"
+checksum = "9c9cc1d47e243d655ace55ed38201c19ae02c148ae56412ab8750e8f0166ab7f"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -5424,7 +5445,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.16",
+ "rustls 0.23.18",
  "rustls-pki-types",
  "tokio",
 ]
@@ -5494,7 +5515,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
- "async-stream",
+ "async-stream 0.3.6",
  "async-trait",
  "axum",
  "base64 0.22.1",

--- a/deploy/prod/common-values-iris-mpc.yaml
+++ b/deploy/prod/common-values-iris-mpc.yaml
@@ -18,17 +18,13 @@ ports:
 #    protocol: TCP
 
 livenessProbe:
-  initialDelaySeconds: 300
   httpGet:
     path: /health
     port: health
 
 readinessProbe:
-  initialDelaySeconds: 300
-  periodSeconds: 30
-  failureThreshold: 10
   httpGet:
-    path: /health
+    path: /ready
     port: health
 
 startupProbe:
@@ -36,7 +32,7 @@ startupProbe:
   failureThreshold: 40
   periodSeconds: 30
   httpGet:
-    path: /health
+    path: /ready
     port: health
 
 resources:

--- a/deploy/prod/smpcv2-0-prod/values-iris-mpc.yaml
+++ b/deploy/prod/smpcv2-0-prod/values-iris-mpc.yaml
@@ -63,7 +63,7 @@ env:
     value: "2"
 
   - name: SMPC__HEARTBEAT_INITIAL_RETRIES
-    value: "1000"
+    value: "30"
 
   - name: SMPC__PATH
     value: "/data/"

--- a/deploy/prod/smpcv2-1-prod/values-iris-mpc.yaml
+++ b/deploy/prod/smpcv2-1-prod/values-iris-mpc.yaml
@@ -63,7 +63,7 @@ env:
     value: "2"
 
   - name: SMPC__HEARTBEAT_INITIAL_RETRIES
-    value: "1000"
+    value: "30"
 
   - name: SMPC__PATH
     value: "/data/"

--- a/deploy/prod/smpcv2-2-prod/values-iris-mpc.yaml
+++ b/deploy/prod/smpcv2-2-prod/values-iris-mpc.yaml
@@ -63,7 +63,7 @@ env:
     value: "2"
 
   - name: SMPC__HEARTBEAT_INITIAL_RETRIES
-    value: "1000"
+    value: "30"
 
   - name: SMPC__PATH
     value: "/data/"

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -15,23 +15,22 @@ ports:
     protocol: TCP
 
 livenessProbe:
-  initialDelaySeconds: 300
   httpGet:
     path: /health
     port: health
 
 readinessProbe:
-  initialDelaySeconds: 300
   periodSeconds: 30
-  failureThreshold: 10
   httpGet:
-    path: /health
+    path: /ready
     port: health
 
 startupProbe:
-  initialDelaySeconds: 300
+  initialDelaySeconds: 60
+  failureThreshold: 40
+  periodSeconds: 30
   httpGet:
-    path: /health
+    path: /ready
     port: health
 
 resources:

--- a/iris-mpc-common/src/config/mod.rs
+++ b/iris-mpc-common/src/config/mod.rs
@@ -92,7 +92,7 @@ fn default_max_batch_size() -> usize {
 }
 
 fn default_heartbeat_interval_secs() -> u64 {
-    30
+    2
 }
 
 fn default_heartbeat_initial_retries() -> u64 {


### PR DESCRIPTION
## Motivation:

We previously used the health check as a readiness check (having finished loading the db). This unfortunately fails to detect restarts of other nodes after NCCL has initialized.

## Scope

- Moves the health check with heartbeat above the NCCL initialization
- Introduces new readiness check before entering the main loop
- Removes unnecessary configuration options from the probes ([readiness and liveness probes are disabled until startup probe succeeds](https://kubernetes.io/docs/concepts/configuration/liveness-readiness-startup-probes/))
- Introduces some "ANCHOR" comments to easier detect the state of the application based on logs and code (in sync with the below flow chart)

```mermaid
flowchart TD
    A[Starting Healthcheck and Readiness server] -->|Health: All nodes up, Ready: False| B[Starting NCCL]
    B --> |NCCL communicator on each device established| C[Syncing latest node state]
    C --> |all nodes are on same serial id| D[Load the database]
    D --> |Finished loading| E[Enable readiness and check all nodes]
    E --> |All nodes are in ready state| F[Start the main loop]
```