### PR TITLE
revert load time tests in prod

### DIFF
--- a/deploy/prod/common-values-iris-mpc.yaml
+++ b/deploy/prod/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:4e250f9b023012dff9580d0f5bd5943345d42848"
+image: "ghcr.io/worldcoin/iris-mpc:v0.12.6"
 
 environment: prod
 replicaCount: 1

--- a/deploy/prod/smpcv2-0-prod/values-iris-mpc.yaml
+++ b/deploy/prod/smpcv2-0-prod/values-iris-mpc.yaml
@@ -84,17 +84,11 @@ env:
     value: "iris-mpc-db-exporter-store-node-0-prod-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_200_partitioned"
+    value: "binary_output_2k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "192"
+    value: "32"
 
-  - name: SMPC__DB_CHUNKS_PARTITION_SIZE
-    value: "1000000"
-
-  - name: SMPC__LOAD_CHUNKS_S3_CLIENTS
-    value: "8"
-    
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"
 

--- a/deploy/prod/smpcv2-1-prod/values-iris-mpc.yaml
+++ b/deploy/prod/smpcv2-1-prod/values-iris-mpc.yaml
@@ -84,16 +84,10 @@ env:
     value: "iris-mpc-db-exporter-store-node-1-prod-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_200_partitioned"
+    value: "binary_output_2k"
 
-  - name: SMPC__DB_CHUNKS_PARTITION_SIZE
-    value: "1000000"
-
-  - name: SMPC__LOAD_CHUNKS_S3_CLIENTS
-    value: "8"
-    
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "192"
+    value: "32"
 
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"

--- a/deploy/prod/smpcv2-2-prod/values-iris-mpc.yaml
+++ b/deploy/prod/smpcv2-2-prod/values-iris-mpc.yaml
@@ -84,16 +84,10 @@ env:
     value: "iris-mpc-db-exporter-store-node-2-prod-eu-north-1"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "binary_output_200_partitioned"
-
-  - name: SMPC__DB_CHUNKS_PARTITION_SIZE
-    value: "1000000"
-
-  - name: SMPC__LOAD_CHUNKS_S3_CLIENTS
-    value: "8"
+    value: "binary_output_2k"
     
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "192"
+    value: "32"
 
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"


### PR DESCRIPTION
**Change**
- Finished load performance tests in prod, reverting back to its original now while only keeping aurora db load parallelism the same (it was 80, now 4). The reason is we load a very small amount of data from aurora