### PR TITLE
Fix non-deterministic buckets

### DIFF
--- a/iris-mpc-common/src/config/mod.rs
+++ b/iris-mpc-common/src/config/mod.rs
@@ -118,6 +118,9 @@ pub struct Config {
     #[serde(default = "default_match_distances_buffer_size")]
     pub match_distances_buffer_size: usize,
 
+    #[serde(default = "default_match_distances_buffer_size_extra_percent")]
+    pub match_distances_buffer_size_extra_percent: usize,
+
     #[serde(default = "default_n_buckets")]
     pub n_buckets: usize,
 
@@ -166,6 +169,10 @@ fn default_db_load_safety_overlap_seconds() -> i64 {
 // This gets multiplied by the number of GPU devices
 fn default_match_distances_buffer_size() -> usize {
     1 << 16
+}
+
+fn default_match_distances_buffer_size_extra_percent() -> usize {
+    10
 }
 
 fn default_n_buckets() -> usize {

--- a/iris-mpc-gpu/tests/e2e.rs
+++ b/iris-mpc-gpu/tests/e2e.rs
@@ -36,6 +36,7 @@ mod e2e_test {
     const MAX_BATCH_SIZE: usize = 64;
     const N_BUCKETS: usize = 10;
     const MATCH_DISTANCES_BUFFER_SIZE: usize = 1 << 7;
+    const MATCH_DISTANCES_BUFFER_SIZE_EXTRA_PERCENT: usize = 100;
     const MAX_DELETIONS_PER_BATCH: usize = 10;
     const THRESHOLD_ABSOLUTE: usize = 4800; // 0.375 * 12800
 
@@ -153,6 +154,7 @@ mod e2e_test {
                 DB_SIZE + DB_BUFFER,
                 MAX_BATCH_SIZE,
                 MATCH_DISTANCES_BUFFER_SIZE,
+                MATCH_DISTANCES_BUFFER_SIZE_EXTRA_PERCENT,
                 N_BUCKETS,
                 true,
                 false,
@@ -184,6 +186,7 @@ mod e2e_test {
                 DB_SIZE + DB_BUFFER,
                 MAX_BATCH_SIZE,
                 MATCH_DISTANCES_BUFFER_SIZE,
+                MATCH_DISTANCES_BUFFER_SIZE_EXTRA_PERCENT,
                 N_BUCKETS,
                 true,
                 false,
@@ -215,6 +218,7 @@ mod e2e_test {
                 DB_SIZE + DB_BUFFER,
                 MAX_BATCH_SIZE,
                 MATCH_DISTANCES_BUFFER_SIZE,
+                MATCH_DISTANCES_BUFFER_SIZE_EXTRA_PERCENT,
                 N_BUCKETS,
                 true,
                 false,

--- a/iris-mpc/src/bin/server.rs
+++ b/iris-mpc/src/bin/server.rs
@@ -1194,6 +1194,7 @@ async fn server_main(config: Config) -> eyre::Result<()> {
             config.max_db_size,
             config.max_batch_size,
             config.match_distances_buffer_size,
+            config.match_distances_buffer_size_extra_percent,
             config.n_buckets,
             config.return_partial_results,
             config.disable_persistence,


### PR DESCRIPTION
The e2e tests were failing seemingly random since including a check for total counts of buckets.
The reason for this was another source of non-determinism across the three nodes in the kernel that saves distances if they are a match. It can happen that the threads on the different nodes / devices arrive at this maximum in different order, such that we end up saving different distances (the sorting can't not solving this).
https://github.com/worldcoin/iris-mpc/blob/1dd0bc686de22ae93a0ffa043fac02f2083732eb/iris-mpc-gpu/src/dot/kernel.cu#L74

It's hard to solve this with the current approach bc the actual number of matches is unpredictable. This fix simply tries to capture a few more distances than needed, do the sorting, and then truncate to the desired length, such that this should very likely contain the same elements.
