### PR TITLE
accept reauth requests

### DIFF
--- a/.github/workflows/temp-branch-build-and-push.yaml
+++ b/.github/workflows/temp-branch-build-and-push.yaml
@@ -3,7 +3,7 @@ name: Branch - Build and push docker image
 on:
   push:
     branches:
-      - "feat/add-anonymized-stats-to-response"
+      - "POP-2056/accept-reauth-requests"
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:95095cc3762b2eb2d300b85a407df847ba11390e"
+image: "ghcr.io/worldcoin/iris-mpc:d9eaed774b8240180eb3e01e32e9643afbcdc002"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:v0.13.25"
+image: "ghcr.io/worldcoin/iris-mpc:02df24f0c7ad223b0552763a3225540fe40f247c"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:d9eaed774b8240180eb3e01e32e9643afbcdc002"
+image: "ghcr.io/worldcoin/iris-mpc:073d400788448fd918c213adfaf332b12c6f51c3"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:073d400788448fd918c213adfaf332b12c6f51c3"
+image: "ghcr.io/worldcoin/iris-mpc:0637d34a9d0d6d5769aa8c507f704e4a2338da7e"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:02df24f0c7ad223b0552763a3225540fe40f247c"
+image: "ghcr.io/worldcoin/iris-mpc:95095cc3762b2eb2d300b85a407df847ba11390e"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -107,6 +107,9 @@ env:
   - name: SMPC__ENABLE_SENDING_ANONYMIZED_STATS_MESSAGE
     value: "true"
 
+  - name: SMPC__ENABLE_REAUTH
+    value: "true"
+
   - name: SMPC__SERVICE__METRICS__HOST
     valueFrom:
       fieldRef:

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -106,7 +106,10 @@ env:
 
   - name: SMPC__ENABLE_SENDING_ANONYMIZED_STATS_MESSAGE
     value: "true"  
-  
+
+  - name: SMPC__ENABLE_REAUTH
+    value: "true"
+
   - name: SMPC__SERVICE__METRICS__HOST
     valueFrom:
       fieldRef:

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -107,6 +107,9 @@ env:
   - name: SMPC__ENABLE_SENDING_ANONYMIZED_STATS_MESSAGE
     value: "true"
 
+  - name: SMPC__ENABLE_REAUTH
+    value: "true"
+
   - name: SMPC__SERVICE__METRICS__HOST
     valueFrom:
       fieldRef:

--- a/iris-mpc-common/src/config/mod.rs
+++ b/iris-mpc-common/src/config/mod.rs
@@ -126,6 +126,9 @@ pub struct Config {
 
     #[serde(default)]
     pub enable_sending_anonymized_stats_message: bool,
+
+    #[serde(default)]
+    pub enable_reauth: bool,
 }
 
 fn default_load_chunks_parallelism() -> usize {

--- a/iris-mpc-common/src/helpers/smpc_request.rs
+++ b/iris-mpc-common/src/helpers/smpc_request.rs
@@ -105,6 +105,7 @@ pub const IDENTITY_DELETION_MESSAGE_TYPE: &str = "identity_deletion";
 pub const ANONYMIZED_STATISTICS_MESSAGE_TYPE: &str = "anonymized_statistics";
 pub const CIRCUIT_BREAKER_MESSAGE_TYPE: &str = "circuit_breaker";
 pub const UNIQUENESS_MESSAGE_TYPE: &str = "uniqueness";
+pub const REAUTH_MESSAGE_TYPE: &str = "reauth";
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct UniquenessRequest {
@@ -122,6 +123,16 @@ pub struct CircuitBreakerRequest {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct IdentityDeletionRequest {
     pub serial_id: u32,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ReAuthRequest {
+    pub reauth_id:               String,
+    pub batch_size:              Option<usize>,
+    pub s3_key:                  String,
+    pub iris_shares_file_hashes: [String; 3],
+    pub serial_id:               u32,
+    pub use_or_rule:             bool,
 }
 
 #[derive(Error, Debug)]
@@ -193,99 +204,96 @@ impl SharesS3Object {
     }
 }
 
-impl UniquenessRequest {
-    pub async fn get_iris_data_by_party_id(
-        &self,
-        party_id: usize,
-        bucket_name: &String,
-        s3_client: &Arc<S3Client>,
-    ) -> Result<String, SharesDecodingError> {
-        let response = s3_client
-            .get_object()
-            .bucket(bucket_name)
-            .key(self.s3_key.as_str())
-            .send()
-            .await
-            .map_err(|err| {
-                tracing::error!("Failed to download file: {}", err);
-                SharesDecodingError::S3ResponseContent {
-                    key:     self.s3_key.clone(),
-                    message: err.to_string(),
-                }
-            })?;
-
-        let object_body = response.body.collect().await.map_err(|e| {
-            tracing::error!("Failed to get object body: {}", e);
+pub async fn get_iris_data_by_party_id(
+    s3_key: &str,
+    party_id: usize,
+    bucket_name: &String,
+    s3_client: &Arc<S3Client>,
+) -> Result<String, SharesDecodingError> {
+    let response = s3_client
+        .get_object()
+        .bucket(bucket_name)
+        .key(s3_key)
+        .send()
+        .await
+        .map_err(|err| {
+            tracing::error!("Failed to download file: {}", err);
             SharesDecodingError::S3ResponseContent {
-                key:     self.s3_key.clone(),
-                message: e.to_string(),
+                key:     s3_key.to_string(),
+                message: err.to_string(),
             }
         })?;
 
-        let bytes = object_body.into_bytes();
+    let object_body = response.body.collect().await.map_err(|e| {
+        tracing::error!("Failed to get object body: {}", e);
+        SharesDecodingError::S3ResponseContent {
+            key:     s3_key.to_string(),
+            message: e.to_string(),
+        }
+    })?;
 
-        let shares_file: SharesS3Object = serde_json::from_slice(&bytes)?;
+    let bytes = object_body.into_bytes();
 
-        let field_name = format!("iris_share_{}", party_id);
+    let shares_file: SharesS3Object = serde_json::from_slice(&bytes)?;
 
-        shares_file.get(party_id).cloned().ok_or_else(|| {
-            tracing::error!("Failed to find field: {}", field_name);
-            SharesDecodingError::SecretStringNotFound
-        })
-    }
+    let field_name = format!("iris_share_{}", party_id);
 
-    pub fn decrypt_iris_share(
-        &self,
-        share: String,
-        key_pairs: SharesEncryptionKeyPairs,
-    ) -> Result<IrisCodesJSON, SharesDecodingError> {
-        let share_bytes = STANDARD
-            .decode(share.as_bytes())
-            .map_err(|_| SharesDecodingError::Base64DecodeError)?;
+    shares_file.get(party_id).cloned().ok_or_else(|| {
+        tracing::error!("Failed to find field: {}", field_name);
+        SharesDecodingError::SecretStringNotFound
+    })
+}
 
-        // try decrypting with key_pairs.current_key_pair, if it fails, try decrypting
-        // with key_pairs.previous_key_pair (if it exists, otherwise, return an error)
-        let decrypted = match key_pairs
-            .current_key_pair
-            .open_sealed_box(share_bytes.clone())
-        {
-            Ok(bytes) => Ok(bytes),
-            Err(_) => {
-                match if let Some(key_pair) = key_pairs.previous_key_pair.clone() {
-                    key_pair.open_sealed_box(share_bytes)
-                } else {
-                    Err(SharesDecodingError::PreviousKeyNotFound)
-                } {
-                    Ok(bytes) => Ok(bytes),
-                    Err(_) => Err(SharesDecodingError::SealedBoxOpenError),
-                }
+pub fn decrypt_iris_share(
+    share: String,
+    key_pairs: SharesEncryptionKeyPairs,
+) -> Result<IrisCodesJSON, SharesDecodingError> {
+    let share_bytes = STANDARD
+        .decode(share.as_bytes())
+        .map_err(|_| SharesDecodingError::Base64DecodeError)?;
+
+    // try decrypting with key_pairs.current_key_pair, if it fails, try decrypting
+    // with key_pairs.previous_key_pair (if it exists, otherwise, return an error)
+    let decrypted = match key_pairs
+        .current_key_pair
+        .open_sealed_box(share_bytes.clone())
+    {
+        Ok(bytes) => Ok(bytes),
+        Err(_) => {
+            match if let Some(key_pair) = key_pairs.previous_key_pair.clone() {
+                key_pair.open_sealed_box(share_bytes)
+            } else {
+                Err(SharesDecodingError::PreviousKeyNotFound)
+            } {
+                Ok(bytes) => Ok(bytes),
+                Err(_) => Err(SharesDecodingError::SealedBoxOpenError),
             }
-        };
+        }
+    };
 
-        let iris_share = match decrypted {
-            Ok(bytes) => {
-                let json_string = String::from_utf8(bytes)
-                    .map_err(SharesDecodingError::DecodedShareParsingToUTF8Error)?;
+    let iris_share = match decrypted {
+        Ok(bytes) => {
+            let json_string = String::from_utf8(bytes)
+                .map_err(SharesDecodingError::DecodedShareParsingToUTF8Error)?;
 
-                let iris_share: IrisCodesJSON =
-                    serde_json::from_str(&json_string).map_err(SharesDecodingError::SerdeError)?;
-                iris_share
-            }
-            Err(e) => return Err(e),
-        };
+            let iris_share: IrisCodesJSON =
+                serde_json::from_str(&json_string).map_err(SharesDecodingError::SerdeError)?;
+            iris_share
+        }
+        Err(e) => return Err(e),
+    };
 
-        Ok(iris_share)
-    }
+    Ok(iris_share)
+}
 
-    pub fn validate_iris_share(
-        &self,
-        party_id: usize,
-        share: IrisCodesJSON,
-    ) -> Result<bool, SharesDecodingError> {
-        let stringified_share = serde_json::to_string(&share)
-            .map_err(SharesDecodingError::SerdeError)?
-            .into_bytes();
+pub fn validate_iris_share(
+    iris_shares_file_hashes: [String; 3],
+    party_id: usize,
+    share: IrisCodesJSON,
+) -> Result<bool, SharesDecodingError> {
+    let stringified_share = serde_json::to_string(&share)
+        .map_err(SharesDecodingError::SerdeError)?
+        .into_bytes();
 
-        Ok(self.iris_shares_file_hashes[party_id] == sha256_as_hex_string(stringified_share))
-    }
+    Ok(iris_shares_file_hashes[party_id] == sha256_as_hex_string(stringified_share))
 }

--- a/iris-mpc-common/tests/smpc_request.rs
+++ b/iris-mpc-common/tests/smpc_request.rs
@@ -5,7 +5,10 @@ mod tests {
     use iris_mpc_common::helpers::{
         key_pair::{SharesDecodingError, SharesEncryptionKeyPairs},
         sha256::sha256_as_hex_string,
-        smpc_request::{IrisCodesJSON, UniquenessRequest},
+        smpc_request::{
+            decrypt_iris_share, get_iris_data_by_party_id, validate_iris_share, IrisCodesJSON,
+            UniquenessRequest,
+        },
     };
     use serde_json::json;
     use sodiumoxide::crypto::{box_::PublicKey, sealedbox};
@@ -46,19 +49,6 @@ mod tests {
             signup_id:               "signup_mock".to_string(),
             s3_key:                  "mock".to_string(),
             iris_shares_file_hashes: hashes,
-        }
-    }
-
-    fn get_mock_request() -> UniquenessRequest {
-        UniquenessRequest {
-            batch_size:              None,
-            signup_id:               "test_signup_id".to_string(),
-            s3_key:                  "package".to_string(),
-            iris_shares_file_hashes: [
-                "hash_0".to_string(),
-                "hash_1".to_string(),
-                "hash_2".to_string(),
-            ],
         }
     }
 
@@ -112,9 +102,13 @@ mod tests {
             ],
         };
 
-        let result = smpc_request
-            .get_iris_data_by_party_id(0, &bucket_name.to_string(), &s3_client)
-            .await;
+        let result = get_iris_data_by_party_id(
+            smpc_request.s3_key.as_str(),
+            0,
+            &bucket_name.to_string(),
+            &s3_client,
+        )
+        .await;
 
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), "share_0_data".to_string());
@@ -140,13 +134,12 @@ mod tests {
         let sealed_box = sealedbox::seal(json_string.as_bytes(), &shares_encryption_public_key);
         let encoded_share = STANDARD.encode(sealed_box);
 
-        let smpc_request = get_mock_request();
         let key_pair = get_key_pairs(
             PREVIOUS_PRIVATE_KEY.to_string(),
             CURRENT_PRIVATE_KEY.to_string(),
         );
 
-        let result = smpc_request.decrypt_iris_share(encoded_share, key_pair);
+        let result = decrypt_iris_share(encoded_share, key_pair);
 
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), iris_codes_json);
@@ -166,7 +159,6 @@ mod tests {
         let sealed_box = sealedbox::seal(json_string.as_bytes(), &shares_encryption_public_key);
         let encoded_share = STANDARD.encode(sealed_box);
 
-        let smpc_request = get_mock_request();
         let key_pair = get_key_pairs(
             PREVIOUS_PRIVATE_KEY.to_string(),
             CURRENT_PRIVATE_KEY.to_string(),
@@ -174,7 +166,7 @@ mod tests {
 
         // Decrypt the share. It will succeed, by first attempting to use the current
         // private key (failing), and then the previous private key (succeeding)
-        let result = smpc_request.decrypt_iris_share(encoded_share, key_pair);
+        let result = decrypt_iris_share(encoded_share, key_pair);
 
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), iris_codes_json);
@@ -195,12 +187,10 @@ mod tests {
         // Set the previous key to be empty
         let key_pair = get_key_pairs(CURRENT_PRIVATE_KEY.to_string(), "".to_string());
 
-        let smpc_request = get_mock_request();
-
         // Decrypt the share. It will fail: it will attempt to decrypt using the current
         // key, but the share was encrypted using the current key. The previous
         // key does not exist, so it will return a sealed box open error
-        let result = smpc_request.decrypt_iris_share(encoded_share, key_pair);
+        let result = decrypt_iris_share(encoded_share, key_pair);
         assert!(matches!(
             result,
             Err(SharesDecodingError::SealedBoxOpenError)
@@ -214,9 +204,8 @@ mod tests {
             CURRENT_PRIVATE_KEY.to_string(),
             CURRENT_PRIVATE_KEY.to_string(),
         );
-        let smpc_request = get_mock_request();
 
-        let result = smpc_request.decrypt_iris_share(invalid_base64.to_string(), key_pair);
+        let result = decrypt_iris_share(invalid_base64.to_string(), key_pair);
 
         assert!(matches!(
             result,
@@ -237,9 +226,8 @@ mod tests {
             PREVIOUS_PRIVATE_KEY.to_string(),
             CURRENT_PRIVATE_KEY.to_string(),
         );
-        let smpc_request = get_mock_request();
 
-        let result = smpc_request.decrypt_iris_share(encoded_share, key_pair);
+        let result = decrypt_iris_share(encoded_share, key_pair);
 
         assert!(matches!(
             result,
@@ -260,9 +248,8 @@ mod tests {
             PREVIOUS_PRIVATE_KEY.to_string(),
             CURRENT_PRIVATE_KEY.to_string(),
         );
-        let smpc_request = get_mock_request();
 
-        let result = smpc_request.decrypt_iris_share(encoded_share, key_pair);
+        let result = decrypt_iris_share(encoded_share, key_pair);
 
         assert!(matches!(result, Err(SharesDecodingError::SerdeError(_))));
     }
@@ -279,9 +266,12 @@ mod tests {
             "dummy_hash_2".to_string(),
         ]);
 
-        let is_valid = smpc_request
-            .validate_iris_share(0, mock_iris_codes_json)
-            .unwrap();
+        let is_valid = validate_iris_share(
+            smpc_request.iris_shares_file_hashes,
+            0,
+            mock_iris_codes_json,
+        )
+        .unwrap();
 
         assert!(is_valid, "The iris share should be valid");
     }
@@ -299,9 +289,12 @@ mod tests {
         ]);
 
         // Act
-        let is_valid = smpc_request
-            .validate_iris_share(0, mock_iris_codes_json)
-            .unwrap();
+        let is_valid = validate_iris_share(
+            smpc_request.iris_shares_file_hashes,
+            0,
+            mock_iris_codes_json,
+        )
+        .unwrap();
 
         // Assert
         assert!(!is_valid, "The iris share should be invalid");

--- a/iris-mpc-gpu/src/server/mod.rs
+++ b/iris-mpc-gpu/src/server/mod.rs
@@ -9,7 +9,7 @@ use iris_mpc_common::{
     galois_engine::degree4::{GaloisRingIrisCodeShare, GaloisRingTrimmedMaskCodeShare},
     helpers::statistics::BucketStatistics,
 };
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{HashMap, HashSet};
 use tokio::sync::oneshot;
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
@@ -66,7 +66,7 @@ pub struct BatchMetadata {
     pub span_id:  String,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct BatchQuery {
     // Enrollment and reauth specific fields
     pub request_ids:              Vec<String>,
@@ -87,7 +87,7 @@ pub struct BatchQuery {
 
     // Only reauth specific fields
     // Map from reauth request id to the index of the target entry to be matched
-    pub reauth_target_indices: BTreeMap<String, u32>,
+    pub reauth_target_indices: HashMap<String, u32>,
 
     // Only deletion specific fields
     pub deletion_requests_indices:  Vec<u32>, // 0-indexed indices of entries to be deleted

--- a/iris-mpc-gpu/src/server/mod.rs
+++ b/iris-mpc-gpu/src/server/mod.rs
@@ -9,7 +9,7 @@ use iris_mpc_common::{
     galois_engine::degree4::{GaloisRingIrisCodeShare, GaloisRingTrimmedMaskCodeShare},
     helpers::statistics::BucketStatistics,
 };
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use tokio::sync::oneshot;
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
@@ -68,22 +68,30 @@ pub struct BatchMetadata {
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct BatchQuery {
-    pub request_ids:                Vec<String>,
-    pub metadata:                   Vec<BatchMetadata>,
-    pub query_left:                 BatchQueryEntries,
-    pub db_left:                    BatchQueryEntries,
-    pub store_left:                 BatchQueryEntries,
-    pub query_left_preprocessed:    BatchQueryEntriesPreprocessed,
-    pub db_left_preprocessed:       BatchQueryEntriesPreprocessed,
-    pub query_right:                BatchQueryEntries,
-    pub db_right:                   BatchQueryEntries,
-    pub store_right:                BatchQueryEntries,
-    pub query_right_preprocessed:   BatchQueryEntriesPreprocessed,
-    pub db_right_preprocessed:      BatchQueryEntriesPreprocessed,
-    pub deletion_requests_indices:  Vec<u32>, // 0-indexed indicies in of entries to be deleted
-    pub deletion_requests_metadata: Vec<BatchMetadata>,
+    // Enrollment and reauth specific fields
+    pub request_ids:              Vec<String>,
+    pub request_types:            Vec<String>,
+    pub metadata:                 Vec<BatchMetadata>,
+    pub query_left:               BatchQueryEntries,
+    pub db_left:                  BatchQueryEntries,
+    pub store_left:               BatchQueryEntries,
+    pub query_left_preprocessed:  BatchQueryEntriesPreprocessed,
+    pub db_left_preprocessed:     BatchQueryEntriesPreprocessed,
+    pub query_right:              BatchQueryEntries,
+    pub db_right:                 BatchQueryEntries,
+    pub store_right:              BatchQueryEntries,
+    pub query_right_preprocessed: BatchQueryEntriesPreprocessed,
+    pub db_right_preprocessed:    BatchQueryEntriesPreprocessed,
     pub or_rule_serial_ids:         Vec<Vec<u32>>,
-    pub valid_entries:              Vec<bool>,
+    pub valid_entries:            Vec<bool>,
+
+    // Only reauth specific fields
+    // Map from reauth request id to the index of the target entry to be matched
+    pub reauth_target_indices: BTreeMap<String, u32>,
+
+    // Only deletion specific fields
+    pub deletion_requests_indices:  Vec<u32>, // 0-indexed indices of entries to be deleted
+    pub deletion_requests_metadata: Vec<BatchMetadata>,
 }
 
 macro_rules! filter_by_indices {

--- a/iris-mpc-gpu/src/server/mod.rs
+++ b/iris-mpc-gpu/src/server/mod.rs
@@ -82,7 +82,7 @@ pub struct BatchQuery {
     pub store_right:              BatchQueryEntries,
     pub query_right_preprocessed: BatchQueryEntriesPreprocessed,
     pub db_right_preprocessed:    BatchQueryEntriesPreprocessed,
-    pub or_rule_serial_ids:         Vec<Vec<u32>>,
+    pub or_rule_serial_ids:       Vec<Vec<u32>>,
     pub valid_entries:            Vec<bool>,
 
     // Only reauth specific fields
@@ -131,6 +131,7 @@ impl BatchQuery {
     pub fn retain(&mut self, indices: &[usize]) {
         let indices_set: HashSet<usize> = indices.iter().cloned().collect();
         filter_by_indices!(self.request_ids, indices_set);
+        filter_by_indices!(self.request_types, indices_set);
         filter_by_indices!(self.metadata, indices_set);
         filter_by_indices!(self.store_left.code, indices_set);
         filter_by_indices!(self.store_left.mask, indices_set);

--- a/iris-mpc/src/bin/server.rs
+++ b/iris-mpc/src/bin/server.rs
@@ -9,7 +9,7 @@ use aws_sdk_sns::{types::MessageAttributeValue, Client as SNSClient};
 use aws_sdk_sqs::{config::Region, Client};
 use axum::{response::IntoResponse, routing::get, Router};
 use clap::Parser;
-use eyre::{eyre, Context};
+use eyre::{eyre, Context, Report};
 use futures::{stream::BoxStream, StreamExt};
 use iris_mpc_common::{
     config::{Config, Opt},
@@ -23,9 +23,11 @@ use iris_mpc_common::{
         kms_dh::derive_shared_secret,
         shutdown_handler::ShutdownHandler,
         smpc_request::{
-            CircuitBreakerRequest, IdentityDeletionRequest, ReceiveRequestError, SQSMessage,
-            UniquenessRequest, ANONYMIZED_STATISTICS_MESSAGE_TYPE, CIRCUIT_BREAKER_MESSAGE_TYPE,
-            IDENTITY_DELETION_MESSAGE_TYPE, UNIQUENESS_MESSAGE_TYPE,
+            decrypt_iris_share, get_iris_data_by_party_id, validate_iris_share,
+            CircuitBreakerRequest, IdentityDeletionRequest, ReAuthRequest, ReceiveRequestError,
+            SQSMessage, UniquenessRequest, ANONYMIZED_STATISTICS_MESSAGE_TYPE,
+            CIRCUIT_BREAKER_MESSAGE_TYPE, IDENTITY_DELETION_MESSAGE_TYPE, REAUTH_MESSAGE_TYPE,
+            UNIQUENESS_MESSAGE_TYPE,
         },
         smpc_response::{
             create_message_type_attribute_map, IdentityDeletionResult, UniquenessResult,
@@ -65,7 +67,7 @@ use std::{
 use telemetry_batteries::tracing::{datadog::DatadogBattery, TracingShutdownHandle};
 use tokio::{
     sync::{mpsc, oneshot, Semaphore},
-    task::spawn_blocking,
+    task::{spawn_blocking, JoinHandle},
     time::timeout,
 };
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -76,6 +78,16 @@ const SQS_POLLING_INTERVAL: Duration = Duration::from_secs(1);
 const MAX_CONCURRENT_REQUESTS: usize = 32;
 
 static CURRENT_BATCH_SIZE: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
+
+type GaloisShares = (
+    GaloisRingIrisCodeShare,
+    GaloisRingTrimmedMaskCodeShare,
+    Vec<GaloisRingIrisCodeShare>,
+    Vec<GaloisRingTrimmedMaskCodeShare>,
+    Vec<GaloisRingIrisCodeShare>,
+    Vec<GaloisRingTrimmedMaskCodeShare>,
+);
+type ParseSharesTaskResult = Result<(GaloisShares, GaloisShares), Report>;
 
 fn decode_iris_message_shares(
     code_share: String,
@@ -91,18 +103,10 @@ fn decode_iris_message_shares(
     Ok((iris_share, mask_share))
 }
 
-#[allow(clippy::type_complexity)]
 fn preprocess_iris_message_shares(
     code_share: GaloisRingIrisCodeShare,
     mask_share: GaloisRingTrimmedMaskCodeShare,
-) -> eyre::Result<(
-    GaloisRingIrisCodeShare,
-    GaloisRingTrimmedMaskCodeShare,
-    Vec<GaloisRingIrisCodeShare>,
-    Vec<GaloisRingTrimmedMaskCodeShare>,
-    Vec<GaloisRingIrisCodeShare>,
-    Vec<GaloisRingTrimmedMaskCodeShare>,
-)> {
+) -> eyre::Result<GaloisShares> {
     let mut code_share = code_share;
     let mut mask_share = mask_share;
 
@@ -139,7 +143,8 @@ async fn receive_batch(
     skip_request_ids: &[String],
     shares_encryption_key_pairs: SharesEncryptionKeyPairs,
     shutdown_handler: &ShutdownHandler,
-    error_result_attributes: &HashMap<String, MessageAttributeValue>,
+    uniqueness_error_result_attributes: &HashMap<String, MessageAttributeValue>,
+    reauth_error_result_attributes: &HashMap<String, MessageAttributeValue>,
 ) -> eyre::Result<Option<BatchQuery>, ReceiveRequestError> {
     let max_batch_size = config.clone().max_batch_size;
     let queue_url = &config.clone().requests_queue_url;
@@ -240,19 +245,20 @@ async fn receive_batch(
                             .await
                             .map_err(ReceiveRequestError::FailedToDeleteFromSQS)?;
                     }
+
                     UNIQUENESS_MESSAGE_TYPE => {
                         msg_counter += 1;
 
                         let shares_encryption_key_pairs = shares_encryption_key_pairs.clone();
 
-                        let smpc_request: UniquenessRequest =
+                        let uniqueness_request: UniquenessRequest =
                             serde_json::from_str(&message.message).map_err(|e| {
                                 ReceiveRequestError::json_parse_error("Uniqueness request", e)
                             })?;
                         metrics::counter!("request.received", "type" => "uniqueness_verification")
                             .increment(1);
                         store
-                            .mark_requests_deleted(&[smpc_request.signup_id.clone()])
+                            .mark_requests_deleted(&[uniqueness_request.signup_id.clone()])
                             .await
                             .map_err(ReceiveRequestError::FailedToMarkRequestAsDeleted)?;
 
@@ -264,22 +270,22 @@ async fn receive_batch(
                             .await
                             .map_err(ReceiveRequestError::FailedToDeleteFromSQS)?;
 
-                        if skip_request_ids.contains(&smpc_request.signup_id) {
+                        if skip_request_ids.contains(&uniqueness_request.signup_id) {
                             // Some party (maybe us) already meant to delete this request, so we
                             // skip it. Ignore this message when calculating the batch size.
                             msg_counter -= 1;
                             metrics::counter!("skip.request.deleted.sqs.request").increment(1);
                             tracing::warn!(
                                 "Skipping request due to it being from synced deleted ids: {}",
-                                smpc_request.signup_id
+                                uniqueness_request.signup_id
                             );
                             // shares
                             send_error_results_to_sns(
-                                smpc_request.signup_id,
+                                uniqueness_request.signup_id,
                                 &batch_metadata,
                                 sns_client,
                                 config,
-                                error_result_attributes,
+                                uniqueness_error_result_attributes,
                                 UNIQUENESS_MESSAGE_TYPE,
                                 ERROR_SKIPPED_REQUEST_PREVIOUS_NODE_BATCH,
                             )
@@ -287,7 +293,7 @@ async fn receive_batch(
                             continue;
                         }
 
-                        if let Some(batch_size) = smpc_request.batch_size {
+                        if let Some(batch_size) = uniqueness_request.batch_size {
                             // Updating the batch size instantly makes it a bit unpredictable, since
                             // if we're already above the new limit, we'll still process the current
                             // batch at the higher limit. On the other
@@ -299,78 +305,97 @@ async fn receive_batch(
                             tracing::info!("Updating batch size to {}", batch_size);
                         }
 
-                        batch_query.request_ids.push(smpc_request.signup_id.clone());
+                        batch_query
+                            .request_ids
+                            .push(uniqueness_request.signup_id.clone());
+                        batch_query
+                            .request_types
+                            .push(UNIQUENESS_MESSAGE_TYPE.to_string());
                         batch_query.metadata.push(batch_metadata);
 
                         let semaphore = Arc::clone(&semaphore);
                         let s3_client_arc = Arc::clone(s3_client);
                         let bucket_name = config.shares_bucket_name.clone();
-                        let handle = tokio::spawn(async move {
-                            let _ = semaphore.acquire().await?;
-
-                            let base_64_encoded_message_payload = match smpc_request
-                                .get_iris_data_by_party_id(party_id, &bucket_name, &s3_client_arc)
-                                .await
-                            {
-                                Ok(iris_message_share) => iris_message_share,
-                                Err(e) => {
-                                    tracing::error!("Failed to get iris shares: {:?}", e);
-                                    eyre::bail!("Failed to get iris shares: {:?}", e);
-                                }
-                            };
-
-                            let iris_message_share = match smpc_request.decrypt_iris_share(
-                                base_64_encoded_message_payload,
-                                shares_encryption_key_pairs.clone(),
-                            ) {
-                                Ok(iris_data) => iris_data,
-                                Err(e) => {
-                                    tracing::error!("Failed to decrypt iris shares: {:?}", e);
-                                    eyre::bail!("Failed to decrypt iris shares: {:?}", e);
-                                }
-                            };
-
-                            match smpc_request
-                                .validate_iris_share(party_id, iris_message_share.clone())
-                            {
-                                Ok(_) => {}
-                                Err(e) => {
-                                    tracing::error!("Failed to validate iris shares: {:?}", e);
-                                    eyre::bail!("Failed to validate iris shares: {:?}", e);
-                                }
-                            }
-
-                            let (left_code, left_mask) = decode_iris_message_shares(
-                                iris_message_share.left_iris_code_shares,
-                                iris_message_share.left_mask_code_shares,
-                            )?;
-
-                            let (right_code, right_mask) = decode_iris_message_shares(
-                                iris_message_share.right_iris_code_shares,
-                                iris_message_share.right_mask_code_shares,
-                            )?;
-
-                            // Preprocess shares for left eye.
-                            let left_future = spawn_blocking(move || {
-                                preprocess_iris_message_shares(left_code, left_mask)
-                            });
-
-                            // Preprocess shares for right eye.
-                            let right_future = spawn_blocking(move || {
-                                preprocess_iris_message_shares(right_code, right_mask)
-                            });
-
-                            let (left_result, right_result) =
-                                tokio::join!(left_future, right_future);
-
-                            Ok((
-                                left_result.context("while processing left iris shares")??,
-                                right_result.context("while processing right iris shares")??,
-                            ))
-                        });
+                        let s3_key = uniqueness_request.s3_key.clone();
+                        let iris_shares_file_hashes = uniqueness_request.iris_shares_file_hashes;
+                        let handle = get_iris_shares_parse_task(
+                            party_id,
+                            shares_encryption_key_pairs,
+                            semaphore,
+                            s3_client_arc,
+                            bucket_name,
+                            s3_key,
+                            iris_shares_file_hashes,
+                        )?;
 
                         handles.push(handle);
                     }
+
+                    REAUTH_MESSAGE_TYPE => {
+                        msg_counter += 1;
+
+                        let shares_encryption_key_pairs = shares_encryption_key_pairs.clone();
+
+                        let reauth_request: ReAuthRequest = serde_json::from_str(&message.message)
+                            .map_err(|e| {
+                                ReceiveRequestError::json_parse_error("Reauth request", e)
+                            })?;
+                        metrics::counter!("request.received", "type" => "reauth").increment(1);
+
+                        tracing::debug!("Received reauth request: {:?}", reauth_request);
+
+                        // TODO: populate sync mechanism table (TBD: rollback or rollforward)
+
+                        client
+                            .delete_message()
+                            .queue_url(queue_url)
+                            .receipt_handle(sqs_message.receipt_handle.unwrap())
+                            .send()
+                            .await
+                            .map_err(ReceiveRequestError::FailedToDeleteFromSQS)?;
+
+                        if let Some(batch_size) = reauth_request.batch_size {
+                            // Updating the batch size instantly makes it a bit unpredictable, since
+                            // if we're already above the new limit, we'll still process the current
+                            // batch at the higher limit. On the other
+                            // hand, updating it after the batch is
+                            // processed would not let us "unblock" the protocol if we're stuck with
+                            // low throughput.
+                            *CURRENT_BATCH_SIZE.lock().unwrap() =
+                                batch_size.clamp(1, max_batch_size);
+                            tracing::info!("Updating batch size to {}", batch_size);
+                        }
+
+                        batch_query
+                            .request_ids
+                            .push(reauth_request.reauth_id.clone());
+                        batch_query
+                            .request_types
+                            .push(REAUTH_MESSAGE_TYPE.to_string());
+                        batch_query.metadata.push(batch_metadata);
+                        batch_query.reauth_target_indices.insert(
+                            reauth_request.reauth_id.clone(),
+                            reauth_request.serial_id - 1,
+                        );
+
+                        let semaphore = Arc::clone(&semaphore);
+                        let s3_client_arc = Arc::clone(s3_client);
+                        let bucket_name = config.shares_bucket_name.clone();
+                        let s3_key = reauth_request.s3_key.clone();
+                        let iris_shares_file_hashes = reauth_request.iris_shares_file_hashes;
+                        let handle = get_iris_shares_parse_task(
+                            party_id,
+                            shares_encryption_key_pairs,
+                            semaphore,
+                            s3_client_arc,
+                            bucket_name,
+                            s3_key,
+                            iris_shares_file_hashes,
+                        )?;
+
+                        handles.push(handle);
+                    }
+
                     _ => {
                         client
                             .delete_message()
@@ -417,13 +442,18 @@ async fn receive_batch(
                 tracing::error!("Failed to process iris shares: {:?}", e);
                 // Return error message back to the signup-service if failed to process iris
                 // shares
+                let result_attributes = match batch_query.request_types[index].as_str() {
+                    UNIQUENESS_MESSAGE_TYPE => uniqueness_error_result_attributes,
+                    REAUTH_MESSAGE_TYPE => reauth_error_result_attributes,
+                    _ => unreachable!(), // we don't push a handle for unknown message types
+                };
                 send_error_results_to_sns(
                     batch_query.request_ids[index].clone(),
                     &batch_query.metadata[index],
                     sns_client,
                     config,
-                    error_result_attributes,
-                    UNIQUENESS_MESSAGE_TYPE,
+                    result_attributes,
+                    batch_query.request_types[index].as_str(),
                     ERROR_FAILED_TO_PROCESS_IRIS_SHARES,
                 )
                 .await?;
@@ -472,7 +502,11 @@ async fn receive_batch(
         batch_query.query_right.mask.extend(mask_shares_right);
     }
 
-    tracing::info!("batch signups ids in order: {:?}", batch_query.request_ids);
+    tracing::info!(
+        "batch request ids: {:?}, types: {:?}",
+        batch_query.request_ids,
+        batch_query.request_types
+    );
 
     // Preprocess query shares here already to avoid blocking the actor
     batch_query.query_left_preprocessed =
@@ -485,6 +519,81 @@ async fn receive_batch(
         BatchQueryEntriesPreprocessed::from(batch_query.db_right.clone());
 
     Ok(Some(batch_query))
+}
+
+fn get_iris_shares_parse_task(
+    party_id: usize,
+    shares_encryption_key_pairs: SharesEncryptionKeyPairs,
+    semaphore: Arc<Semaphore>,
+    s3_client_arc: Arc<S3Client>,
+    bucket_name: String,
+    s3_key: String,
+    iris_shares_file_hashes: [String; 3],
+) -> Result<JoinHandle<ParseSharesTaskResult>, ReceiveRequestError> {
+    let handle =
+        tokio::spawn(async move {
+            let _ = semaphore.acquire().await?;
+
+            let base_64_encoded_message_payload =
+                match get_iris_data_by_party_id(&s3_key, party_id, &bucket_name, &s3_client_arc)
+                    .await
+                {
+                    Ok(iris_message_share) => iris_message_share,
+                    Err(e) => {
+                        tracing::error!("Failed to get iris shares: {:?}", e);
+                        eyre::bail!("Failed to get iris shares: {:?}", e);
+                    }
+                };
+
+            let iris_message_share = match decrypt_iris_share(
+                base_64_encoded_message_payload,
+                shares_encryption_key_pairs.clone(),
+            ) {
+                Ok(iris_data) => iris_data,
+                Err(e) => {
+                    tracing::error!("Failed to decrypt iris shares: {:?}", e);
+                    eyre::bail!("Failed to decrypt iris shares: {:?}", e);
+                }
+            };
+
+            match validate_iris_share(
+                iris_shares_file_hashes,
+                party_id,
+                iris_message_share.clone(),
+            ) {
+                Ok(_) => {}
+                Err(e) => {
+                    tracing::error!("Failed to validate iris shares: {:?}", e);
+                    eyre::bail!("Failed to validate iris shares: {:?}", e);
+                }
+            }
+
+            let (left_code, left_mask) = decode_iris_message_shares(
+                iris_message_share.left_iris_code_shares,
+                iris_message_share.left_mask_code_shares,
+            )?;
+
+            let (right_code, right_mask) = decode_iris_message_shares(
+                iris_message_share.right_iris_code_shares,
+                iris_message_share.right_mask_code_shares,
+            )?;
+
+            // Preprocess shares for left eye.
+            let left_future =
+                spawn_blocking(move || preprocess_iris_message_shares(left_code, left_mask));
+
+            // Preprocess shares for right eye.
+            let right_future =
+                spawn_blocking(move || preprocess_iris_message_shares(right_code, right_mask));
+
+            let (left_result, right_result) = tokio::join!(left_future, right_future);
+
+            Ok((
+                left_result.context("while processing left iris shares")??,
+                right_result.context("while processing right iris shares")??,
+            ))
+        });
+    Ok(handle)
 }
 
 fn initialize_tracing(config: &Config) -> eyre::Result<TracingShutdownHandle> {
@@ -1544,7 +1653,9 @@ async fn server_main(config: Config) -> eyre::Result<()> {
     tracing::info!("⚓️ ANCHOR: Start the main loop");
 
     let processing_timeout = Duration::from_secs(config.processing_timeout_secs);
-    let error_result_attribute = create_message_type_attribute_map(UNIQUENESS_MESSAGE_TYPE);
+    let uniqueness_error_result_attribute =
+        create_message_type_attribute_map(UNIQUENESS_MESSAGE_TYPE);
+    let reauth_error_result_attribute = create_message_type_attribute_map(REAUTH_MESSAGE_TYPE);
     let res: eyre::Result<()> = async {
         tracing::info!("Entering main loop");
         // **Tensor format of queries**
@@ -1575,7 +1686,8 @@ async fn server_main(config: Config) -> eyre::Result<()> {
             &skip_request_ids,
             shares_encryption_key_pair.clone(),
             &shutdown_handler,
-            &error_result_attribute,
+            &uniqueness_error_result_attribute,
+            &reauth_error_result_attribute,
         );
 
         let dummy_shares_for_deletions = get_dummy_shares_for_deletion(party_id);
@@ -1629,7 +1741,8 @@ async fn server_main(config: Config) -> eyre::Result<()> {
                 &skip_request_ids,
                 shares_encryption_key_pair.clone(),
                 &shutdown_handler,
-                &error_result_attribute,
+                &uniqueness_error_result_attribute,
+                &reauth_error_result_attribute,
             );
 
             // await the result

--- a/iris-mpc/src/bin/server.rs
+++ b/iris-mpc/src/bin/server.rs
@@ -503,9 +503,12 @@ async fn receive_batch(
     }
 
     tracing::info!(
-        "batch request ids: {:?}, types: {:?}",
-        batch_query.request_ids,
-        batch_query.request_types
+        "Batch requests: {:?}",
+        batch_query
+            .request_ids
+            .iter()
+            .zip(batch_query.request_types.iter())
+            .collect::<Vec<_>>()
     );
 
     // Preprocess query shares here already to avoid blocking the actor


### PR DESCRIPTION
**Main Change**
- In this PR, we introduce a new primitive: `Reauth` (along with `Enrollment` and `Deletion`)
- We see `Reauth` as part of the batch because we'll need all the matches for these requests to decide if they're successful or not.
- In a following PR, we'll process the `Reauth` requests in actor and mark them as success only if they match with given index

**Refactors**
- Moving `get_iris_data_by_party_id`, `decrypt_iris_share`, and `validate_iris_share` methods out of `UniquenessRequest` member functions so that they can be used by both Reauth and Uniqueness requests.
- Adding `request_types` entry to the `BatchQuery` to distinguish various request types keeping in mind that it can expand in the future.
- Moving the logic to download & parse iris shares future from uniqueness_request's body to a common function. Also, adding `GaloisShares` and `ParseSharesTaskResult` type aliases for better readability.

**Notes**
- Please note that `use_or_rule` will be consumed after the LUC PR is merged. So, that's why it's unused for now.