### PR TITLE
Fix NCCL/EFA of base docker image for smaller images

### DIFF
--- a/.github/workflows/temp-branch-build-and-push.yaml
+++ b/.github/workflows/temp-branch-build-and-push.yaml
@@ -3,7 +3,7 @@ name: Branch - Build and push docker image
 on:
   push:
     branches:
-      - "POP-2067/handle-conn-reset-during-s3-load"
+      - "fix-nccl-version"
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ WORKDIR /src/gpu-iris-mpc
 COPY . .
 RUN cargo build --release --target x86_64-unknown-linux-gnu --bin nccl --bin server --bin client --bin key-manager --bin upgrade-server --bin upgrade-client --bin upgrade-checker --bin reshare-server --bin reshare-client
 
-FROM --platform=linux/amd64 ghcr.io/worldcoin/iris-mpc-base:cuda12_2-nccl2_22_3_1
+FROM --platform=linux/amd64 ghcr.io/worldcoin/iris-mpc-base:cuda-libraries12_2-nccl2_22_3_1
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Include client, server and key-manager, upgrade-client and upgrade-server binaries

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,9 +38,6 @@ COPY --from=build-app /src/gpu-iris-mpc/target/x86_64-unknown-linux-gnu/release/
 COPY --from=build-app /src/gpu-iris-mpc/target/x86_64-unknown-linux-gnu/release/server /bin/server
 COPY --from=build-app /src/gpu-iris-mpc/target/x86_64-unknown-linux-gnu/release/client /bin/client
 COPY --from=build-app /src/gpu-iris-mpc/target/x86_64-unknown-linux-gnu/release/key-manager /bin/key-manager
-COPY --from=build-app /src/gpu-iris-mpc/target/x86_64-unknown-linux-gnu/release/upgrade-server /bin/upgrade-server
-COPY --from=build-app /src/gpu-iris-mpc/target/x86_64-unknown-linux-gnu/release/upgrade-client /bin/upgrade-client
-COPY --from=build-app /src/gpu-iris-mpc/target/x86_64-unknown-linux-gnu/release/upgrade-checker /bin/upgrade-checker
 COPY --from=build-app /src/gpu-iris-mpc/target/x86_64-unknown-linux-gnu/release/reshare-server /bin/reshare-server
 COPY --from=build-app /src/gpu-iris-mpc/target/x86_64-unknown-linux-gnu/release/reshare-client /bin/reshare-client
 

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -89,7 +89,6 @@ RUN mkdir -p /lib/x86_64-linux-gnu && \
     ln -sf /usr/lib/x86_64-linux-gnu/librdmacm.so.1 . && \
     ln -sf /usr/lib/x86_64-linux-gnu/libibverbs.so.1 .
 
-# Test EFA and NCCL installation
+# Test EFA installation
 RUN ldconfig && \
     /opt/amazon/efa/bin/fi_info --version
-

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -53,22 +53,43 @@ FROM --platform=linux/amd64 ubuntu:22.04 as build-image
 
 RUN apt-get update && apt-get install -y pkg-config wget
 
-RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb \
+FROM --platform=linux/amd64 ubuntu:22.04 as runtime-image
+RUN apt-get update && apt-get install -y pkg-config wget \
+    && wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb \
     && dpkg -i cuda-keyring_1.1-1_all.deb \
     && apt-get update \
     && apt-get install -y cuda-libraries-12-2 libnccl2=2.22.3-1+cuda12.2 libnccl-dev=2.22.3-1+cuda12.2 \
-    && rm -f cuda-keyring_1.1-1_all.deb
-
-# Set environment variables for runtime
-ENV LD_LIBRARY_PATH=/usr/local/cuda/extras/CUPTI/lib64:/opt/aws-ofi-nccl/install/lib:/usr/local/cuda/lib64:$LD_LIBRARY_PATH
-ENV PATH=/opt/aws-ofi-nccl/install/bin:/usr/local/cuda/bin:$PATH
+    && rm -f cuda-keyring_1.1-1_all.deb \
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy necessary files from build stage
 COPY --from=base-image /opt/gdrcopy /opt/gdrcopy
-COPY --from=base-image /opt/aws-ofi-nccl/install /opt/aws-ofi-nccl/install
-COPY --from=base-image /opt/amazon/efa /opt/amazon/efa
+COPY --from=base-image /opt/aws-ofi-nccl /opt/aws-ofi-nccl
+COPY --from=base-image /opt/amazon /opt/amazon
 
-ENV LD_LIBRARY_PATH=/opt/gdrcopy/lib:/usr/local/cuda/compat:$LD_LIBRARY_PATH
+# Copy all required shared libraries
+COPY --from=base-image /usr/lib/x86_64-linux-gnu/libfabric.so* /usr/lib/x86_64-linux-gnu/
+COPY --from=base-image /usr/lib/x86_64-linux-gnu/libefa.so* /usr/lib/x86_64-linux-gnu/
+COPY --from=base-image /usr/lib/x86_64-linux-gnu/librdmacm.so* /usr/lib/x86_64-linux-gnu/
+COPY --from=base-image /usr/lib/x86_64-linux-gnu/libibverbs.so* /usr/lib/x86_64-linux-gnu/
+COPY --from=base-image /usr/lib/x86_64-linux-gnu/libnl-3.so* /usr/lib/x86_64-linux-gnu/
+COPY --from=base-image /usr/lib/x86_64-linux-gnu/libnl-route-3.so* /usr/lib/x86_64-linux-gnu/
+
+ENV PATH=/opt/aws-ofi-nccl/install/bin:/usr/local/cuda/bin:/opt/amazon/efa/bin:$PATH
+ENV LD_LIBRARY_PATH=/usr/local/cuda/extras/CUPTI/lib64:/opt/aws-ofi-nccl/install/lib:/opt/amazon/efa/lib:/opt/amazon/openmpi/lib:/usr/local/cuda/lib64:/opt/nccl/build/lib:/opt/gdrcopy/lib:/usr/local/cuda/compat:/usr/local/lib:$LD_LIBRARY_PATH
 ENV LIBRARY_PATH=/opt/gdrcopy/lib:/usr/local/cuda/compat/:$LIBRARY_PATH
 ENV CPATH=/opt/gdrcopy/include:$CPATH
-ENV PATH=/opt/gdrcopy/bin:$PATH
+
+# Create symbolic links for libraries
+# Make sure libraries are properly linked
+RUN mkdir -p /lib/x86_64-linux-gnu && \
+    cd /lib/x86_64-linux-gnu && \
+    rm -f libefa.so.1 librdmacm.so.1 libibverbs.so.1 && \
+    ln -sf /usr/lib/x86_64-linux-gnu/libefa.so.1 . && \
+    ln -sf /usr/lib/x86_64-linux-gnu/librdmacm.so.1 . && \
+    ln -sf /usr/lib/x86_64-linux-gnu/libibverbs.so.1 .
+
+# Test EFA and NCCL installation
+RUN ldconfig && \
+    /opt/amazon/efa/bin/fi_info --version
+


### PR DESCRIPTION
### Notes
* This fixes the EFA and NCCL installation by creating symlinks and copying more packages to the base image
* remove upgrade protocol from main image

### Testing
* its tested by checking the EFA version on the docker image
* we no longer see any degradation in performance in staging
* https://app.datadoghq.com/logs?query=service%3Airis-mpc%20cluster_name%3Asmpcv2-%2A-stage%20%21Heartbeat%20%22Batch%20took%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice%2Caws_eks_cluster-name&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1738760228709&to_ts=1738760506000&live=false