### PR TITLE
Refactor SMPC protocol implementation

### DIFF
--- a/iris-mpc-cpu/benches/hnsw.rs
+++ b/iris-mpc-cpu/benches/hnsw.rs
@@ -5,7 +5,7 @@ use iris_mpc_common::iris_db::{db::IrisDB, iris::IrisCode};
 use iris_mpc_cpu::{
     database_generators::{create_random_sharing, generate_galois_iris_shares},
     execution::local::LocalRuntime,
-    hawkers::{galois_store::LocalNetAby3NgStoreProtocol, plaintext_store::PlaintextStore},
+    hawkers::{galois_store::Aby3Runner, plaintext_store::PlaintextStore},
     protocol::ops::{
         batch_signed_lift_vec, cross_compare, galois_ring_pairwise_distance, galois_ring_to_rep3,
     },
@@ -178,7 +178,7 @@ fn bench_gr_ready_made_hnsw(c: &mut Criterion) {
 
         let secret_searcher = rt.block_on(async move {
             let mut rng = AesRng::seed_from_u64(0_u64);
-            LocalNetAby3NgStoreProtocol::lazy_setup_from_files_with_grpc(
+            Aby3Runner::lazy_setup_from_files_with_grpc(
                 "./data/store.ndjson",
                 &format!("./data/graph_{}.dat", database_size),
                 &mut rng,

--- a/iris-mpc-cpu/benches/hnsw.rs
+++ b/iris-mpc-cpu/benches/hnsw.rs
@@ -5,7 +5,7 @@ use iris_mpc_common::iris_db::{db::IrisDB, iris::IrisCode};
 use iris_mpc_cpu::{
     database_generators::{create_random_sharing, generate_galois_iris_shares},
     execution::local::LocalRuntime,
-    hawkers::{galois_store::Aby3Runner, plaintext_store::PlaintextStore},
+    hawkers::{aby3_store::Aby3Store, plaintext_store::PlaintextStore},
     protocol::ops::{
         batch_signed_lift_vec, cross_compare, galois_ring_pairwise_distance, galois_ring_to_rep3,
     },
@@ -75,7 +75,7 @@ fn bench_hnsw_primitives(c: &mut Criterion) {
             let runtime = LocalRuntime::mock_setup_with_grpc().await.unwrap();
 
             let mut jobs = JoinSet::new();
-            for (index, player) in runtime.identities.iter().enumerate() {
+            for (index, player) in runtime.get_identities().iter().enumerate() {
                 let d1i = d1[index].clone();
                 let d2i = d2[index].clone();
                 let t1i = t1[index].clone();
@@ -123,7 +123,7 @@ fn bench_gr_primitives(c: &mut Criterion) {
             let y2 = generate_galois_iris_shares(&mut rng, iris_db[3].clone());
 
             let mut jobs = JoinSet::new();
-            for (index, player) in runtime.identities.iter().enumerate() {
+            for (index, player) in runtime.get_identities().iter().enumerate() {
                 let x1 = x1[index].clone();
                 let mut y1 = y1[index].clone();
 
@@ -178,7 +178,7 @@ fn bench_gr_ready_made_hnsw(c: &mut Criterion) {
 
         let secret_searcher = rt.block_on(async move {
             let mut rng = AesRng::seed_from_u64(0_u64);
-            Aby3Runner::lazy_setup_from_files_with_grpc(
+            Aby3Store::lazy_setup_from_files_with_grpc(
                 "./data/store.ndjson",
                 &format!("./data/graph_{}.dat", database_size),
                 &mut rng,

--- a/iris-mpc-cpu/bin/local_hnsw.rs
+++ b/iris-mpc-cpu/bin/local_hnsw.rs
@@ -1,6 +1,6 @@
 use aes_prng::AesRng;
 use clap::Parser;
-use iris_mpc_cpu::hawkers::galois_store::LocalNetAby3NgStoreProtocol;
+use iris_mpc_cpu::hawkers::galois_store::Aby3Runner;
 use rand::SeedableRng;
 use std::error::Error;
 
@@ -18,7 +18,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     println!("Starting Local HNSW with {} vectors", database_size);
     let mut rng = AesRng::seed_from_u64(0_u64);
 
-    LocalNetAby3NgStoreProtocol::shared_random_setup_with_grpc(&mut rng, database_size).await?;
+    Aby3Runner::shared_random_setup_with_grpc(&mut rng, database_size).await?;
 
     Ok(())
 }

--- a/iris-mpc-cpu/bin/local_hnsw.rs
+++ b/iris-mpc-cpu/bin/local_hnsw.rs
@@ -1,6 +1,6 @@
 use aes_prng::AesRng;
 use clap::Parser;
-use iris_mpc_cpu::hawkers::galois_store::Aby3Runner;
+use iris_mpc_cpu::hawkers::aby3_store::Aby3Store;
 use rand::SeedableRng;
 use std::error::Error;
 
@@ -18,7 +18,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     println!("Starting Local HNSW with {} vectors", database_size);
     let mut rng = AesRng::seed_from_u64(0_u64);
 
-    Aby3Runner::shared_random_setup_with_grpc(&mut rng, database_size).await?;
+    Aby3Store::shared_random_setup_with_grpc(&mut rng, database_size).await?;
 
     Ok(())
 }

--- a/iris-mpc-cpu/src/hawkers/mod.rs
+++ b/iris-mpc-cpu/src/hawkers/mod.rs
@@ -1,2 +1,2 @@
-pub mod galois_store;
+pub mod aby3_store;
 pub mod plaintext_store;

--- a/iris-mpc-cpu/src/network/grpc.rs
+++ b/iris-mpc-cpu/src/network/grpc.rs
@@ -340,7 +340,7 @@ mod tests {
     use super::*;
     use crate::{
         execution::{local::generate_local_identities, player::Role},
-        hawkers::galois_store::Aby3Runner,
+        hawkers::aby3_store::Aby3Store,
     };
     use aes_prng::AesRng;
     use hawk_pack::HawkSearcher;
@@ -571,7 +571,7 @@ mod tests {
         let mut rng = AesRng::seed_from_u64(0_u64);
         let database_size = 2;
         let searcher = HawkSearcher::default();
-        let mut vectors_and_graphs = Aby3Runner::shared_random_setup(
+        let mut vectors_and_graphs = Aby3Store::shared_random_setup(
             &mut rng,
             database_size,
             crate::network::NetworkType::GrpcChannel,

--- a/iris-mpc-cpu/src/network/grpc.rs
+++ b/iris-mpc-cpu/src/network/grpc.rs
@@ -585,7 +585,7 @@ mod tests {
                 let mut store = store.clone();
                 let mut graph = graph.clone();
                 let searcher = searcher.clone();
-                let q = store.prepare_query(store.storage.get_vector(&i.into()).clone());
+                let q = store.prepare_query(store.storage.get_vector(&i.into()));
                 jobs.spawn(async move {
                     let secret_neighbors = searcher.search(&mut store, &mut graph, &q, 1).await;
                     searcher.is_match(&mut store, &[secret_neighbors]).await

--- a/iris-mpc-cpu/src/network/grpc.rs
+++ b/iris-mpc-cpu/src/network/grpc.rs
@@ -340,7 +340,7 @@ mod tests {
     use super::*;
     use crate::{
         execution::{local::generate_local_identities, player::Role},
-        hawkers::galois_store::LocalNetAby3NgStoreProtocol,
+        hawkers::galois_store::Aby3Runner,
     };
     use aes_prng::AesRng;
     use hawk_pack::HawkSearcher;
@@ -571,7 +571,7 @@ mod tests {
         let mut rng = AesRng::seed_from_u64(0_u64);
         let database_size = 2;
         let searcher = HawkSearcher::default();
-        let mut vectors_and_graphs = LocalNetAby3NgStoreProtocol::shared_random_setup(
+        let mut vectors_and_graphs = Aby3Runner::shared_random_setup(
             &mut rng,
             database_size,
             crate::network::NetworkType::GrpcChannel,

--- a/iris-mpc-cpu/src/protocol/ops.rs
+++ b/iris-mpc-cpu/src/protocol/ops.rs
@@ -551,7 +551,7 @@ mod tests {
         let second_entry = generate_galois_iris_shares(&mut rng, iris_db[1].clone());
 
         let mut jobs = JoinSet::new();
-        for (index, player) in runtime.identities.iter().cloned().enumerate() {
+        for (index, player) in runtime.get_identities().iter().cloned().enumerate() {
             let mut player_session = runtime.sessions.get(&player).unwrap().clone();
             let mut own_shares = vec![(first_entry[index].clone(), second_entry[index].clone())];
             own_shares.iter_mut().for_each(|(_x, y)| {


### PR DESCRIPTION
The main goal of this change is to make an implementation of the SMPC protocol (`Aby3Store` formerly known as `LocalNetAby3NgStoreProtocol`) more atomic, lightweight and independent of implementation details not related to the protocol. In particular,
- shared points are passed through `Arc` to avoid unnecessary copying;
- runtime is replaced with a session that abstracts away all the networking details; this fits into the previous assumption that each instance of the protocol should be run within a single session.

In addition, `LocalRuntime` is simplified by removing unused fields. 