### PR TITLE
disable importer in prod

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -10,6 +10,7 @@ ignore = [
     { id = "RUSTSEC-2024-0384", reason = "waiting for `web-time` crate to remove the dependency" },
     { id = "RUSTSEC-2024-0388", reason = "waiting for `mongodb` crate to remove the deprecated dependency" },
     { id = "RUSTSEC-2024-0402", reason = "wating for `index-map` crate to remove the dependency" },
+    { id = "RUSTSEC-2024-0421", reason = "waiting for `mongodb` crate to remove the deprecated dependency" },
 ]
 
 [sources]

--- a/deploy/prod/smpcv2-0-prod/values-iris-mpc.yaml
+++ b/deploy/prod/smpcv2-0-prod/values-iris-mpc.yaml
@@ -77,8 +77,8 @@ env:
   - name: SMPC__PUBLIC_KEY_BASE_URL
     value: "https://pki-smpc.worldcoin.org"
 
-  - name: SMPC__ENABLE_S3_IMPORTER
-    value: "false"
+#  - name: SMPC__ENABLE_S3_IMPORTER
+#    value: "false"
 
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "iris-mpc-db-exporter-store-node-0-prod-eu-north-1"

--- a/deploy/prod/smpcv2-0-prod/values-iris-mpc.yaml
+++ b/deploy/prod/smpcv2-0-prod/values-iris-mpc.yaml
@@ -77,6 +77,9 @@ env:
   - name: SMPC__PUBLIC_KEY_BASE_URL
     value: "https://pki-smpc.worldcoin.org"
 
+  - name: SMPC__ENABLE_S3_IMPORTER
+    value: "false"
+
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "iris-mpc-db-exporter-store-node-0-prod-eu-north-1"
 

--- a/deploy/prod/smpcv2-1-prod/values-iris-mpc.yaml
+++ b/deploy/prod/smpcv2-1-prod/values-iris-mpc.yaml
@@ -77,6 +77,9 @@ env:
   - name: SMPC__PUBLIC_KEY_BASE_URL
     value: "https://pki-smpc.worldcoin.org"
 
+  - name: SMPC__ENABLE_S3_IMPORTER
+    value: "false"
+
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "iris-mpc-db-exporter-store-node-1-prod-eu-north-1"
 

--- a/deploy/prod/smpcv2-1-prod/values-iris-mpc.yaml
+++ b/deploy/prod/smpcv2-1-prod/values-iris-mpc.yaml
@@ -77,8 +77,8 @@ env:
   - name: SMPC__PUBLIC_KEY_BASE_URL
     value: "https://pki-smpc.worldcoin.org"
 
-  - name: SMPC__ENABLE_S3_IMPORTER
-    value: "false"
+#  - name: SMPC__ENABLE_S3_IMPORTER
+#    value: "false"
 
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "iris-mpc-db-exporter-store-node-1-prod-eu-north-1"

--- a/deploy/prod/smpcv2-2-prod/values-iris-mpc.yaml
+++ b/deploy/prod/smpcv2-2-prod/values-iris-mpc.yaml
@@ -77,6 +77,9 @@ env:
   - name: SMPC__PUBLIC_KEY_BASE_URL
     value: "https://pki-smpc.worldcoin.org"
 
+  - name: SMPC__ENABLE_S3_IMPORTER
+    value: "false"
+
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "iris-mpc-db-exporter-store-node-2-prod-eu-north-1"
 

--- a/deploy/prod/smpcv2-2-prod/values-iris-mpc.yaml
+++ b/deploy/prod/smpcv2-2-prod/values-iris-mpc.yaml
@@ -77,8 +77,8 @@ env:
   - name: SMPC__PUBLIC_KEY_BASE_URL
     value: "https://pki-smpc.worldcoin.org"
 
-  - name: SMPC__ENABLE_S3_IMPORTER
-    value: "false"
+#  - name: SMPC__ENABLE_S3_IMPORTER
+#    value: "false"
 
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "iris-mpc-db-exporter-store-node-2-prod-eu-north-1"

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:v0.12.2"
+image: "ghcr.io/worldcoin/iris-mpc:v0.12.3"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -69,7 +69,7 @@ env:
     value: "wf-smpcv2-stage-sns-requests"
 
   - name: SMPC__ENABLE_S3_IMPORTER
-    value: "true"
+    value: "false"
 
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "iris-mpc-db-exporter-store-node-0-stage-eu-north-1"

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -68,6 +68,9 @@ env:
   - name: SMPC__SHARES_BUCKET_NAME
     value: "wf-smpcv2-stage-sns-requests"
 
+  - name: SMPC__ENABLE_S3_IMPORTER
+    value: "true"
+
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "iris-mpc-db-exporter-store-node-0-stage-eu-north-1"
 

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -69,7 +69,7 @@ env:
     value: "wf-smpcv2-stage-sns-requests"
 
   - name: SMPC__ENABLE_S3_IMPORTER
-    value: "true"
+    value: "false"
 
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "iris-mpc-db-exporter-store-node-1-stage-eu-north-1"

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -68,6 +68,9 @@ env:
   - name: SMPC__SHARES_BUCKET_NAME
     value: "wf-smpcv2-stage-sns-requests"
 
+  - name: SMPC__ENABLE_S3_IMPORTER
+    value: "true"
+
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "iris-mpc-db-exporter-store-node-1-stage-eu-north-1"
 

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -68,6 +68,9 @@ env:
   - name: SMPC__SHARES_BUCKET_NAME
     value: "wf-smpcv2-stage-sns-requests"
 
+  - name: SMPC__ENABLE_S3_IMPORTER
+    value: "true"
+
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "iris-mpc-db-exporter-store-node-2-stage-eu-north-1"
 

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -69,7 +69,7 @@ env:
     value: "wf-smpcv2-stage-sns-requests"
 
   - name: SMPC__ENABLE_S3_IMPORTER
-    value: "true"
+    value: "false"
 
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "iris-mpc-db-exporter-store-node-2-stage-eu-north-1"

--- a/iris-mpc-common/src/config/mod.rs
+++ b/iris-mpc-common/src/config/mod.rs
@@ -89,6 +89,9 @@ pub struct Config {
     pub image_name: String,
 
     #[serde(default)]
+    pub enable_s3_importer: bool,
+    
+    #[serde(default)]
     pub db_chunks_bucket_name: String,
 
     #[serde(default = "default_load_chunks_parallelism")]

--- a/iris-mpc-common/src/config/mod.rs
+++ b/iris-mpc-common/src/config/mod.rs
@@ -90,7 +90,7 @@ pub struct Config {
 
     #[serde(default)]
     pub enable_s3_importer: bool,
-    
+
     #[serde(default)]
     pub db_chunks_bucket_name: String,
 

--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -167,7 +167,7 @@ impl Store {
     /// Stream irises in parallel, without a particular order.
     pub async fn stream_irises_par(
         &self,
-        min_last_modified_at: i64,
+        min_last_modified_at: Option<i64>,
         partitions: usize,
     ) -> impl Stream<Item = eyre::Result<StoredIris>> + '_ {
         let count = self.count_irises().await.expect("Failed count_irises");
@@ -179,14 +179,23 @@ impl Store {
             let start_id = 1 + partition_size * i;
             let end_id = start_id + partition_size - 1;
 
-            let partition_stream = sqlx::query_as::<_, StoredIris>(
-                "SELECT * FROM irises WHERE id BETWEEN $1 AND $2 AND last_modified_at >= $3",
-            )
-            .bind(start_id as i64)
-            .bind(end_id as i64)
-            .bind(min_last_modified_at)
-            .fetch(&self.pool)
-            .map_err(Into::into);
+            let partition_stream = match min_last_modified_at {
+                Some(min_last_modified_at) => {
+                    sqlx::query_as::<_, StoredIris>("SELECT * FROM irises WHERE id BETWEEN $1 AND $2 AND last_modified_at >= $3")
+                        .bind(start_id as i64)
+                        .bind(end_id as i64)
+                        .bind(min_last_modified_at)
+                        .fetch(&self.pool)
+                        .map_err(Into::into)
+                }
+                None => {
+                    sqlx::query_as::<_, StoredIris>("SELECT * FROM irises WHERE id BETWEEN $1 AND $2")
+                        .bind(start_id as i64)
+                        .bind(end_id as i64)
+                        .fetch(&self.pool)
+                        .map_err(Into::into)
+                }
+            };
 
             partition_streams.push(Box::pin(partition_stream)
                 as Pin<Box<dyn Stream<Item = eyre::Result<StoredIris>> + Send>>);
@@ -509,7 +518,7 @@ mod tests {
         let got: Vec<StoredIris> = store.stream_irises().await.try_collect().await?;
         assert_eq!(got.len(), 0);
 
-        let got: Vec<StoredIris> = store.stream_irises_par(0, 2).await.try_collect().await?;
+        let got: Vec<StoredIris> = store.stream_irises_par(Some(0), 2).await.try_collect().await?;
         assert_eq!(got.len(), 0);
 
         let codes_and_masks = &[
@@ -545,7 +554,7 @@ mod tests {
         let got: Vec<StoredIris> = store.stream_irises().await.try_collect().await?;
 
         let mut got_par: Vec<StoredIris> =
-            store.stream_irises_par(0, 2).await.try_collect().await?;
+            store.stream_irises_par(Some(0), 2).await.try_collect().await?;
         got_par.sort_by_key(|iris| iris.id);
         assert_eq!(got, got_par);
 
@@ -623,7 +632,7 @@ mod tests {
         // Compare with the parallel version with several edge-cases.
         for parallelism in [1, 5, MAX_CONNECTIONS as usize + 1] {
             let mut got_par: Vec<StoredIris> = store
-                .stream_irises_par(0, parallelism)
+                .stream_irises_par(Some(0), parallelism)
                 .await
                 .try_collect()
                 .await?;

--- a/iris-mpc/src/bin/server.rs
+++ b/iris-mpc/src/bin/server.rs
@@ -987,13 +987,15 @@ async fn server_main(config: Config) -> eyre::Result<()> {
                             true => {
                                 tracing::info!("S3 importer enabled. Fetching from s3 + db");
                                 // First fetch last snapshot from S3
-                                let last_snapshot_timestamp = last_snapshot_timestamp(&s3_store).await?;
+                                let last_snapshot_timestamp =
+                                    last_snapshot_timestamp(&s3_store).await?;
                                 let min_last_modified_at =
                                     last_snapshot_timestamp - config.db_load_safety_overlap_seconds;
-                                let stream_s3 = fetch_and_parse_chunks(&s3_store, load_chunks_parallelism)
-                                    .await
-                                    .map(|result| result.map(IrisSource::S3))
-                                    .boxed();
+                                let stream_s3 =
+                                    fetch_and_parse_chunks(&s3_store, load_chunks_parallelism)
+                                        .await
+                                        .map(|result| result.map(IrisSource::S3))
+                                        .boxed();
 
                                 let stream_db = store
                                     .stream_irises_par(Some(min_last_modified_at), parallelism)


### PR DESCRIPTION
**Change**
- Use `SMPC__ENABLE_S3_IMPORTER` to run the s3 importer or not. Set false in prod, true in stage
- Make `min_last_modified_at` optional in store lib function. So that we pass `None` for only-db import  and execute old query w/o import. And pass `Some` for s3 import.