### PR TITLE
Implement or rule on reauth requests

### DIFF
--- a/iris-mpc-common/src/helpers/smpc_response.rs
+++ b/iris-mpc-common/src/helpers/smpc_response.rs
@@ -46,6 +46,21 @@ impl UniquenessResult {
             error_reason: None,
         }
     }
+
+    pub fn new_error_result(node_id: usize, signup_id: String, error_reason: &str) -> Self {
+        Self {
+            node_id,
+            serial_id: None,
+            is_match: false,
+            signup_id,
+            matched_serial_ids: None,
+            matched_serial_ids_left: None,
+            matched_serial_ids_right: None,
+            matched_batch_request_ids: None,
+            error: Some(true),
+            error_reason: Some(error_reason.to_string()),
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -67,11 +82,15 @@ impl IdentityDeletionResult {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ReAuthResult {
-    pub reauth_id:          String,
-    pub node_id:            usize,
-    pub serial_id:          u32,
-    pub success:            bool,
-    pub matched_serial_ids: Option<Vec<u32>>,
+    pub reauth_id: String,
+    pub node_id: usize,
+    pub serial_id: u32,
+    pub success: bool,
+    pub and_rule_matched_serial_ids: Vec<u32>,
+    pub or_rule_used: bool,
+    pub or_rule_matched: Option<bool>,
+    pub error: Option<bool>,
+    pub error_reason: Option<String>,
 }
 
 impl ReAuthResult {
@@ -80,14 +99,39 @@ impl ReAuthResult {
         node_id: usize,
         serial_id: u32,
         success: bool,
-        matched_serial_ids: Option<Vec<u32>>,
+        and_rule_matched_serial_ids: Vec<u32>,
+        or_rule_used: bool,
+        or_rule_matched: Option<bool>,
     ) -> Self {
         Self {
             reauth_id,
             node_id,
             serial_id,
             success,
-            matched_serial_ids,
+            and_rule_matched_serial_ids,
+            or_rule_used,
+            or_rule_matched,
+            error: None,
+            error_reason: None,
+        }
+    }
+
+    pub fn new_error_result(
+        reauth_id: String,
+        node_id: usize,
+        serial_id: u32,
+        error_reason: &str,
+    ) -> Self {
+        Self {
+            reauth_id,
+            node_id,
+            serial_id,
+            success: false,
+            and_rule_matched_serial_ids: vec![],
+            or_rule_used: false,
+            or_rule_matched: None,
+            error: Some(true),
+            error_reason: Some(error_reason.to_string()),
         }
     }
 }

--- a/iris-mpc-gpu/src/server/mod.rs
+++ b/iris-mpc-gpu/src/server/mod.rs
@@ -89,6 +89,7 @@ pub struct BatchQuery {
     // Only reauth specific fields
     // Map from reauth request id to the index of the target entry to be matched
     pub reauth_target_indices: HashMap<String, u32>,
+    pub reauth_use_or_rule:    HashMap<String, bool>,
 
     // Only deletion specific fields
     pub deletion_requests_indices:  Vec<u32>, // 0-indexed indices of entries to be deleted
@@ -197,6 +198,7 @@ pub struct ServerJobResult {
     pub anonymized_bucket_statistics_right: BucketStatistics,
     pub successful_reauths: Vec<bool>, // true if request type is reauth and it's successful
     pub reauth_target_indices: HashMap<String, u32>,
+    pub reauth_or_rule_used: HashMap<String, bool>,
 }
 
 enum Eye {

--- a/iris-mpc-gpu/tests/e2e.rs
+++ b/iris-mpc-gpu/tests/e2e.rs
@@ -1068,7 +1068,7 @@ mod e2e_test {
 
         /// Returns a template with flipped bits of given `db_index`.
         ///
-        /// If `will_match` is true, the template will be flipped to above
+        /// If `will_match` is false, the template will be flipped to above
         /// threshold on both sides If `flip_right` is true, the right
         /// side will be flipped to above threshold
         fn prepare_flipped_codes(

--- a/iris-mpc-gpu/tests/e2e.rs
+++ b/iris-mpc-gpu/tests/e2e.rs
@@ -374,7 +374,7 @@ mod e2e_test {
                 batch.request_types.push(REAUTH_MESSAGE_TYPE.to_string());
                 batch
                     .reauth_use_or_rule
-                    .insert(request_id.clone(), !or_rule_serial_ids.is_empty());
+                    .insert(request_id.clone(), !or_rule_indices.is_empty());
                 batch
                     .reauth_target_indices
                     .insert(request_id.clone(), *target_index);
@@ -1030,7 +1030,7 @@ mod e2e_test {
                         self.or_rule_matches.push(request_id.to_string());
                         self.reauth_target_indices
                             .insert(request_id.to_string(), db_index as u32);
-                        or_rule_serial_ids = vec![db_index as u32];
+                        or_rule_indices = vec![db_index as u32];
                         let will_match = true;
                         let flip_right = Some(self.rng.gen());
                         let template = self.prepare_flipped_codes(db_index, will_match, flip_right);
@@ -1050,7 +1050,7 @@ mod e2e_test {
                         self.db_indices_used_in_current_batch.insert(db_index);
                         self.reauth_target_indices
                             .insert(request_id.to_string(), db_index as u32);
-                        or_rule_serial_ids = vec![db_index as u32];
+                        or_rule_indices = vec![db_index as u32];
                         let will_match = false;
                         let template = self.prepare_flipped_codes(db_index, will_match, None);
                         self.expected_results

--- a/iris-mpc-gpu/tests/e2e.rs
+++ b/iris-mpc-gpu/tests/e2e.rs
@@ -558,6 +558,12 @@ mod e2e_test {
         /// Send a reauth request not matching target serial id's iris code
         /// (failed reauth)
         ReauthNonMatchingTarget,
+        /// Send a reauth request with OR rule matching one side of target
+        /// serial id's iris code (successful reauth)
+        ReauthOrRuleMatchingTarget,
+        /// Send a reauth request with OR rule not matching any sides of target
+        /// serial id's iris code (failed reauth)
+        ReauthOrRuleNonMatchingTarget,
     }
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -765,6 +771,8 @@ mod e2e_test {
                 TestCases::WithOrRuleSet,
                 TestCases::ReauthNonMatchingTarget,
                 TestCases::ReauthMatchingTarget,
+                TestCases::ReauthOrRuleNonMatchingTarget,
+                TestCases::ReauthOrRuleMatchingTarget,
             ];
             if !self.inserted_responses.is_empty() {
                 options.push(TestCases::PreviouslyInserted);
@@ -938,38 +946,19 @@ mod e2e_test {
                         // comparison against this item will use the OR rule
                         or_rule_indices = db_indexes_copy.iter().map(|&x| x as u32).collect();
 
-                        // Will always match under the OR rule
-                        self.expected_results
-                            .insert(request_id.to_string(), ExpectedResult {
-                                db_index:             Some(matching_db_index as u32),
-                                is_batch_match:       false,
-                                is_reauth_successful: None,
-                            });
-
-                        let mut code_left = self.initial_db_state.db[matching_db_index].clone();
-                        let mut code_right = self.initial_db_state.db[matching_db_index].clone();
-
-                        assert_eq!(code_left.mask, IrisCodeArray::ONES);
-                        assert_eq!(code_right.mask, IrisCodeArray::ONES);
-
                         // apply variation to either right of left code
                         let will_match: bool = self.rng.gen();
-                        let flip_right: bool = self.rng.gen();
-                        let variation = self.rng.gen_range(1..100);
+                        let flip_right = if will_match {
+                            Some(self.rng.gen())
+                        } else {
+                            None
+                        };
+
+                        let template =
+                            self.prepare_flipped_codes(matching_db_index, will_match, flip_right);
 
                         if will_match {
                             self.or_rule_matches.push(request_id.to_string());
-                            if flip_right {
-                                // Flip right bits to above threshold - (right) does not match
-                                for i in 0..(THRESHOLD_ABSOLUTE as i32 + variation) as usize {
-                                    code_right.code.flip_bit(i);
-                                }
-                            } else {
-                                // Flip left bits to above threshold - (left) does not match
-                                for i in 0..(THRESHOLD_ABSOLUTE as i32 + variation) as usize {
-                                    code_left.code.flip_bit(i);
-                                }
-                            }
                             self.expected_results
                                 .insert(request_id.to_string(), ExpectedResult {
                                     db_index:             Some(matching_db_index as u32),
@@ -977,11 +966,6 @@ mod e2e_test {
                                     is_reauth_successful: None,
                                 });
                         } else {
-                            // Flip both to above threshold - neither match
-                            for i in 0..(THRESHOLD_ABSOLUTE as i32 + variation) as usize {
-                                code_left.code.flip_bit(i);
-                                code_right.code.flip_bit(i);
-                            }
                             self.db_indices_used_in_current_batch
                                 .insert(matching_db_index);
                             self.disallowed_queries.push(matching_db_index as u32);
@@ -992,13 +976,12 @@ mod e2e_test {
                                     is_reauth_successful: None,
                                 });
                         }
-                        E2ETemplate {
-                            left:  code_left,
-                            right: code_right,
-                        }
+                        template
                     }
                     TestCases::ReauthMatchingTarget => {
-                        tracing::info!("Sending reauth request matching the target index");
+                        tracing::info!(
+                            "Sending reauth request with AND rule matching the target index"
+                        );
                         let (db_index, template) = self.get_iris_code_in_db(DatabaseRange::Full);
                         self.db_indices_used_in_current_batch.insert(db_index);
                         self.reauth_target_indices
@@ -1015,26 +998,109 @@ mod e2e_test {
                         }
                     }
                     TestCases::ReauthNonMatchingTarget => {
-                        tracing::info!("Sending reauth request non-matching the target index");
-                        let (db_index, _) = self.get_iris_code_in_db(DatabaseRange::Full);
+                        tracing::info!(
+                            "Sending reauth request with AND rule non-matching the target index"
+                        );
+                        let (db_index, _) = self.get_iris_code_in_db(DatabaseRange::FullMaskOnly);
                         self.db_indices_used_in_current_batch.insert(db_index);
                         self.reauth_target_indices
                             .insert(request_id.to_string(), db_index as u32);
-                        let template = IrisCode::random_rng(&mut self.rng);
+                        let will_match = true;
+                        let flip_right = Some(self.rng.gen());
+                        let template = self.prepare_flipped_codes(db_index, will_match, flip_right);
                         self.expected_results
                             .insert(request_id.to_string(), ExpectedResult {
                                 db_index:             None,
                                 is_batch_match:       false,
                                 is_reauth_successful: Some(false),
                             });
-                        E2ETemplate {
-                            left:  template.clone(),
-                            right: template,
-                        }
+                        template
+                    }
+                    TestCases::ReauthOrRuleMatchingTarget => {
+                        tracing::info!(
+                            "Sending reauth request with OR rule matching the target index"
+                        );
+                        let (db_index, _) = self.get_iris_code_in_db(DatabaseRange::FullMaskOnly);
+                        self.db_indices_used_in_current_batch.insert(db_index);
+                        self.disallowed_queries.push(db_index as u32);
+                        self.reauth_target_indices
+                            .insert(request_id.to_string(), db_index as u32);
+                        let will_match = true;
+                        let flip_right = Some(self.rng.gen());
+                        let template = self.prepare_flipped_codes(db_index, will_match, flip_right);
+                        self.expected_results
+                            .insert(request_id.to_string(), ExpectedResult {
+                                db_index:             Some(db_index as u32),
+                                is_batch_match:       false,
+                                is_reauth_successful: Some(true),
+                            });
+                        template
+                    }
+                    TestCases::ReauthOrRuleNonMatchingTarget => {
+                        tracing::info!(
+                            "Sending reauth request with OR rule non-matching the target index"
+                        );
+                        let (db_index, _) = self.get_iris_code_in_db(DatabaseRange::FullMaskOnly);
+                        self.db_indices_used_in_current_batch.insert(db_index);
+                        self.reauth_target_indices
+                            .insert(request_id.to_string(), db_index as u32);
+                        let will_match = false;
+                        let template = self.prepare_flipped_codes(db_index, will_match, None);
+                        self.expected_results
+                            .insert(request_id.to_string(), ExpectedResult {
+                                db_index:             Some(db_index as u32),
+                                is_batch_match:       false,
+                                is_reauth_successful: Some(true),
+                            });
+                        template
                     }
                 }
             };
             (request_id, e2e_template, or_rule_indices)
+        }
+
+        /// Returns a template with flipped bits of given `db_index`.
+        ///
+        /// If `will_match` is true, the template will be flipped to above
+        /// threshold on both sides If `flip_right` is true, the right
+        /// side will be flipped to above threshold
+        fn prepare_flipped_codes(
+            &mut self,
+            db_index: usize,
+            will_match: bool,
+            flip_right: Option<bool>,
+        ) -> E2ETemplate {
+            let mut code_left = self.initial_db_state.db[db_index].clone();
+            let mut code_right = self.initial_db_state.db[db_index].clone();
+
+            assert_eq!(code_left.mask, IrisCodeArray::ONES);
+            assert_eq!(code_right.mask, IrisCodeArray::ONES);
+
+            let variation = self.rng.gen_range(1..100);
+            if will_match {
+                let flip_right = flip_right.unwrap_or(self.rng.gen());
+                if flip_right {
+                    // Flip right bits to above threshold - (right) does not match
+                    for i in 0..(THRESHOLD_ABSOLUTE as i32 + variation) as usize {
+                        code_right.code.flip_bit(i);
+                    }
+                } else {
+                    // Flip left bits to above threshold - (left) does not match
+                    for i in 0..(THRESHOLD_ABSOLUTE as i32 + variation) as usize {
+                        code_left.code.flip_bit(i);
+                    }
+                }
+            } else {
+                // Flip both to above threshold - neither match
+                for i in 0..(THRESHOLD_ABSOLUTE as i32 + variation) as usize {
+                    code_left.code.flip_bit(i);
+                    code_right.code.flip_bit(i);
+                }
+            }
+            E2ETemplate {
+                left:  code_left,
+                right: code_right,
+            }
         }
 
         // check a received result against the expected results

--- a/iris-mpc-gpu/tests/or_policy.rs
+++ b/iris-mpc-gpu/tests/or_policy.rs
@@ -1,6 +1,6 @@
 mod or_policy_test {
-
     use iris_mpc_gpu::server::{generate_luc_records, prepare_or_policy_bitmap};
+    use std::collections::HashSet;
 
     const MAX_DB_SIZE: usize = 8 * 1000;
 
@@ -37,7 +37,13 @@ mod or_policy_test {
         let or_rule_indices = vec![];
         let lookback_records = 5;
 
-        let result = generate_luc_records(latest_index, or_rule_indices, lookback_records, 2);
+        let result = generate_luc_records(
+            latest_index,
+            or_rule_indices,
+            lookback_records,
+            2,
+            HashSet::new(),
+        );
 
         let expected = vec![vec![5, 6, 7, 8, 9, 10], vec![5, 6, 7, 8, 9, 10]];
         assert_eq!(result, expected);
@@ -49,8 +55,13 @@ mod or_policy_test {
         let or_rule_indices = vec![vec![1, 3], vec![4, 5, 9]];
         let lookback_records = 0;
 
-        let result =
-            generate_luc_records(latest_index, or_rule_indices.clone(), lookback_records, 1);
+        let result = generate_luc_records(
+            latest_index,
+            or_rule_indices.clone(),
+            lookback_records,
+            1,
+            HashSet::new(),
+        );
 
         // No lookback, so we expect the same as the input.
         let expected = or_rule_indices.clone();
@@ -67,8 +78,13 @@ mod or_policy_test {
         // Suppose our existing IDs are:
         let or_rule_indices = vec![vec![1, 3], vec![4, 5, 9]];
 
-        let result =
-            generate_luc_records(latest_lookback_index, or_rule_indices, lookback_records, 2);
+        let result = generate_luc_records(
+            latest_lookback_index,
+            or_rule_indices,
+            lookback_records,
+            2,
+            HashSet::new(),
+        );
         // We expect 7, 8, 9 to be appended (9 is already in second vector).
         let expected = vec![
             vec![1, 3, 7, 8, 9, 10], // was [1, 3] + [7, 8, 9, 10]
@@ -88,11 +104,48 @@ mod or_policy_test {
         // Already has duplicates in the first vector
         let or_rule_indices = vec![vec![1, 1, 2, 3], vec![3, 3, 4]];
 
-        let result = generate_luc_records(latest_index, or_rule_indices, lookback_records, 2);
+        let result = generate_luc_records(
+            latest_index,
+            or_rule_indices,
+            lookback_records,
+            2,
+            HashSet::new(),
+        );
         // After merging, each vector should include [3, 4] (some of which are
         // duplicates). Then we sort and deduplicate.
         let expected = vec![vec![1, 2, 3, 4, 5], vec![3, 4, 5]];
 
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_skip_lookback_requests() {
+        // We'll choose a latest index of 10, and a lookback of 3, which generates [8,
+        // 9, 10].
+        let latest_index = 10;
+        let lookback_records = 3;
+
+        // Suppose we have two requests in batch with OR-rule indices initially:
+        //   Index 0: [1, 2]
+        //   Index 1: [4, 5]
+        // We'll skip adding the lookback to request 0, but allow it for request 1.
+        let or_rule_indices = vec![vec![1, 2], vec![4, 5]];
+        let batch_size = or_rule_indices.len();
+
+        // Skip lookback for request 0.
+        let skip_positions = std::collections::HashSet::from([0]);
+
+        let result = generate_luc_records(
+            latest_index,
+            or_rule_indices.clone(),
+            lookback_records,
+            batch_size,
+            skip_positions,
+        );
+
+        // Request 0 should remain unchanged: [1, 2].
+        // Request 1 should have [7, 8, 9, 10] appended (then deduplicated and sorted).
+        let expected = vec![vec![1, 2], vec![4, 5, 7, 8, 9, 10]];
         assert_eq!(result, expected);
     }
 }

--- a/iris-mpc/src/bin/server.rs
+++ b/iris-mpc/src/bin/server.rs
@@ -279,15 +279,28 @@ async fn receive_batch(
                                 "Skipping request due to it being from synced deleted ids: {}",
                                 uniqueness_request.signup_id
                             );
+                            let message: UniquenessResult = UniquenessResult {
+                                node_id:                   config.party_id,
+                                serial_id:                 None,
+                                is_match:                  false,
+                                signup_id:                 uniqueness_request.signup_id,
+                                matched_serial_ids:        None,
+                                matched_serial_ids_left:   None,
+                                matched_serial_ids_right:  None,
+                                matched_batch_request_ids: None,
+                                error:                     Some(true),
+                                error_reason:              Some(
+                                    ERROR_SKIPPED_REQUEST_PREVIOUS_NODE_BATCH.to_string(),
+                                ),
+                            };
                             // shares
                             send_error_results_to_sns(
-                                uniqueness_request.signup_id,
+                                serde_json::to_string(&message).unwrap(),
                                 &batch_metadata,
                                 sns_client,
                                 config,
                                 uniqueness_error_result_attributes,
                                 UNIQUENESS_MESSAGE_TYPE,
-                                ERROR_SKIPPED_REQUEST_PREVIOUS_NODE_BATCH,
                             )
                             .await?;
                             continue;
@@ -370,6 +383,17 @@ async fn receive_batch(
                             .send()
                             .await
                             .map_err(ReceiveRequestError::FailedToDeleteFromSQS)?;
+
+                        if reauth_request.use_or_rule
+                            && !(config.luc_enabled && config.luc_serial_ids_from_smpc_request)
+                        {
+                            tracing::error!(
+                                "Received a reauth request with use_or_rule set to true, but LUC \
+                                 is not enabled. Skipping request."
+                            );
+                            // TODO: send error message to signup-service
+                            continue;
+                        }
 
                         if config.enable_reauth {
                             msg_counter += 1;
@@ -466,19 +490,37 @@ async fn receive_batch(
                 tracing::error!("Failed to process iris shares: {:?}", e);
                 // Return error message back to the signup-service if failed to process iris
                 // shares
-                let result_attributes = match batch_query.request_types[index].as_str() {
-                    UNIQUENESS_MESSAGE_TYPE => uniqueness_error_result_attributes,
-                    REAUTH_MESSAGE_TYPE => reauth_error_result_attributes,
+                let request_id = batch_query.request_ids[index].clone();
+                let (result_attributes, message) = match batch_query.request_types[index].as_str() {
+                    UNIQUENESS_MESSAGE_TYPE => {
+                        let message = UniquenessResult::new_error_result(
+                            config.party_id,
+                            request_id,
+                            ERROR_FAILED_TO_PROCESS_IRIS_SHARES,
+                        );
+                        let serialized = serde_json::to_string(&message).unwrap();
+                        (uniqueness_error_result_attributes, serialized)
+                    }
+                    REAUTH_MESSAGE_TYPE => {
+                        let message = ReAuthResult::new_error_result(
+                            request_id.clone(),
+                            config.party_id,
+                            *batch_query.reauth_target_indices.get(&request_id).unwrap(),
+                            ERROR_FAILED_TO_PROCESS_IRIS_SHARES,
+                        );
+                        let serialized = serde_json::to_string(&message).unwrap();
+                        (reauth_error_result_attributes, serialized)
+                    }
                     _ => unreachable!(), // we don't push a handle for unknown message types
                 };
+
                 send_error_results_to_sns(
-                    batch_query.request_ids[index].clone(),
+                    message,
                     &batch_query.metadata[index],
                     sns_client,
                     config,
                     result_attributes,
                     batch_query.request_types[index].as_str(),
-                    ERROR_FAILED_TO_PROCESS_IRIS_SHARES,
                 )
                 .await?;
                 // If we failed to process the iris shares, we include a dummy entry in the
@@ -726,34 +768,20 @@ async fn initialize_chacha_seeds(config: Config) -> eyre::Result<([u32; 8], [u32
 }
 
 async fn send_error_results_to_sns(
-    signup_id: String,
+    serialised_json_message: String,
     metadata: &BatchMetadata,
     sns_client: &SNSClient,
     config: &Config,
     base_message_attributes: &HashMap<String, MessageAttributeValue>,
     message_type: &str,
-    error_reason: &str,
 ) -> eyre::Result<()> {
-    let message: UniquenessResult = UniquenessResult {
-        node_id: config.party_id,
-        serial_id: None,
-        is_match: false,
-        signup_id,
-        matched_serial_ids: None,
-        matched_serial_ids_left: None,
-        matched_serial_ids_right: None,
-        matched_batch_request_ids: None,
-        error: Some(true),
-        error_reason: Some(String::from(error_reason)),
-    };
-    let message_serialised = serde_json::to_string(&message)?;
     let mut message_attributes = base_message_attributes.clone();
     let trace_attributes = construct_message_attributes(&metadata.trace_id, &metadata.span_id)?;
     message_attributes.extend(trace_attributes);
     sns_client
         .publish()
         .topic_arn(&config.results_topic_arn)
-        .message(message_serialised)
+        .message(serialised_json_message)
         .message_group_id(format!("party-id-{}", config.party_id))
         .set_message_attributes(Some(message_attributes))
         .send()
@@ -762,6 +790,7 @@ async fn send_error_results_to_sns(
 
     Ok(())
 }
+
 async fn send_results_to_sns(
     result_events: Vec<String>,
     metadata: &[BatchMetadata],
@@ -1615,10 +1644,9 @@ async fn server_main(config: Config) -> eyre::Result<()> {
                         party_id,
                         reauth_target_indices.get(&reauth_id).unwrap() + 1,
                         successful_reauths[i],
-                        match match_ids[i].is_empty() {
-                            false => Some(match_ids[i].iter().map(|x| x + 1).collect::<Vec<_>>()),
-                            true => None,
-                        },
+                        match_ids[i].iter().map(|x| x + 1).collect::<Vec<_>>(),
+                        false,
+                        None,
                     );
                     serde_json::to_string(&result_event)
                         .wrap_err("failed to serialize reauth result")

--- a/iris-mpc/src/bin/server.rs
+++ b/iris-mpc/src/bin/server.rs
@@ -422,7 +422,7 @@ async fn receive_batch(
                             } else {
                                 vec![]
                             };
-                            batch_query.or_rule_serial_ids.push(or_rule_indices);
+                            batch_query.or_rule_indices.push(or_rule_indices);
 
                             let semaphore = Arc::clone(&semaphore);
                             let s3_client_arc = Arc::clone(s3_client);

--- a/iris-mpc/src/bin/server.rs
+++ b/iris-mpc/src/bin/server.rs
@@ -279,20 +279,11 @@ async fn receive_batch(
                                 "Skipping request due to it being from synced deleted ids: {}",
                                 uniqueness_request.signup_id
                             );
-                            let message: UniquenessResult = UniquenessResult {
-                                node_id:                   config.party_id,
-                                serial_id:                 None,
-                                is_match:                  false,
-                                signup_id:                 uniqueness_request.signup_id,
-                                matched_serial_ids:        None,
-                                matched_serial_ids_left:   None,
-                                matched_serial_ids_right:  None,
-                                matched_batch_request_ids: None,
-                                error:                     Some(true),
-                                error_reason:              Some(
-                                    ERROR_SKIPPED_REQUEST_PREVIOUS_NODE_BATCH.to_string(),
-                                ),
-                            };
+                            let message = UniquenessResult::new_error_result(
+                                config.party_id,
+                                uniqueness_request.signup_id,
+                                ERROR_SKIPPED_REQUEST_PREVIOUS_NODE_BATCH,
+                            );
                             // shares
                             send_error_results_to_sns(
                                 serde_json::to_string(&message).unwrap(),


### PR DESCRIPTION
**Main Change**
- Change `ReauthResult` to include information on or rule usage and result.
- As agreed with AI team, finalize reauth as success if any side of the target serial id is matching. Do not consider AND matches with the other serial ids but just report those back to SNS.
- Write reauth result as 1-based serial id insead of 0-based index to SNS.
- Add e2e tests for reauth or rule matching and non-matching.
  - Refactor existing or rule e2e tests by extracting `prepare_flipped_codes` function.


**Side Changes**
- Fix returning correct result message on reauth share parsing errors -> it used to be uniqueness result.
- Create `new_error_results` method on `Reauth` and `Uniqueness` results for easier construction.