### PR TITLE
Optimize mock setup generation

### DIFF
--- a/iris-mpc-cpu/benches/hnsw.rs
+++ b/iris-mpc-cpu/benches/hnsw.rs
@@ -177,6 +177,7 @@ fn bench_gr_ready_made_hnsw(c: &mut Criterion) {
             LocalNetAby3NgStoreProtocol::lazy_random_setup_with_local_channel(
                 &mut rng,
                 database_size,
+                false,
             )
             .await
             .unwrap()

--- a/iris-mpc-cpu/benches/hnsw.rs
+++ b/iris-mpc-cpu/benches/hnsw.rs
@@ -260,10 +260,10 @@ fn bench_gr_ready_made_hnsw(c: &mut Criterion) {
 
 criterion_group! {
     hnsw,
-    //bench_plaintext_hnsw,
+    bench_plaintext_hnsw,
     bench_gr_ready_made_hnsw,
-    //bench_hnsw_primitives,
-    //bench_gr_primitives,
+    bench_hnsw_primitives,
+    bench_gr_primitives,
 }
 
 criterion_main!(hnsw);


### PR DESCRIPTION
It speeds up `lazy_random_setup` by generating distance shares in a naive way as additive shares (distance, 0, 0).

The current speed up for hnsw benchmarks is about 2x in the preprocessing stage with async channels.