### PR TITLE
async SharedIrisesRef

### DIFF
--- a/iris-mpc-cpu/src/hawkers/aby3_store.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3_store.rs
@@ -30,10 +30,10 @@ use std::{
     fmt::{Debug, Display},
     num::ParseIntError,
     str::FromStr,
-    sync::{Arc, RwLock},
+    sync::Arc,
     vec,
 };
-use tokio::task::JoinSet;
+use tokio::{sync::RwLock, task::JoinSet};
 
 #[derive(Copy, Default, Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct VectorId {
@@ -94,7 +94,7 @@ pub struct SharedIrisesRef {
 
 impl std::fmt::Debug for SharedIrisesRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.body.read().unwrap().points.fmt(f)
+        std::fmt::Debug::fmt("SharedIrisesRef", f)
     }
 }
 
@@ -129,13 +129,21 @@ impl SharedIrisesRef {
         })
     }
 
-    pub fn get_vector(&self, vector: &VectorId) -> GaloisRingSharedIris {
-        let body = self.body.read().unwrap();
+    pub async fn get_vector(&self, vector: &VectorId) -> GaloisRingSharedIris {
+        let body = self.body.read().await;
         body.points[vector.id].clone()
     }
 
-    fn insert(&mut self, query: &QueryRef) -> VectorId {
-        let mut body = self.body.write().unwrap();
+    pub async fn iter_vectors<'a>(
+        &'a self,
+        vector_ids: &'a [VectorId],
+    ) -> impl Iterator<Item = GaloisRingSharedIris> + 'a {
+        let body = self.body.read().await;
+        vector_ids.iter().map(move |v| body.points[v.id].clone())
+    }
+
+    async fn insert(&mut self, query: &QueryRef) -> VectorId {
+        let mut body = self.body.write().await;
         body.points.push(query.query.clone());
 
         let new_id = body.points.len() - 1;
@@ -263,7 +271,7 @@ impl VectorStore for Aby3Store {
     type DistanceRef = DistanceShare<u32>; // Distance represented as shares.
 
     async fn insert(&mut self, query: &Self::QueryRef) -> Self::VectorRef {
-        self.storage.insert(query)
+        self.storage.insert(query).await
     }
 
     async fn eval_distance(
@@ -271,7 +279,7 @@ impl VectorStore for Aby3Store {
         query: &Self::QueryRef,
         vector: &Self::VectorRef,
     ) -> Self::DistanceRef {
-        let vector_point = self.storage.get_vector(vector);
+        let vector_point = self.storage.get_vector(vector).await;
         let pairs = vec![(query.processed_query.clone(), vector_point)];
         let dist = self.eval_pairwise_distances(pairs).await;
         self.lift_distances(dist).await.unwrap()[0].clone()
@@ -285,13 +293,13 @@ impl VectorStore for Aby3Store {
         if vectors.is_empty() {
             return vec![];
         }
-        let pairs = vectors
-            .iter()
-            .map(|vector_id| {
-                let vector_point = self.storage.get_vector(vector_id);
-                (query.processed_query.clone(), vector_point)
-            })
+        let pairs = self
+            .storage
+            .iter_vectors(vectors)
+            .await
+            .map(|vector| (query.processed_query.clone(), vector))
             .collect::<Vec<_>>();
+
         let dist = self.eval_pairwise_distances(pairs).await;
         self.lift_distances(dist).await.unwrap()
     }
@@ -342,8 +350,8 @@ impl Aby3Store {
         vector1: &<Aby3Store as VectorStore>::VectorRef,
         vector2: &<Aby3Store as VectorStore>::VectorRef,
     ) -> <Aby3Store as VectorStore>::DistanceRef {
-        let point1 = self.storage.get_vector(vector1);
-        let mut point2 = self.storage.get_vector(vector2);
+        let point1 = self.storage.get_vector(vector1).await;
+        let mut point2 = self.storage.get_vector(vector2).await;
         point2.code.preprocess_iris_code_query_share();
         point2.mask.preprocess_mask_code_query_share();
         let pairs = vec![(point1.clone(), point2)];
@@ -668,7 +676,7 @@ mod tests {
                 // Search for the same codes and find matches.
                 let mut matching_results = vec![];
                 for v in inserted.into_iter() {
-                    let query = store.prepare_query(store.storage.get_vector(&v));
+                    let query = store.prepare_query(store.storage.get_vector(&v).await);
                     let neighbors = db.search(&mut store, &mut aby3_graph, &query, 1).await;
                     tracing::debug!("Finished checking query");
                     matching_results.push(db.is_match(&mut store, &[neighbors]).await)
@@ -709,8 +717,8 @@ mod tests {
             vector_graph_stores.iter().zip(secret_data.iter())
         {
             assert_eq!(
-                v_from_scratch.storage.body.read().unwrap().points,
-                premade_v.storage.body.read().unwrap().points
+                v_from_scratch.storage.body.read().await.points,
+                premade_v.storage.body.read().await.points
             );
         }
         let hawk_searcher = HnswSearcher::default();
@@ -730,7 +738,7 @@ mod tests {
                 let hawk_searcher = hawk_searcher.clone();
                 let mut v = v.clone();
                 let mut g = g.clone();
-                let q = v.prepare_query(v.storage.get_vector(&i.into()));
+                let q = v.prepare_query(v.storage.get_vector(&i.into()).await);
                 jobs.spawn(async move {
                     let secret_neighbors = hawk_searcher.search(&mut v, &mut g, &q, 1).await;
 
@@ -745,7 +753,7 @@ mod tests {
                 let mut v = v.clone();
                 let mut g = g.clone();
                 jobs.spawn(async move {
-                    let query = v.prepare_query(v.storage.get_vector(&i.into()));
+                    let query = v.prepare_query(v.storage.get_vector(&i.into()).await);
                     let secret_neighbors = hawk_searcher.search(&mut v, &mut g, &query, 1).await;
 
                     hawk_searcher.is_match(&mut v, &[secret_neighbors]).await
@@ -872,7 +880,7 @@ mod tests {
                 let mut store = store.clone();
                 let mut graph = graph.clone();
                 let searcher = searcher.clone();
-                let q = store.prepare_query(store.storage.get_vector(&i.into()));
+                let q = store.prepare_query(store.storage.get_vector(&i.into()).await);
                 jobs.spawn(async move {
                     let secret_neighbors = searcher.search(&mut store, &mut graph, &q, 1).await;
                     searcher.is_match(&mut store, &[secret_neighbors]).await

--- a/iris-mpc-cpu/src/network/grpc.rs
+++ b/iris-mpc-cpu/src/network/grpc.rs
@@ -635,7 +635,7 @@ mod tests {
                 let mut store = store.clone();
                 let mut graph = graph.clone();
                 let searcher = searcher.clone();
-                let q = store.prepare_query(store.storage.get_vector(&i.into()));
+                let q = store.prepare_query(store.storage.get_vector(&i.into()).await);
                 jobs.spawn(async move {
                     let secret_neighbors = searcher.search(&mut store, &mut graph, &q, 1).await;
                     searcher.is_match(&mut store, &[secret_neighbors]).await


### PR DESCRIPTION
- Replace `sync::RwLock` with `tokio::RwLock` to avoid blocking threads and deadlock hazards.
- Share the lock acquisition in `eval_distance_batch`.
- Remove verbose Debug.

Maybe related to https://github.com/worldcoin/iris-mpc/issues/959.