### PR TITLE
Handle empty batches in eval_distance

### DIFF
--- a/iris-mpc-cpu/src/hawkers/galois_store.rs
+++ b/iris-mpc-cpu/src/hawkers/galois_store.rs
@@ -250,6 +250,9 @@ impl VectorStore for LocalNetAby3NgStoreProtocol {
         query: &Self::QueryRef,
         vectors: &[Self::VectorRef],
     ) -> Vec<Self::DistanceRef> {
+        if vectors.is_empty() {
+            return vec![];
+        }
         let pairs = vectors
             .iter()
             .map(|vector_id| {

--- a/iris-mpc-cpu/src/hawkers/galois_store.rs
+++ b/iris-mpc-cpu/src/hawkers/galois_store.rs
@@ -200,6 +200,9 @@ impl LocalNetAby3NgStoreProtocol {
         &mut self,
         distances: Vec<Share<u16>>,
     ) -> eyre::Result<Vec<DistanceShare<u32>>> {
+        if distances.is_empty() {
+            return Ok(vec![]);
+        }
         let mut player_session = self.get_owner_session();
         let distances = batch_signed_lift_vec(&mut player_session, distances).await?;
         Ok(distances
@@ -215,6 +218,9 @@ impl LocalNetAby3NgStoreProtocol {
         &mut self,
         pairs: Vec<(GaloisRingSharedIris, GaloisRingSharedIris)>,
     ) -> Vec<Share<u16>> {
+        if pairs.is_empty() {
+            return vec![];
+        }
         let mut player_session = self.get_owner_session();
         let ds_and_ts = galois_ring_pairwise_distance(&mut player_session, &pairs)
             .await


### PR DESCRIPTION
When evaluating distances, we didn't check whether input batches are empty. As a result, parties could participate in dummy communication rounds exchanging empty messages associated with resharing and lifting.

As expected, the performance gain is prominent for tiny database sizes and almost non-existent for large ones.

```bash
gr_ready_made_hnsw/gr-big-hnsw-insertions/1
                        time:   [3.3035 ms 3.3572 ms 3.4230 ms]
                        change: [-29.183% -26.669% -23.296%] (p = 0.00 < 0.05)
gr_ready_made_hnsw/gr-big-hnsw-searches/1
                        time:   [5.2834 ms 5.3542 ms 5.4132 ms]
                        change: [-21.178% -18.720% -16.394%] (p = 0.00 < 0.05)
gr_ready_made_hnsw/gr-big-hnsw-insertions/10
                        time:   [143.18 ms 147.85 ms 154.14 ms]
                        change: [-11.098% -7.8902% -4.2252%] (p = 0.00 < 0.05)
gr_ready_made_hnsw/gr-big-hnsw-searches/10
                        time:   [85.704 ms 87.801 ms 90.830 ms]
                        change: [-20.434% -16.121% -11.309%] (p = 0.00 < 0.05)
gr_ready_made_hnsw/gr-big-hnsw-insertions/100
                        time:   [2.0003 s 2.0485 s 2.0977 s]
                        change: [-7.2597% -4.6239% -1.7906%] (p = 0.01 < 0.05)
gr_ready_made_hnsw/gr-big-hnsw-searches/100
                        time:   [1.2372 s 1.2783 s 1.3223 s]
                        change: [-7.2040% -3.6666% +0.0969%] (p = 0.07 > 0.05)
gr_ready_made_hnsw/gr-big-hnsw-insertions/1000
                        time:   [5.6561 s 5.7666 s 5.8758 s]
                        change: [-4.4093% -2.1166% +0.3032%] (p = 0.12 > 0.05)
gr_ready_made_hnsw/gr-big-hnsw-searches/1000
                        time:   [3.1735 s 3.2459 s 3.3202 s]
                        change: [-7.7168% -4.2638% -1.4155%] (p = 0.02 < 0.05)
gr_ready_made_hnsw/gr-big-hnsw-insertions/10000
                        time:   [10.469 s 10.581 s 10.684 s]
                        change: [-2.1569% -0.5242% +0.9304%] (p = 0.54 > 0.05)
gr_ready_made_hnsw/gr-big-hnsw-searches/10000
                        time:   [5.5848 s 5.7317 s 5.9033 s]
                        change: [-6.5633% -3.5336% +0.4494%] (p = 0.07 > 0.05)
gr_ready_made_hnsw/gr-big-hnsw-insertions/100000
                        time:   [13.020 s 13.314 s 13.611 s]
                        change: [+2.4897% +4.9690% +7.5601%] (p = 0.00 < 0.05)
gr_ready_made_hnsw/gr-big-hnsw-searches/100000
                        time:   [6.8439 s 6.9146 s 6.9843 s]
                        change: [+1.7506% +3.1133% +4.5234%] (p = 0.00 < 0.05)
```