### PR TITLE
fix: avoid incrementing memory size for record overrides from db

### DIFF
--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:v0.12.4"
+image: "ghcr.io/worldcoin/iris-mpc:v0.12.5"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -87,7 +87,7 @@ env:
     value: "800000"
 
   - name: SMPC__MAX_DB_SIZE
-    value: "1100000"
+    value: "1000000"
 
   - name: SMPC__MAX_BATCH_SIZE
     value: "64"

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -87,7 +87,7 @@ env:
     value: "800000"
 
   - name: SMPC__MAX_DB_SIZE
-    value: "1100000"
+    value: "1000000"
 
   - name: SMPC__MAX_BATCH_SIZE
     value: "64"

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -87,7 +87,7 @@ env:
     value: "800000"
 
   - name: SMPC__MAX_DB_SIZE
-    value: "1100000"
+    value: "1000000"
 
   - name: SMPC__MAX_BATCH_SIZE
     value: "64"

--- a/iris-mpc-gpu/src/dot/share_db.rs
+++ b/iris-mpc-gpu/src/dot/share_db.rs
@@ -281,7 +281,7 @@ impl ShareDB {
         n_shards: usize,
         code_length: usize,
     ) {
-        assert!(record.len() == code_length);
+        assert_eq!(record.len(), code_length);
 
         let a0_host = record
             .iter()

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -461,6 +461,9 @@ impl ServerActor {
             self.device_manager.device_count(),
             MASK_CODE_LENGTH,
         );
+    }
+
+    pub fn increment_db_size(&mut self, index: usize) {
         self.current_db_sizes[index % self.device_manager.device_count()] += 1;
     }
 

--- a/iris-mpc/src/bin/server.rs
+++ b/iris-mpc/src/bin/server.rs
@@ -1087,6 +1087,12 @@ async fn server_main(config: Config) -> eyre::Result<()> {
                                 iris.right_code(),
                                 iris.right_mask(),
                             );
+
+                            // if the serial id hasn't been loaded before, count is as unique record
+                            if all_serial_ids.contains(&(iris.index() as i64)) {
+                                actor.increment_db_size(iris.index() - 1);
+                            }
+
                             time_loading_into_memory += now_load_summary.elapsed();
                             now_load_summary = Instant::now();
 


### PR DESCRIPTION
**Change**
- This PR fixes the error we saw earlier where the actor processing got stalled. 
- We basically do not increment the cuda memory shard upon overrides for the same record from db.