### PR TITLE
Improve load time (mpsc channel, post page-lock, directory buckets)

### DIFF
--- a/.github/workflows/temp-branch-build-and-push.yaml
+++ b/.github/workflows/temp-branch-build-and-push.yaml
@@ -3,7 +3,7 @@ name: Branch - Build and push docker image
 on:
   push:
     branches:
-      - "ps/buckets"
+      - "test-benchmark"
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,7 +748,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.0",
+ "hyper 1.5.2",
  "hyper-util",
  "itoa",
  "matchit",
@@ -763,7 +763,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.1",
  "tokio",
- "tower 0.5.1",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2402,9 +2402,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.5.0"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
+checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2445,7 +2445,7 @@ checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.5.0",
+ "hyper 1.5.2",
  "hyper-util",
  "log",
  "rustls 0.23.18",
@@ -2462,7 +2462,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.5.0",
+ "hyper 1.5.2",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2490,7 +2490,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.5.0",
+ "hyper 1.5.2",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2509,7 +2509,7 @@ dependencies = [
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.1",
- "hyper 1.5.0",
+ "hyper 1.5.2",
  "pin-project-lite",
  "socket2 0.5.7",
  "tokio",
@@ -3190,7 +3190,7 @@ checksum = "b4f0c8427b39666bf970460908b213ec09b3b350f20c0c2eabcbba51704a08e6"
 dependencies = [
  "base64 0.22.1",
  "http-body-util",
- "hyper 1.5.0",
+ "hyper 1.5.2",
  "hyper-rustls 0.27.3",
  "hyper-util",
  "indexmap 2.6.0",
@@ -4359,7 +4359,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.0",
+ "hyper 1.5.2",
  "hyper-rustls 0.27.3",
  "hyper-tls 0.6.0",
  "hyper-util",
@@ -5656,7 +5656,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.0",
+ "hyper 1.5.2",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -5710,14 +5710,14 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 0.1.2",
+ "sync_wrapper 1.0.1",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -6477,7 +6477,7 @@ dependencies = [
  "futures",
  "http 1.1.0",
  "http-body-util",
- "hyper 1.5.0",
+ "hyper 1.5.2",
  "hyper-util",
  "log",
  "once_cell",

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:v0.13.23"
+image: "ghcr.io/worldcoin/iris-mpc:v0.13.24"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -75,13 +75,16 @@ env:
     value: "true"
 
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
-    value: "iris-mpc-db-exporter-store-node-0-stage-eu-north-1"
+    value: "iris-mpc-db-exporter-store-node-0-stage--eun1-az3--x-s3"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
     value: "even_odd_binary_output_16k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "32"
+    value: "64"
+
+  - name: SMPC__LOAD_CHUNKS_BUFFER_SIZE
+    value: "1024"
 
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -75,13 +75,16 @@ env:
     value: "true"
 
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
-    value: "iris-mpc-db-exporter-store-node-1-stage-eu-north-1"
+    value: "iris-mpc-db-exporter-store-node-1-stage--eun1-az3--x-s3"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
     value: "even_odd_binary_output_16k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "32"
+    value: "64"
+
+  - name: SMPC__LOAD_CHUNKS_BUFFER_SIZE
+    value: "1024"
 
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -75,14 +75,17 @@ env:
     value: "true"
 
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
-    value: "iris-mpc-db-exporter-store-node-2-stage-eu-north-1"
+    value: "iris-mpc-db-exporter-store-node-2-stage--eun1-az3--x-s3"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
     value: "even_odd_binary_output_16k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
-    value: "32"
+    value: "64"
 
+  - name: SMPC__LOAD_CHUNKS_BUFFER_SIZE
+    value: "1024"
+  
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"
 

--- a/iris-mpc-common/src/config/mod.rs
+++ b/iris-mpc-common/src/config/mod.rs
@@ -117,6 +117,9 @@ pub struct Config {
 
     #[serde(default = "default_n_buckets")]
     pub n_buckets: usize,
+
+    #[serde(default)]
+    pub load_chunks_buffer_size: usize,
 }
 
 fn default_load_chunks_parallelism() -> usize {

--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -2,7 +2,6 @@
 
 mod s3_importer;
 
-use crate::s3_importer::S3StoredIris;
 use bytemuck::cast_slice;
 use eyre::{eyre, Result};
 use futures::{
@@ -15,7 +14,9 @@ use iris_mpc_common::{
     iris_db::iris::IrisCode,
 };
 use rand::{rngs::StdRng, Rng, SeedableRng};
-pub use s3_importer::{fetch_and_parse_chunks, last_snapshot_timestamp, ObjectStore, S3Store};
+pub use s3_importer::{
+    fetch_and_parse_chunks, last_snapshot_timestamp, ObjectStore, S3Store, S3StoredIris,
+};
 use sqlx::{
     migrate::Migrator, postgres::PgPoolOptions, Executor, PgPool, Postgres, Row, Transaction,
 };
@@ -186,7 +187,7 @@ impl Store {
         &self,
         min_last_modified_at: Option<i64>,
         partitions: usize,
-    ) -> impl Stream<Item = eyre::Result<StoredIris>> + '_ {
+    ) -> impl Stream<Item = eyre::Result<DbStoredIris>> + '_ {
         let count = self.count_irises().await.expect("Failed count_irises");
         let partition_size = count.div_ceil(partitions).max(1);
 
@@ -197,7 +198,7 @@ impl Store {
             let end_id = start_id + partition_size - 1;
 
             // This base query yields `DbStoredIris`
-            let base_stream = match min_last_modified_at {
+            let stream = match min_last_modified_at {
                 Some(min_last_modified_at) => sqlx::query_as::<_, DbStoredIris>(
                     "SELECT id, left_code, left_mask, right_code, right_mask FROM irises WHERE id \
                      BETWEEN $1 AND $2 AND last_modified_at >= $3",
@@ -205,29 +206,22 @@ impl Store {
                 .bind(start_id as i64)
                 .bind(end_id as i64)
                 .bind(min_last_modified_at)
-                .fetch(&self.pool),
+                .fetch(&self.pool)
+                .map_err(Into::into),
                 None => sqlx::query_as::<_, DbStoredIris>(
                     "SELECT id, left_code, left_mask, right_code, right_mask FROM irises WHERE id \
                      BETWEEN $1 AND $2",
                 )
                 .bind(start_id as i64)
                 .bind(end_id as i64)
-                .fetch(&self.pool),
-            };
+                .fetch(&self.pool)
+                .map_err(Into::into),
+            }
+            .boxed();
 
-            // Convert `Stream<Item = Result<DbStoredIris, sqlx::Error>>`
-            //  -> `Stream<Item = eyre::Result<DbStoredIris>>` using map_err,
-            //  -> then map_ok(StoredIris::Db) to unify the output type:
-            let partition_stream = base_stream
-                .map_err(Into::into) // `sqlx::Error` -> `eyre::Error`
-                .map_ok(StoredIris::DB) // `DbStoredIris` -> `StoredIris::Db(...)`
-                .boxed();
-
-            partition_streams.push(partition_stream);
+            partition_streams.push(stream);
         }
 
-        // `select_all` requires that all streams have the same Item type:
-        // which is `Result<StoredIris, eyre::Error>` now.
         stream::select_all(partition_streams)
     }
 
@@ -548,10 +542,6 @@ mod tests {
         let got: Vec<DbStoredIris> = store
             .stream_irises_par(Some(0), 2)
             .await
-            .map_ok(|stored_iris| match stored_iris {
-                StoredIris::DB(db_iris) => db_iris,
-                StoredIris::S3(_) => panic!("Unexpected S3 variant in this test!"),
-            })
             .try_collect()
             .await?;
         assert_eq!(got.len(), 0);
@@ -591,10 +581,6 @@ mod tests {
         let mut got_par: Vec<DbStoredIris> = store
             .stream_irises_par(Some(0), 2)
             .await
-            .map_ok(|stored_iris| match stored_iris {
-                StoredIris::DB(db_iris) => db_iris,
-                StoredIris::S3(_) => panic!("Unexpected S3 variant in this test!"),
-            })
             .try_collect()
             .await?;
         got_par.sort_by_key(|iris| iris.id);
@@ -676,10 +662,6 @@ mod tests {
             let mut got_par: Vec<DbStoredIris> = store
                 .stream_irises_par(Some(0), parallelism)
                 .await
-                .map_ok(|stored_iris| match stored_iris {
-                    StoredIris::DB(db_iris) => db_iris,
-                    StoredIris::S3(_) => panic!("Unexpected S3 variant in this test!"),
-                })
                 .try_collect()
                 .await?;
             got_par.sort_by_key(|iris| iris.id);

--- a/iris-mpc-store/src/s3_importer.rs
+++ b/iris-mpc-store/src/s3_importer.rs
@@ -1,19 +1,9 @@
-use crate::StoredIris;
 use async_trait::async_trait;
 use aws_sdk_s3::{primitives::ByteStream, Client};
 use eyre::eyre;
-use futures::{stream, Stream, StreamExt};
 use iris_mpc_common::{IRIS_CODE_LENGTH, MASK_CODE_LENGTH};
-use std::{
-    mem,
-    pin::Pin,
-    sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc,
-    },
-    time::Instant,
-};
-use tokio::io::AsyncReadExt;
+use std::{collections::VecDeque, mem, sync::Arc};
+use tokio::{io::AsyncReadExt, sync::mpsc::Sender, task};
 
 const SINGLE_ELEMENT_SIZE: usize = IRIS_CODE_LENGTH * mem::size_of::<u16>() * 2
     + MASK_CODE_LENGTH * mem::size_of::<u16>() * 2
@@ -187,7 +177,7 @@ impl ObjectStore for S3Store {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct LastSnapshotDetails {
     pub timestamp:      i64,
     pub last_serial_id: i64,
@@ -232,85 +222,72 @@ pub async fn last_snapshot_timestamp(
 }
 
 pub async fn fetch_and_parse_chunks(
-    store: &impl ObjectStore,
+    store: Arc<impl ObjectStore>,
     concurrency: usize,
     prefix_name: String,
     last_snapshot_details: LastSnapshotDetails,
-) -> Pin<Box<dyn Stream<Item = eyre::Result<StoredIris>> + Send + '_>> {
+    tx: Sender<S3StoredIris>,
+) -> eyre::Result<()> {
     tracing::info!("Generating chunk files using: {:?}", last_snapshot_details);
     let range_size = if last_snapshot_details.chunk_size as usize > MAX_RANGE_SIZE {
         MAX_RANGE_SIZE
     } else {
         last_snapshot_details.chunk_size as usize
     };
-    let total_bytes = Arc::new(AtomicUsize::new(0));
-    let now = Instant::now();
+    let mut handles: VecDeque<task::JoinHandle<Result<(), eyre::Error>>> =
+        VecDeque::with_capacity(concurrency);
 
-    let result_stream =
-        stream::iter((1..=last_snapshot_details.last_serial_id).step_by(range_size))
-            .map({
-                let total_bytes_clone = total_bytes.clone();
-                move |chunk| {
-                    let counter = total_bytes_clone.clone();
-                    let prefix_name = prefix_name.clone();
-                    async move {
-                        let chunk_id = (chunk / last_snapshot_details.chunk_size)
-                            * last_snapshot_details.chunk_size
-                            + 1;
-                        let offset_within_chunk = (chunk - chunk_id) as usize;
-                        let mut object_stream = store
-                            .get_object(
-                                &format!("{}/{}.bin", prefix_name, chunk_id),
-                                (
-                                    offset_within_chunk * SINGLE_ELEMENT_SIZE,
-                                    (offset_within_chunk + range_size) * SINGLE_ELEMENT_SIZE,
-                                ),
-                            )
-                            .await?
-                            .into_async_read();
-                        let mut records = Vec::with_capacity(range_size);
-                        let mut buf = vec![0u8; SINGLE_ELEMENT_SIZE];
-                        loop {
-                            match object_stream.read_exact(&mut buf).await {
-                                Ok(_) => {
-                                    let iris = S3StoredIris::from_bytes(&buf);
-                                    records.push(iris);
-                                    counter.fetch_add(SINGLE_ELEMENT_SIZE, Ordering::Relaxed);
-                                }
-                                Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
-                                Err(e) => return Err(e.into()),
-                            }
+    for chunk in (1..=last_snapshot_details.last_serial_id).step_by(range_size) {
+        let chunk_id =
+            (chunk / last_snapshot_details.chunk_size) * last_snapshot_details.chunk_size + 1;
+        let prefix_name = prefix_name.clone();
+        let offset_within_chunk = (chunk - chunk_id) as usize;
+
+        // Wait if we've hit the concurrency limit
+        if handles.len() >= concurrency {
+            let handle = handles.pop_front().expect("No s3 import handles to pop");
+            handle.await??;
+        }
+
+        handles.push_back(task::spawn({
+            let store = Arc::clone(&store);
+            let mut slice = vec![0u8; SINGLE_ELEMENT_SIZE];
+            let tx = tx.clone();
+            async move {
+                let mut result = store
+                    .get_object(
+                        &format!("{}/{}.bin", prefix_name, chunk_id),
+                        (
+                            offset_within_chunk * SINGLE_ELEMENT_SIZE,
+                            (offset_within_chunk + range_size) * SINGLE_ELEMENT_SIZE,
+                        ),
+                    )
+                    .await?
+                    .into_async_read();
+
+                loop {
+                    match result.read_exact(&mut slice).await {
+                        Ok(_) => {
+                            let iris = S3StoredIris::from_bytes(&slice)?;
+                            tx.send(iris).await?;
                         }
-                        let stream_of_stored_iris =
-                            stream::iter(records).map(|res_s3| res_s3.map(StoredIris::S3));
-
-                        Ok::<_, eyre::Error>(stream_of_stored_iris)
+                        Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
+                        Err(e) => return Err(e.into()),
                     }
                 }
-            })
-            .buffer_unordered(concurrency)
-            .flat_map(|result| match result {
-                Ok(stream) => stream.boxed(),
-                Err(e) => stream::once(async move { Err(e) }).boxed(),
-            })
-            .inspect({
-                let counter = Arc::new(AtomicUsize::new(0));
-                move |_| {
-                    if counter.fetch_add(1, Ordering::Relaxed) % 1_000_000 == 0 {
-                        let elapsed = now.elapsed().as_secs_f32();
-                        if elapsed > 0.0 {
-                            let bytes = total_bytes.load(Ordering::Relaxed);
-                            tracing::info!(
-                                "Current download throughput: {:.2} Gbps",
-                                bytes as f32 * 8.0 / 1e9 / elapsed
-                            );
-                        }
-                    }
-                }
-            })
-            .boxed();
 
-    result_stream
+                Ok(())
+            }
+        }));
+    }
+
+    tracing::info!("All s3 import tasks are spawned. Waiting for them to finish");
+    // Wait for remaining handles
+    for handle in handles {
+        handle.await??;
+    }
+    tracing::info!("All s3 import tasks are finished.");
+    Ok(())
 }
 
 #[cfg(test)]
@@ -320,6 +297,7 @@ mod tests {
     use aws_sdk_s3::primitives::SdkBody;
     use rand::Rng;
     use std::{cmp::min, collections::HashSet};
+    use tokio::sync::mpsc;
 
     #[derive(Default, Clone)]
     pub struct MockStore {
@@ -423,12 +401,14 @@ mod tests {
             last_serial_id: MOCK_ENTRIES as i64,
             chunk_size:     MOCK_CHUNK_SIZE as i64,
         };
-        let mut chunks =
-            fetch_and_parse_chunks(&store, 1, "out".to_string(), last_snapshot_details).await;
+        let (tx, mut rx) = mpsc::channel::<S3StoredIris>(1024);
+        let store_arc = Arc::new(store);
+        let _res =
+            fetch_and_parse_chunks(store_arc, 1, "out".to_string(), last_snapshot_details, tx)
+                .await;
         let mut count = 0;
         let mut ids: HashSet<usize> = HashSet::from_iter(1..MOCK_ENTRIES);
-        while let Some(chunk) = chunks.next().await {
-            let chunk = chunk.unwrap();
+        while let Some(chunk) = rx.recv().await {
             ids.remove(&(chunk.index()));
             count += 1;
         }


### PR DESCRIPTION
**Change**

This PR improves load time via:
1. Switching from (returning vector of streams followed by `select_all` and `try_next`) to (spawning a separate tokio task for each `get_object` and sending items to a tokio mpsc channel). Instead of polling multiple dynamically changed list of streams, we now wait for a single channel.
2. Having page locking later than import: Working on memory at the same time with page-lock and import writes is affecting the performance. When we move the page-lock after the import, we saw that page-lock time decreases by 70% while import time remains almost the same
3. Infra change:  Directory buckets (s3express) bring more stable s3 throughput which used to be varying a lot for general purpose buckets. Overall, it improved the performance in stage by around 20-25%.

**Background & More Details**
- We need page-lock for better batch performance and this is why we do not start processing them before page lock finishes. It takes around 7,75s to page-lock 1M records in memory. Parallelizing it does not help as it's probably serialized on OS level.
- We used to start page-lock in the background and immediately start s3 and aurora streams to write into the memory. This used to affect memory write and stream performance indirectly.
- Since we move page-locked after importing everything, the real s3 throughput became obvious where we exceeded aws defined network throughput by around 20-25% in our stage instances.
- In order not to waste the whole time for page-lock, we tried to divide it into chunks and start writing into the memory chunk which is already page-locked. However, chunked page locks resulted in `CUDA_ERROR_INVALID_VALUE` errors. So, we abandoned them.
- With these changes, current bottleneck seems to be memory writing
- Please note that we can further avoid the time to send items to tokio mpsc channel by directly writing into the memory in importer. 