### PR TITLE
reuse events

### DIFF
--- a/.github/workflows/temp-branch-build-and-push.yaml
+++ b/.github/workflows/temp-branch-build-and-push.yaml
@@ -3,7 +3,7 @@ name: Branch - Build and push docker image
 on:
   push:
     branches:
-      - "ps/host-mem-alloc"
+      - "ps/reuse-events"
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:4f8b1c6901378d829923a8d1a84f0be64f9e6fc4"
+image: "ghcr.io/worldcoin/iris-mpc:v0.13.6"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:6b358589c25ef528f58ba02980103670b037a614"
+image: "ghcr.io/worldcoin/iris-mpc:4f8b1c6901378d829923a8d1a84f0be64f9e6fc4"
 
 environment: stage
 replicaCount: 1

--- a/iris-mpc-gpu/src/helpers/device_manager.rs
+++ b/iris-mpc-gpu/src/helpers/device_manager.rs
@@ -103,8 +103,9 @@ impl DeviceManager {
     }
 
     pub fn destroy_events(&self, events: Vec<CUevent>) {
-        for event in events {
-            unsafe { event::destroy(event).unwrap() };
+        for (device_idx, event) in events.iter().enumerate() {
+            self.device(device_idx).bind_to_thread().unwrap();
+            unsafe { event::destroy(*event).unwrap() };
         }
     }
 

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -1361,18 +1361,18 @@ impl ServerActor {
         tracing::info!(party_id = self.party_id, "db search finished");
 
         // Destroy all events
-        for events in [
-            current_dot_events,
-            next_dot_events,
-            current_exchange_events,
-            next_exchange_events,
-            current_phase2_events,
-            next_phase2_events,
-        ] {
-            for event in events {
-                self.device_manager.destroy_events(event);
-            }
-        }
+        // for events in [
+        //     current_dot_events,
+        //     next_dot_events,
+        //     current_exchange_events,
+        //     next_exchange_events,
+        //     current_phase2_events,
+        //     next_phase2_events,
+        // ] {
+        //     for event in events {
+        //         self.device_manager.destroy_events(event);
+        //     }
+        // }
 
         // Reset the results buffers for reuse
         for dst in &[&self.results, &self.batch_results, &self.final_results] {


### PR DESCRIPTION
Instead of creating events for each chunk, we can just reuse them and use them for the whole db. This is supposed to also fix the mem leak that causes the service to crash on creating a new event after running for a long while.