### PR TITLE
aurel/parallel-search: Introduce parallelism with sessions

### DIFF
--- a/iris-mpc-cpu/bin/hawk_main.rs
+++ b/iris-mpc-cpu/bin/hawk_main.rs
@@ -4,5 +4,6 @@ use iris_mpc_cpu::execution::hawk_main::{hawk_main, HawkArgs};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    hawk_main(HawkArgs::parse()).await
+    let _ = hawk_main(HawkArgs::parse()).await?;
+    Ok(())
 }

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -286,6 +286,7 @@ impl HawkActor {
     ) -> Result<()> {
         let plans = join_plans(plans);
         for plan in plans {
+            // TODO: Parallel insertions are not supported, so only one session is needed.
             let mut session = sessions[0].write().await;
             self.insert_one(&mut session, plan).await?;
         }

--- a/iris-mpc-cpu/src/hnsw/searcher.rs
+++ b/iris-mpc-cpu/src/hnsw/searcher.rs
@@ -223,7 +223,7 @@ impl HnswSearcher {
     async fn search_init<V: VectorStore, G: GraphStore<V>>(
         &self,
         vector_store: &mut V,
-        graph_store: &mut G,
+        graph_store: &G,
         query: &V::QueryRef,
     ) -> (FurthestQueueV<V>, usize) {
         if let Some((entry_point, layer)) = graph_store.get_entry_point().await {
@@ -246,7 +246,7 @@ impl HnswSearcher {
     async fn search_layer<V: VectorStore, G: GraphStore<V>>(
         &self,
         vector_store: &mut V,
-        graph_store: &mut G,
+        graph_store: &G,
         q: &V::QueryRef,
         W: &mut FurthestQueueV<V>,
         ef: usize,
@@ -384,7 +384,7 @@ impl HnswSearcher {
     pub async fn search_to_insert<V: VectorStore, G: GraphStore<V>>(
         &self,
         vector_store: &mut V,
-        graph_store: &mut G,
+        graph_store: &G,
         query: &V::QueryRef,
         insertion_layer: usize,
     ) -> (Vec<FurthestQueueV<V>>, bool) {


### PR DESCRIPTION
Follow-up to #955.

* Introduce parallelism of searches over multiple sessions.
* Send search requests over async queues.