### PR TITLE
chore: Prevent time consuming workflows on config/docs changes

### DIFF
--- a/.github/workflows/build-all-targets.yml
+++ b/.github/workflows/build-all-targets.yml
@@ -35,7 +35,6 @@ jobs:
 
       # Building tests in release mode checks warnings and compiler errors that depend on optimisations
       - name: Build Tests
-        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: cargo build --release --all-features --tests
 
   build-bins:

--- a/.github/workflows/build-all-targets.yml
+++ b/.github/workflows/build-all-targets.yml
@@ -13,36 +13,91 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Get all test, doc and src files that have changed
+        id: changed-files-yaml
+        uses: tj-actions/changed-files@v45
+        with:
+          files_yaml: |
+            docs:
+              - '**.md'
+            adr:
+              - adr/**
+            config:
+              - certs/**
+              - deploy/**
+              - scripts/**
+            src:
+              - iris-*/**
+
+      # The following steps will only run if any of the src files have changed
       - name: Install Dependencies
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: sudo apt install protobuf-compiler
+
       - name: Cache build products
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         uses: Swatinem/rust-cache@v2.7.3
         with:
           # Split the test and bench caches, the have different debug settings
           key: "test"
+
       - name: Install Rust nightly
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: rustup toolchain install nightly-2024-07-10
+
       - name: Set Rust nightly as default
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: rustup default nightly-2024-07-10
+
       # Building tests in release mode checks warnings and compiler errors that depend on optimisations
       - name: Build Tests
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: cargo build --release --all-features --tests
+
   build-bins:
     runs-on:
       labels: ubuntu-22.04-64core
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Get all test, doc and src files that have changed
+        id: changed-files-yaml
+        uses: tj-actions/changed-files@v45
+        with:
+          files_yaml: |
+            docs:
+              - '**.md'
+            adr:
+              - adr/**
+            config:
+              - certs/**
+              - deploy/**
+              - scripts/**
+            src:
+              - iris-*/**
+
+      # The following steps will only run if any of the src files have changed
       - name: Install Dependencies
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: sudo apt install protobuf-compiler
+
       - name: Cache build products
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         uses: Swatinem/rust-cache@v2.7.3
         with:
           # Split the test and bench caches, they have different debug settings
           key: "bench"
+
       - name: Install Rust nightly
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: rustup toolchain install nightly-2024-07-10
+
       - name: Set Rust nightly as default
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: rustup default nightly-2024-07-10
+
       - name: Build All Targets
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: cargo build --release --all-features --lib --bins --benches --examples

--- a/.github/workflows/build-all-targets.yml
+++ b/.github/workflows/build-all-targets.yml
@@ -2,6 +2,10 @@ name: Build All Targets
 
 on:
   push:
+    paths-ignore:
+      - 'adr/**'
+      - 'deploy/**'
+      - '.github/**'
 
 concurrency:
   group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
@@ -14,40 +18,19 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Get all test, doc and src files that have changed
-        id: changed-files-yaml
-        uses: tj-actions/changed-files@v45
-        with:
-          files_yaml: |
-            docs:
-              - '**.md'
-            adr:
-              - adr/**
-            config:
-              - certs/**
-              - deploy/**
-              - scripts/**
-            src:
-              - iris-*/**
-
-      # The following steps will only run if any of the src files have changed
       - name: Install Dependencies
-        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: sudo apt install protobuf-compiler
 
       - name: Cache build products
-        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         uses: Swatinem/rust-cache@v2.7.3
         with:
           # Split the test and bench caches, the have different debug settings
           key: "test"
 
       - name: Install Rust nightly
-        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: rustup toolchain install nightly-2024-07-10
 
       - name: Set Rust nightly as default
-        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: rustup default nightly-2024-07-10
 
       # Building tests in release mode checks warnings and compiler errors that depend on optimisations
@@ -62,42 +45,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Get all test, doc and src files that have changed
-        id: changed-files-yaml
-        uses: tj-actions/changed-files@v45
-        with:
-          files_yaml: |
-            docs:
-              - '**.md'
-            adr:
-              - adr/**
-            config:
-              - certs/**
-              - deploy/**
-              - scripts/**
-            src:
-              - iris-*/**
-
-      # The following steps will only run if any of the src files have changed
       - name: Install Dependencies
-        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: sudo apt install protobuf-compiler
 
       - name: Cache build products
-        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         uses: Swatinem/rust-cache@v2.7.3
         with:
           # Split the test and bench caches, they have different debug settings
           key: "bench"
 
       - name: Install Rust nightly
-        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: rustup toolchain install nightly-2024-07-10
 
       - name: Set Rust nightly as default
-        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: rustup default nightly-2024-07-10
 
       - name: Build All Targets
-        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: cargo build --release --all-features --lib --bins --benches --examples

--- a/.github/workflows/build-only.yaml
+++ b/.github/workflows/build-only.yaml
@@ -1,10 +1,7 @@
 name: Build only docker image
 
 on:
-  push:
-    branches-ignore:
-      - 'main'
-      - 'v*'
+  workflow_dispatch:
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -18,35 +18,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Get all test, doc and src files that have changed
-        id: changed-files-yaml
-        uses: tj-actions/changed-files@v45
-        with:
-          files_yaml: |
-            src:
-              - Dockerfile*
-              - Cargo.lock
-              - Cargo.toml
-              - deny.toml
-              - iris-*/**
-
-      # The following steps will only run if any of the src files have changed
       - name: Install Dependencies
-        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: sudo apt install protobuf-compiler
 
       - name: Show errors inline
-        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         uses: r7kamura/rust-problem-matchers@v1
 
       - name: Install Rust nightly
-        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: rustup toolchain install nightly-2024-07-10
 
       - name: Set Rust nightly as default
-        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: rustup default nightly-2024-07-10
 
       - name: Build Docs
-        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: cargo doc --all-features --no-deps --document-private-items

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -23,14 +23,6 @@ jobs:
         uses: tj-actions/changed-files@v45
         with:
           files_yaml: |
-            docs:
-              - '**.md'
-            adr:
-              - adr/**
-            config:
-              - certs/**
-              - deploy/**
-              - scripts/**
             src:
               - iris-*/**
 

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -2,6 +2,10 @@ name: Check Doc Syntax
 
 on:
   push:
+    paths-ignore:
+      - 'adr/**'
+      - 'deploy/**'
+      - '.github/**'
 
 concurrency:
   group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -13,13 +13,40 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Get all test, doc and src files that have changed
+        id: changed-files-yaml
+        uses: tj-actions/changed-files@v45
+        with:
+          files_yaml: |
+            docs:
+              - '**.md'
+            adr:
+              - adr/**
+            config:
+              - certs/**
+              - deploy/**
+              - scripts/**
+            src:
+              - iris-*/**
+
+      # The following steps will only run if any of the src files have changed
       - name: Install Dependencies
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: sudo apt install protobuf-compiler
+
       - name: Show errors inline
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         uses: r7kamura/rust-problem-matchers@v1
+
       - name: Install Rust nightly
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: rustup toolchain install nightly-2024-07-10
+
       - name: Set Rust nightly as default
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: rustup default nightly-2024-07-10
+
       - name: Build Docs
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: cargo doc --all-features --no-deps --document-private-items

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -24,6 +24,10 @@ jobs:
         with:
           files_yaml: |
             src:
+              - Dockerfile*
+              - Cargo.lock
+              - Cargo.toml
+              - deny.toml
               - iris-*/**
 
       # The following steps will only run if any of the src files have changed

--- a/.github/workflows/lint-clippy.yaml
+++ b/.github/workflows/lint-clippy.yaml
@@ -28,7 +28,7 @@ jobs:
         with:
           files_yaml: |
             docs:
-              - **.md
+              - '**.md'
             adr:
               - adr/**
             config:

--- a/.github/workflows/lint-clippy.yaml
+++ b/.github/workflows/lint-clippy.yaml
@@ -2,10 +2,6 @@ name: Lint Clippy
 
 on:
   push:
-    paths-ignore:
-      - 'adr/**'
-      - 'deploy/**'
-      - '.github/**'
 
 concurrency:
   group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
@@ -25,13 +21,40 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Get all test, doc and src files that have changed
+        id: changed-files-yaml
+        uses: tj-actions/changed-files@v45
+        with:
+          files_yaml: |
+            docs:
+              - **.md
+            adr:
+              - adr/**
+            config:
+              - certs/**
+              - deploy/**
+              - scripts/**
+            src:
+              - iris-*/**
+
+      # The following steps will only run if any of the src files have changed
       - name: Install Dependencies
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: sudo apt install protobuf-compiler
+
       - name: Install Rust nightly
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: rustup toolchain install nightly-2024-07-10
+
       - name: Set Rust nightly as default
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: rustup default nightly-2024-07-10
+
       - name: Install Rust clippy for checking clippy errors
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: rustup component add clippy
+
       - name: Clippy
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: cargo clippy --all-targets --all-features -- -D warnings --no-deps

--- a/.github/workflows/lint-clippy.yaml
+++ b/.github/workflows/lint-clippy.yaml
@@ -2,6 +2,10 @@ name: Lint Clippy
 
 on:
   push:
+    paths-ignore:
+      - 'adr/**'
+      - 'deploy/**'
+      - '.github/**'
 
 concurrency:
   group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"

--- a/.github/workflows/lint-clippy.yaml
+++ b/.github/workflows/lint-clippy.yaml
@@ -28,6 +28,10 @@ jobs:
         with:
           files_yaml: |
             src:
+              - Dockerfile*
+              - Cargo.lock
+              - Cargo.toml
+              - deny.toml
               - iris-*/**
 
       # The following steps will only run if any of the src files have changed

--- a/.github/workflows/lint-clippy.yaml
+++ b/.github/workflows/lint-clippy.yaml
@@ -27,14 +27,6 @@ jobs:
         uses: tj-actions/changed-files@v45
         with:
           files_yaml: |
-            docs:
-              - '**.md'
-            adr:
-              - adr/**
-            config:
-              - certs/**
-              - deploy/**
-              - scripts/**
             src:
               - iris-*/**
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,9 +2,17 @@ name: Release Drafter
 
 on:
   push:
+    paths-ignore:
+      - 'adr/**'
+      - 'deploy/**'
+      - '.github/**'
     branches:
       - main
   pull_request:
+    paths-ignore:
+      - 'adr/**'
+      - 'deploy/**'
+      - '.github/**'
     types: [opened, reopened, synchronize]
 
 permissions:

--- a/.github/workflows/run-unit-tests.yaml
+++ b/.github/workflows/run-unit-tests.yaml
@@ -2,17 +2,9 @@ name: Run unit tests
 
 on:
   push:
-    paths-ignore:
-      - 'adr/**'
-      - 'deploy/**'
-      - '.github/**'
     branches:
       - main
   pull_request:
-    paths-ignore:
-      - 'adr/**'
-      - 'deploy/**'
-      - '.github/**'
     types: [opened, synchronize]
 
 concurrency:
@@ -36,18 +28,47 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Get all test, doc and src files that have changed
+        id: changed-files-yaml
+        uses: tj-actions/changed-files@v45
+        with:
+          files_yaml: |
+            docs:
+              - **.md
+            adr:
+              - adr/**
+            config:
+              - certs/**
+              - deploy/**
+              - scripts/**
+            src:
+              - iris-*/**
+
+      # The following steps will only run if any of the src files have changed
       - name: Install Dependencies
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: sudo apt install protobuf-compiler
+
       - name: Cache build products
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         uses: Swatinem/rust-cache@v2.7.3
         with:
           # Split the test and bench caches, the have different debug settings
           key: "test"
+
       - name: Install Rust nightly
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: rustup toolchain install nightly-2024-07-10
+
       - name: Set Rust nightly as default
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: rustup default nightly-2024-07-10
+
       - name: Run Tests
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: cargo test --release -- --test-threads=1
+
       - name: Run Tests with DB
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: cargo test --release --features db_dependent -- --test-threads=1

--- a/.github/workflows/run-unit-tests.yaml
+++ b/.github/workflows/run-unit-tests.yaml
@@ -2,9 +2,17 @@ name: Run unit tests
 
 on:
   push:
+    paths-ignore:
+      - 'adr/**'
+      - 'deploy/**'
+      - '.github/**'
     branches:
       - main
   pull_request:
+    paths-ignore:
+      - 'adr/**'
+      - 'deploy/**'
+      - '.github/**'
     types: [opened, synchronize]
 
 concurrency:

--- a/.github/workflows/run-unit-tests.yaml
+++ b/.github/workflows/run-unit-tests.yaml
@@ -34,14 +34,6 @@ jobs:
         uses: tj-actions/changed-files@v45
         with:
           files_yaml: |
-            docs:
-              - '**.md'
-            adr:
-              - adr/**
-            config:
-              - certs/**
-              - deploy/**
-              - scripts/**
             src:
               - iris-*/**
 

--- a/.github/workflows/run-unit-tests.yaml
+++ b/.github/workflows/run-unit-tests.yaml
@@ -35,6 +35,10 @@ jobs:
         with:
           files_yaml: |
             src:
+              - Dockerfile*
+              - Cargo.lock
+              - Cargo.toml
+              - deny.toml
               - iris-*/**
 
       # The following steps will only run if any of the src files have changed

--- a/.github/workflows/run-unit-tests.yaml
+++ b/.github/workflows/run-unit-tests.yaml
@@ -35,7 +35,7 @@ jobs:
         with:
           files_yaml: |
             docs:
-              - **.md
+              - '**.md'
             adr:
               - adr/**
             config:

--- a/.github/workflows/test-gpu.yaml
+++ b/.github/workflows/test-gpu.yaml
@@ -19,14 +19,6 @@ jobs:
         uses: tj-actions/changed-files@v45
         with:
           files_yaml: |
-            docs:
-              - '**.md'
-            adr:
-              - adr/**
-            config:
-              - certs/**
-              - deploy/**
-              - scripts/**
             src:
               - iris-*/**
       # The following steps will only run if any of the src files have changed

--- a/.github/workflows/test-gpu.yaml
+++ b/.github/workflows/test-gpu.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           files_yaml: |
             docs:
-              - **.md
+              - '**.md'
             adr:
               - adr/**
             config:

--- a/.github/workflows/test-gpu.yaml
+++ b/.github/workflows/test-gpu.yaml
@@ -2,6 +2,10 @@ name: Rust GPU Tests
 
 on:
   pull_request:
+    paths-ignore:
+      - 'adr/**'
+      - 'deploy/**'
+      - '.github/**'
 
 concurrency:
   group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"

--- a/.github/workflows/test-gpu.yaml
+++ b/.github/workflows/test-gpu.yaml
@@ -20,7 +20,13 @@ jobs:
         with:
           files_yaml: |
             src:
-              - iris-*/**
+            - Dockerfile*
+            - Cargo.lock
+            - Cargo.toml
+            - deny.toml
+            - iris-*/**
+      
+
       # The following steps will only run if any of the src files have changed
       - name: Validate presence of GPU devices
         if: steps.changed-files-yaml.outputs.src_any_changed == 'true'

--- a/.github/workflows/test-gpu.yaml
+++ b/.github/workflows/test-gpu.yaml
@@ -2,10 +2,6 @@ name: Rust GPU Tests
 
 on:
   pull_request:
-    paths-ignore:
-      - 'adr/**'
-      - 'deploy/**'
-      - '.github/**'
 
 concurrency:
   group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
@@ -18,13 +14,32 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Get all test, doc and src files that have changed
+        id: changed-files-yaml
+        uses: tj-actions/changed-files@v45
+        with:
+          files_yaml: |
+            docs:
+              - **.md
+            adr:
+              - adr/**
+            config:
+              - certs/**
+              - deploy/**
+              - scripts/**
+            src:
+              - iris-*/**
+      # The following steps will only run if any of the src files have changed
       - name: Validate presence of GPU devices
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: nvidia-smi
 
       - name: Check shared memory size
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: df -h
 
       - name: Update gcc to version 11
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential manpages-dev software-properties-common
@@ -35,10 +50,11 @@ jobs:
           gcc --version
 
       - name: Install OpenSSL && pkg-config && protobuf-compiler
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev protobuf-compiler
 
       - name: Install CUDA and NCCL dependencies
-        if: steps.cache-cuda-nccl.outputs.cache-hit != 'true'
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true' && steps.cache-cuda-nccl.outputs.cache-hit != 'true'
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
@@ -48,9 +64,11 @@ jobs:
           sudo apt install -y cuda-toolkit-12-2 cuda-command-line-tools-12-2 libnccl2 libnccl-dev
 
       - name: Find libs
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: find /usr -name "libnvrtc*" && find /usr -name libcuda.so
 
       - name: Cache Rust build
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         uses: actions/cache@v4
         id: cache-rust
         with:
@@ -63,14 +81,17 @@ jobs:
             rust-build-${{ runner.os }}-
 
       - name: Find libs
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: find /usr -name "libnvrtc*" && find /usr -name libcuda.so
 
       - name: Install Rust nightly
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
 
       - name: GPU Dependent Tests
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         timeout-minutes: 10
         run: cargo test --release --features gpu_dependent -- --test-threads=1
         shell: bash


### PR DESCRIPTION
Do not run GPU tests or unit tests on the config changes.

EDIT: I altered the way the docker image build is run, so far it was running on every commit which seems a touch excessive, wdyt?