### PR TITLE
generate masks and templates for left and right

### DIFF
--- a/iris-mpc-gpu/tests/e2e.rs
+++ b/iris-mpc-gpu/tests/e2e.rs
@@ -37,9 +37,9 @@ mod e2e_test {
     #[derive(Clone)]
     pub struct E2ESharedTemplate {
         pub left_shared_code:  [GaloisRingIrisCodeShare; 3],
-        pub left_shared_mask:  Vec<GaloisRingTrimmedMaskCodeShare>,
+        pub left_shared_mask:  [GaloisRingTrimmedMaskCodeShare; 3],
         pub right_shared_code: [GaloisRingIrisCodeShare; 3],
-        pub right_shared_mask: Vec<GaloisRingTrimmedMaskCodeShare>,
+        pub right_shared_mask: [GaloisRingTrimmedMaskCodeShare; 3],
     }
 
     fn generate_db(party_id: usize) -> Result<(Vec<u16>, Vec<u16>)> {
@@ -596,14 +596,17 @@ mod e2e_test {
         rng: &mut StdRng,
     ) -> (
         [GaloisRingIrisCodeShare; 3],
-        Vec<GaloisRingTrimmedMaskCodeShare>,
+        [GaloisRingTrimmedMaskCodeShare; 3],
     ) {
         let mut shared_code =
             GaloisRingIrisCodeShare::encode_iris_code(&template.code, &template.mask, rng);
 
         let shared_mask = GaloisRingIrisCodeShare::encode_mask_code(&template.mask, rng);
-        let mut shared_mask: Vec<GaloisRingTrimmedMaskCodeShare> =
+        let shared_mask_vector: Vec<GaloisRingTrimmedMaskCodeShare> =
             shared_mask.iter().map(|x| x.clone().into()).collect();
+
+        let mut shared_mask: [GaloisRingTrimmedMaskCodeShare; 3] =
+            shared_mask_vector.try_into().unwrap();
 
         if !is_valid {
             shared_code[0] = GaloisRingIrisCodeShare::default_for_party(1);

--- a/iris-mpc-gpu/tests/e2e.rs
+++ b/iris-mpc-gpu/tests/e2e.rs
@@ -360,6 +360,15 @@ mod e2e_test {
                                 right: db.db[deleted_idx as usize].clone(),
                             }
                         }
+                        // TODO: implement test that enables testing the bitmap OR rule setting.
+                        // This will require setting the left and right iris code to be different,
+                        // one of them below the threshold and the other
+                        // above the threshold against the other codes. It will
+                        // also be required to set the param BatchQuery.threshold_bitmap_or to true
+                        // for the specific iris codes to be matched against
+                        // 5 => {
+                        // println!("Sending iris codes that match on right but not left with the OR
+                        // rule set");
                         _ => unreachable!(),
                     }
                 };


### PR DESCRIPTION
Addressing the TODO: instead of copying the left batch values into the right batch, we generate them separately. This will be essential for testing a future feature of the protocol, e.g. the ability to pass a custom set of serial ids against which to perform OR-rule (between left and right codes) matching.

See the PR that implements such logic: https://github.com/worldcoin/iris-mpc/pull/951

See the TODO comment: https://github.com/worldcoin/iris-mpc/pull/956/files#diff-0c1888f81c1fbf6d412eaebb8144b3f97d10ae89d279ca4153b4f900003a69bdR363-R371