### PR TITLE
Fix-graceful-shutdown-continue-for-panics

### DIFF
--- a/iris-mpc/src/bin/server.rs
+++ b/iris-mpc/src/bin/server.rs
@@ -889,6 +889,7 @@ async fn server_main(config: Config) -> eyre::Result<()> {
                     } else {
                         tracing::info!("Node {} has already started graceful shutdown.", host);
                     }
+                    continue;
                 }
 
                 let probe_response = res


### PR DESCRIPTION
### Notes
* ensure for graceful shutdown we do not deserialise the probe response