### PR TITLE
first alloc, then register

### DIFF
--- a/.github/workflows/temp-branch-build-and-push.yaml
+++ b/.github/workflows/temp-branch-build-and-push.yaml
@@ -3,7 +3,7 @@ name: Branch - Build and push docker image
 on:
   push:
     branches:
-      - "ps/feat/load-in-ranges"
+      - "ps/host-mem-alloc"
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2785,6 +2785,7 @@ dependencies = [
  "hex",
  "iris-mpc-common",
  "itertools 0.13.0",
+ "memmap2",
  "metrics 0.22.3",
  "metrics-exporter-statsd 0.7.0",
  "ndarray",
@@ -3141,6 +3142,15 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "memmap2"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ hawk-pack = { git = "https://github.com/Inversed-Tech/hawk-pack.git", rev = "ba9
 hex = "0.4.3"
 itertools = "0.13"
 num-traits = "0.2"
+memmap2 = "0.9.5"
 serde = { version = "1.0", features = ["derive"] }
 serde-big-array = "0.5.1"
 serde_json = "1"

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:v0.13.5"
+image: "ghcr.io/worldcoin/iris-mpc:6b358589c25ef528f58ba02980103670b037a614"
 
 environment: stage
 replicaCount: 1

--- a/iris-mpc-gpu/Cargo.toml
+++ b/iris-mpc-gpu/Cargo.toml
@@ -31,6 +31,7 @@ iris-mpc-common = { path = "../iris-mpc-common" }
 base64 = "0.22.1"
 metrics = "0.22.1"
 metrics-exporter-statsd = "0.7"
+memmap2.workspace = true
 
 [dev-dependencies]
 criterion = "0.5"

--- a/iris-mpc-gpu/src/dot/share_db.rs
+++ b/iris-mpc-gpu/src/dot/share_db.rs
@@ -888,7 +888,7 @@ mod tests {
             .unwrap();
         let query_sums = engine.query_sums(&preprocessed_query, &streams, &blass);
         let mut db_slices = engine.alloc_db(DB_SIZE);
-        engine.register_db_slices(&db_slices);
+        engine.register_host_memory(&db_slices);
         let db_sizes = engine.load_full_db(&mut db_slices, &db);
 
         engine.dot(
@@ -990,7 +990,7 @@ mod tests {
                 .unwrap();
             let query_sums = engine.query_sums(&preprocessed_query, &streams, &blass);
             let mut db_slices = engine.alloc_db(DB_SIZE);
-            engine.register_db_slices(&db_slices);
+            engine.register_host_memory(&db_slices);
             let db_sizes = engine.load_full_db(&mut db_slices, &codes_db);
 
             engine.dot(
@@ -1124,8 +1124,8 @@ mod tests {
             let db_sizes = codes_engine.load_full_db(&mut code_db_slices, &codes_db);
             let mut mask_db_slices = masks_engine.alloc_db(DB_SIZE);
             let mask_db_sizes = masks_engine.load_full_db(&mut mask_db_slices, &masks_db);
-            codes_engine.register_db_slices(&code_db_slices);
-            masks_engine.register_db_slices(&mask_db_slices);
+            codes_engine.register_host_memory(&code_db_slices);
+            masks_engine.register_host_memory(&mask_db_slices);
 
             assert_eq!(db_sizes, mask_db_sizes);
 

--- a/iris-mpc-gpu/src/dot/share_db.rs
+++ b/iris-mpc-gpu/src/dot/share_db.rs
@@ -888,6 +888,7 @@ mod tests {
             .unwrap();
         let query_sums = engine.query_sums(&preprocessed_query, &streams, &blass);
         let mut db_slices = engine.alloc_db(DB_SIZE);
+        engine.register_db_slices(&db_slices);
         let db_sizes = engine.load_full_db(&mut db_slices, &db);
 
         engine.dot(
@@ -989,6 +990,7 @@ mod tests {
                 .unwrap();
             let query_sums = engine.query_sums(&preprocessed_query, &streams, &blass);
             let mut db_slices = engine.alloc_db(DB_SIZE);
+            engine.register_db_slices(&db_slices);
             let db_sizes = engine.load_full_db(&mut db_slices, &codes_db);
 
             engine.dot(
@@ -1122,6 +1124,8 @@ mod tests {
             let db_sizes = codes_engine.load_full_db(&mut code_db_slices, &codes_db);
             let mut mask_db_slices = masks_engine.alloc_db(DB_SIZE);
             let mask_db_sizes = masks_engine.load_full_db(&mut mask_db_slices, &masks_db);
+            codes_engine.register_db_slices(&code_db_slices);
+            masks_engine.register_db_slices(&mask_db_slices);
 
             assert_eq!(db_sizes, mask_db_sizes);
 

--- a/iris-mpc-gpu/src/dot/share_db.rs
+++ b/iris-mpc-gpu/src/dot/share_db.rs
@@ -888,7 +888,7 @@ mod tests {
             .unwrap();
         let query_sums = engine.query_sums(&preprocessed_query, &streams, &blass);
         let mut db_slices = engine.alloc_db(DB_SIZE);
-        engine.register_host_memory(&db_slices);
+        engine.register_host_memory(&db_slices, DB_SIZE);
         let db_sizes = engine.load_full_db(&mut db_slices, &db);
 
         engine.dot(
@@ -990,7 +990,7 @@ mod tests {
                 .unwrap();
             let query_sums = engine.query_sums(&preprocessed_query, &streams, &blass);
             let mut db_slices = engine.alloc_db(DB_SIZE);
-            engine.register_host_memory(&db_slices);
+            engine.register_host_memory(&db_slices, DB_SIZE);
             let db_sizes = engine.load_full_db(&mut db_slices, &codes_db);
 
             engine.dot(
@@ -1124,8 +1124,8 @@ mod tests {
             let db_sizes = codes_engine.load_full_db(&mut code_db_slices, &codes_db);
             let mut mask_db_slices = masks_engine.alloc_db(DB_SIZE);
             let mask_db_sizes = masks_engine.load_full_db(&mut mask_db_slices, &masks_db);
-            codes_engine.register_host_memory(&code_db_slices);
-            masks_engine.register_host_memory(&mask_db_slices);
+            codes_engine.register_host_memory(&code_db_slices, DB_SIZE);
+            masks_engine.register_host_memory(&mask_db_slices, DB_SIZE);
 
             assert_eq!(db_sizes, mask_db_sizes);
 

--- a/iris-mpc-gpu/src/dot/share_db.rs
+++ b/iris-mpc-gpu/src/dot/share_db.rs
@@ -21,7 +21,7 @@ use cudarc::{
     },
     driver::{
         result::{self, malloc_async},
-        sys::CUdeviceptr,
+        sys::{CUdeviceptr, CU_MEMHOSTALLOC_PORTABLE},
         CudaFunction, CudaSlice, CudaStream, CudaView, DevicePtr, DeviceSlice, LaunchAsync,
     },
     nccl,
@@ -279,7 +279,13 @@ impl ShareDB {
                 let _ = cudarc::driver::sys::lib().cuMemHostRegister_v2(
                     db.code_gr.limb_0[device_index] as *mut _,
                     max_size * self.code_length,
-                    0,
+                    CU_MEMHOSTALLOC_PORTABLE,
+                );
+
+                let _ = cudarc::driver::sys::lib().cuMemHostRegister_v2(
+                    db.code_gr.limb_1[device_index] as *mut _,
+                    max_size * self.code_length,
+                    CU_MEMHOSTALLOC_PORTABLE,
                 );
             }
         }

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -486,6 +486,17 @@ impl ServerActor {
             .preprocess_db(&mut self.right_mask_db_slices, &self.current_db_sizes);
     }
 
+    pub fn register_host_memory(&self) {
+        self.codes_engine
+            .register_host_memory(&self.left_code_db_slices, self.max_db_size);
+        self.masks_engine
+            .register_host_memory(&self.left_mask_db_slices, self.max_db_size);
+        self.codes_engine
+            .register_host_memory(&self.right_code_db_slices, self.max_db_size);
+        self.masks_engine
+            .register_host_memory(&self.right_mask_db_slices, self.max_db_size);
+    }
+
     fn process_batch_query(
         &mut self,
         batch: BatchQuery,

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -238,10 +238,14 @@ impl ServerActor {
             comms.clone(),
         );
 
+        let now = Instant::now();
+
         let left_code_db_slices = codes_engine.alloc_db(max_db_size);
         let left_mask_db_slices = masks_engine.alloc_db(max_db_size);
         let right_code_db_slices = codes_engine.alloc_db(max_db_size);
         let right_mask_db_slices = masks_engine.alloc_db(max_db_size);
+
+        tracing::info!("Allocated db in {:?}", now.elapsed());
 
         // Engines for inflight queries
         let batch_codes_engine = ShareDB::init(

--- a/iris-mpc-gpu/tests/e2e.rs
+++ b/iris-mpc-gpu/tests/e2e.rs
@@ -132,6 +132,7 @@ mod e2e_test {
             ) {
                 Ok((mut actor, handle)) => {
                     actor.load_full_db(&(&db0.0, &db0.1), &(&db0.0, &db0.1), DB_SIZE);
+                    actor.register_host_memory();
                     tx0.send(Ok(handle)).unwrap();
                     actor
                 }
@@ -159,6 +160,7 @@ mod e2e_test {
             ) {
                 Ok((mut actor, handle)) => {
                     actor.load_full_db(&(&db1.0, &db1.1), &(&db1.0, &db1.1), DB_SIZE);
+                    actor.register_host_memory();
                     tx1.send(Ok(handle)).unwrap();
                     actor
                 }
@@ -186,6 +188,7 @@ mod e2e_test {
             ) {
                 Ok((mut actor, handle)) => {
                     actor.load_full_db(&(&db2.0, &db2.1), &(&db2.0, &db2.1), DB_SIZE);
+                    actor.register_host_memory();
                     tx2.send(Ok(handle)).unwrap();
                     actor
                 }

--- a/iris-mpc/src/bin/server.rs
+++ b/iris-mpc/src/bin/server.rs
@@ -1132,6 +1132,9 @@ async fn server_main(config: Config) -> eyre::Result<()> {
                         tracing::info!("Preprocessing db");
                         actor.preprocess_db();
 
+                        tracing::info!("Page-lock host memory");
+                        actor.register_host_memory();
+
                         tracing::info!(
                             "Loaded {} records from db into memory [DB sizes: {:?}]",
                             record_counter,


### PR DESCRIPTION
Previously we allocated all memory for the db with `cuMemAllocHost_v2`, which [allocates and page-locks the memory](https://surban.github.io/managedCuda/api/ManagedCuda.DriverAPINativeMethods.MemoryManagement.html#ManagedCuda_DriverAPINativeMethods_MemoryManagement_cuMemAllocHost_v2_System_IntPtr__ManagedCuda_BasicTypes_SizeT_). This causes the program to block for quite some time. This PR tries to instead allocate the memory by the OS, fill it while loading, and only then hand it over to CUDA to page-lock it.