### PR TITLE
bump max db size to 20m

### DIFF
--- a/deploy/prod/smpcv2-0-prod/values-iris-mpc.yaml
+++ b/deploy/prod/smpcv2-0-prod/values-iris-mpc.yaml
@@ -96,7 +96,7 @@ env:
     value: "0"
 
   - name: SMPC__MAX_DB_SIZE
-    value: "11000000"
+    value: "20000000"
 
   - name: SMPC__FAKE_DB_SIZE
     value: "0"

--- a/deploy/prod/smpcv2-1-prod/values-iris-mpc.yaml
+++ b/deploy/prod/smpcv2-1-prod/values-iris-mpc.yaml
@@ -96,7 +96,7 @@ env:
     value: "0"
 
   - name: SMPC__MAX_DB_SIZE
-    value: "11000000"
+    value: "20000000"
 
   - name: SMPC__FAKE_DB_SIZE
     value: "0"

--- a/deploy/prod/smpcv2-2-prod/values-iris-mpc.yaml
+++ b/deploy/prod/smpcv2-2-prod/values-iris-mpc.yaml
@@ -96,7 +96,7 @@ env:
     value: "0"
 
   - name: SMPC__MAX_DB_SIZE
-    value: "11000000"
+    value: "20000000"
 
   - name: SMPC__FAKE_DB_SIZE
     value: "0"


### PR DESCRIPTION
**Change**
- Now that memory limit is increased, let's try again setting the max db size to 20m