### PR TITLE
Add returning error result for skipped requests due to nodes not being synced

### DIFF
--- a/.github/workflows/temp-branch-build-and-push.yaml
+++ b/.github/workflows/temp-branch-build-and-push.yaml
@@ -3,7 +3,7 @@ name: Branch - Build and push docker image
 on:
   push:
     branches:
-      - "chore/increase-stalled-stream-protection"
+      - "add-error-handling-skipped-requests"
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'

--- a/iris-mpc-common/src/helpers/smpc_response.rs
+++ b/iris-mpc-common/src/helpers/smpc_response.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 pub const SMPC_MESSAGE_TYPE_ATTRIBUTE: &str = "message_type";
 // Error Reasons
 pub const ERROR_FAILED_TO_PROCESS_IRIS_SHARES: &str = "failed_to_process_iris_shares";
+pub const ERROR_SKIPPED_REQUEST_PREVIOUS_NODE_BATCH: &str = "skipped_request_previous_node_batch";
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct UniquenessResult {

--- a/iris-mpc/src/bin/server.rs
+++ b/iris-mpc/src/bin/server.rs
@@ -29,7 +29,8 @@ use iris_mpc_common::{
         },
         smpc_response::{
             create_message_type_attribute_map, IdentityDeletionResult, UniquenessResult,
-            ERROR_FAILED_TO_PROCESS_IRIS_SHARES, SMPC_MESSAGE_TYPE_ATTRIBUTE,
+            ERROR_FAILED_TO_PROCESS_IRIS_SHARES, ERROR_SKIPPED_REQUEST_PREVIOUS_NODE_BATCH,
+            SMPC_MESSAGE_TYPE_ATTRIBUTE,
         },
         sync::SyncState,
         task_monitor::TaskMonitor,
@@ -271,6 +272,17 @@ async fn receive_batch(
                                 "Skipping request due to it being from synced deleted ids: {}",
                                 smpc_request.signup_id
                             );
+                            // shares
+                            send_error_results_to_sns(
+                                smpc_request.signup_id,
+                                &batch_metadata,
+                                sns_client,
+                                config,
+                                error_result_attributes,
+                                UNIQUENESS_MESSAGE_TYPE,
+                                ERROR_SKIPPED_REQUEST_PREVIOUS_NODE_BATCH,
+                            )
+                            .await?;
                             continue;
                         }
 


### PR DESCRIPTION
### Notes
* follow up from investigation on why nodes self healed

```
Hey Philipp,
We figured out why the queues sync up again and its due to the sync table where we pass the recently deleted signup ids.
Ie: on the next run, the ids that were already read by the desynced queue and communicated to all nodes. Therefore they are ignored by the rest of the nodes when processing. The nodes sync up again.
It is a feature then!
Follow ups:
add error handling to send back errors to signup-service. this should avoid manual intervention.
metric when the hashing fails with an alarm. just a slack message when this occurs (pod restarts should wake us up).
```