### PR TITLE
Send tuples of values over network

### DIFF
--- a/iris-mpc-cpu/src/network/value.rs
+++ b/iris-mpc-cpu/src/network/value.rs
@@ -15,6 +15,8 @@ pub enum NetworkValue {
     VecRing16(Vec<RingElement<u16>>),
     VecRing32(Vec<RingElement<u32>>),
     VecRing64(Vec<RingElement<u64>>),
+    // Can contain network values of different types
+    Tuple(Vec<NetworkValue>),
 }
 
 impl NetworkValue {
@@ -23,7 +25,14 @@ impl NetworkValue {
     }
 
     pub fn from_network(serialized: eyre::Result<Vec<u8>>) -> eyre::Result<Self> {
-        bincode::deserialize::<Self>(&serialized?).map_err(|_e| eyre!("failed to parse value"))
+        bincode::deserialize::<Self>(&serialized?).map_err(|_e| eyre!("Failed to parse value"))
+    }
+
+    pub fn to_vector(&self) -> eyre::Result<Vec<Self>> {
+        match self {
+            NetworkValue::Tuple(x) => Ok(x.clone()),
+            _ => Err(eyre!("NetworkValue is not a tuple, but {:?}", self)),
+        }
     }
 }
 
@@ -33,14 +42,44 @@ impl From<Vec<RingElement<u16>>> for NetworkValue {
     }
 }
 
+impl From<Vec<NetworkValue>> for NetworkValue {
+    fn from(value: Vec<NetworkValue>) -> Self {
+        NetworkValue::Tuple(value)
+    }
+}
+
 impl TryFrom<NetworkValue> for Vec<RingElement<u16>> {
     type Error = eyre::Error;
     fn try_from(value: NetworkValue) -> eyre::Result<Self> {
         match value {
             NetworkValue::VecRing16(x) => Ok(x),
             _ => Err(eyre!(
-                "could not convert Network Value into Vec<RingElement<u16>>"
+                "Could not convert Network Value into Vec<RingElement<u16>>"
             )),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_vec() -> eyre::Result<()> {
+        let values = (0..2).map(RingElement).collect::<Vec<_>>();
+        let network_values = values
+            .iter()
+            .map(|v| NetworkValue::RingElement16(*v))
+            .collect::<Vec<_>>();
+        let network_value: NetworkValue = network_values.clone().into();
+        let serialized = network_value.to_network();
+        let result = NetworkValue::from_network(Ok(serialized))?;
+        assert!(matches!(result, NetworkValue::Tuple(_)));
+        let result_vec = result.to_vector()?;
+        assert_eq!(network_values, result_vec);
+        let fail = result_vec[0].clone().to_vector();
+        assert!(fail.is_err());
+
+        Ok(())
     }
 }

--- a/iris-mpc-cpu/src/protocol/binary.rs
+++ b/iris-mpc-cpu/src/protocol/binary.rs
@@ -282,15 +282,30 @@ async fn bit_inject_ot_2round_receiver(
     let sid = session.session_id();
 
     let (m0, m1, wc) = tokio::spawn(async move {
-        let reply_m0 = network.receive(&next_id, &sid).await;
-        let m0 = match NetworkValue::from_network(reply_m0) {
-            Ok(NetworkValue::VecRing16(val)) => Ok(val),
+        let reply_m0_and_m1 = network.receive(&next_id, &sid).await;
+        let m0_and_m1 = match NetworkValue::from_network(reply_m0_and_m1) {
+            Ok(NetworkValue::Tuple(val)) => {
+                if val.len() == 2 {
+                    Ok((val[0].clone(), val[1].clone()))
+                } else {
+                    Err(eyre!(
+                        "Could not deserialize m0 and m1 properly in bit inject: wrong length"
+                    ))
+                }
+            }
+            _ => Err(eyre!(
+                "Could not deserialize m0 and m1 properly in bit inject"
+            )),
+        };
+        let (m0, m1) = m0_and_m1.unwrap();
+
+        let m0 = match m0 {
+            NetworkValue::VecRing16(val) => Ok(val),
             _ => Err(eyre!("Could not deserialize properly in bit inject")),
         };
 
-        let reply_m1 = network.receive(&next_id, &sid).await;
-        let m1 = match NetworkValue::from_network(reply_m1) {
-            Ok(NetworkValue::VecRing16(val)) => Ok(val),
+        let m1 = match m1 {
+            NetworkValue::VecRing16(val) => Ok(val),
             _ => Err(eyre!("Could not deserialize properly in bit inject")),
         };
 
@@ -365,20 +380,20 @@ async fn bit_inject_ot_2round_sender(
     let prev_id = session.prev_identity()?;
     let sid = session.session_id();
     // TODO(Dragos) Note this can be compressed in a single round.
+    let m0_and_m1: NetworkValue = [m0, m1]
+        .into_iter()
+        .map(NetworkValue::VecRing16)
+        .collect::<Vec<_>>()
+        .into();
     // Reshare to Helper
     tokio::spawn(async move {
-        let _ = network
-            .send(NetworkValue::VecRing16(m0).to_network(), &prev_id, &sid)
-            .await;
-        let _ = network
-            .send(NetworkValue::VecRing16(m1).to_network(), &prev_id, &sid)
-            .await;
+        let _ = network.send(m0_and_m1.to_network(), &prev_id, &sid).await;
     })
     .await?;
     Ok(shares)
 }
 
-// TODO this is inbalanced, so a real implementation should actually rotate
+// TODO this is unbalanced, so a real implementation should actually rotate
 // parties around
 pub(crate) async fn bit_inject_ot_2round(
     session: &mut Session,


### PR DESCRIPTION
This adds a new `NetworkValue` type that can contain different values of this enum. In this way, we can batch values of different types and send them in one message over the network, thus avoiding unnecessary rounds of communication.