### PR TITLE
Add retrieving s3 shares via getObject

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.8"
+version = "1.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07c9cdc179e6afbf5d391ab08c85eac817b51c87e1892a5edb5f7bbdc64314b4"
+checksum = "4fbd94a32b3a7d55d3806fe27d98d3ad393050439dd05eb53ece36ec5e3d3510"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -868,7 +868,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -2623,6 +2623,7 @@ name = "iris-mpc"
 version = "0.1.0"
 dependencies = [
  "aws-config",
+ "aws-sdk-s3",
  "aws-sdk-sns",
  "aws-sdk-sqs",
  "axum",
@@ -2659,6 +2660,7 @@ name = "iris-mpc-common"
 version = "0.1.0"
 dependencies = [
  "aws-config",
+ "aws-credential-types",
  "aws-sdk-kms",
  "aws-sdk-s3",
  "aws-sdk-secretsmanager",

--- a/iris-mpc-common/Cargo.toml
+++ b/iris-mpc-common/Cargo.toml
@@ -50,6 +50,7 @@ serde-big-array.workspace = true
 
 [dev-dependencies]
 float_eq = "1"
+aws-credential-types = "1.2.1"
 
 [[bin]]
 name = "key-manager"

--- a/iris-mpc-common/src/config/mod.rs
+++ b/iris-mpc-common/src/config/mod.rs
@@ -49,6 +49,9 @@ pub struct Config {
     #[serde(default)]
     pub public_key_base_url: String,
 
+    #[serde(default = "default_shares_bucket_name")]
+    pub shares_bucket_name: String,
+
     #[serde(default)]
     pub clear_db_before_init: bool,
 
@@ -104,6 +107,10 @@ fn default_heartbeat_initial_retries() -> u64 {
 
 fn default_shutdown_last_results_sync_timeout_secs() -> u64 {
     10
+}
+
+fn default_shares_bucket_name() -> String {
+    "wf-mpc-prod-smpcv2-sns-requests".to_string()
 }
 
 impl Config {

--- a/iris-mpc-common/src/helpers/key_pair.rs
+++ b/iris-mpc-common/src/helpers/key_pair.rs
@@ -47,6 +47,8 @@ pub enum SharesDecodingError {
         url:     String,
         message: String,
     },
+    #[error("Received error message from S3 for key {}: {}", .key, .message)]
+    S3ResponseContent { key: String, message: String },
     #[error(transparent)]
     SerdeError(#[from] serde_json::error::Error),
     #[error(transparent)]

--- a/iris-mpc-common/src/helpers/smpc_request.rs
+++ b/iris-mpc-common/src/helpers/smpc_request.rs
@@ -1,5 +1,6 @@
 use super::{key_pair::SharesDecodingError, sha256::calculate_sha256};
 use crate::helpers::key_pair::SharesEncryptionKeyPairs;
+use aws_sdk_s3::Client as S3Client;
 use aws_sdk_sns::types::MessageAttributeValue;
 use aws_sdk_sqs::{
     error::SdkError,
@@ -7,15 +8,10 @@ use aws_sdk_sqs::{
 };
 use base64::{engine::general_purpose::STANDARD, Engine};
 use eyre::Report;
-use reqwest::Client;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
-use std::{collections::HashMap, sync::LazyLock};
+use std::{collections::HashMap, sync::Arc};
 use thiserror::Error;
-use tokio_retry::{
-    strategy::{jitter, FixedInterval},
-    Retry,
-};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct SQSMessage {
@@ -113,7 +109,7 @@ pub const UNIQUENESS_MESSAGE_TYPE: &str = "uniqueness";
 pub struct UniquenessRequest {
     pub batch_size:              Option<usize>,
     pub signup_id:               String,
-    pub s3_presigned_url:        String,
+    pub s3_key:                  String,
     pub iris_shares_file_hashes: [String; 3],
 }
 
@@ -196,51 +192,45 @@ impl SharesS3Object {
     }
 }
 
-static S3_HTTP_CLIENT: LazyLock<Client> = LazyLock::new(Client::new);
-
 impl UniquenessRequest {
     pub async fn get_iris_data_by_party_id(
         &self,
         party_id: usize,
+        bucket_name: &String,
+        s3_client: &Arc<S3Client>,
     ) -> Result<String, SharesDecodingError> {
-        // Send a GET request to the presigned URL
-        let retry_strategy = FixedInterval::from_millis(200).map(jitter).take(5);
-        let response = Retry::spawn(retry_strategy, || async {
-            S3_HTTP_CLIENT
-                .get(self.s3_presigned_url.clone())
-                .send()
-                .await
-        })
-        .await?;
-
-        // Ensure the request was successful
-        if response.status().is_success() {
-            // Parse the JSON response into the SharesS3Object struct
-            let shares_file: SharesS3Object = match response.json().await {
-                Ok(file) => file,
-                Err(e) => {
-                    tracing::error!("Failed to parse JSON: {}", e);
-                    return Err(SharesDecodingError::RequestError(e));
+        let response = s3_client
+            .get_object()
+            .bucket(bucket_name)
+            .key(self.s3_key.as_str())
+            .send()
+            .await
+            .map_err(|err| {
+                tracing::error!("Failed to download file: {}", err);
+                SharesDecodingError::S3ResponseContent {
+                    key:     self.s3_key.clone(),
+                    message: err.to_string(),
                 }
-            };
+            })?;
 
-            // Construct the field name dynamically
-            let field_name = format!("iris_share_{}", party_id);
-            // Access the field dynamically
-            if let Some(value) = shares_file.get(party_id) {
-                Ok(value.to_string())
-            } else {
-                tracing::error!("Failed to find field: {}", field_name);
-                Err(SharesDecodingError::SecretStringNotFound)
+        let object_body = response.body.collect().await.map_err(|e| {
+            tracing::error!("Failed to get object body: {}", e);
+            SharesDecodingError::S3ResponseContent {
+                key:     self.s3_key.clone(),
+                message: e.to_string(),
             }
-        } else {
-            tracing::error!("Failed to download file: {}", response.status());
-            Err(SharesDecodingError::ResponseContent {
-                status:  response.status(),
-                url:     self.s3_presigned_url.clone(),
-                message: response.text().await.unwrap_or_default(),
-            })
-        }
+        })?;
+
+        let bytes = object_body.into_bytes();
+
+        let shares_file: SharesS3Object = serde_json::from_slice(&bytes)?;
+
+        let field_name = format!("iris_share_{}", party_id);
+
+        shares_file.get(party_id).cloned().ok_or_else(|| {
+            tracing::error!("Failed to find field: {}", field_name);
+            SharesDecodingError::SecretStringNotFound
+        })
     }
 
     pub fn decrypt_iris_share(

--- a/iris-mpc/Cargo.toml
+++ b/iris-mpc/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 aws-config.workspace = true
 aws-sdk-sns.workspace = true
 aws-sdk-sqs.workspace = true
+aws-sdk-s3.workspace = true
 axum.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/iris-mpc/src/bin/client.rs
+++ b/iris-mpc/src/bin/client.rs
@@ -372,7 +372,7 @@ async fn main() -> eyre::Result<()> {
                 let request_message = UniquenessRequest {
                     batch_size: None,
                     signup_id: request_id.to_string(),
-                    s3_presigned_url: presigned_url,
+                    s3_key: presigned_url,
                     iris_shares_file_hashes,
                 };
 


### PR DESCRIPTION
### Notes
* add retrieving shares via S3 Objects. This is because URL's expire when the role credentials expire https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-presigned-url.html#PresignedUrl-Expiration
* we will only release this once SS sends shares keys only