### PR TITLE
64 s3 load parallelism + 8 aurora load parallelism in prod

### DIFF
--- a/deploy/prod/smpcv2-0-prod/values-iris-mpc.yaml
+++ b/deploy/prod/smpcv2-0-prod/values-iris-mpc.yaml
@@ -36,7 +36,7 @@ env:
     value: "true"
 
   - name: SMPC__DATABASE__LOAD_PARALLELISM
-    value: "80"
+    value: "8"
 
   - name: SMPC__AWS__REGION
     value: "eu-north-1"
@@ -86,8 +86,8 @@ env:
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
     value: "binary_output_16k"
 
-  - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "128"
+  - name: SMPC__DATABASE__LOAD_PARALLELISM
+    value: "64"
 
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"

--- a/deploy/prod/smpcv2-1-prod/values-iris-mpc.yaml
+++ b/deploy/prod/smpcv2-1-prod/values-iris-mpc.yaml
@@ -36,7 +36,7 @@ env:
     value: "true"
 
   - name: SMPC__DATABASE__LOAD_PARALLELISM
-    value: "80"
+    value: "8"
 
   - name: SMPC__AWS__REGION
     value: "eu-north-1"
@@ -86,8 +86,8 @@ env:
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
     value: "binary_output_16k"
 
-  - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "128"
+  - name: SMPC__DATABASE__LOAD_PARALLELISM
+    value: "64"
 
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"

--- a/deploy/prod/smpcv2-2-prod/values-iris-mpc.yaml
+++ b/deploy/prod/smpcv2-2-prod/values-iris-mpc.yaml
@@ -36,7 +36,7 @@ env:
     value: "true"
 
   - name: SMPC__DATABASE__LOAD_PARALLELISM
-    value: "80"
+    value: "8"
 
   - name: SMPC__AWS__REGION
     value: "eu-north-1"
@@ -86,8 +86,8 @@ env:
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
     value: "binary_output_16k"
 
-  - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "128"
+  - name: SMPC__DATABASE__LOAD_PARALLELISM
+    value: "64"
 
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"


### PR DESCRIPTION
**Change**
- We have the best performance with 64 s3 load parallelism in prod. Let's stick to it.
- Also, let's reduce the Aurora load parallelism as we fetch very few items from it