### PR TITLE
use fixed chacha seeds for e2e tests

### DIFF
--- a/deploy/e2e/iris-mpc-0.yaml.tpl
+++ b/deploy/e2e/iris-mpc-0.yaml.tpl
@@ -188,6 +188,9 @@ iris-mpc-0:
     - name: SMPC__RETURN_PARTIAL_RESULTS
       value: "true"
 
+    - name: SMPC__FIXED_SHARED_SECRETS
+      value: "true"
+
     - name: SMPC__NODE_HOSTNAMES
       value: '["iris-mpc-0.svc.cluster.local","iris-mpc-1.svc.cluster.local","iris-mpc-2.svc.cluster.local"]'
 

--- a/deploy/e2e/iris-mpc-1.yaml.tpl
+++ b/deploy/e2e/iris-mpc-1.yaml.tpl
@@ -188,6 +188,9 @@ iris-mpc-1:
     - name: SMPC__RETURN_PARTIAL_RESULTS
       value: "true"
 
+    - name: SMPC__FIXED_SHARED_SECRETS
+      value: "true"
+      
     - name: SMPC__NODE_HOSTNAMES
       value: '["iris-mpc-0.svc.cluster.local","iris-mpc-1.svc.cluster.local","iris-mpc-2.svc.cluster.local"]'
 

--- a/deploy/e2e/iris-mpc-2.yaml.tpl
+++ b/deploy/e2e/iris-mpc-2.yaml.tpl
@@ -188,6 +188,9 @@ iris-mpc-2:
     - name: SMPC__RETURN_PARTIAL_RESULTS
       value: "true"
 
+    - name: SMPC__FIXED_SHARED_SECRETS
+      value: "true"
+
     - name: SMPC__NODE_HOSTNAMES
       value: '["iris-mpc-0.svc.cluster.local","iris-mpc-1.svc.cluster.local","iris-mpc-2.svc.cluster.local"]'
 

--- a/iris-mpc-common/src/config/mod.rs
+++ b/iris-mpc-common/src/config/mod.rs
@@ -108,6 +108,9 @@ pub struct Config {
 
     #[serde(default)]
     pub db_chunks_folder_name: String,
+
+    #[serde(default)]
+    pub fixed_shared_secrets: bool,
 }
 
 fn default_load_chunks_parallelism() -> usize {

--- a/iris-mpc/src/bin/server.rs
+++ b/iris-mpc/src/bin/server.rs
@@ -9,7 +9,7 @@ use clap::Parser;
 use eyre::{eyre, Context};
 use futures::{stream::select_all, StreamExt, TryStreamExt};
 use iris_mpc_common::{
-    config::{json_wrapper::JsonStrWrapper, Config, Opt},
+    config::{Config, Opt},
     galois_engine::degree4::{GaloisRingIrisCodeShare, GaloisRingTrimmedMaskCodeShare},
     helpers::{
         aws::{
@@ -528,35 +528,41 @@ fn initialize_tracing(config: &Config) -> eyre::Result<TracingShutdownHandle> {
     }
 }
 
-async fn initialize_chacha_seeds(
-    kms_key_arns: &JsonStrWrapper<Vec<String>>,
-    party_id: usize,
-) -> eyre::Result<([u32; 8], [u32; 8])> {
+async fn initialize_chacha_seeds(config: Config) -> eyre::Result<([u32; 8], [u32; 8])> {
     // Init RNGs
-    let own_key_arn = kms_key_arns
+    let own_key_arn = config
+        .kms_key_arns
         .0
-        .get(party_id)
+        .get(config.party_id)
         .expect("Expected value not found in kms_key_arns");
-    let dh_pairs = match party_id {
+    let dh_pairs = match config.party_id {
         0 => (1usize, 2usize),
         1 => (2usize, 0usize),
         2 => (0usize, 1usize),
         _ => unimplemented!(),
     };
 
-    let dh_pair_0: &str = kms_key_arns
+    let dh_pair_0: &str = config
+        .kms_key_arns
         .0
         .get(dh_pairs.0)
         .expect("Expected value not found in kms_key_arns");
-    let dh_pair_1: &str = kms_key_arns
+    let dh_pair_1: &str = config
+        .kms_key_arns
         .0
         .get(dh_pairs.1)
         .expect("Expected value not found in kms_key_arns");
 
-    let chacha_seeds = (
-        bytemuck::cast(derive_shared_secret(own_key_arn, dh_pair_0).await?),
-        bytemuck::cast(derive_shared_secret(own_key_arn, dh_pair_1).await?),
-    );
+    // To be used only for e2e testing where we use localstack. There's a bug in
+    // localstack's implementation of `derive_shared_secret`. See: https://github.com/localstack/localstack/pull/12071
+    let chacha_seeds: ([u32; 8], [u32; 8]) = if config.fixed_shared_secrets {
+        ([0u32; 8], [0u32; 8])
+    } else {
+        (
+            bytemuck::cast(derive_shared_secret(own_key_arn, dh_pair_0).await?),
+            bytemuck::cast(derive_shared_secret(own_key_arn, dh_pair_1).await?),
+        )
+    };
 
     Ok(chacha_seeds)
 }
@@ -695,7 +701,7 @@ async fn server_main(config: Config) -> eyre::Result<()> {
 
     let party_id = config.party_id;
     tracing::info!("Deriving shared secrets");
-    let chacha_seeds = initialize_chacha_seeds(&config.kms_key_arns, party_id).await?;
+    let chacha_seeds = initialize_chacha_seeds(config.clone()).await?;
 
     let uniqueness_result_attributes = create_message_type_attribute_map(UNIQUENESS_MESSAGE_TYPE);
     let identity_deletion_result_attributes =


### PR DESCRIPTION
This is a similar workaround as the one used in:

- oprf: https://github.com/worldcoin/oprf-mpc/blob/c03f60826c696c2e6c377c8fb81c9cdd938c04ab/src/bin/oprf-node.rs#L1004-L1015
- reshare protocol: https://github.com/worldcoin/iris-mpc/blob/47a08a85c6c36b4b8eab1edef9ee15f0aed9703a/iris-mpc-upgrade/src/bin/reshare-client.rs#L25