### PR TITLE
pass or rule indexes to actor instead of serial ids

### DIFF
--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -712,13 +712,13 @@ impl ServerActor {
                 && batch_size * ROTATIONS == batch.db_right_preprocessed.len(),
             "Query batch sizes mismatch"
         );
-        if !batch.or_rule_serial_ids.is_empty() || batch.luc_lookback_records > 0 {
+        if !batch.or_rule_indices.is_empty() || batch.luc_lookback_records > 0 {
             assert!(
-                (batch.or_rule_serial_ids.len() == batch_size) || (batch.luc_lookback_records > 0)
+                (batch.or_rule_indices.len() == batch_size) || (batch.luc_lookback_records > 0)
             );
-            batch.or_rule_serial_ids = generate_luc_records(
+            batch.or_rule_indices = generate_luc_records(
                 (self.current_db_sizes.iter().sum::<usize>() - 1) as u32,
-                batch.or_rule_serial_ids.clone(),
+                batch.or_rule_indices.clone(),
                 batch.luc_lookback_records,
                 batch_size,
             );
@@ -887,20 +887,17 @@ impl ServerActor {
         // Format: host_results[device_index][query_index]
 
         // Initialize bitmap with OR rule, if exists
-        if !batch.or_rule_serial_ids.is_empty()
-            && !batch
-                .or_rule_serial_ids
-                .iter()
-                .all(|inner| inner.is_empty())
+        if !batch.or_rule_indices.is_empty()
+            && !batch.or_rule_indices.iter().all(|inner| inner.is_empty())
         {
-            assert_eq!(batch.or_rule_serial_ids.len(), batch_size);
+            assert_eq!(batch.or_rule_indices.len(), batch_size);
 
             let now = Instant::now();
             tracing::info!("Preparing and allocating OR policy bitmap");
             // Populate the pre-allocated OR policy bitmap with the serial ids
             let host_or_policy_bitmap = prepare_or_policy_bitmap(
                 self.max_db_size,
-                batch.or_rule_serial_ids.clone(),
+                batch.or_rule_indices.clone(),
                 self.max_batch_size,
             );
 
@@ -2406,7 +2403,7 @@ fn sort_shares_by_indices(
 
 pub fn prepare_or_policy_bitmap(
     max_db_size: usize,
-    or_rule_serial_ids: Vec<Vec<u32>>,
+    or_rule_indices: Vec<Vec<u32>>,
     batch_size: usize,
 ) -> Vec<u64> {
     let row_stride64 = (max_db_size + 63) / 64;
@@ -2415,7 +2412,7 @@ pub fn prepare_or_policy_bitmap(
     // Create the bitmap on the host
     let mut bitmap = vec![0u64; total_size];
 
-    for (query_idx, db_indices) in or_rule_serial_ids.iter().enumerate() {
+    for (query_idx, db_indices) in or_rule_indices.iter().enumerate() {
         for &db_idx in db_indices {
             let row_start = query_idx * row_stride64;
             let word_idx = row_start + (db_idx as usize / 64);
@@ -2428,13 +2425,13 @@ pub fn prepare_or_policy_bitmap(
 
 pub fn generate_luc_records(
     latest_luc_index: u32,
-    mut or_rule_serial_ids: Vec<Vec<u32>>,
+    mut or_rule_indices: Vec<Vec<u32>>,
     lookback_records: usize,
     batch_size: usize,
 ) -> Vec<Vec<u32>> {
-    // If lookback_records is 0, return the original or_rule_serial_ids
+    // If lookback_records is 0, return the original or_rule_indices
     if lookback_records == 0 {
-        return or_rule_serial_ids;
+        return or_rule_indices;
     }
     // Generate the lookback serial IDs: [current_db_size - luc_lookback_records,
     // current_db_size)
@@ -2443,17 +2440,17 @@ pub fn generate_luc_records(
     let lookback_records: Vec<Vec<u32>> = vec![lookback_ids; batch_size];
 
     // If there are no OR rules, return only the lookback records
-    if or_rule_serial_ids.is_empty() {
+    if or_rule_indices.is_empty() {
         return lookback_records;
     }
 
-    // Otherwise, merge them into each inner vector of or_rule_serial_ids
-    for (or_ids, luc_ids) in izip!(or_rule_serial_ids.iter_mut(), lookback_records.iter()) {
+    // Otherwise, merge them into each inner vector of or_rule_indices
+    for (or_ids, luc_ids) in izip!(or_rule_indices.iter_mut(), lookback_records.iter()) {
         // Add the lookback IDs
         or_ids.extend_from_slice(luc_ids);
         // Sort and remove duplicates
         or_ids.sort_unstable();
         or_ids.dedup();
     }
-    or_rule_serial_ids
+    or_rule_indices
 }

--- a/iris-mpc-gpu/src/server/mod.rs
+++ b/iris-mpc-gpu/src/server/mod.rs
@@ -83,7 +83,7 @@ pub struct BatchQuery {
     pub store_right:              BatchQueryEntries,
     pub query_right_preprocessed: BatchQueryEntriesPreprocessed,
     pub db_right_preprocessed:    BatchQueryEntriesPreprocessed,
-    pub or_rule_serial_ids:       Vec<Vec<u32>>,
+    pub or_rule_indices:          Vec<Vec<u32>>,
     pub luc_lookback_records:     usize,
     pub valid_entries:            Vec<bool>,
 
@@ -139,7 +139,7 @@ impl BatchQuery {
         filter_by_indices!(self.store_left.mask, indices_set);
         filter_by_indices!(self.store_right.code, indices_set);
         filter_by_indices!(self.store_right.mask, indices_set);
-        filter_by_indices!(self.or_rule_serial_ids, indices_set);
+        filter_by_indices!(self.or_rule_indices, indices_set);
         filter_by_indices_with_rotations!(self.query_left.code, indices_set);
         filter_by_indices_with_rotations!(self.query_left.mask, indices_set);
         filter_by_indices_with_rotations!(self.db_left.code, indices_set);

--- a/iris-mpc-gpu/tests/e2e.rs
+++ b/iris-mpc-gpu/tests/e2e.rs
@@ -366,7 +366,7 @@ mod e2e_test {
         request_id: String,
         batch_idx: usize,
         mut e2e_shared_template: E2ESharedTemplate,
-        or_rule_serial_ids: Vec<u32>,
+        or_rule_indices: Vec<u32>,
         maybe_reauth_target_index: Option<&u32>,
     ) -> Result<()> {
         batch.metadata.push(Default::default());
@@ -386,7 +386,7 @@ mod e2e_test {
             }
         }
 
-        batch.or_rule_serial_ids.push(or_rule_serial_ids);
+        batch.or_rule_indices.push(or_rule_indices);
 
         batch
             .store_left
@@ -658,7 +658,7 @@ mod e2e_test {
             self.or_rule_matches.clear();
 
             for idx in 0..batch_size {
-                let (request_id, e2e_template, or_rule_serial_ids) = self.generate_query(idx);
+                let (request_id, e2e_template, or_rule_indices) = self.generate_query(idx);
 
                 // Invalidate 10% of the queries, but ignore the batch duplicates
                 let is_valid = self.rng.gen_bool(0.10) || self.skip_invalidate;
@@ -676,7 +676,7 @@ mod e2e_test {
                     request_id.to_string(),
                     0,
                     shared_template.clone(),
-                    or_rule_serial_ids.clone(),
+                    or_rule_indices.clone(),
                     maybe_reauth_target_index,
                 )?;
 
@@ -686,7 +686,7 @@ mod e2e_test {
                     request_id.to_string(),
                     1,
                     shared_template.clone(),
-                    or_rule_serial_ids.clone(),
+                    or_rule_indices.clone(),
                     maybe_reauth_target_index,
                 )?;
 
@@ -696,7 +696,7 @@ mod e2e_test {
                     request_id.to_string(),
                     2,
                     shared_template,
-                    or_rule_serial_ids.clone(),
+                    or_rule_indices.clone(),
                     maybe_reauth_target_index,
                 )?;
             }
@@ -773,7 +773,7 @@ mod e2e_test {
                 options.push(TestCases::PreviouslyDeleted);
             };
 
-            let mut or_rule_serial_ids: Vec<u32> = Vec::new();
+            let mut or_rule_indices: Vec<u32> = Vec::new();
 
             // with a 10% chance we pick a template from the batch, to test the batch
             // deduplication mechanism
@@ -936,7 +936,7 @@ mod e2e_test {
                             db_indexes_copy[self.rng.gen_range(0..db_indexes_copy.len())];
 
                         // comparison against this item will use the OR rule
-                        or_rule_serial_ids = db_indexes_copy.iter().map(|&x| x as u32).collect();
+                        or_rule_indices = db_indexes_copy.iter().map(|&x| x as u32).collect();
 
                         // Will always match under the OR rule
                         self.expected_results
@@ -1034,7 +1034,7 @@ mod e2e_test {
                     }
                 }
             };
-            (request_id, e2e_template, or_rule_serial_ids)
+            (request_id, e2e_template, or_rule_indices)
         }
 
         // check a received result against the expected results

--- a/iris-mpc-gpu/tests/or_policy.rs
+++ b/iris-mpc-gpu/tests/or_policy.rs
@@ -33,12 +33,11 @@ mod or_policy_test {
 
     #[test]
     fn test_only_lookback_records() {
-        let latest_serial_id = 10;
-        let or_rule_serial_ids = vec![];
+        let latest_index = 10;
+        let or_rule_indices = vec![];
         let lookback_records = 5;
 
-        let result =
-            generate_luc_records(latest_serial_id, or_rule_serial_ids, lookback_records, 2);
+        let result = generate_luc_records(latest_index, or_rule_indices, lookback_records, 2);
 
         let expected = vec![vec![5, 6, 7, 8, 9, 10], vec![5, 6, 7, 8, 9, 10]];
         assert_eq!(result, expected);
@@ -46,38 +45,30 @@ mod or_policy_test {
 
     #[test]
     fn test_empty_zero_lookback_records() {
-        let latest_serial_id = 10;
-        let or_rule_serial_ids = vec![vec![1, 3], vec![4, 5, 9]];
+        let latest_index = 10;
+        let or_rule_indices = vec![vec![1, 3], vec![4, 5, 9]];
         let lookback_records = 0;
 
-        let result = generate_luc_records(
-            latest_serial_id,
-            or_rule_serial_ids.clone(),
-            lookback_records,
-            1,
-        );
+        let result =
+            generate_luc_records(latest_index, or_rule_indices.clone(), lookback_records, 1);
 
         // No lookback, so we expect the same as the input.
-        let expected = or_rule_serial_ids.clone();
+        let expected = or_rule_indices.clone();
         assert_eq!(result, expected);
     }
 
     #[test]
     fn test_basic_lookback() {
-        // If latest_serial_id=10 and lookback_records=3,
+        // If latest_index=10 and lookback_records=3,
         // then lookback range is [7, 8, 9].
         let latest_lookback_index = 10;
         let lookback_records = 3;
 
         // Suppose our existing IDs are:
-        let or_rule_serial_ids = vec![vec![1, 3], vec![4, 5, 9]];
+        let or_rule_indices = vec![vec![1, 3], vec![4, 5, 9]];
 
-        let result = generate_luc_records(
-            latest_lookback_index,
-            or_rule_serial_ids,
-            lookback_records,
-            2,
-        );
+        let result =
+            generate_luc_records(latest_lookback_index, or_rule_indices, lookback_records, 2);
         // We expect 7, 8, 9 to be appended (9 is already in second vector).
         let expected = vec![
             vec![1, 3, 7, 8, 9, 10], // was [1, 3] + [7, 8, 9, 10]
@@ -91,14 +82,13 @@ mod or_policy_test {
     fn test_duplicate_ids() {
         // Check that duplicates (both pre-existing and from the lookback) are removed
         // We use a small range so we can see the effect clearly.
-        let latest_serial_id = 5; // Suppose we want [3, 4] as lookback
+        let latest_index = 5; // Suppose we want [3, 4] as lookback
         let lookback_records = 2;
 
         // Already has duplicates in the first vector
-        let or_rule_serial_ids = vec![vec![1, 1, 2, 3], vec![3, 3, 4]];
+        let or_rule_indices = vec![vec![1, 1, 2, 3], vec![3, 3, 4]];
 
-        let result =
-            generate_luc_records(latest_serial_id, or_rule_serial_ids, lookback_records, 2);
+        let result = generate_luc_records(latest_index, or_rule_indices, lookback_records, 2);
         // After merging, each vector should include [3, 4] (some of which are
         // duplicates). Then we sort and deduplicate.
         let expected = vec![vec![1, 2, 3, 4, 5], vec![3, 4, 5]];

--- a/iris-mpc/src/bin/server.rs
+++ b/iris-mpc/src/bin/server.rs
@@ -312,7 +312,10 @@ async fn receive_batch(
                                 if let Some(serial_ids) =
                                     uniqueness_request.or_rule_serial_ids.clone()
                                 {
-                                    batch_query.or_rule_serial_ids.push(serial_ids);
+                                    // convert from 1-based serial id to 0-based index in actor
+                                    batch_query
+                                        .or_rule_indices
+                                        .push(serial_ids.iter().map(|x| x - 1).collect());
                                 } else {
                                     tracing::error!(
                                         "Received a uniqueness request without serial_ids"


### PR DESCRIPTION
**Change**
- We used send each id as 0-indexed to actor.rs by decrementing 1 from each given serial_id in server.rs
- This PR applies the same for `or_rule_serial_ids` and also renames it to `or_rule_indices`