### PR TITLE
bump startup probe and version in stage

### DIFF
--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:v0.13.15"
+image: "ghcr.io/worldcoin/iris-mpc:v0.13.19"
 
 environment: stage
 replicaCount: 1
@@ -27,7 +27,7 @@ readinessProbe:
 
 startupProbe:
   initialDelaySeconds: 60
-  failureThreshold: 60
+  failureThreshold: 120
   periodSeconds: 30
   httpGet:
     path: /ready


### PR DESCRIPTION
**Change**
- Give stage more time to seed the database with 1.2M items w/o crushing