### PR TITLE
slight refactors and tests additions

### DIFF
--- a/iris-mpc-common/src/helpers/statistics.rs
+++ b/iris-mpc-common/src/helpers/statistics.rs
@@ -25,12 +25,13 @@ pub struct BucketStatistics {
     pub party_id: usize,
     pub eye: Eye,
     #[serde(with = "ts_seconds")]
-    pub start_timestamp: DateTime<Utc>,
+    pub start_time_utc_timestamp: DateTime<Utc>,
     #[serde(with = "ts_seconds_option")]
-    pub end_timestamp: Option<DateTime<Utc>>,
+    pub end_time_utc_timestamp: Option<DateTime<Utc>>,
     #[serde(skip_serializing)]
+    #[serde(skip_deserializing)]
     #[serde(with = "ts_seconds_option")]
-    pub next_start_timestamp: Option<DateTime<Utc>>,
+    pub next_start_time_utc_timestamp: Option<DateTime<Utc>>,
 }
 
 impl BucketStatistics {
@@ -43,10 +44,10 @@ impl fmt::Display for BucketStatistics {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "    party_id: {}", self.party_id)?;
         writeln!(f, "    eye: {:?}", self.eye)?;
-        writeln!(f, "    start_timestamp: {}", self.start_timestamp)?;
-        match &self.end_timestamp {
-            Some(end) => writeln!(f, "    end_timestamp: {}", end)?,
-            None => writeln!(f, "    end_timestamp: <none>")?,
+        writeln!(f, "    start_time_utc: {}", self.start_time_utc_timestamp)?;
+        match &self.end_time_utc_timestamp {
+            Some(end) => writeln!(f, "    end_time_utc: {}", end)?,
+            None => writeln!(f, "    end_time_utc: <none>")?,
         }
         for bucket in &self.buckets {
             writeln!(
@@ -73,9 +74,9 @@ impl BucketStatistics {
             eye,
             match_distances_buffer_size,
             party_id,
-            start_timestamp: Utc::now(),
-            end_timestamp: None,
-            next_start_timestamp: None,
+            start_time_utc_timestamp: Utc::now(),
+            end_time_utc_timestamp: None,
+            next_start_time_utc_timestamp: None,
         }
     }
 
@@ -98,7 +99,7 @@ impl BucketStatistics {
 
         // clear just in case, we already clear it on sending the message
         self.buckets.clear();
-        self.end_timestamp = Some(now_timestamp);
+        self.end_time_utc_timestamp = Some(now_timestamp);
 
         let step = match_threshold_ratio / (self.n_buckets as f64);
         for i in 0..buckets_array.len() {
@@ -119,9 +120,9 @@ impl BucketStatistics {
         // otherwise, it means it was the first iteration (ServerActor
         // instantiation)
         if let Some(start_timestamp) = start_timestamp {
-            self.start_timestamp = start_timestamp;
+            self.start_time_utc_timestamp = start_timestamp;
         }
         // Set the next start timestamp to now
-        self.next_start_timestamp = Some(now_timestamp);
+        self.next_start_time_utc_timestamp = Some(now_timestamp);
     }
 }

--- a/iris-mpc-common/tests/statistics.rs
+++ b/iris-mpc-common/tests/statistics.rs
@@ -1,0 +1,174 @@
+mod tests {
+    use chrono::{TimeZone, Utc};
+    use iris_mpc_common::helpers::statistics::{BucketResult, BucketStatistics, Eye};
+    use serde_json::{json, Value};
+
+    #[test]
+    fn test_serde_serialization() {
+        // Let's pick some fixed timestamps for reproducible tests
+        let known_start_time = Utc.timestamp_opt(1_700_000_000, 0).single().unwrap(); // ~ 2023-11-28T00:00:00Z
+        let known_end_time = Utc.timestamp_opt(1_700_000_100, 0).single().unwrap(); // 100s later
+
+        // Create a struct with some data
+        let stats = BucketStatistics {
+            buckets: vec![
+                BucketResult {
+                    count:                   10,
+                    hamming_distance_bucket: [0.00, 0.10],
+                },
+                BucketResult {
+                    count:                   20,
+                    hamming_distance_bucket: [0.10, 0.20],
+                },
+            ],
+            n_buckets: 2,
+            match_distances_buffer_size: 128,
+            party_id: 999,
+            eye: Eye::Right,
+            start_time_utc_timestamp: known_start_time,
+            end_time_utc_timestamp: Some(known_end_time),
+            // This field is #[serde(skip_serializing)]
+            next_start_time_utc_timestamp: Some(Utc::now()),
+        };
+
+        // Serialize to JSON
+        let json_str = serde_json::to_string(&stats).unwrap();
+        let value: Value = serde_json::from_str(&json_str).unwrap();
+
+        // 1) Check that the required fields appear in JSON
+        //
+        // Because of `#[serde(with = "ts_seconds")]`, `start_time_utc`
+        // should be an integer with the timestamp in seconds
+        assert_eq!(value["start_time_utc_timestamp"], json!(1_700_000_000_i64));
+
+        // `end_time_utc` should likewise be an integer
+        assert_eq!(value["end_time_utc_timestamp"], json!(1_700_000_100_i64));
+
+        // The optional next_start_time_utc has `#[serde(skip_serializing)]` so it
+        // should NOT appear
+        assert!(!value
+            .as_object()
+            .unwrap()
+            .contains_key("next_start_time_utc_timestamp"));
+
+        // Eye is an enum with `#[derive(Serialize)]`, so it should appear as a string
+        assert_eq!(value["eye"], json!("Right"));
+
+        // We can check the buckets array
+        assert_eq!(value["buckets"].as_array().unwrap().len(), 2);
+        // For instance, check the first bucket
+        assert_eq!(
+            value["buckets"][0],
+            json!({
+                "count": 10,
+                "hamming_distance_bucket": [0.00, 0.10]
+            })
+        );
+
+        // 2) Check that party_id, n_buckets, etc. appear as expected
+        assert_eq!(value["party_id"], json!(999));
+        assert_eq!(value["n_buckets"], json!(2));
+        assert_eq!(value["match_distances_buffer_size"], json!(128));
+    }
+
+    #[test]
+    fn test_serde_deserialization() {
+        // Imagine we receive this JSON from somewhere
+        // Notice that we do NOT include next_start_time_utc
+        // because it's skip_serializing in your struct
+        let incoming_json = json!({
+            "buckets": [
+                {
+                    "count": 50,
+                    "hamming_distance_bucket": [0.0, 0.3]
+                }
+            ],
+            "n_buckets": 1,
+            "match_distances_buffer_size": 1024,
+            "party_id": 123,
+            "eye": "Left",
+            "start_time_utc_timestamp": 1700000000,
+            "end_time_utc_timestamp": null
+        })
+        .to_string();
+
+        let stats: BucketStatistics = serde_json::from_str(&incoming_json).unwrap();
+
+        // Check that fields were deserialized
+        assert_eq!(stats.buckets.len(), 1);
+        assert_eq!(stats.buckets[0].count, 50);
+        assert_eq!(stats.buckets[0].hamming_distance_bucket, [0.0, 0.3]);
+
+        assert_eq!(stats.n_buckets, 1);
+        assert_eq!(stats.match_distances_buffer_size, 1024);
+        assert_eq!(stats.party_id, 123);
+        assert!(matches!(stats.eye, Eye::Left));
+
+        // start_time_utc is with seconds, so check that
+        let expected_start = Utc.timestamp_opt(1_700_000_000, 0).single().unwrap();
+        assert_eq!(stats.start_time_utc_timestamp, expected_start);
+
+        // end_time_utc was null
+        assert_eq!(stats.end_time_utc_timestamp, None);
+
+        // next_start_time_utc is skip_serializing, so it wouldn't appear in JSON.
+        // If your struct allows it in deserialization, it would default to None
+        assert_eq!(stats.next_start_time_utc_timestamp, None);
+    }
+
+    #[test]
+    fn test_serde_roundtrip() {
+        // Create an instance
+        let original_stats = BucketStatistics {
+            buckets: vec![BucketResult {
+                count:                   100,
+                hamming_distance_bucket: [0.33, 0.66],
+            }],
+            n_buckets: 1,
+            match_distances_buffer_size: 42,
+            party_id: 777,
+            eye: Eye::Right,
+            start_time_utc_timestamp: Utc.timestamp_opt(1_700_000_000, 0).single().unwrap(),
+            end_time_utc_timestamp: Some(
+                Utc.timestamp_opt(1_700_000_000, 0).single().unwrap()
+                    + chrono::Duration::seconds(15),
+            ),
+            next_start_time_utc_timestamp: None,
+        };
+
+        // Serialize
+        let json_str = serde_json::to_string(&original_stats).unwrap();
+        println!("{}", json_str);
+
+        // Deserialize
+        let roundtrip_stats: BucketStatistics = serde_json::from_str(&json_str).unwrap();
+
+        // Because next_start_time_utc is skip_serializing, it does NOT appear in the
+        // JSON. So after deserialization, it won't be recovered. All other
+        // fields, however, should match.
+        assert_eq!(roundtrip_stats.buckets.len(), 1);
+        assert_eq!(roundtrip_stats.buckets[0].count, 100);
+        assert_eq!(roundtrip_stats.buckets[0].hamming_distance_bucket, [
+            0.33, 0.66
+        ]);
+
+        assert_eq!(roundtrip_stats.n_buckets, 1);
+        assert_eq!(roundtrip_stats.match_distances_buffer_size, 42);
+        assert_eq!(roundtrip_stats.party_id, 777);
+        assert!(matches!(roundtrip_stats.eye, Eye::Right));
+
+        // Timestamps (except next_start_time_utc) should match
+        assert_eq!(
+            roundtrip_stats.start_time_utc_timestamp,
+            original_stats.start_time_utc_timestamp
+        );
+        assert_eq!(
+            roundtrip_stats.end_time_utc_timestamp,
+            original_stats.end_time_utc_timestamp
+        );
+
+        // next_start_time_utc won't match because it was not serialized
+        // So it should come back as None
+        assert_eq!(roundtrip_stats.next_start_time_utc_timestamp, None);
+    }
+}

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -1343,7 +1343,8 @@ impl ServerActor {
                     self.anonymized_bucket_statistics_left.fill_buckets(
                         &buckets,
                         MATCH_THRESHOLD_RATIO,
-                        self.anonymized_bucket_statistics_left.next_start_timestamp,
+                        self.anonymized_bucket_statistics_left
+                            .next_start_time_utc_timestamp,
                     );
                     tracing::info!(
                         "Bucket results:\n{}",
@@ -1354,7 +1355,8 @@ impl ServerActor {
                     self.anonymized_bucket_statistics_right.fill_buckets(
                         &buckets,
                         MATCH_THRESHOLD_RATIO,
-                        self.anonymized_bucket_statistics_right.next_start_timestamp,
+                        self.anonymized_bucket_statistics_right
+                            .next_start_time_utc_timestamp,
                     );
                     tracing::info!(
                         "Bucket results:\n{}",

--- a/iris-mpc-gpu/tests/e2e.rs
+++ b/iris-mpc-gpu/tests/e2e.rs
@@ -431,7 +431,10 @@ mod e2e_test {
             return Ok(());
         }
         assert_eq!(bucket_statistics.buckets.len(), N_BUCKETS);
-        assert!(bucket_statistics.end_timestamp > Some(bucket_statistics.start_timestamp));
+        assert!(
+            bucket_statistics.end_time_utc_timestamp
+                > Some(bucket_statistics.start_time_utc_timestamp)
+        );
         let total_count = bucket_statistics
             .buckets
             .iter()


### PR DESCRIPTION
Messages are being produced and delivered correctly. I just wanted to make the field a bit more specific in its naming, and also add some tests for round-tripping. This will make development of the receiving end more straightforward and obvious. See sample message, as retrieved via the AWS console

Also fixed a smal bug in deserealization, even though that probably won't be needd


```
{"buckets":[{"count":64,"hamming_distance_bucket":[0.0,0.0375]},{"count":0,"hamming_distance_bucket":[0.0375,0.075]},{"count":0,"hamming_distance_bucket":[0.075,0.11249999999999999]},{"count":0,"hamming_distance_bucket":[0.11249999999999999,0.15]},{"count":0,"hamming_distance_bucket":[0.15,0.1875]},{"count":0,"hamming_distance_bucket":[0.1875,0.22499999999999998]},{"count":0,"hamming_distance_bucket":[0.22499999999999998,0.2625]},{"count":0,"hamming_distance_bucket":[0.2625,0.3]},{"count":0,"hamming_distance_bucket":[0.3,0.33749999999999997]},{"count":0,"hamming_distance_bucket":[0.33749999999999997,0.375]}],"n_buckets":10,"match_distances_buffer_size":64,"party_id":0,"eye":"Right","start_timestamp":1738452293,"end_timestamp":1738512192}
```
<img width="1420" alt="Screenshot 2025-02-02 at 18 27 48" src="https://github.com/user-attachments/assets/e6ef7aa7-0699-4ad9-b26a-3d0fbd9686b0" />


The integration with the signup-service is also tested here: https://github.com/worldcoin/signup-service/pull/1079/files#diff-9ea68412e68b82b9d0939a23905056c8b6137b669b892a3d3ae32d754087e232R660-R711
