### PR TITLE
Load smaller partitioned chunks from s3 using multiple clients

### DIFF
--- a/.github/workflows/temp-branch-build-and-push.yaml
+++ b/.github/workflows/temp-branch-build-and-push.yaml
@@ -3,7 +3,7 @@ name: Branch - Build and push docker image
 on:
   push:
     branches:
-      - "ertugrul/change-to-binary"
+      - "chore/partition-data"
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2819,6 +2819,7 @@ name = "iris-mpc-store"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "aws-config",
  "aws-sdk-s3",
  "bytemuck",
  "bytes",

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:205925db9adc0cd2a76667bef4abfe3840a2d56c"
+image: "ghcr.io/worldcoin/iris-mpc:4e250f9b023012dff9580d0f5bd5943345d42848"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:v0.12.6"
+image: "ghcr.io/worldcoin/iris-mpc:8129a3b365b888c8e5bee0266e5d0ed70c6ce72d"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:03ae6cd5f71cf443c42f5de83798ce87cf8da5cc"
+image: "ghcr.io/worldcoin/iris-mpc:205925db9adc0cd2a76667bef4abfe3840a2d56c"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:8129a3b365b888c8e5bee0266e5d0ed70c6ce72d"
+image: "ghcr.io/worldcoin/iris-mpc:03ae6cd5f71cf443c42f5de83798ce87cf8da5cc"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -75,7 +75,7 @@ env:
     value: "iris-mpc-db-exporter-store-node-0-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_2k_partitioned"
+    value: "binary_output_1k_partitioned"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
     value: "64"

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -75,7 +75,7 @@ env:
     value: "iris-mpc-db-exporter-store-node-0-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_1k_partitioned"
+    value: "binary_output_100_partitioned"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
     value: "64"

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -30,7 +30,7 @@ env:
     value: "true"
 
   - name: SMPC__DATABASE__LOAD_PARALLELISM
-    value: "8"
+    value: "1"
 
   - name: SMPC__AWS__REGION
     value: "eu-north-1"

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -75,13 +75,16 @@ env:
     value: "iris-mpc-db-exporter-store-node-0-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_2k"
+    value: "binary_output_2k_partitioned"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "8"
+    value: "32"
 
   - name: SMPC__DB_CHUNKS_PARTITION_SIZE
     value: "100000"
+
+  - name: SMPC__LOAD_CHUNKS_S3_CLIENTS
+    value: "8"
 
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -30,7 +30,7 @@ env:
     value: "true"
 
   - name: SMPC__DATABASE__LOAD_PARALLELISM
-    value: "8"
+    value: "1"
 
   - name: SMPC__AWS__REGION
     value: "eu-north-1"
@@ -78,7 +78,7 @@ env:
     value: "binary_output_2k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "16"
+    value: "8"
 
   - name: SMPC__DB_CHUNKS_PARTITION_SIZE
     value: "100000"

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -75,13 +75,13 @@ env:
     value: "iris-mpc-db-exporter-store-node-0-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_250_partitioned"
+    value: "binary_output_200_partitioned_20k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
     value: "64"
 
   - name: SMPC__DB_CHUNKS_PARTITION_SIZE
-    value: "100000"
+    value: "20000"
 
   - name: SMPC__LOAD_CHUNKS_S3_CLIENTS
     value: "8"

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -75,7 +75,7 @@ env:
     value: "iris-mpc-db-exporter-store-node-0-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_100_partitioned"
+    value: "binary_output_200_partitioned"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
     value: "64"

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -78,11 +78,11 @@ env:
     value: "binary_output_2k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "32"
+    value: "64"
 
   - name: SMPC__DB_CHUNKS_PARTITION_SIZE
     value: "100000"
-    
+
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"
 

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -75,13 +75,13 @@ env:
     value: "iris-mpc-db-exporter-store-node-0-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_150_partitioned"
+    value: "binary_output_250_partitioned"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
     value: "64"
 
   - name: SMPC__DB_CHUNKS_PARTITION_SIZE
-    value: "99000"
+    value: "100000"
 
   - name: SMPC__LOAD_CHUNKS_S3_CLIENTS
     value: "8"

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -75,13 +75,13 @@ env:
     value: "iris-mpc-db-exporter-store-node-0-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_200_partitioned"
+    value: "binary_output_150_partitioned"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
     value: "64"
 
   - name: SMPC__DB_CHUNKS_PARTITION_SIZE
-    value: "100000"
+    value: "99000"
 
   - name: SMPC__LOAD_CHUNKS_S3_CLIENTS
     value: "8"

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -80,6 +80,9 @@ env:
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
     value: "32"
 
+  - name: SMPC__DB_CHUNKS_PARTITION_SIZE
+    value: "100000"
+    
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"
 

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -78,7 +78,7 @@ env:
     value: "binary_output_2k_partitioned"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "32"
+    value: "64"
 
   - name: SMPC__DB_CHUNKS_PARTITION_SIZE
     value: "100000"

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -78,7 +78,7 @@ env:
     value: "binary_output_2k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "64"
+    value: "16"
 
   - name: SMPC__DB_CHUNKS_PARTITION_SIZE
     value: "100000"

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -75,13 +75,13 @@ env:
     value: "iris-mpc-db-exporter-store-node-0-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_200_partitioned_20k"
+    value: "binary_output_200_partitioned_50k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
     value: "64"
 
   - name: SMPC__DB_CHUNKS_PARTITION_SIZE
-    value: "20000"
+    value: "50000"
 
   - name: SMPC__LOAD_CHUNKS_S3_CLIENTS
     value: "8"

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -30,7 +30,7 @@ env:
     value: "true"
 
   - name: SMPC__DATABASE__LOAD_PARALLELISM
-    value: "1"
+    value: "8"
 
   - name: SMPC__AWS__REGION
     value: "eu-north-1"
@@ -75,13 +75,13 @@ env:
     value: "iris-mpc-db-exporter-store-node-0-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_200_partitioned_50k"
+    value: "binary_output_200_partitioned"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "128"
+    value: "64"
 
   - name: SMPC__DB_CHUNKS_PARTITION_SIZE
-    value: "50000"
+    value: "100000"
 
   - name: SMPC__LOAD_CHUNKS_S3_CLIENTS
     value: "8"

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -78,7 +78,7 @@ env:
     value: "binary_output_200_partitioned_50k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "64"
+    value: "128"
 
   - name: SMPC__DB_CHUNKS_PARTITION_SIZE
     value: "50000"

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -75,13 +75,13 @@ env:
     value: "iris-mpc-db-exporter-store-node-1-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_150_partitioned"
+    value: "binary_output_250_partitioned"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
     value: "64"
 
   - name: SMPC__DB_CHUNKS_PARTITION_SIZE
-    value: "99000"
+    value: "100000"
 
   - name: SMPC__LOAD_CHUNKS_S3_CLIENTS
     value: "8"

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -30,7 +30,7 @@ env:
     value: "true"
 
   - name: SMPC__DATABASE__LOAD_PARALLELISM
-    value: "1"
+    value: "8"
 
   - name: SMPC__AWS__REGION
     value: "eu-north-1"
@@ -75,13 +75,13 @@ env:
     value: "iris-mpc-db-exporter-store-node-1-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_200_partitioned_50k"
+    value: "binary_output_200_partitioned"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "128"
+    value: "64"
 
   - name: SMPC__DB_CHUNKS_PARTITION_SIZE
-    value: "50000"
+    value: "100000"
 
   - name: SMPC__LOAD_CHUNKS_S3_CLIENTS
     value: "8"

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -30,7 +30,7 @@ env:
     value: "true"
 
   - name: SMPC__DATABASE__LOAD_PARALLELISM
-    value: "8"
+    value: "1"
 
   - name: SMPC__AWS__REGION
     value: "eu-north-1"

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -30,7 +30,7 @@ env:
     value: "true"
 
   - name: SMPC__DATABASE__LOAD_PARALLELISM
-    value: "8"
+    value: "1"
 
   - name: SMPC__AWS__REGION
     value: "eu-north-1"
@@ -78,7 +78,7 @@ env:
     value: "binary_output_2k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "16"
+    value: "8"
 
   - name: SMPC__DB_CHUNKS_PARTITION_SIZE
     value: "100000"

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -75,13 +75,13 @@ env:
     value: "iris-mpc-db-exporter-store-node-1-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_200_partitioned"
+    value: "binary_output_150_partitioned"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
     value: "64"
 
   - name: SMPC__DB_CHUNKS_PARTITION_SIZE
-    value: "100000"
+    value: "99000"
 
   - name: SMPC__LOAD_CHUNKS_S3_CLIENTS
     value: "8"

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -75,13 +75,13 @@ env:
     value: "iris-mpc-db-exporter-store-node-1-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_250_partitioned"
+    value: "binary_output_200_partitioned_20k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
     value: "64"
 
   - name: SMPC__DB_CHUNKS_PARTITION_SIZE
-    value: "100000"
+    value: "20000"
 
   - name: SMPC__LOAD_CHUNKS_S3_CLIENTS
     value: "8"

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -75,7 +75,7 @@ env:
     value: "iris-mpc-db-exporter-store-node-1-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_1k_partitioned"
+    value: "binary_output_100_partitioned"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
     value: "64"

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -78,11 +78,11 @@ env:
     value: "binary_output_2k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "32"
+    value: "64"
 
   - name: SMPC__DB_CHUNKS_PARTITION_SIZE
     value: "100000"
-    
+
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"
 

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -75,13 +75,13 @@ env:
     value: "iris-mpc-db-exporter-store-node-1-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_200_partitioned_20k"
+    value: "binary_output_200_partitioned_50k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
     value: "64"
 
   - name: SMPC__DB_CHUNKS_PARTITION_SIZE
-    value: "20000"
+    value: "50000"
 
   - name: SMPC__LOAD_CHUNKS_S3_CLIENTS
     value: "8"

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -75,7 +75,7 @@ env:
     value: "iris-mpc-db-exporter-store-node-1-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_100_partitioned"
+    value: "binary_output_200_partitioned"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
     value: "64"

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -75,13 +75,16 @@ env:
     value: "iris-mpc-db-exporter-store-node-1-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_2k"
+    value: "binary_output_2k_partitioned"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "8"
+    value: "32"
 
   - name: SMPC__DB_CHUNKS_PARTITION_SIZE
     value: "100000"
+
+  - name: SMPC__LOAD_CHUNKS_S3_CLIENTS
+    value: "8"
 
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -80,6 +80,9 @@ env:
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
     value: "32"
 
+  - name: SMPC__DB_CHUNKS_PARTITION_SIZE
+    value: "100000"
+    
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"
 

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -78,7 +78,7 @@ env:
     value: "binary_output_2k_partitioned"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "32"
+    value: "64"
 
   - name: SMPC__DB_CHUNKS_PARTITION_SIZE
     value: "100000"

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -78,7 +78,7 @@ env:
     value: "binary_output_2k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "64"
+    value: "16"
 
   - name: SMPC__DB_CHUNKS_PARTITION_SIZE
     value: "100000"

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -78,7 +78,7 @@ env:
     value: "binary_output_200_partitioned_50k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "64"
+    value: "128"
 
   - name: SMPC__DB_CHUNKS_PARTITION_SIZE
     value: "50000"

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -75,7 +75,7 @@ env:
     value: "iris-mpc-db-exporter-store-node-1-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_2k_partitioned"
+    value: "binary_output_1k_partitioned"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
     value: "64"

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -75,7 +75,7 @@ env:
     value: "iris-mpc-db-exporter-store-node-2-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_2k_partitioned"
+    value: "binary_output_1k_partitioned"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
     value: "64"

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -30,7 +30,7 @@ env:
     value: "true"
 
   - name: SMPC__DATABASE__LOAD_PARALLELISM
-    value: "1"
+    value: "8"
 
   - name: SMPC__AWS__REGION
     value: "eu-north-1"
@@ -75,13 +75,13 @@ env:
     value: "iris-mpc-db-exporter-store-node-2-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_200_partitioned_50k"
+    value: "binary_output_200_partitioned"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "128"
+    value: "64"
 
   - name: SMPC__DB_CHUNKS_PARTITION_SIZE
-    value: "50000"
+    value: "100000"
 
   - name: SMPC__LOAD_CHUNKS_S3_CLIENTS
     value: "8"

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -30,7 +30,7 @@ env:
     value: "true"
 
   - name: SMPC__DATABASE__LOAD_PARALLELISM
-    value: "8"
+    value: "1"
 
   - name: SMPC__AWS__REGION
     value: "eu-north-1"

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -75,13 +75,13 @@ env:
     value: "iris-mpc-db-exporter-store-node-2-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_150_partitioned"
+    value: "binary_output_250_partitioned"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
     value: "64"
 
   - name: SMPC__DB_CHUNKS_PARTITION_SIZE
-    value: "99000"
+    value: "100000"
 
   - name: SMPC__LOAD_CHUNKS_S3_CLIENTS
     value: "8"

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -30,7 +30,7 @@ env:
     value: "true"
 
   - name: SMPC__DATABASE__LOAD_PARALLELISM
-    value: "8"
+    value: "1"
 
   - name: SMPC__AWS__REGION
     value: "eu-north-1"
@@ -78,7 +78,7 @@ env:
     value: "binary_output_2k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "16"
+    value: "8"
 
   - name: SMPC__DB_CHUNKS_PARTITION_SIZE
     value: "100000"

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -75,13 +75,13 @@ env:
     value: "iris-mpc-db-exporter-store-node-2-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_200_partitioned_20k"
+    value: "binary_output_200_partitioned_50k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
     value: "64"
 
   - name: SMPC__DB_CHUNKS_PARTITION_SIZE
-    value: "20000"
+    value: "50000"
 
   - name: SMPC__LOAD_CHUNKS_S3_CLIENTS
     value: "8"

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -75,7 +75,7 @@ env:
     value: "iris-mpc-db-exporter-store-node-2-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_1k_partitioned"
+    value: "binary_output_100_partitioned"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
     value: "64"

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -75,7 +75,7 @@ env:
     value: "iris-mpc-db-exporter-store-node-2-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_100_partitioned"
+    value: "binary_output_200_partitioned"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
     value: "64"

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -78,11 +78,11 @@ env:
     value: "binary_output_2k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "32"
+    value: "64"
 
   - name: SMPC__DB_CHUNKS_PARTITION_SIZE
     value: "100000"
-    
+
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"
 

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -75,13 +75,13 @@ env:
     value: "iris-mpc-db-exporter-store-node-2-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_250_partitioned"
+    value: "binary_output_200_partitioned_20k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
     value: "64"
 
   - name: SMPC__DB_CHUNKS_PARTITION_SIZE
-    value: "100000"
+    value: "20000"
 
   - name: SMPC__LOAD_CHUNKS_S3_CLIENTS
     value: "8"

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -75,13 +75,16 @@ env:
     value: "iris-mpc-db-exporter-store-node-2-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_2k"
+    value: "binary_output_2k_partitioned"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "8"
+    value: "32"
 
   - name: SMPC__DB_CHUNKS_PARTITION_SIZE
     value: "100000"
+
+  - name: SMPC__LOAD_CHUNKS_S3_CLIENTS
+    value: "8"
 
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -80,6 +80,9 @@ env:
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
     value: "32"
 
+  - name: SMPC__DB_CHUNKS_PARTITION_SIZE
+    value: "100000"
+    
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"
 

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -78,7 +78,7 @@ env:
     value: "binary_output_2k_partitioned"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "32"
+    value: "64"
 
   - name: SMPC__DB_CHUNKS_PARTITION_SIZE
     value: "100000"

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -78,7 +78,7 @@ env:
     value: "binary_output_2k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "64"
+    value: "16"
 
   - name: SMPC__DB_CHUNKS_PARTITION_SIZE
     value: "100000"

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -75,13 +75,13 @@ env:
     value: "iris-mpc-db-exporter-store-node-2-stage-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_200_partitioned"
+    value: "binary_output_150_partitioned"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
     value: "64"
 
   - name: SMPC__DB_CHUNKS_PARTITION_SIZE
-    value: "100000"
+    value: "99000"
 
   - name: SMPC__LOAD_CHUNKS_S3_CLIENTS
     value: "8"

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -78,7 +78,7 @@ env:
     value: "binary_output_200_partitioned_50k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "64"
+    value: "128"
 
   - name: SMPC__DB_CHUNKS_PARTITION_SIZE
     value: "50000"

--- a/iris-mpc-common/src/config/mod.rs
+++ b/iris-mpc-common/src/config/mod.rs
@@ -100,6 +100,9 @@ pub struct Config {
     #[serde(default)]
     pub db_chunks_partition_size: i64,
 
+    #[serde(default = "default_load_chunks_s3_clients")]
+    pub load_chunks_s3_clients: usize,
+
     /// Defines the safety overlap to load the DB records >last_modified_at in
     /// seconds This is to ensure we don't miss any records that were
     /// updated during the DB export to S3
@@ -140,6 +143,10 @@ fn default_shares_bucket_name() -> String {
 
 fn default_db_load_safety_overlap_seconds() -> i64 {
     60
+}
+
+fn default_load_chunks_s3_clients() -> usize {
+    1
 }
 
 impl Config {

--- a/iris-mpc-common/src/config/mod.rs
+++ b/iris-mpc-common/src/config/mod.rs
@@ -97,6 +97,9 @@ pub struct Config {
     #[serde(default = "default_load_chunks_parallelism")]
     pub load_chunks_parallelism: usize,
 
+    #[serde(default)]
+    pub db_chunks_partition_size: i64,
+
     /// Defines the safety overlap to load the DB records >last_modified_at in
     /// seconds This is to ensure we don't miss any records that were
     /// updated during the DB export to S3

--- a/iris-mpc-store/Cargo.toml
+++ b/iris-mpc-store/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+aws-config.workspace = true
 aws-sdk-s3.workspace = true
 bytes.workspace = true
 async-trait.workspace = true

--- a/iris-mpc-store/src/s3_importer.rs
+++ b/iris-mpc-store/src/s3_importer.rs
@@ -319,8 +319,9 @@ mod tests {
         for i in 0..n_chunks {
             let start_serial_id = i * MOCK_CHUNK_SIZE + 1;
             let end_serial_id = min((i + 1) * MOCK_CHUNK_SIZE, MOCK_ENTRIES);
+            let partition_id = i / (MOCK_PARTITION_SIZE / MOCK_CHUNK_SIZE as i64) as usize;
             store.add_test_data(
-                &format!("out/{start_serial_id}.bin"),
+                &format!("out/{partition_id}/{start_serial_id}.bin"),
                 (start_serial_id..=end_serial_id).map(dummy_entry).collect(),
             );
         }

--- a/iris-mpc-store/src/s3_importer.rs
+++ b/iris-mpc-store/src/s3_importer.rs
@@ -4,8 +4,12 @@ use aws_sdk_s3::{config::Region, Client as S3Client};
 use bytes::Bytes;
 use futures::{stream, Stream, StreamExt};
 use iris_mpc_common::{IRIS_CODE_LENGTH, MASK_CODE_LENGTH};
-use std::{cmp::min, mem, pin::Pin, time::Instant};
-use std::cmp::max;
+use std::{
+    cmp::{max, min},
+    mem,
+    pin::Pin,
+    time::Instant,
+};
 use tokio::task;
 
 const SINGLE_ELEMENT_SIZE: usize = IRIS_CODE_LENGTH * mem::size_of::<u16>() * 2

--- a/iris-mpc/src/bin/server.rs
+++ b/iris-mpc/src/bin/server.rs
@@ -1003,6 +1003,8 @@ async fn server_main(config: Config) -> eyre::Result<()> {
                                     last_snapshot_details.timestamp,
                                     min_last_modified_at
                                 );
+
+                                tracing::info!("Initiating s3 streams.");
                                 let stream_s3 = fetch_and_parse_chunks(
                                     &s3_store,
                                     load_chunks_parallelism,
@@ -1013,12 +1015,15 @@ async fn server_main(config: Config) -> eyre::Result<()> {
                                 .await
                                 .map(|result| result.map(IrisSource::S3))
                                 .boxed();
+                                tracing::info!("Initiated s3 streams.");
 
+                                tracing::info!("Initiating db streams.");
                                 let stream_db = store
                                     .stream_irises_par(Some(min_last_modified_at), parallelism)
                                     .await
                                     .map(|result| result.map(IrisSource::DB))
                                     .boxed();
+                                tracing::info!("Initiated db streams.");
 
                                 select_all(vec![stream_s3, stream_db])
                             }

--- a/iris-mpc/src/bin/server.rs
+++ b/iris-mpc/src/bin/server.rs
@@ -1004,7 +1004,6 @@ async fn server_main(config: Config) -> eyre::Result<()> {
                                     min_last_modified_at
                                 );
 
-                                tracing::info!("Initiating s3 streams.");
                                 let stream_s3 = fetch_and_parse_chunks(
                                     &s3_store,
                                     load_chunks_parallelism,
@@ -1015,15 +1014,12 @@ async fn server_main(config: Config) -> eyre::Result<()> {
                                 .await
                                 .map(|result| result.map(IrisSource::S3))
                                 .boxed();
-                                tracing::info!("Initiated s3 streams.");
 
-                                tracing::info!("Initiating db streams.");
                                 let stream_db = store
                                     .stream_irises_par(Some(min_last_modified_at), parallelism)
                                     .await
                                     .map(|result| result.map(IrisSource::DB))
                                     .boxed();
-                                tracing::info!("Initiated db streams.");
 
                                 select_all(vec![stream_s3, stream_db])
                             }

--- a/iris-mpc/src/bin/server.rs
+++ b/iris-mpc/src/bin/server.rs
@@ -906,6 +906,7 @@ async fn server_main(config: Config) -> eyre::Result<()> {
     let load_chunks_parallelism = config.load_chunks_parallelism;
     let db_chunks_bucket_name = config.db_chunks_bucket_name.clone();
     let db_chunks_folder_name = config.db_chunks_folder_name.clone();
+    let db_chunks_partition_size = config.db_chunks_partition_size;
 
     let (tx, rx) = oneshot::channel();
     background_tasks.spawn_blocking(move || {
@@ -1007,6 +1008,7 @@ async fn server_main(config: Config) -> eyre::Result<()> {
                                     load_chunks_parallelism,
                                     db_chunks_folder_name,
                                     last_snapshot_details,
+                                    db_chunks_partition_size,
                                 )
                                 .await
                                 .map(|result| result.map(IrisSource::S3))


### PR DESCRIPTION
**Change**
- This PR improves the loading time by 35%
- It partitions the data in s3 into prefixes - to utilize [this](https://docs.aws.amazon.com/AmazonS3/latest/userguide/optimizing-performance.html)
- It brings ability to specify the number of s3 clients and lets each partition use a separate s3 client
- It uses smaller chunks 2000 => 200 items in a chunk