### PR TITLE
bump init db size in stage

### DIFF
--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -69,7 +69,7 @@ env:
     value: "true"
 
   - name: SMPC__INIT_DB_SIZE
-    value: "0"
+    value: "10"
 
   - name: SMPC__MAX_DB_SIZE
     value: "1000000"

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -69,7 +69,7 @@ env:
     value: "true"
 
   - name: SMPC__INIT_DB_SIZE
-    value: "0"
+    value: "10"
 
   - name: SMPC__MAX_DB_SIZE
     value: "1000000"

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -69,7 +69,7 @@ env:
     value: "true"
 
   - name: SMPC__INIT_DB_SIZE
-    value: "0"
+    value: "10"
 
   - name: SMPC__MAX_DB_SIZE
     value: "1000000"


### PR DESCRIPTION
**Change**
- empty db is causing issues for iris-mpc to start up in stage after resetting db.
- this PR adds some initial elements