### PR TITLE
Add graceful shutdown to all health check failures

### DIFF
--- a/iris-mpc-common/src/helpers/shutdown_handler.rs
+++ b/iris-mpc-common/src/helpers/shutdown_handler.rs
@@ -29,6 +29,10 @@ impl ShutdownHandler {
         self.shutdown_received.load(Ordering::Relaxed)
     }
 
+    pub fn trigger_manual_shutdown(&self) {
+        self.shutdown_received.store(true, Ordering::Relaxed);
+    }
+
     pub async fn wait_for_shutdown_signal(&self) {
         let shutdown_flag = self.shutdown_received.clone();
         tokio::spawn(async move {


### PR DESCRIPTION
### Notes
* enforce sending graceful shutdown signals to all nodes
* argo CD only triggers graceful shutdown every 3 minutes meaning during roll outs we do not see all 3 pods having graceful shutdown
* this shares between pods to start gracefully shutting down