### PR TITLE
bump prod heartbeat timeout and max db size

### DIFF
--- a/deploy/prod/smpcv2-0-prod/values-iris-mpc.yaml
+++ b/deploy/prod/smpcv2-0-prod/values-iris-mpc.yaml
@@ -60,7 +60,7 @@ env:
     value: "2"
 
   - name: SMPC__HEARTBEAT_INITIAL_RETRIES
-    value: "30"
+    value: "65"
 
   - name: SMPC__PATH
     value: "/data/"
@@ -96,7 +96,7 @@ env:
     value: "0"
 
   - name: SMPC__MAX_DB_SIZE
-    value: "10000000"
+    value: "20000000"
 
   - name: SMPC__FAKE_DB_SIZE
     value: "0"

--- a/deploy/prod/smpcv2-1-prod/values-iris-mpc.yaml
+++ b/deploy/prod/smpcv2-1-prod/values-iris-mpc.yaml
@@ -60,7 +60,7 @@ env:
     value: "2"
 
   - name: SMPC__HEARTBEAT_INITIAL_RETRIES
-    value: "30"
+    value: "65"
 
   - name: SMPC__PATH
     value: "/data/"
@@ -96,7 +96,7 @@ env:
     value: "0"
 
   - name: SMPC__MAX_DB_SIZE
-    value: "10000000"
+    value: "20000000"
 
   - name: SMPC__FAKE_DB_SIZE
     value: "0"

--- a/deploy/prod/smpcv2-2-prod/values-iris-mpc.yaml
+++ b/deploy/prod/smpcv2-2-prod/values-iris-mpc.yaml
@@ -60,7 +60,7 @@ env:
     value: "2"
 
   - name: SMPC__HEARTBEAT_INITIAL_RETRIES
-    value: "30"
+    value: "65"
 
   - name: SMPC__PATH
     value: "/data/"
@@ -96,7 +96,7 @@ env:
     value: "0"
 
   - name: SMPC__MAX_DB_SIZE
-    value: "10000000"
+    value: "20000000"
 
   - name: SMPC__FAKE_DB_SIZE
     value: "0"


### PR DESCRIPTION
**Change**
- We recently had an issue where batch processing stalled and we just exited silently.
- This was because we have 2 minutes for `SMPC__PROCESSING_TIMEOUT_SECS` but 1 minute for heartbeat timeout.
- This PR bumps heartbeat timeout to 130 seconds so that we properly capture the batch timeout error
- It also bumps max db size in prod to 20M 