### PR TITLE
add deregister locked memory on shutdown

### DIFF
--- a/.github/workflows/temp-branch-build-and-push.yaml
+++ b/.github/workflows/temp-branch-build-and-push.yaml
@@ -3,7 +3,7 @@ name: Branch - Build and push docker image
 on:
   push:
     branches:
-      - "POP-2067/handle-conn-reset-during-s3-load"
+      - "POP-2085/unlock-page-on-exit"
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'

--- a/.github/workflows/temp-branch-build-and-push.yaml
+++ b/.github/workflows/temp-branch-build-and-push.yaml
@@ -3,7 +3,7 @@ name: Branch - Build and push docker image
 on:
   push:
     branches:
-      - "POP-2085/unlock-page-on-exit"
+      - "POP-2067/handle-conn-reset-during-s3-load"
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:b432ad1c0d225cde6da46b13771ece64940e1f4d"
+image: "ghcr.io/worldcoin/iris-mpc:v0.14.2"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -82,4 +82,4 @@ preStop:
   sleepPeriod: 10
 
 # terminationGracePeriodSeconds specifies the grace time between SIGTERM and SIGKILL
-terminationGracePeriodSeconds: 20
+terminationGracePeriodSeconds: 120

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:v0.14.2"
+image: "ghcr.io/worldcoin/iris-mpc:b432ad1c0d225cde6da46b13771ece64940e1f4d"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:v0.14.2"
+image: "ghcr.io/worldcoin/iris-mpc:f560a4c077acdf73c5797dfd771c0328baaf7b65"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:65ba24469cddbf4443ebef3b94f47e1b218a50e3"
+image: "ghcr.io/worldcoin/iris-mpc:b432ad1c0d225cde6da46b13771ece64940e1f4d"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:f560a4c077acdf73c5797dfd771c0328baaf7b65"
+image: "ghcr.io/worldcoin/iris-mpc:65ba24469cddbf4443ebef3b94f47e1b218a50e3"
 
 environment: stage
 replicaCount: 1

--- a/iris-mpc-gpu/src/helpers/device_manager.rs
+++ b/iris-mpc-gpu/src/helpers/device_manager.rs
@@ -308,8 +308,8 @@ impl DeviceManager {
 
 impl Drop for DeviceManager {
     fn drop(&mut self) {
-        // Get all tracked DBs
         let page_unlock_ts = Instant::now();
+        // Get all tracked DBs
         if let Ok(locked_dbs) = self.locked_dbs.lock() {
             tracing::info!(
                 "DeviceManager is dropping memory for {:?} number of dbs",

--- a/iris-mpc-gpu/src/helpers/device_manager.rs
+++ b/iris-mpc-gpu/src/helpers/device_manager.rs
@@ -1,6 +1,6 @@
 use super::{
     comm::NcclComm,
-    query_processor::{CudaVec2DSlicerU8, StreamAwareCudaSlice},
+    query_processor::{CudaVec2DSlicerRawPointer, CudaVec2DSlicerU8, StreamAwareCudaSlice},
 };
 use crate::dot::ROTATIONS;
 use cudarc::{
@@ -15,14 +15,19 @@ use cudarc::{
     },
     nccl::Id,
 };
-use std::{sync::Arc, thread::sleep, time::Duration};
+use std::{
+    sync::{Arc, Mutex},
+    thread::sleep,
+    time::{Duration, Instant},
+};
 
 pub const NCCL_START_WAIT_TIME: Duration = Duration::from_secs(5);
 pub const NCCL_START_RETRIES: usize = 5;
 
 #[derive(Debug, Clone)]
 pub struct DeviceManager {
-    devices: Vec<Arc<CudaDevice>>,
+    devices:    Vec<Arc<CudaDevice>>,
+    locked_dbs: Arc<Mutex<Vec<CudaVec2DSlicerRawPointer>>>,
 }
 
 impl DeviceManager {
@@ -34,7 +39,10 @@ impl DeviceManager {
 
         tracing::info!("Found {} devices", devices.len());
 
-        Self { devices }
+        Self {
+            devices,
+            locked_dbs: Arc::new(Mutex::new(Vec::new())),
+        }
     }
 
     pub fn init_with_streams() -> Self {
@@ -45,7 +53,10 @@ impl DeviceManager {
 
         tracing::info!("Found {} devices", devices.len());
 
-        Self { devices }
+        Self {
+            devices,
+            locked_dbs: Arc::new(Mutex::new(Vec::new())),
+        }
     }
 
     /// Splits the devices into n chunks, returning a device manager for each
@@ -60,7 +71,8 @@ impl DeviceManager {
         let mut ret = vec![];
         for i in 0..n {
             ret.push(DeviceManager {
-                devices: self.devices[i * chunk_size..(i + 1) * chunk_size].to_vec(),
+                devices:    self.devices[i * chunk_size..(i + 1) * chunk_size].to_vec(),
+                locked_dbs: self.locked_dbs.clone(),
             });
         }
         Ok(ret)
@@ -187,6 +199,13 @@ impl DeviceManager {
         })
     }
 
+    // Method to add a db to tracking
+    pub fn track_locked_db(&self, db: CudaVec2DSlicerRawPointer) {
+        if let Ok(mut locked) = self.locked_dbs.lock() {
+            locked.push(db);
+        }
+    }
+
     pub fn device(&self, index: usize) -> Arc<CudaDevice> {
         self.devices[index].clone()
     }
@@ -284,5 +303,34 @@ impl DeviceManager {
             }
         }
         Ok(comms)
+    }
+}
+
+impl Drop for DeviceManager {
+    fn drop(&mut self) {
+        // Get all tracked DBs
+        let page_unlock_ts = Instant::now();
+        if let Ok(locked_dbs) = self.locked_dbs.lock() {
+            tracing::info!(
+                "DeviceManager is dropping memory for {:?} number of dbs",
+                locked_dbs.len()
+            );
+            for db in locked_dbs.iter() {
+                // For each DB, unregister all its memory
+                for (device_index, device) in self.devices.iter().enumerate() {
+                    device.bind_to_thread().unwrap();
+                    unsafe {
+                        let _ = cudarc::driver::sys::lib()
+                            .cuMemHostUnregister(db.limb_0[device_index] as *mut _);
+                        let _ = cudarc::driver::sys::lib()
+                            .cuMemHostUnregister(db.limb_1[device_index] as *mut _);
+                    }
+                }
+            }
+        }
+        tracing::info!(
+            "DeviceManager dropped, all memory unregistered in {:?} ",
+            page_unlock_ts.elapsed()
+        );
     }
 }

--- a/iris-mpc-gpu/src/helpers/mod.rs
+++ b/iris-mpc-gpu/src/helpers/mod.rs
@@ -193,4 +193,5 @@ pub fn register_host_memory(
             );
         }
     }
+    device_manager.track_locked_db(db.clone());
 }

--- a/iris-mpc-gpu/src/helpers/query_processor.rs
+++ b/iris-mpc-gpu/src/helpers/query_processor.rs
@@ -68,7 +68,7 @@ impl<T> Drop for StreamAwareCudaSlice<T> {
 
 /// Holds the raw memory pointers for the 2D slices.
 /// Memory is not freed when the struct is dropped, but must be freed manually.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct CudaVec2DSlicerRawPointer {
     pub limb_0: Vec<u64>,
     pub limb_1: Vec<u64>,

--- a/iris-mpc/src/bin/server.rs
+++ b/iris-mpc/src/bin/server.rs
@@ -1148,10 +1148,11 @@ async fn server_main(config: Config) -> eyre::Result<()> {
     let s3_chunks_folder_name = config.db_chunks_folder_name.clone();
     let s3_load_max_retries = config.load_chunks_max_retries;
     let s3_load_initial_backoff_ms = config.load_chunks_initial_backoff_ms;
+    let device_manager_init = Arc::new(DeviceManager::init());
+    let device_manager = Arc::clone(&device_manager_init);
 
     let (tx, rx) = oneshot::channel();
     background_tasks.spawn_blocking(move || {
-        let device_manager = Arc::new(DeviceManager::init());
         let ids = device_manager.get_ids_from_magic(0);
 
         // --------------------------------------------------------------------------
@@ -1812,7 +1813,7 @@ async fn server_main(config: Config) -> eyre::Result<()> {
             background_tasks.check_tasks_finished();
         }
     }
-
+    drop(device_manager_init);
     Ok(())
 }
 


### PR DESCRIPTION
### Notes
#### Issue
* in prod we see that a node takes around 4 minutes to remove all memory (DB size 11 mil)
* in stage this is around ~25 seconds (DB size of 1 mil)
#### Solution explanation and Testing
* this forces the unlocking of all page locks on closing (only if not triggered by kubernetes termination)
* testing with and without it on staging link https://www.notion.so/worldcoin/Testing-Startup-changes-in-1918614bdf8c801c8ca1e48a3c17dd9d?showMoveTo=true&saveParent=true
   * in reduced the time from ~ 25s to 14s