### PR TITLE
Optimize preprocessing of queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2711,6 +2711,7 @@ dependencies = [
  "bincode",
  "bytemuck",
  "bytes",
+ "clap",
  "criterion",
  "dashmap",
  "eyre",
@@ -2732,6 +2733,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-test",
+ "uuid",
 ]
 
 [[package]]

--- a/iris-mpc-common/src/galois_engine.rs
+++ b/iris-mpc-common/src/galois_engine.rs
@@ -44,9 +44,10 @@ pub mod degree4 {
             .for_each(|chunk| chunk.rotate_left(by * 4));
     }
 
-    #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+    #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
     pub struct GaloisRingTrimmedMaskCodeShare {
         pub id:    usize,
+        #[serde(with = "BigArray")]
         pub coefs: [u16; MASK_CODE_LENGTH],
     }
 

--- a/iris-mpc-cpu/Cargo.toml
+++ b/iris-mpc-cpu/Cargo.toml
@@ -16,6 +16,7 @@ backoff = {version="0.4.0", features = ["tokio"]}
 bincode.workspace = true
 bytes = "1.7"
 bytemuck.workspace = true
+clap.workspace = true
 dashmap = "6.1.0"
 eyre.workspace = true
 futures.workspace = true
@@ -35,6 +36,7 @@ tonic = "0.12.3"
 tracing.workspace = true
 tracing-subscriber.workspace = true
 tracing-test = "0.2.5"
+uuid.workspace = true
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["async_tokio"] }
@@ -48,3 +50,7 @@ harness = false
 
 [[example]]
 name = "hnsw-ex"
+
+[[bin]]
+name = "local_hnsw"
+path = "bin/local_hnsw.rs"

--- a/iris-mpc-cpu/benches/hnsw.rs
+++ b/iris-mpc-cpu/benches/hnsw.rs
@@ -89,7 +89,7 @@ fn bench_hnsw_primitives(c: &mut Criterion) {
             let t1 = create_random_sharing(&mut rng, 10_u16);
             let t2 = create_random_sharing(&mut rng, 10_u16);
 
-            let runtime = LocalRuntime::mock_setup_with_channel().await.unwrap();
+            let runtime = LocalRuntime::mock_setup_with_grpc().await.unwrap();
 
             let mut jobs = JoinSet::new();
             for (index, player) in runtime.identities.iter().enumerate() {
@@ -116,7 +116,7 @@ fn bench_gr_primitives(c: &mut Criterion) {
             .build()
             .unwrap();
         b.to_async(&rt).iter(|| async move {
-            let runtime = LocalRuntime::mock_setup_with_channel().await.unwrap();
+            let runtime = LocalRuntime::mock_setup_with_grpc().await.unwrap();
             let mut rng = AesRng::seed_from_u64(0);
             let iris_db = IrisDB::new_random_rng(4, &mut rng).db;
 

--- a/iris-mpc-cpu/benches/hnsw.rs
+++ b/iris-mpc-cpu/benches/hnsw.rs
@@ -174,12 +174,9 @@ fn bench_gr_ready_made_hnsw(c: &mut Criterion) {
 
         let (_, secret_searcher) = rt.block_on(async move {
             let mut rng = AesRng::seed_from_u64(0_u64);
-            LocalNetAby3NgStoreProtocol::lazy_random_setup_with_local_channel(
-                &mut rng,
-                database_size,
-            )
-            .await
-            .unwrap()
+            LocalNetAby3NgStoreProtocol::lazy_random_setup_with_grpc(&mut rng, database_size)
+                .await
+                .unwrap()
         });
 
         group.bench_function(
@@ -207,12 +204,13 @@ fn bench_gr_ready_made_hnsw(c: &mut Criterion) {
                                 let neighbors = searcher
                                     .search_to_insert(&mut vector_store, &mut graph_store, &query)
                                     .await;
+                                let inserted_query = vector_store.insert(&query).await;
                                 searcher
                                     .insert_from_search_results(
                                         &mut vector_store,
                                         &mut graph_store,
                                         &mut rng,
-                                        query,
+                                        inserted_query,
                                         neighbors,
                                     )
                                     .await;

--- a/iris-mpc-cpu/bin/local_hnsw.rs
+++ b/iris-mpc-cpu/bin/local_hnsw.rs
@@ -1,0 +1,24 @@
+use aes_prng::AesRng;
+use clap::Parser;
+use iris_mpc_cpu::hawkers::galois_store::LocalNetAby3NgStoreProtocol;
+use rand::SeedableRng;
+use std::error::Error;
+
+#[derive(Parser)]
+struct Args {
+    #[clap(short = 'n', default_value = "1000")]
+    database_size: usize,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let args = Args::parse();
+    let database_size = args.database_size;
+
+    println!("Starting Local HNSW with {} vectors", database_size);
+    let mut rng = AesRng::seed_from_u64(0_u64);
+
+    LocalNetAby3NgStoreProtocol::shared_random_setup_with_grpc(&mut rng, database_size).await?;
+
+    Ok(())
+}

--- a/iris-mpc-cpu/src/database_generators.rs
+++ b/iris-mpc-cpu/src/database_generators.rs
@@ -4,11 +4,12 @@ use iris_mpc_common::{
     iris_db::iris::IrisCode,
 };
 use rand::{CryptoRng, Rng, RngCore};
+use serde::{Deserialize, Serialize};
 
 type ShareRing = u16;
 type ShareRingPlain = RingElement<ShareRing>;
 
-#[derive(PartialEq, Eq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize, Hash)]
 pub struct GaloisRingSharedIris {
     pub code: GaloisRingIrisCodeShare,
     pub mask: GaloisRingTrimmedMaskCodeShare,

--- a/iris-mpc-cpu/src/execution/local.rs
+++ b/iris-mpc-cpu/src/execution/local.rs
@@ -65,6 +65,10 @@ impl LocalRuntime {
         Self::mock_setup(NetworkType::LocalChannel).await
     }
 
+    pub async fn mock_setup_with_grpc() -> eyre::Result<Self> {
+        Self::mock_setup(NetworkType::GrpcChannel).await
+    }
+
     pub async fn new_with_network_type(
         identities: Vec<Identity>,
         seeds: Vec<PrfSeed>,

--- a/iris-mpc-cpu/src/hawkers/galois_store.rs
+++ b/iris-mpc-cpu/src/hawkers/galois_store.rs
@@ -57,7 +57,7 @@ pub struct Query {
     pub processed_query: GaloisRingPoint,
 }
 
-type QueryId = Arc<Query>;
+type QueryRef = Arc<Query>;
 
 #[derive(Default, Clone)]
 pub struct Aby3NgStorePlayer {
@@ -75,7 +75,7 @@ impl Aby3NgStorePlayer {
         Aby3NgStorePlayer { points: data }
     }
 
-    pub fn prepare_query(&mut self, raw_query: GaloisRingSharedIris) -> QueryId {
+    pub fn prepare_query(&mut self, raw_query: GaloisRingSharedIris) -> QueryRef {
         let mut preprocessed_query = raw_query.clone();
         preprocessed_query.code.preprocess_iris_code_query_share();
         preprocessed_query.mask.preprocess_mask_code_query_share();
@@ -92,7 +92,7 @@ impl Aby3NgStorePlayer {
 }
 
 impl Aby3NgStorePlayer {
-    fn insert(&mut self, query: &QueryId) -> VectorId {
+    fn insert(&mut self, query: &QueryRef) -> VectorId {
         // The query is now accepted in the store.
         self.points.push(query.query.clone());
 
@@ -188,7 +188,7 @@ pub async fn setup_local_store_aby3_players(
 }
 
 impl LocalNetAby3NgStoreProtocol {
-    pub fn prepare_query(&mut self, code: GaloisRingSharedIris) -> QueryId {
+    pub fn prepare_query(&mut self, code: GaloisRingSharedIris) -> QueryRef {
         self.storage.prepare_query(code)
     }
 }
@@ -207,7 +207,7 @@ async fn eval_pairwise_distances(
 }
 
 impl VectorStore for LocalNetAby3NgStoreProtocol {
-    type QueryRef = QueryId; // Point ID, pending insertion.
+    type QueryRef = QueryRef; // Point ID, pending insertion.
     type VectorRef = VectorId; // Point ID, inserted.
     type DistanceRef = DistanceShare<u16>; // Distance represented as shares.
 

--- a/iris-mpc-cpu/src/hawkers/galois_store.rs
+++ b/iris-mpc-cpu/src/hawkers/galois_store.rs
@@ -223,6 +223,7 @@ impl LocalNetAby3NgStoreProtocol {
     }
 }
 
+/// Assumes that the first iris of each pair is preprocessed.
 async fn eval_pairwise_distances(
     pairs: Vec<(GaloisRingSharedIris, GaloisRingSharedIris)>,
     player_session: &mut Session,

--- a/iris-mpc-cpu/src/hawkers/galois_store.rs
+++ b/iris-mpc-cpu/src/hawkers/galois_store.rs
@@ -23,20 +23,8 @@ use hawk_pack::{
 use iris_mpc_common::iris_db::{db::IrisDB, iris::IrisCode};
 use rand::{CryptoRng, RngCore, SeedableRng};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, fmt::Debug, vec};
+use std::{collections::HashMap, fmt::Debug, sync::Arc, vec};
 use tokio::task::JoinSet;
-use uuid::Uuid;
-
-#[derive(Copy, Default, Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct QueryId {
-    id: PointId,
-}
-
-impl From<PointId> for QueryId {
-    fn from(id: PointId) -> Self {
-        QueryId { id }
-    }
-}
 
 #[derive(Copy, Default, Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct VectorId {
@@ -63,16 +51,17 @@ impl From<usize> for VectorId {
 
 type GaloisRingPoint = GaloisRingSharedIris;
 
-#[derive(Clone)]
-struct Query {
+#[derive(Clone, Serialize, Deserialize, Hash, Eq, PartialEq, Debug)]
+pub struct Query {
     pub query:           GaloisRingPoint,
     pub processed_query: GaloisRingPoint,
 }
 
+type QueryId = Arc<Query>;
+
 #[derive(Default, Clone)]
 pub struct Aby3NgStorePlayer {
-    points:  Vec<GaloisRingPoint>,
-    queries: HashMap<QueryId, Query>,
+    points: Vec<GaloisRingPoint>,
 }
 
 impl std::fmt::Debug for Aby3NgStorePlayer {
@@ -83,10 +72,7 @@ impl std::fmt::Debug for Aby3NgStorePlayer {
 
 impl Aby3NgStorePlayer {
     pub fn new_with_shared_db(data: Vec<GaloisRingSharedIris>) -> Self {
-        Aby3NgStorePlayer {
-            points:  data,
-            queries: HashMap::new(),
-        }
+        Aby3NgStorePlayer { points: data }
     }
 
     pub fn prepare_query(&mut self, raw_query: GaloisRingSharedIris) -> QueryId {
@@ -94,24 +80,10 @@ impl Aby3NgStorePlayer {
         preprocessed_query.code.preprocess_iris_code_query_share();
         preprocessed_query.mask.preprocess_mask_code_query_share();
 
-        let query_id = QueryId {
-            id: (Uuid::new_v4().as_u64_pair().0 as usize).into(),
-        };
-
-        self.queries.insert(query_id, Query {
+        Arc::new(Query {
             query:           raw_query,
             processed_query: preprocessed_query,
-        });
-
-        query_id
-    }
-
-    pub fn get_query(&self, query_id: &QueryId) -> &GaloisRingPoint {
-        &self.queries[query_id].query
-    }
-
-    pub fn get_processed_query(&self, query_id: &QueryId) -> &GaloisRingPoint {
-        &self.queries[query_id].processed_query
+        })
     }
 
     pub fn get_vector(&self, vector: &VectorId) -> &GaloisRingPoint {
@@ -122,9 +94,7 @@ impl Aby3NgStorePlayer {
 impl Aby3NgStorePlayer {
     fn insert(&mut self, query: &QueryId) -> VectorId {
         // The query is now accepted in the store.
-        self.points.push(self.get_query(query).clone());
-        // Remove query from the list of queries.
-        self.queries.remove(query);
+        self.points.push(query.query.clone());
 
         let new_id = self.points.len() - 1;
         VectorId { id: new_id.into() }
@@ -251,9 +221,8 @@ impl VectorStore for LocalNetAby3NgStoreProtocol {
         vector: &Self::VectorRef,
     ) -> Self::DistanceRef {
         let mut player_session = self.get_owner_session();
-        let query_point = self.storage.get_processed_query(query);
         let vector_point = self.storage.get_vector(vector);
-        let pairs = vec![(query_point.clone(), vector_point.clone())];
+        let pairs = vec![(query.processed_query.clone(), vector_point.clone())];
         let ds_and_ts = eval_pairwise_distances(pairs, &mut player_session).await;
         DistanceShare::new(ds_and_ts[0].clone(), ds_and_ts[1].clone())
     }
@@ -264,12 +233,11 @@ impl VectorStore for LocalNetAby3NgStoreProtocol {
         vectors: &[Self::VectorRef],
     ) -> Vec<Self::DistanceRef> {
         let mut player_session = self.get_owner_session();
-        let query_point = self.storage.get_processed_query(query);
         let pairs = vectors
             .iter()
             .map(|vector_id| {
                 let vector_point = self.storage.get_vector(vector_id);
-                (query_point.clone(), vector_point.clone())
+                (query.processed_query.clone(), vector_point.clone())
             })
             .collect::<Vec<_>>();
         let ds_and_ts = eval_pairwise_distances(pairs, &mut player_session).await;

--- a/iris-mpc-cpu/src/network/grpc.rs
+++ b/iris-mpc-cpu/src/network/grpc.rs
@@ -587,10 +587,10 @@ mod tests {
                 let mut store = store.clone();
                 let mut graph = graph.clone();
                 let searcher = searcher.clone();
+                let q = store.prepare_query(store.storage.get_vector(&i.into()).clone());
                 jobs.spawn(async move {
-                    let secret_neighbors = searcher
-                        .search_to_insert(&mut store, &mut graph, &i.into())
-                        .await;
+                    let secret_neighbors =
+                        searcher.search_to_insert(&mut store, &mut graph, &q).await;
                     searcher.is_match(&mut store, &secret_neighbors).await
                 });
             }


### PR DESCRIPTION
Previously, preprocessing of Galois vectors and queries took about 70% of all local operations. This was caused by computing preprocessing for each call of `eval_distance`. Now, a query is pre-processed only once before any computation.
This PR also separates query IDs and IDs of already inserted vectors such that we can keep both the original query for insertion and its pre-processed form for computations. 

To create a flame graph, I also added a binary that creates an HNSW graph from scratch. 

This change didn't really affect the performance of the entire protocol as the main bottleneck is gRPC networking. So we have to reduce the number of communication rounds to see any running time improvement.
