### PR TITLE
bump max db size to 20M and aurora load parallelism in prod

### DIFF
--- a/deploy/prod/smpcv2-0-prod/values-iris-mpc.yaml
+++ b/deploy/prod/smpcv2-0-prod/values-iris-mpc.yaml
@@ -96,7 +96,7 @@ env:
     value: "0"
 
   - name: SMPC__MAX_DB_SIZE
-    value: "10000000"
+    value: "20000000"
 
   - name: SMPC__FAKE_DB_SIZE
     value: "0"

--- a/deploy/prod/smpcv2-0-prod/values-iris-mpc.yaml
+++ b/deploy/prod/smpcv2-0-prod/values-iris-mpc.yaml
@@ -36,7 +36,7 @@ env:
     value: "true"
 
   - name: SMPC__DATABASE__LOAD_PARALLELISM
-    value: "8"
+    value: "80"
 
   - name: SMPC__AWS__REGION
     value: "eu-north-1"

--- a/deploy/prod/smpcv2-1-prod/values-iris-mpc.yaml
+++ b/deploy/prod/smpcv2-1-prod/values-iris-mpc.yaml
@@ -96,7 +96,7 @@ env:
     value: "0"
 
   - name: SMPC__MAX_DB_SIZE
-    value: "10000000"
+    value: "20000000"
 
   - name: SMPC__FAKE_DB_SIZE
     value: "0"

--- a/deploy/prod/smpcv2-1-prod/values-iris-mpc.yaml
+++ b/deploy/prod/smpcv2-1-prod/values-iris-mpc.yaml
@@ -36,7 +36,7 @@ env:
     value: "true"
 
   - name: SMPC__DATABASE__LOAD_PARALLELISM
-    value: "8"
+    value: "80"
 
   - name: SMPC__AWS__REGION
     value: "eu-north-1"

--- a/deploy/prod/smpcv2-2-prod/values-iris-mpc.yaml
+++ b/deploy/prod/smpcv2-2-prod/values-iris-mpc.yaml
@@ -96,7 +96,7 @@ env:
     value: "0"
 
   - name: SMPC__MAX_DB_SIZE
-    value: "10000000"
+    value: "20000000"
 
   - name: SMPC__FAKE_DB_SIZE
     value: "0"

--- a/deploy/prod/smpcv2-2-prod/values-iris-mpc.yaml
+++ b/deploy/prod/smpcv2-2-prod/values-iris-mpc.yaml
@@ -36,7 +36,7 @@ env:
     value: "true"
 
   - name: SMPC__DATABASE__LOAD_PARALLELISM
-    value: "8"
+    value: "80"
 
   - name: SMPC__AWS__REGION
     value: "eu-north-1"


### PR DESCRIPTION
**Change**
- This PR doubles the max allowed db size in prod to be safe