### PR TITLE
add last modified at column

### DIFF
--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:v0.11.0"
+image: "ghcr.io/worldcoin/iris-mpc:v0.11.1"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/common-values-upgrade-server-right.yaml
+++ b/deploy/stage/common-values-upgrade-server-right.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:v0.10.2"
+image: "ghcr.io/worldcoin/iris-mpc:v0.11.1"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/common-values-upgrade-server-right.yaml
+++ b/deploy/stage/common-values-upgrade-server-right.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:v0.11.1"
+image: "ghcr.io/worldcoin/iris-mpc:v0.10.2"
 
 environment: stage
 replicaCount: 1

--- a/iris-mpc-store/migrations/20241128150412_add-modified-at.down.sql
+++ b/iris-mpc-store/migrations/20241128150412_add-modified-at.down.sql
@@ -1,0 +1,3 @@
+DROP TRIGGER IF EXISTS set_last_modified_at ON irises;
+DROP FUNCTION IF EXISTS update_last_modified_at();
+ALTER TABLE irises DROP COLUMN last_modified_at;

--- a/iris-mpc-store/migrations/20241128150412_add-modified-at.up.sql 
+++ b/iris-mpc-store/migrations/20241128150412_add-modified-at.up.sql 
@@ -1,0 +1,14 @@
+ALTER TABLE irises ADD COLUMN last_modified_at BIGINT;
+
+CREATE OR REPLACE FUNCTION update_last_modified_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.last_modified_at = EXTRACT(EPOCH FROM NOW())::BIGINT;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER set_last_modified_at
+    BEFORE INSERT OR UPDATE ON irises
+    FOR EACH ROW
+    EXECUTE FUNCTION update_last_modified_at();


### PR DESCRIPTION
**Change**
- We'll switch to importer logic. However, we need an export first. And for export to work, we need `last_modified_at` column
- This PR migrates the logic from [@philsippl's PR](https://github.com/worldcoin/iris-mpc/pull/731/files#diff-eafc6ad08dc189acc3bf010cd73cf46930350fb604f98536e13b8ad9aca11705)
- We'll first merge this one, let the new column created and then merge importer PR  