### PR TITLE
Change importer to work with binary

### DIFF
--- a/.github/workflows/temp-branch-build-and-push.yaml
+++ b/.github/workflows/temp-branch-build-and-push.yaml
@@ -2,6 +2,8 @@ name: Branch - Build and push docker image
 
 on:
   push:
+    branches:
+      - "ertugrul/change-to-binary"
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'

--- a/.github/workflows/temp-branch-build-and-push.yaml
+++ b/.github/workflows/temp-branch-build-and-push.yaml
@@ -1,0 +1,45 @@
+name: Branch - Build and push docker image
+
+on:
+  push:
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  docker:
+    runs-on:
+      labels: ubuntu-22.04-64core
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and Push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:8c73f24672532e788228ad7d9104648f7e16940f"
+image: "ghcr.io/worldcoin/iris-mpc:9ef40074bb611315c4c03d481bc704ee41000124"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:9ef40074bb611315c4c03d481bc704ee41000124"
+image: "ghcr.io/worldcoin/iris-mpc:ac92dd22dda2ae8419dec47a4da60809da09b31a"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -82,4 +82,4 @@ preStop:
   sleepPeriod: 10
 
 # terminationGracePeriodSeconds specifies the grace time between SIGTERM and SIGKILL
-terminationGracePeriodSeconds: 180 # 3x SMPC__PROCESSING_TIMEOUT_SECS
+terminationGracePeriodSeconds: 20 # 3x SMPC__PROCESSING_TIMEOUT_SECS

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:v0.12.3"
+image: "ghcr.io/worldcoin/iris-mpc:8c73f24672532e788228ad7d9104648f7e16940f"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:ac92dd22dda2ae8419dec47a4da60809da09b31a"
+image: "ghcr.io/worldcoin/iris-mpc:v0.12.4"
 
 environment: stage
 replicaCount: 1
@@ -82,4 +82,4 @@ preStop:
   sleepPeriod: 10
 
 # terminationGracePeriodSeconds specifies the grace time between SIGTERM and SIGKILL
-terminationGracePeriodSeconds: 20 # 3x SMPC__PROCESSING_TIMEOUT_SECS
+terminationGracePeriodSeconds: 20

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -75,10 +75,10 @@ env:
     value: "iris-mpc-db-exporter-store-node-0-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_2k"
+    value: "binary_output_1k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "32"
+    value: "64"
 
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -75,10 +75,10 @@ env:
     value: "iris-mpc-db-exporter-store-node-0-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_2k"
+    value: "binary_output_8k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "64"
+    value: "8"
 
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -78,7 +78,7 @@ env:
     value: "binary_output_2k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "8"
+    value: "32"
 
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -75,8 +75,8 @@ env:
     value: "iris-mpc-db-exporter-store-node-0-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_4k"
-    
+    value: "binary_output_8k"
+
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"
 

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -75,11 +75,11 @@ env:
     value: "iris-mpc-db-exporter-store-node-0-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_8k"
+    value: "binary_output_2k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "8"
-    
+    value: "16"
+
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"
 

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -75,7 +75,7 @@ env:
     value: "iris-mpc-db-exporter-store-node-0-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_512"
+    value: "binary_output_2k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
     value: "32"

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -78,7 +78,7 @@ env:
     value: "binary_output_2k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "32"
+    value: "64"
 
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -75,10 +75,10 @@ env:
     value: "iris-mpc-db-exporter-store-node-0-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_8k"
+    value: "binary_output_2k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "8"
+    value: "32"
 
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -75,10 +75,10 @@ env:
     value: "iris-mpc-db-exporter-store-node-0-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_1k"
+    value: "binary_output_512"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "64"
+    value: "32"
 
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -77,6 +77,9 @@ env:
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
     value: "binary_output_8k"
 
+  - name: SMPC__LOAD_CHUNKS_PARALLELISM
+    value: "8"
+    
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"
 

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -74,6 +74,9 @@ env:
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "iris-mpc-db-exporter-store-node-0-stage-eu-north-1"
 
+  - name: SMPC__DB_CHUNKS_FOLDER_NAME
+    value: "binary_output_4k"
+    
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"
 

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -78,7 +78,7 @@ env:
     value: "binary_output_2k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "16"
+    value: "8"
 
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -78,7 +78,7 @@ env:
     value: "binary_output_2k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "8"
+    value: "32"
 
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -75,11 +75,11 @@ env:
     value: "iris-mpc-db-exporter-store-node-1-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_8k"
+    value: "binary_output_2k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "8"
-    
+    value: "16"
+
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"
 

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -75,10 +75,10 @@ env:
     value: "iris-mpc-db-exporter-store-node-1-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_8k"
+    value: "binary_output_2k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "8"
+    value: "32"
 
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -75,8 +75,8 @@ env:
     value: "iris-mpc-db-exporter-store-node-1-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_4k"
-    
+    value: "binary_output_8k"
+
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"
 

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -78,7 +78,7 @@ env:
     value: "binary_output_2k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "32"
+    value: "64"
 
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -74,6 +74,9 @@ env:
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "iris-mpc-db-exporter-store-node-1-stage-eu-north-1"
 
+  - name: SMPC__DB_CHUNKS_FOLDER_NAME
+    value: "binary_output_4k"
+    
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"
 

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -75,10 +75,10 @@ env:
     value: "iris-mpc-db-exporter-store-node-1-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_2k"
+    value: "binary_output_8k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "64"
+    value: "8"
 
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -77,6 +77,9 @@ env:
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
     value: "binary_output_8k"
 
+  - name: SMPC__LOAD_CHUNKS_PARALLELISM
+    value: "8"
+    
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"
 

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -78,7 +78,7 @@ env:
     value: "binary_output_2k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "16"
+    value: "8"
 
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -75,10 +75,10 @@ env:
     value: "iris-mpc-db-exporter-store-node-2-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_8k"
+    value: "binary_output_2k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "8"
+    value: "32"
 
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -78,7 +78,7 @@ env:
     value: "binary_output_2k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "8"
+    value: "32"
 
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -75,11 +75,11 @@ env:
     value: "iris-mpc-db-exporter-store-node-2-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_8k"
+    value: "binary_output_2k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "8"
-    
+    value: "16"
+
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"
 

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -74,6 +74,9 @@ env:
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "iris-mpc-db-exporter-store-node-2-stage-eu-north-1"
 
+  - name: SMPC__DB_CHUNKS_FOLDER_NAME
+    value: "binary_output_4k"
+    
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"
 

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -75,10 +75,10 @@ env:
     value: "iris-mpc-db-exporter-store-node-2-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_2k"
+    value: "binary_output_8k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "64"
+    value: "8"
 
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -78,7 +78,7 @@ env:
     value: "binary_output_2k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "32"
+    value: "64"
 
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -75,8 +75,8 @@ env:
     value: "iris-mpc-db-exporter-store-node-2-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_4k"
-    
+    value: "binary_output_8k"
+
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"
 

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -77,6 +77,9 @@ env:
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
     value: "binary_output_8k"
 
+  - name: SMPC__LOAD_CHUNKS_PARALLELISM
+    value: "8"
+    
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"
 

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -78,7 +78,7 @@ env:
     value: "binary_output_2k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "16"
+    value: "8"
 
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"

--- a/iris-mpc-common/src/config/mod.rs
+++ b/iris-mpc-common/src/config/mod.rs
@@ -102,6 +102,9 @@ pub struct Config {
     /// updated during the DB export to S3
     #[serde(default = "default_db_load_safety_overlap_seconds")]
     pub db_load_safety_overlap_seconds: i64,
+
+    #[serde(default)]
+    pub db_chunks_folder_name: String,
 }
 
 fn default_load_chunks_parallelism() -> usize {

--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -18,7 +18,7 @@ pub use s3_importer::{fetch_and_parse_chunks, last_snapshot_timestamp, ObjectSto
 use sqlx::{
     migrate::Migrator, postgres::PgPoolOptions, Executor, PgPool, Postgres, Row, Transaction,
 };
-use std::{ops::DerefMut, pin::Pin, u32};
+use std::{ops::DerefMut, pin::Pin};
 
 const APP_NAME: &str = "SMPC";
 const MAX_CONNECTIONS: u32 = 100;

--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -12,6 +12,7 @@ use iris_mpc_common::{
     config::Config,
     galois_engine::degree4::{GaloisRingIrisCodeShare, GaloisRingTrimmedMaskCodeShare},
     iris_db::iris::IrisCode,
+    IRIS_CODE_LENGTH, MASK_CODE_LENGTH,
 };
 use rand::{rngs::StdRng, Rng, SeedableRng};
 pub use s3_importer::{fetch_and_parse_chunks, last_snapshot_timestamp, ObjectStore, S3Store};
@@ -100,10 +101,10 @@ impl StoredIris {
         ) as i64;
 
         // parse codes and masks
-        let left_code = extract_slice(bytes, &mut cursor, 25_600)?;
-        let left_mask = extract_slice(bytes, &mut cursor, 12_800)?;
-        let right_code = extract_slice(bytes, &mut cursor, 25_600)?;
-        let right_mask = extract_slice(bytes, &mut cursor, 12_800)?;
+        let left_code = extract_slice(bytes, &mut cursor, IRIS_CODE_LENGTH * size_of::<u16>())?;
+        let left_mask = extract_slice(bytes, &mut cursor, MASK_CODE_LENGTH * size_of::<u16>())?;
+        let right_code = extract_slice(bytes, &mut cursor, IRIS_CODE_LENGTH * size_of::<u16>())?;
+        let right_mask = extract_slice(bytes, &mut cursor, MASK_CODE_LENGTH * size_of::<u16>())?;
 
         Ok(StoredIris {
             id,

--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -18,7 +18,7 @@ pub use s3_importer::{fetch_and_parse_chunks, last_snapshot_timestamp, ObjectSto
 use sqlx::{
     migrate::Migrator, postgres::PgPoolOptions, Executor, PgPool, Postgres, Row, Transaction,
 };
-use std::{ops::DerefMut, pin::Pin};
+use std::{ops::DerefMut, pin::Pin, u32};
 
 const APP_NAME: &str = "SMPC";
 const MAX_CONNECTIONS: u32 = 100;
@@ -93,11 +93,11 @@ impl StoredIris {
 
         // Parse `id` (i64)
         let id_bytes = extract_slice(bytes, &mut cursor, 4)?;
-        let id = i64::from_be_bytes(
+        let id = u32::from_be_bytes(
             id_bytes
                 .try_into()
                 .map_err(|_| eyre!("Failed to convert id bytes to i64"))?,
-        );
+        ) as i64;
 
         // parse codes and masks
         let left_code = extract_slice(bytes, &mut cursor, 25_600)?;

--- a/iris-mpc-store/src/s3_importer.rs
+++ b/iris-mpc-store/src/s3_importer.rs
@@ -135,14 +135,6 @@ pub async fn fetch_and_parse_chunks(
     tracing::info!("Generated {} chunk names", chunks.len());
 
     let result_stream = stream::iter(chunks)
-        .filter_map(|chunk| async move {
-            if chunk.ends_with(".bin") {
-                tracing::info!("Processing chunk: {}", chunk);
-                Some(chunk)
-            } else {
-                None
-            }
-        })
         .map(move |chunk| async move {
             let mut now = Instant::now();
             let result = store.get_object(&chunk).await?;

--- a/iris-mpc-store/src/s3_importer.rs
+++ b/iris-mpc-store/src/s3_importer.rs
@@ -77,33 +77,62 @@ impl ObjectStore for S3Store {
     }
 }
 
+#[derive(Debug)]
+pub struct LastSnapshotDetails {
+    pub timestamp:      i64,
+    pub last_serial_id: i64,
+    pub chunk_size:     i64,
+}
+
+impl LastSnapshotDetails {
+    // Parse last snapshot from s3 file name.
+    // It is in {unixTime}_{batchSize}_{lastSerialId} format.
+    pub fn new_from_str(last_snapshot_str: &str) -> Option<Self> {
+        let parts: Vec<&str> = last_snapshot_str.split('_').collect();
+        match parts.len() {
+            3 => Some(Self {
+                timestamp:      parts[0].parse().unwrap(),
+                chunk_size:     parts[1].parse().unwrap(),
+                last_serial_id: parts[2].parse().unwrap(),
+            }),
+            _ => {
+                tracing::warn!("Invalid export timestamp file name: {}", last_snapshot_str);
+                None
+            }
+        }
+    }
+}
+
 pub async fn last_snapshot_timestamp(
     store: &impl ObjectStore,
-    folder_name: String,
-) -> eyre::Result<i64> {
-    tracing::info!("Looking for last snapshot time in folder: {}", folder_name);
-    let start_path = format!("{}/", folder_name);
+    prefix_name: String,
+) -> eyre::Result<LastSnapshotDetails> {
+    tracing::info!("Looking for last snapshot time in prefix: {}", prefix_name);
+    let timestamps_path = format!("{}/timestamps/", prefix_name);
     store
-        .list_objects(folder_name.as_str())
+        .list_objects(timestamps_path.as_str())
         .await?
         .into_iter()
-        .filter(|f| f.starts_with(start_path.as_str()) && f.ends_with(".timestamp"))
-        .filter_map(|f| {
-            f.replace(".timestamp", "")
-                .replace(start_path.as_str(), "")
-                .parse::<i64>()
-                .ok()
+        .filter_map(|f| match f.split('/').last() {
+            Some(file_name) => LastSnapshotDetails::new_from_str(file_name),
+            _ => None,
         })
-        .max()
+        .max_by_key(|s| s.timestamp)
         .ok_or_else(|| eyre::eyre!("No snapshot found"))
 }
 
 pub async fn fetch_and_parse_chunks(
     store: &impl ObjectStore,
     concurrency: usize,
-    folder_name: String,
+    prefix_name: String,
+    last_snapshot_details: LastSnapshotDetails,
 ) -> Pin<Box<dyn Stream<Item = eyre::Result<StoredIris>> + Send + '_>> {
-    let chunks = store.list_objects(folder_name.as_str()).await.unwrap();
+    tracing::info!("Generating chunk files using: {:?}", last_snapshot_details);
+    let chunks: Vec<String> = (1..=last_snapshot_details.last_serial_id)
+        .step_by(last_snapshot_details.chunk_size as usize)
+        .map(|num| format!("{}/{}.bin", prefix_name, num))
+        .collect();
+    tracing::info!("Generated {} chunk names", chunks.len());
 
     let result_stream = stream::iter(chunks)
         .filter_map(|chunk| async move {
@@ -166,6 +195,10 @@ mod tests {
             Self::default()
         }
 
+        pub fn add_timestamp_file(&mut self, key: &str) {
+            self.objects.insert(key.to_string(), Vec::new());
+        }
+        
         pub fn add_test_data(&mut self, key: &str, records: Vec<StoredIris>) {
             let mut csv = Vec::new();
             {
@@ -223,6 +256,19 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_last_snapshot_timestamp() {
+        let mut store = MockStore::new();
+        store.add_timestamp_file("out/timestamps/123_100_954");
+        store.add_timestamp_file("out/timestamps/124_100_958");
+        store.add_timestamp_file("out/timestamps/125_100_958");
+
+        let last_snapshot = last_snapshot_timestamp(&store, "out".to_string()).await.unwrap();
+        assert_eq!(last_snapshot.timestamp, 125);
+        assert_eq!(last_snapshot.last_serial_id, 958);
+        assert_eq!(last_snapshot.chunk_size, 100);
+    }
+
+    #[tokio::test]
     async fn test_fetch_and_parse_chunks() {
         const MOCK_ENTRIES: usize = 107;
         const MOCK_CHUNK_SIZE: usize = 10;
@@ -232,17 +278,22 @@ mod tests {
             let start_serial_id = i * MOCK_CHUNK_SIZE + 1;
             let end_serial_id = min((i + 1) * MOCK_CHUNK_SIZE, MOCK_ENTRIES);
             store.add_test_data(
-                &format!("{start_serial_id}.csv"),
+                &format!("out/{start_serial_id}.bin"),
                 (start_serial_id..=end_serial_id).map(dummy_entry).collect(),
             );
         }
 
         assert_eq!(
             store.list_objects("").await.unwrap().len(),
-            MOCK_ENTRIES.div_ceil(MOCK_CHUNK_SIZE)
+            n_chunks
         );
-
-        let mut chunks = fetch_and_parse_chunks(&store, 1, String::new()).await;
+        let last_snapshot_details = LastSnapshotDetails {
+            timestamp:      0,
+            last_serial_id: MOCK_ENTRIES as i64,
+            chunk_size:     MOCK_CHUNK_SIZE as i64,
+        };
+        let mut chunks =
+            fetch_and_parse_chunks(&store, 1, "out".to_string(), last_snapshot_details).await;
         let mut count = 0;
         let mut ids: HashSet<usize> = HashSet::from_iter(1..MOCK_ENTRIES);
         while let Some(chunk) = chunks.next().await {

--- a/iris-mpc-store/src/s3_importer.rs
+++ b/iris-mpc-store/src/s3_importer.rs
@@ -190,7 +190,7 @@ mod tests {
         pub fn add_timestamp_file(&mut self, key: &str) {
             self.objects.insert(key.to_string(), Vec::new());
         }
-        
+
         pub fn add_test_data(&mut self, key: &str, records: Vec<StoredIris>) {
             let mut result = Vec::new();
             for record in records {
@@ -243,7 +243,9 @@ mod tests {
         store.add_timestamp_file("out/timestamps/124_100_958");
         store.add_timestamp_file("out/timestamps/125_100_958");
 
-        let last_snapshot = last_snapshot_timestamp(&store, "out".to_string()).await.unwrap();
+        let last_snapshot = last_snapshot_timestamp(&store, "out".to_string())
+            .await
+            .unwrap();
         assert_eq!(last_snapshot.timestamp, 125);
         assert_eq!(last_snapshot.last_serial_id, 958);
         assert_eq!(last_snapshot.chunk_size, 100);
@@ -264,10 +266,7 @@ mod tests {
             );
         }
 
-        assert_eq!(
-            store.list_objects("").await.unwrap().len(),
-            n_chunks
-        );
+        assert_eq!(store.list_objects("").await.unwrap().len(), n_chunks);
         let last_snapshot_details = LastSnapshotDetails {
             timestamp:      0,
             last_serial_id: MOCK_ENTRIES as i64,

--- a/iris-mpc-store/src/s3_importer.rs
+++ b/iris-mpc-store/src/s3_importer.rs
@@ -200,26 +200,15 @@ mod tests {
         }
         
         pub fn add_test_data(&mut self, key: &str, records: Vec<StoredIris>) {
-            let mut csv = Vec::new();
-            {
-                let mut writer = csv::Writer::from_writer(&mut csv);
-                writer
-                    .write_record(["id", "left_code", "left_mask", "right_code", "right_mask"])
-                    .unwrap();
-
-                for record in records {
-                    writer
-                        .write_record(&[
-                            record.id.to_string(),
-                            hex::encode(record.left_code),
-                            hex::encode(record.left_mask),
-                            hex::encode(record.right_code),
-                            hex::encode(record.right_mask),
-                        ])
-                        .unwrap();
-                }
+            let mut result = Vec::new();
+            for record in records {
+                result.extend_from_slice(&(record.id as u32).to_be_bytes());
+                result.extend_from_slice(&record.left_code);
+                result.extend_from_slice(&record.left_mask);
+                result.extend_from_slice(&record.right_code);
+                result.extend_from_slice(&record.right_mask);
             }
-            self.objects.insert(key.to_string(), csv);
+            self.objects.insert(key.to_string(), result);
         }
     }
 

--- a/iris-mpc-store/src/s3_importer.rs
+++ b/iris-mpc-store/src/s3_importer.rs
@@ -72,15 +72,20 @@ impl ObjectStore for S3Store {
     }
 }
 
-pub async fn last_snapshot_timestamp(store: &impl ObjectStore) -> eyre::Result<i64> {
+pub async fn last_snapshot_timestamp(
+    store: &impl ObjectStore,
+    folder_name: String,
+) -> eyre::Result<i64> {
+    tracing::info!("Looking for last snapshot time in folder: {}", folder_name);
+    let start_path = format!("{}/", folder_name);
     store
         .list_objects()
         .await?
         .into_iter()
-        .filter(|f| f.starts_with("output/") && f.ends_with(".timestamp"))
+        .filter(|f| f.starts_with(start_path.as_str()) && f.ends_with(".timestamp"))
         .filter_map(|f| {
             f.replace(".timestamp", "")
-                .replace("output/", "")
+                .replace(start_path.as_str(), "")
                 .parse::<i64>()
                 .ok()
         })

--- a/iris-mpc/src/bin/server.rs
+++ b/iris-mpc/src/bin/server.rs
@@ -988,23 +988,26 @@ async fn server_main(config: Config) -> eyre::Result<()> {
                             true => {
                                 tracing::info!("S3 importer enabled. Fetching from s3 + db");
                                 // First fetch last snapshot from S3
-                                let last_snapshot_timestamp =
-                                    last_snapshot_timestamp(&s3_store).await?;
+                                let last_snapshot_timestamp = last_snapshot_timestamp(
+                                    &s3_store,
+                                    db_chunks_folder_name.clone(),
+                                )
+                                .await?;
                                 let min_last_modified_at =
                                     last_snapshot_timestamp - config.db_load_safety_overlap_seconds;
                                 tracing::info!(
-                            "Last snapshot timestamp: {}, min_last_modified_at: {}",
-                            last_snapshot_timestamp,
-                            min_last_modified_at
-                        );
+                                    "Last snapshot timestamp: {}, min_last_modified_at: {}",
+                                    last_snapshot_timestamp,
+                                    min_last_modified_at
+                                );
                                 let stream_s3 = fetch_and_parse_chunks(
                                     &s3_store,
                                     load_chunks_parallelism,
                                     db_chunks_folder_name,
                                 )
-                                        .await
-                                        .map(|result| result.map(IrisSource::S3))
-                                        .boxed();
+                                .await
+                                .map(|result| result.map(IrisSource::S3))
+                                .boxed();
 
                                 let stream_db = store
                                     .stream_irises_par(Some(min_last_modified_at), parallelism)

--- a/iris-mpc/src/bin/server.rs
+++ b/iris-mpc/src/bin/server.rs
@@ -988,22 +988,23 @@ async fn server_main(config: Config) -> eyre::Result<()> {
                             true => {
                                 tracing::info!("S3 importer enabled. Fetching from s3 + db");
                                 // First fetch last snapshot from S3
-                                let last_snapshot_timestamp = last_snapshot_timestamp(
+                                let last_snapshot_details = last_snapshot_timestamp(
                                     &s3_store,
                                     db_chunks_folder_name.clone(),
                                 )
                                 .await?;
-                                let min_last_modified_at =
-                                    last_snapshot_timestamp - config.db_load_safety_overlap_seconds;
+                                let min_last_modified_at = last_snapshot_details.timestamp
+                                    - config.db_load_safety_overlap_seconds;
                                 tracing::info!(
                                     "Last snapshot timestamp: {}, min_last_modified_at: {}",
-                                    last_snapshot_timestamp,
+                                    last_snapshot_details.timestamp,
                                     min_last_modified_at
                                 );
                                 let stream_s3 = fetch_and_parse_chunks(
                                     &s3_store,
                                     load_chunks_parallelism,
                                     db_chunks_folder_name,
+                                    last_snapshot_details,
                                 )
                                 .await
                                 .map(|result| result.map(IrisSource::S3))

--- a/iris-mpc/src/bin/server.rs
+++ b/iris-mpc/src/bin/server.rs
@@ -997,8 +997,11 @@ async fn server_main(config: Config) -> eyre::Result<()> {
                             last_snapshot_timestamp,
                             min_last_modified_at
                         );
-                                let stream_s3 =
-                                    fetch_and_parse_chunks(&s3_store, load_chunks_parallelism)
+                                let stream_s3 = fetch_and_parse_chunks(
+                                    &s3_store,
+                                    load_chunks_parallelism,
+                                    db_chunks_folder_name,
+                                )
                                         .await
                                         .map(|result| result.map(IrisSource::S3))
                                         .boxed();

--- a/iris-mpc/src/bin/server.rs
+++ b/iris-mpc/src/bin/server.rs
@@ -903,6 +903,7 @@ async fn server_main(config: Config) -> eyre::Result<()> {
 
     let load_chunks_parallelism = config.load_chunks_parallelism;
     let db_chunks_bucket_name = config.db_chunks_bucket_name.clone();
+    let db_chunks_folder_name = config.db_chunks_folder_name.clone();
 
     let (tx, rx) = oneshot::channel();
     background_tasks.spawn_blocking(move || {
@@ -991,6 +992,11 @@ async fn server_main(config: Config) -> eyre::Result<()> {
                                     last_snapshot_timestamp(&s3_store).await?;
                                 let min_last_modified_at =
                                     last_snapshot_timestamp - config.db_load_safety_overlap_seconds;
+                                tracing::info!(
+                            "Last snapshot timestamp: {}, min_last_modified_at: {}",
+                            last_snapshot_timestamp,
+                            min_last_modified_at
+                        );
                                 let stream_s3 =
                                     fetch_and_parse_chunks(&s3_store, load_chunks_parallelism)
                                         .await


### PR DESCRIPTION
**Change**
- This PR converts from hex + csv import format into binary format.
- This helps us get half the size of csv file for the same number of items and also avoids time spent on hex decoding.
- In stage, it gives us 66% decrease on import time

**Side change**
- Instead of calling s3 listObjects to get the chunks, we now generate the chunk paths out of timestamp file. Timestamp file's structure is changed to `{unixTime}_{batchSize}_{lastSerialId}`