### PR TITLE
Process reauth messages

### DIFF
--- a/iris-mpc-common/src/helpers/smpc_response.rs
+++ b/iris-mpc-common/src/helpers/smpc_response.rs
@@ -65,6 +65,33 @@ impl IdentityDeletionResult {
     }
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ReAuthResult {
+    pub reauth_id:          String,
+    pub node_id:            usize,
+    pub serial_id:          u32,
+    pub success:            bool,
+    pub matched_serial_ids: Option<Vec<u32>>,
+}
+
+impl ReAuthResult {
+    pub fn new(
+        reauth_id: String,
+        node_id: usize,
+        serial_id: u32,
+        success: bool,
+        matched_serial_ids: Option<Vec<u32>>,
+    ) -> Self {
+        Self {
+            reauth_id,
+            node_id,
+            serial_id,
+            success,
+            matched_serial_ids,
+        }
+    }
+}
+
 pub fn create_message_type_attribute_map(
     message_type: &str,
 ) -> HashMap<String, MessageAttributeValue> {

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -676,7 +676,17 @@ impl ServerActor {
         let now = Instant::now();
         let mut events: HashMap<&str, Vec<Vec<CUevent>>> = HashMap::new();
 
-        tracing::info!("Started processing batch");
+        let n_reauths = batch
+            .request_types
+            .iter()
+            .filter(|x| *x == REAUTH_MESSAGE_TYPE)
+            .count();
+        tracing::info!(
+            "Started processing batch: {} uniqueness, {} reauth, {} deletion requests",
+            batch.request_types.len() - n_reauths,
+            n_reauths,
+            batch.deletion_requests_indices.len(),
+        );
 
         let mut batch = batch;
         let mut batch_size = batch.store_left.code.len();
@@ -1178,7 +1188,7 @@ impl ServerActor {
                                 *batch.reauth_target_indices.get(&reauth_id).unwrap();
                             let device_db_index =
                                 reauth_index / self.device_manager.device_count() as u32;
-                            tracing::debug!(
+                            tracing::info!(
                                 "Writing succesful reauth index {} at device {} to {}",
                                 reauth_index,
                                 i,

--- a/iris-mpc-gpu/src/server/mod.rs
+++ b/iris-mpc-gpu/src/server/mod.rs
@@ -196,7 +196,7 @@ pub struct ServerJobResult {
     pub matched_batch_request_ids: Vec<Vec<String>>,
     pub anonymized_bucket_statistics_left: BucketStatistics,
     pub anonymized_bucket_statistics_right: BucketStatistics,
-    pub successful_reauth_positions: Vec<usize>,
+    pub successful_reauths: Vec<bool>, // true if request type is reauth and it's successful
     pub reauth_target_indices: HashMap<String, u32>,
 }
 

--- a/iris-mpc-gpu/src/server/mod.rs
+++ b/iris-mpc-gpu/src/server/mod.rs
@@ -184,6 +184,7 @@ pub struct ServerJob {
 pub struct ServerJobResult {
     pub merged_results: Vec<u32>,
     pub request_ids: Vec<String>,
+    pub request_types: Vec<String>,
     pub metadata: Vec<BatchMetadata>,
     pub matches: Vec<bool>,
     pub match_ids: Vec<Vec<u32>>,
@@ -195,6 +196,8 @@ pub struct ServerJobResult {
     pub matched_batch_request_ids: Vec<Vec<String>>,
     pub anonymized_bucket_statistics_left: BucketStatistics,
     pub anonymized_bucket_statistics_right: BucketStatistics,
+    pub successful_reauth_positions: Vec<usize>,
+    pub reauth_target_indices: HashMap<String, u32>,
 }
 
 enum Eye {

--- a/iris-mpc-gpu/tests/e2e.rs
+++ b/iris-mpc-gpu/tests/e2e.rs
@@ -4,7 +4,7 @@ mod e2e_test {
     use eyre::Result;
     use iris_mpc_common::{
         galois_engine::degree4::{GaloisRingIrisCodeShare, GaloisRingTrimmedMaskCodeShare},
-        helpers::statistics::BucketStatistics,
+        helpers::{smpc_request::UNIQUENESS_MESSAGE_TYPE, statistics::BucketStatistics},
         iris_db::{
             db::IrisDB,
             iris::{IrisCode, IrisCodeArray},
@@ -358,6 +358,9 @@ mod e2e_test {
         batch.metadata.push(Default::default());
         batch.valid_entries.push(is_valid);
         batch.request_ids.push(request_id);
+        batch
+            .request_types
+            .push(UNIQUENESS_MESSAGE_TYPE.to_string());
 
         batch.or_rule_serial_ids.push(or_rule_serial_ids);
 

--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -530,6 +530,7 @@ fn cast_u8_to_u16(s: &[u8]) -> &[u16] {
 }
 
 #[cfg(test)]
+#[cfg(feature = "db_dependent")]
 mod tests {
     const DOTENV_TEST: &str = ".env.test";
 

--- a/iris-mpc/src/bin/server.rs
+++ b/iris-mpc/src/bin/server.rs
@@ -30,9 +30,9 @@ use iris_mpc_common::{
             UNIQUENESS_MESSAGE_TYPE,
         },
         smpc_response::{
-            create_message_type_attribute_map, IdentityDeletionResult, UniquenessResult,
-            ERROR_FAILED_TO_PROCESS_IRIS_SHARES, ERROR_SKIPPED_REQUEST_PREVIOUS_NODE_BATCH,
-            SMPC_MESSAGE_TYPE_ATTRIBUTE,
+            create_message_type_attribute_map, IdentityDeletionResult, ReAuthResult,
+            UniquenessResult, ERROR_FAILED_TO_PROCESS_IRIS_SHARES,
+            ERROR_SKIPPED_REQUEST_PREVIOUS_NODE_BATCH, SMPC_MESSAGE_TYPE_ATTRIBUTE,
         },
         sync::SyncState,
         task_monitor::TaskMonitor,
@@ -875,6 +875,7 @@ async fn server_main(config: Config) -> eyre::Result<()> {
     let chacha_seeds = initialize_chacha_seeds(config.clone()).await?;
 
     let uniqueness_result_attributes = create_message_type_attribute_map(UNIQUENESS_MESSAGE_TYPE);
+    let reauth_result_attributes = create_message_type_attribute_map(REAUTH_MESSAGE_TYPE);
     let anonymized_statistics_attributes =
         create_message_type_attribute_map(ANONYMIZED_STATISTICS_MESSAGE_TYPE);
     let identity_deletion_result_attributes =
@@ -1459,6 +1460,7 @@ async fn server_main(config: Config) -> eyre::Result<()> {
         while let Some(ServerJobResult {
             merged_results,
             request_ids,
+            request_types,
             metadata,
             matches,
             match_ids,
@@ -1470,12 +1472,15 @@ async fn server_main(config: Config) -> eyre::Result<()> {
             matched_batch_request_ids,
             anonymized_bucket_statistics_left,
             anonymized_bucket_statistics_right,
+            successful_reauth_positions,
+            reauth_target_indices,
         }) = rx.recv().await
         {
             // returned serial_ids are 0 indexed, but we want them to be 1 indexed
             let uniqueness_results = merged_results
                 .iter()
                 .enumerate()
+                .filter(|(i, _)| request_types[*i] == UNIQUENESS_MESSAGE_TYPE)
                 .map(|(i, &idx_result)| {
                     let result_event = UniquenessResult::new(
                         party_id,
@@ -1514,7 +1519,7 @@ async fn server_main(config: Config) -> eyre::Result<()> {
                 })
                 .collect::<eyre::Result<Vec<_>>>()?;
 
-            // Insert non-matching queries into the persistent store.
+            // Insert non-matching uniqueness queries into the persistent store.
             let (memory_serial_ids, codes_and_masks): (Vec<i64>, Vec<StoredIrisRef>) = matches
                 .iter()
                 .enumerate()
@@ -1535,11 +1540,34 @@ async fn server_main(config: Config) -> eyre::Result<()> {
                 })
                 .unzip();
 
+            let reauth_results = request_types
+                .iter()
+                .enumerate()
+                .filter(|(_, request_type)| *request_type == REAUTH_MESSAGE_TYPE)
+                .map(|(i, _)| {
+                    let reauth_id = request_ids[i].clone();
+                    let result_event = ReAuthResult::new(
+                        reauth_id.clone(),
+                        party_id,
+                        reauth_target_indices.get(&reauth_id).unwrap() + 1,
+                        successful_reauth_positions.contains(&i),
+                        match match_ids[i].is_empty() {
+                            false => Some(match_ids[i].iter().map(|x| x + 1).collect::<Vec<_>>()),
+                            true => None,
+                        },
+                    );
+                    serde_json::to_string(&result_event)
+                        .wrap_err("failed to serialize reauth result")
+                })
+                .collect::<eyre::Result<Vec<_>>>()?;
+
             let mut tx = store_bg.tx().await?;
 
             store_bg
                 .insert_results(&mut tx, &uniqueness_results)
                 .await?;
+
+            // TODO: update modifications table to store reauth and deletion results
 
             if !codes_and_masks.is_empty() && !config_bg.disable_persistence {
                 let db_serial_ids = store_bg.insert_irises(&mut tx, &codes_and_masks).await?;
@@ -1556,6 +1584,25 @@ async fn server_main(config: Config) -> eyre::Result<()> {
                         memory_serial_ids,
                         db_serial_ids
                     ));
+                }
+
+                tracing::info!(
+                    "Persisting {} reauths into postgres",
+                    successful_reauth_positions.len()
+                );
+                for i in successful_reauth_positions.iter() {
+                    let reauth_id = request_ids[*i].clone();
+                    let serial_id = *reauth_target_indices.get(&reauth_id).unwrap();
+                    store_bg
+                        .update_iris(
+                            Some(&mut tx),
+                            serial_id as i64,
+                            &store_left.code[*i],
+                            &store_left.mask[*i],
+                            &store_right.code[*i],
+                            &store_right.mask[*i],
+                        )
+                        .await?;
                 }
             }
 
@@ -1574,6 +1621,17 @@ async fn server_main(config: Config) -> eyre::Result<()> {
                 &config_bg,
                 &uniqueness_result_attributes,
                 UNIQUENESS_MESSAGE_TYPE,
+            )
+            .await?;
+
+            tracing::info!("Sending {} reauth results", reauth_results.len());
+            send_results_to_sns(
+                reauth_results,
+                &metadata,
+                &sns_client_bg,
+                &config_bg,
+                &reauth_result_attributes,
+                REAUTH_MESSAGE_TYPE,
             )
             .await?;
 
@@ -1890,6 +1948,7 @@ async fn process_identity_deletions(
         // note that both serial_id and postgres db are 1-indexed.
         store
             .update_iris(
+                None,
                 serial_id as i64,
                 dummy_iris_share,
                 dummy_mask_share,


### PR DESCRIPTION
**Change**
- Process the reauth requests in actor. 
- Only consider the AND rule for now. 
  - If there's exactly one match to the target serial id -> consider it as successful reauth. write into memory and db
  - Else -> consider is as failed reauth. do not persist anything and send result to SNS.

**Notes**
- OR rule will be handled in a follow-up PR
- Sync mechanism will be handled in a follow-up PR
- `ServerJobResult` could probably be refactored to separate reauth and uniqueness results but i didn't want to spend time on it for now.
- There'll be an e2e PR as well targeting this branch. I'll merge e2e into this branch and then branch to main.