### PR TITLE
disable stalled stream protection in s3 client

### DIFF
--- a/.github/workflows/temp-branch-build-and-push.yaml
+++ b/.github/workflows/temp-branch-build-and-push.yaml
@@ -3,7 +3,7 @@ name: Branch - Build and push docker image
 on:
   push:
     branches:
-      - "feat/even-odd-import-from-s3"
+      - "chore/increase-stalled-stream-protection"
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'

--- a/iris-mpc/src/bin/server.rs
+++ b/iris-mpc/src/bin/server.rs
@@ -692,12 +692,9 @@ async fn server_main(config: Config) -> eyre::Result<()> {
     // Increase S3 retries to 5
     let retry_config = RetryConfig::standard().with_max_attempts(5);
 
-    // Bump stalled stream protection grace period to 30 seconds
-    let mut stream_protection = StalledStreamProtectionConfig::enabled();
-    stream_protection.set_grace_period(Some(Duration::from_secs(40)));
-
     let s3_config = S3ConfigBuilder::from(&shared_config)
-        .stalled_stream_protection(stream_protection.build())
+        // disable stalled stream protection to avoid panics during s3 import
+        .stalled_stream_protection(StalledStreamProtectionConfig::disabled())
         .retry_config(retry_config)
         .build();
     let s3_client = Arc::new(S3Client::from_conf(s3_config));


### PR DESCRIPTION
**Change**
- Disabling stalled stream protection to get rid of panics on `minimum throughput was specified at 1 B/s, but throughput of 0 B/s was observed` during s3 import which ends up with restarting the parties.
- Ref: https://github.com/awslabs/distill-cli/pull/10