### PR TITLE
Batch hash

### DIFF
--- a/iris-mpc-common/src/helpers/sha256.rs
+++ b/iris-mpc-common/src/helpers/sha256.rs
@@ -1,5 +1,9 @@
 use sha2::{Digest, Sha256};
 
-pub fn calculate_sha256<T: AsRef<[u8]>>(data: T) -> String {
-    hex::encode(Sha256::digest(data.as_ref()))
+pub fn sha256_as_hex_string<T: AsRef<[u8]>>(data: T) -> String {
+    hex::encode(sha256_bytes(data))
+}
+
+pub fn sha256_bytes<T: AsRef<[u8]>>(data: T) -> [u8; 32] {
+    Sha256::digest(data.as_ref()).into()
 }

--- a/iris-mpc-common/src/helpers/smpc_request.rs
+++ b/iris-mpc-common/src/helpers/smpc_request.rs
@@ -1,4 +1,4 @@
-use super::{key_pair::SharesDecodingError, sha256::calculate_sha256};
+use super::{key_pair::SharesDecodingError, sha256::sha256_as_hex_string};
 use crate::helpers::key_pair::SharesEncryptionKeyPairs;
 use aws_sdk_s3::Client as S3Client;
 use aws_sdk_sns::types::MessageAttributeValue;
@@ -285,6 +285,6 @@ impl UniquenessRequest {
             .map_err(SharesDecodingError::SerdeError)?
             .into_bytes();
 
-        Ok(self.iris_shares_file_hashes[party_id] == calculate_sha256(stringified_share))
+        Ok(self.iris_shares_file_hashes[party_id] == sha256_as_hex_string(stringified_share))
     }
 }

--- a/iris-mpc-common/tests/sha256.rs
+++ b/iris-mpc-common/tests/sha256.rs
@@ -1,5 +1,5 @@
 mod tests {
-    use iris_mpc_common::helpers::sha256::calculate_sha256;
+    use iris_mpc_common::helpers::sha256::sha256_as_hex_string;
 
     #[test]
     fn test_calculate_sha256() {
@@ -8,7 +8,7 @@ mod tests {
         let expected_hash = "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3";
 
         // Act
-        let calculated_hash = calculate_sha256(data);
+        let calculated_hash = sha256_as_hex_string(data);
 
         // Assert
         assert_eq!(
@@ -24,7 +24,7 @@ mod tests {
         let expected_hash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
 
         // Act
-        let calculated_hash = calculate_sha256(data);
+        let calculated_hash = sha256_as_hex_string(data);
 
         // Assert
         assert_eq!(
@@ -38,8 +38,8 @@ mod tests {
         // Arrange
         let data_1 = "Data 1";
         let data_2 = "Data 2";
-        let hash_1 = calculate_sha256(data_1);
-        let hash_2 = calculate_sha256(data_2);
+        let hash_1 = sha256_as_hex_string(data_1);
+        let hash_2 = sha256_as_hex_string(data_2);
 
         // Act & Assert
         assert_ne!(

--- a/iris-mpc-common/tests/smpc_request.rs
+++ b/iris-mpc-common/tests/smpc_request.rs
@@ -4,7 +4,7 @@ mod tests {
     use base64::{engine::general_purpose::STANDARD, Engine};
     use iris_mpc_common::helpers::{
         key_pair::{SharesDecodingError, SharesEncryptionKeyPairs},
-        sha256::calculate_sha256,
+        sha256::sha256_as_hex_string,
         smpc_request::{IrisCodesJSON, UniquenessRequest},
     };
     use serde_json::json;
@@ -271,7 +271,7 @@ mod tests {
     async fn test_validate_iris_share() {
         let mock_iris_codes_json = mock_iris_codes_json();
         let mock_serialized_iris = serde_json::to_string(&mock_iris_codes_json).unwrap();
-        let mock_hash = calculate_sha256(mock_serialized_iris.into_bytes());
+        let mock_hash = sha256_as_hex_string(mock_serialized_iris.into_bytes());
 
         let smpc_request = get_mock_smpc_request_with_hashes([
             mock_hash.clone(),

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -1499,7 +1499,7 @@ impl ServerActor {
             .collect();
 
         // Only keep entries that are valid on all nodes
-        let mut valid_merged = vec![false; max_batch_size];
+        let mut valid_merged = vec![true; max_batch_size];
         for i in 0..self.comms[0].world_size() {
             for j in 0..max_batch_size {
                 valid_merged[j] &= results[i][j] == 1;

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -656,7 +656,7 @@ impl ServerActor {
 
         // Compute hash of the request ids concatenated
         let batch_hash = sha256_bytes(&batch.request_ids.join(""));
-        tracing::info!("Current batch hash: 0x{}", hex::encode(batch_hash));
+        tracing::info!("Current batch hash: {}", hex::encode(&batch_hash[0..4]));
 
         let valid_entries =
             self.sync_batch_entries(&batch.valid_entries, self.max_batch_size, &batch_hash)?;

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -655,7 +655,7 @@ impl ServerActor {
         tracing::info!("Syncing batch entries");
 
         // Compute hash of the request ids concatenated
-        let batch_hash = sha256_bytes(&batch.request_ids.join(""));
+        let batch_hash = sha256_bytes(batch.request_ids.join(""));
         tracing::info!("Current batch hash: {}", hex::encode(&batch_hash[0..4]));
 
         let valid_entries =

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -1482,7 +1482,7 @@ impl ServerActor {
         let mut host_buffer = vec![0u8; max_batch_size + hash_len];
         host_buffer[..valid_entries.len()]
             .copy_from_slice(&valid_entries.iter().map(|&x| x as u8).collect::<Vec<u8>>());
-        host_buffer[max_batch_size..].copy_from_slice(&batch_hash);
+        host_buffer[max_batch_size..].copy_from_slice(batch_hash);
 
         let buffer_self = self.device_manager.device(0).htod_copy(host_buffer)?;
 

--- a/iris-mpc/src/bin/client.rs
+++ b/iris-mpc/src/bin/client.rs
@@ -9,7 +9,7 @@ use iris_mpc_common::{
     galois_engine::degree4::GaloisRingIrisCodeShare,
     helpers::{
         key_pair::download_public_key,
-        sha256::calculate_sha256,
+        sha256::sha256_as_hex_string,
         smpc_request::{IrisCodesJSON, UniquenessRequest, UNIQUENESS_MESSAGE_TYPE},
         smpc_response::{create_message_type_attribute_map, UniquenessResult},
         sqs_s3_helper::upload_file_and_generate_presigned_url,
@@ -339,7 +339,7 @@ async fn main() -> eyre::Result<()> {
                         .clone();
 
                     // calculate hash of the object
-                    let hash_string = calculate_sha256(&serialized_iris_codes_json);
+                    let hash_string = sha256_as_hex_string(&serialized_iris_codes_json);
 
                     // encrypt the object using sealed box and public key
                     let encrypted_bytes = sealedbox::seal(


### PR DESCRIPTION
Calculates a hash out of the signup ids of the current batch and syncs this hash across the node. This makes sure the queues are actually in sync before starting processing. This just throws an error and the actor can't recover it on its own requiring manual intervention.