### PR TITLE
Update Hawk Pack dependency and Python bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2175,7 +2175,7 @@ dependencies = [
 [[package]]
 name = "hawk-pack"
 version = "0.1.0"
-source = "git+https://github.com/Inversed-Tech/hawk-pack.git?rev=893035b6#893035b67b01616374466fde9575587e23357cf6"
+source = "git+https://github.com/Inversed-Tech/hawk-pack.git?rev=ba995e09#ba995e096116a564a0cc8fc43a6b75b2515c34ff"
 dependencies = [
  "aes-prng 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2175,7 +2175,7 @@ dependencies = [
 [[package]]
 name = "hawk-pack"
 version = "0.1.0"
-source = "git+https://github.com/Inversed-Tech/hawk-pack.git?rev=29e888ed#29e888edfe19cd69e5925fa676ca07d1f64214da"
+source = "git+https://github.com/Inversed-Tech/hawk-pack.git?rev=893035b6#893035b67b01616374466fde9575587e23357cf6"
 dependencies = [
  "aes-prng 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion",
@@ -2184,6 +2184,7 @@ dependencies = [
  "futures",
  "rand",
  "rand_core",
+ "rand_distr",
  "serde",
  "serde_json",
  "sqlx",
@@ -4117,6 +4118,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ bytemuck = { version = "1.17", features = ["derive"] }
 dotenvy = "0.15"
 eyre = "0.6"
 futures = "0.3.30"
-hawk-pack = { git = "https://github.com/Inversed-Tech/hawk-pack.git", rev = "29e888ed" }
+hawk-pack = { git = "https://github.com/Inversed-Tech/hawk-pack.git", rev = "893035b6" }
 hex = "0.4.3"
 itertools = "0.13"
 num-traits = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ bytemuck = { version = "1.17", features = ["derive"] }
 dotenvy = "0.15"
 eyre = "0.6"
 futures = "0.3.30"
-hawk-pack = { git = "https://github.com/Inversed-Tech/hawk-pack.git", rev = "893035b6" }
+hawk-pack = { git = "https://github.com/Inversed-Tech/hawk-pack.git", rev = "ba995e09" }
 hex = "0.4.3"
 itertools = "0.13"
 num-traits = "0.2"

--- a/iris-mpc-cpu/examples/hnsw-ex.rs
+++ b/iris-mpc-cpu/examples/hnsw-ex.rs
@@ -1,5 +1,5 @@
 use aes_prng::AesRng;
-use hawk_pack::{graph_store::GraphMem, hnsw_db::HawkSearcher, VectorStore};
+use hawk_pack::{graph_store::GraphMem, HawkSearcher};
 use iris_mpc_common::iris_db::iris::IrisCode;
 use iris_mpc_cpu::hawkers::plaintext_store::PlaintextStore;
 use rand::SeedableRng;
@@ -21,12 +21,8 @@ fn main() {
         for idx in 0..DATABASE_SIZE {
             let raw_query = IrisCode::random_rng(&mut rng);
             let query = vector.prepare_query(raw_query.clone());
-            let neighbors = searcher
-                .search_to_insert(&mut vector, &mut graph, &query)
-                .await;
-            let inserted = vector.insert(&query).await;
             searcher
-                .insert_from_search_results(&mut vector, &mut graph, &mut rng, inserted, neighbors)
+                .insert(&mut vector, &mut graph, &query, &mut rng)
                 .await;
             if idx % 100 == 99 {
                 println!("{}", idx + 1);

--- a/iris-mpc-cpu/src/hawkers/galois_store.rs
+++ b/iris-mpc-cpu/src/hawkers/galois_store.rs
@@ -19,9 +19,9 @@ use crate::{
 };
 use aes_prng::AesRng;
 use hawk_pack::{
-    graph_store::{graph_mem::Layer, EntryPoint, GraphMem},
-    hnsw_db::{FurthestQueue, HawkSearcher},
-    GraphStore, VectorStore,
+    data_structures::queue::FurthestQueue,
+    graph_store::{graph_mem::Layer, GraphMem},
+    GraphStore, HawkSearcher, VectorStore,
 };
 use iris_mpc_common::iris_db::{db::IrisDB, iris::IrisCode};
 use rand::{CryptoRng, RngCore, SeedableRng};
@@ -316,10 +316,7 @@ impl LocalNetAby3NgStoreProtocol {
         recompute_distances: bool,
     ) -> GraphMem<LocalNetAby3NgStoreProtocol> {
         let ep = graph_store.get_entry_point().await;
-        let new_ep = ep.map(|ep| EntryPoint {
-            vector_ref:  VectorId { id: ep.vector_ref },
-            layer_count: ep.layer_count,
-        });
+        let new_ep = ep.map(|(vector_ref, layer_count)| (VectorId { id: vector_ref }, layer_count));
 
         let layers = graph_store.get_layers();
 
@@ -469,18 +466,8 @@ impl LocalNetAby3NgStoreProtocol {
                 let searcher = HawkSearcher::default();
                 // insert queries
                 for query in queries.iter() {
-                    let neighbors = searcher
-                        .search_to_insert(&mut store, &mut graph_store, query)
-                        .await;
-                    let inserted_query = store.insert(query).await;
                     searcher
-                        .insert_from_search_results(
-                            &mut store,
-                            &mut graph_store,
-                            &mut rng_searcher,
-                            inserted_query,
-                            neighbors,
-                        )
+                        .insert(&mut store, &mut graph_store, query, &mut rng_searcher)
                         .await;
                 }
                 (store, graph_store)
@@ -518,7 +505,7 @@ mod tests {
     use super::*;
     use crate::database_generators::generate_galois_iris_shares;
     use aes_prng::AesRng;
-    use hawk_pack::{graph_store::GraphMem, hnsw_db::HawkSearcher};
+    use hawk_pack::{graph_store::GraphMem, HawkSearcher};
     use itertools::Itertools;
     use rand::SeedableRng;
     use tracing_test::traced_test;
@@ -552,30 +539,19 @@ mod tests {
                 let mut inserted = vec![];
                 // insert queries
                 for query in queries.iter() {
-                    let neighbors = db
-                        .search_to_insert(&mut store, &mut aby3_graph, query)
+                    let inserted_vector = db
+                        .insert(&mut store, &mut aby3_graph, query, &mut rng)
                         .await;
-                    let inserted_query = store.insert(query).await;
-                    inserted.push(inserted_query);
-                    db.insert_from_search_results(
-                        &mut store,
-                        &mut aby3_graph,
-                        &mut rng,
-                        inserted_query,
-                        neighbors,
-                    )
-                    .await;
+                    inserted.push(inserted_vector)
                 }
                 tracing::debug!("FINISHED INSERTING");
                 // Search for the same codes and find matches.
                 let mut matching_results = vec![];
                 for v in inserted.into_iter() {
                     let query = store.prepare_query(store.storage.get_vector(&v).clone());
-                    let neighbors = db
-                        .search_to_insert(&mut store, &mut aby3_graph, &query)
-                        .await;
+                    let neighbors = db.search(&mut store, &mut aby3_graph, &query, 1).await;
                     tracing::debug!("Finished checking query");
-                    matching_results.push(db.is_match(&mut store, &neighbors).await)
+                    matching_results.push(db.is_match(&mut store, &[neighbors]).await)
                 }
                 matching_results
             });
@@ -622,11 +598,11 @@ mod tests {
 
         for i in 0..database_size {
             let cleartext_neighbors = hawk_searcher
-                .search_to_insert(&mut cleartext_data.0, &mut cleartext_data.1, &i.into())
+                .search(&mut cleartext_data.0, &mut cleartext_data.1, &i.into(), 1)
                 .await;
             assert!(
                 hawk_searcher
-                    .is_match(&mut cleartext_data.0, &cleartext_neighbors)
+                    .is_match(&mut cleartext_data.0, &[cleartext_neighbors])
                     .await,
             );
 
@@ -637,9 +613,9 @@ mod tests {
                 let mut g = g.clone();
                 let q = v.prepare_query(v.storage.get_vector(&i.into()).clone());
                 jobs.spawn(async move {
-                    let secret_neighbors = hawk_searcher.search_to_insert(&mut v, &mut g, &q).await;
+                    let secret_neighbors = hawk_searcher.search(&mut v, &mut g, &q, 1).await;
 
-                    hawk_searcher.is_match(&mut v, &secret_neighbors).await
+                    hawk_searcher.is_match(&mut v, &[secret_neighbors]).await
                 });
             }
             let scratch_results = jobs.join_all().await;
@@ -651,10 +627,9 @@ mod tests {
                 let mut g = g.clone();
                 jobs.spawn(async move {
                     let query = v.prepare_query(v.storage.get_vector(&i.into()).clone());
-                    let secret_neighbors =
-                        hawk_searcher.search_to_insert(&mut v, &mut g, &query).await;
+                    let secret_neighbors = hawk_searcher.search(&mut v, &mut g, &query, 1).await;
 
-                    hawk_searcher.is_match(&mut v, &secret_neighbors).await
+                    hawk_searcher.is_match(&mut v, &[secret_neighbors]).await
                 });
             }
             let premade_results = jobs.join_all().await;
@@ -783,9 +758,8 @@ mod tests {
                 let searcher = searcher.clone();
                 let q = store.prepare_query(store.storage.get_vector(&i.into()).clone());
                 jobs.spawn(async move {
-                    let secret_neighbors =
-                        searcher.search_to_insert(&mut store, &mut graph, &q).await;
-                    searcher.is_match(&mut store, &secret_neighbors).await
+                    let secret_neighbors = searcher.search(&mut store, &mut graph, &q, 1).await;
+                    searcher.is_match(&mut store, &[secret_neighbors]).await
                 });
             }
             let res = jobs.join_all().await;

--- a/iris-mpc-cpu/src/network/grpc.rs
+++ b/iris-mpc-cpu/src/network/grpc.rs
@@ -345,7 +345,7 @@ mod tests {
         hawkers::galois_store::LocalNetAby3NgStoreProtocol,
     };
     use aes_prng::AesRng;
-    use hawk_pack::hnsw_db::HawkSearcher;
+    use hawk_pack::HawkSearcher;
     use rand::SeedableRng;
     use tokio::task::JoinSet;
     use tracing_test::traced_test;
@@ -589,9 +589,8 @@ mod tests {
                 let searcher = searcher.clone();
                 let q = store.prepare_query(store.storage.get_vector(&i.into()).clone());
                 jobs.spawn(async move {
-                    let secret_neighbors =
-                        searcher.search_to_insert(&mut store, &mut graph, &q).await;
-                    searcher.is_match(&mut store, &secret_neighbors).await
+                    let secret_neighbors = searcher.search(&mut store, &mut graph, &q, 1).await;
+                    searcher.is_match(&mut store, &[secret_neighbors]).await
                 });
             }
             let res = jobs.join_all().await;

--- a/iris-mpc-py/README.md
+++ b/iris-mpc-py/README.md
@@ -23,7 +23,7 @@ Once successfully installed, the native rust module `iris_mpc_py` can be importe
 ```python
 from iris_mpc_py import PyHawkSearcher, PyPlaintextStore, PyGraphStore, PyIrisCode
 
-hnsw = PyHawkSearcher.new_uniform(32, 32) # M, ef
+hnsw = PyHawkSearcher(32, 64, 32) # M, ef_constr, ef_search
 vector = PyPlaintextStore()
 graph = PyGraphStore()
 
@@ -61,7 +61,7 @@ graph = PyGraphStore.read_from_bin("graph.dat")
 Second, to construct an HNSW index dynamically from streamed database entries:
 
 ```python
-hnsw = PyHawkSearcher.new_uniform(32, 32)
+hnsw = PyHawkSearcher(32, 64, 32)
 vector = PyPlaintextStore()
 graph = PyGraphStore()
 hnsw.fill_from_ndjson_file("large_vector_database.ndjson", vector, graph, 10000)

--- a/iris-mpc-py/examples-py/test_integration.py
+++ b/iris-mpc-py/examples-py/test_integration.py
@@ -12,7 +12,7 @@ print("Writing vector store to file...")
 vector_init.write_to_ndjson("vector.ndjson")
 
 print("Generating HNSW graphs for 10k imported iris codes...")
-hnsw = PyHawkSearcher.new_uniform(32, 32)
+hnsw = PyHawkSearcher(32, 64, 32)
 vector1 = PyPlaintextStore()
 graph1 = PyGraphStore()
 hnsw.fill_from_ndjson_file("vector.ndjson", vector1, graph1, 10000)

--- a/iris-mpc-py/src/py_hnsw/pyclasses/hawk_searcher.rs
+++ b/iris-mpc-py/src/py_hnsw/pyclasses/hawk_searcher.rs
@@ -1,5 +1,8 @@
 use super::{graph_store::PyGraphStore, iris_code::PyIrisCode, plaintext_store::PyPlaintextStore};
-use hawk_pack::hnsw_db::{HawkSearcher, Params};
+use hawk_pack::{
+    hawk_searcher::{HawkerParams, N_PARAM_LAYERS},
+    HawkSearcher,
+};
 use iris_mpc_cpu::py_bindings;
 use pyo3::{exceptions::PyIOError, prelude::*};
 
@@ -17,13 +20,36 @@ impl PyHawkSearcher {
 
     #[staticmethod]
     pub fn new_standard(M: usize, ef_constr: usize, ef_search: usize) -> Self {
-        let params = Params::new_standard(ef_constr, ef_search, M);
+        let params = HawkerParams::new(ef_constr, ef_search, M);
         Self(HawkSearcher { params })
     }
 
     #[staticmethod]
     pub fn new_uniform(M: usize, ef: usize) -> Self {
-        let params = Params::new_uniform(ef, M);
+        let params = HawkerParams::new_uniform(ef, M);
+        Self(HawkSearcher { params })
+    }
+
+    /// Construct `HawkSearcher` with fully general parameters, specifying the
+    /// values of various parameters used during construction and search at
+    /// different levels of the graph hierarchy.
+    #[staticmethod]
+    pub fn new_general(
+        M: [usize; N_PARAM_LAYERS],
+        M_max: [usize; N_PARAM_LAYERS],
+        ef_constr_search: [usize; N_PARAM_LAYERS],
+        ef_constr_insert: [usize; N_PARAM_LAYERS],
+        ef_search: [usize; N_PARAM_LAYERS],
+        layer_probability: f64,
+    ) -> Self {
+        let params = HawkerParams {
+            M,
+            M_max,
+            ef_constr_search,
+            ef_constr_insert,
+            ef_search,
+            layer_probability,
+        };
         Self(HawkSearcher { params })
     }
 


### PR DESCRIPTION
PR bumps the version of `hawk-pack`, adding support for variable `ef` and `M` parameters for construction and search, and additionally exposes the generalized functionality to the Python plaintext HNSW bindings.

This also updates the tests and benchmarks to use standard HNSW variable parameters for insertion and search, in particular for `ef` values: on insertion, `ef_constr` is used for insertion layers and `ef = 1` for higher layers; and on search, `ef_search` is used for layer 0 and `ef = 1` for higher layers.  This change exposes a trade-off space of somewhat reduced recall in exchange for improved computation cost.

The benchmarks below indicate that at least by measurement of total non-parallelized latency (correlated with total numbers of different operations), the difference in overall computation cost is fairly substantial in particular for higher index sizes.  It will likely be worth investigating where the optimal trade-off with accuracy is achieved.

```text
gr_ready_made_hnsw/gr-big-hnsw-insertions/1
                        time:   [4.6768 ms 4.7120 ms 4.7390 ms]
                        change: [-1.8629% -0.8707% +0.2502%] (p = 0.15 > 0.05)
gr_ready_made_hnsw/gr-big-hnsw-searches/1
                        time:   [8.6649 ms 8.7134 ms 8.7611 ms]
                        change: [-1.1453% +1.2795% +3.3837%] (p = 0.32 > 0.05)
gr_ready_made_hnsw/gr-big-hnsw-insertions/10
                        time:   [300.57 ms 302.51 ms 304.62 ms]
                        change: [-0.8783% +0.0349% +0.9019%] (p = 0.94 > 0.05)
gr_ready_made_hnsw/gr-big-hnsw-searches/10
                        time:   [180.12 ms 181.10 ms 182.12 ms]
                        change: [-1.4768% -0.6847% +0.1091%] (p = 0.11 > 0.05)
gr_ready_made_hnsw/gr-big-hnsw-insertions/100
                        time:   [4.4997 s 4.5176 s 4.5359 s]
                        change: [-3.1475% -2.6779% -2.1624%] (p = 0.00 < 0.05)
gr_ready_made_hnsw/gr-big-hnsw-searches/100
                        time:   [2.8143 s 2.8292 s 2.8456 s]
                        change: [-28.850% -28.365% -27.865%] (p = 0.00 < 0.05)
gr_ready_made_hnsw/gr-big-hnsw-insertions/1000
                        time:   [10.839 s 10.891 s 10.952 s]
                        change: [-4.2484% -3.7256% -3.0907%] (p = 0.00 < 0.05)
gr_ready_made_hnsw/gr-big-hnsw-searches/1000
                        time:   [6.7269 s 6.7531 s 6.7801 s]
                        change: [-36.649% -36.357% -36.060%] (p = 0.00 < 0.05)
gr_ready_made_hnsw/gr-big-hnsw-insertions/10000
                        time:   [16.666 s 16.694 s 16.723 s]
                        change: [-35.799% -35.274% -34.776%] (p = 0.00 < 0.05)
gr_ready_made_hnsw/gr-big-hnsw-searches/10000
                        time:   [9.3214 s 9.3418 s 9.3653 s]
                        change: [-62.873% -62.600% -62.348%] (p = 0.00 < 0.05)
gr_ready_made_hnsw/gr-big-hnsw-insertions/100000
                        time:   [28.144 s 28.178 s 28.213 s]
                        change: [-35.697% -35.465% -35.214%] (p = 0.00 < 0.05)
gr_ready_made_hnsw/gr-big-hnsw-searches/100000
                        time:   [15.957 s 15.985 s 16.015 s]
                        change: [-62.805% -62.618% -62.432%] (p = 0.00 < 0.05)
```