### PR TITLE
Encapsulate GPU preprocessing

### DIFF
--- a/iris-mpc-common/src/helpers/statistics.rs
+++ b/iris-mpc-common/src/helpers/statistics.rs
@@ -1,15 +1,10 @@
+use crate::job::Eye;
 use chrono::{
     serde::{ts_seconds, ts_seconds_option},
     DateTime, Utc,
 };
 use serde::{Deserialize, Serialize};
 use std::fmt;
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum Eye {
-    Left,
-    Right,
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BucketResult {

--- a/iris-mpc-common/src/job.rs
+++ b/iris-mpc-common/src/job.rs
@@ -1,0 +1,79 @@
+use crate::{
+    galois_engine::degree4::{GaloisRingIrisCodeShare, GaloisRingTrimmedMaskCodeShare},
+    helpers::statistics::BucketStatistics,
+};
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, future::Future};
+
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct BatchQueryEntries {
+    pub code: Vec<GaloisRingIrisCodeShare>,
+    pub mask: Vec<GaloisRingTrimmedMaskCodeShare>,
+}
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct BatchMetadata {
+    pub node_id:  String,
+    pub trace_id: String,
+    pub span_id:  String,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
+pub struct BatchQuery {
+    // Enrollment and reauth specific fields
+    pub request_ids:          Vec<String>,
+    pub request_types:        Vec<String>,
+    pub metadata:             Vec<BatchMetadata>,
+    pub query_left:           BatchQueryEntries,
+    pub db_left:              BatchQueryEntries,
+    pub store_left:           BatchQueryEntries,
+    pub query_right:          BatchQueryEntries,
+    pub db_right:             BatchQueryEntries,
+    pub store_right:          BatchQueryEntries,
+    pub or_rule_indices:      Vec<Vec<u32>>,
+    pub luc_lookback_records: usize,
+    pub valid_entries:        Vec<bool>,
+
+    // Only reauth specific fields
+    // Map from reauth request id to the index of the target entry to be matched
+    pub reauth_target_indices: HashMap<String, u32>,
+    pub reauth_use_or_rule:    HashMap<String, bool>,
+
+    // Only deletion specific fields
+    pub deletion_requests_indices:  Vec<u32>, // 0-indexed indices of entries to be deleted
+    pub deletion_requests_metadata: Vec<BatchMetadata>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ServerJobResult {
+    pub merged_results: Vec<u32>,
+    pub request_ids: Vec<String>,
+    pub request_types: Vec<String>,
+    pub metadata: Vec<BatchMetadata>,
+    pub matches: Vec<bool>,
+    pub match_ids: Vec<Vec<u32>>,
+    pub partial_match_ids_left: Vec<Vec<u32>>,
+    pub partial_match_ids_right: Vec<Vec<u32>>,
+    pub store_left: BatchQueryEntries,
+    pub store_right: BatchQueryEntries,
+    pub deleted_ids: Vec<u32>,
+    pub matched_batch_request_ids: Vec<Vec<String>>,
+    pub anonymized_bucket_statistics_left: BucketStatistics,
+    pub anonymized_bucket_statistics_right: BucketStatistics,
+    pub successful_reauths: Vec<bool>, // true if request type is reauth and it's successful
+    pub reauth_target_indices: HashMap<String, u32>,
+    pub reauth_or_rule_used: HashMap<String, bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Eye {
+    Left,
+    Right,
+}
+
+pub trait JobSubmissionHandle {
+    #[allow(async_fn_in_trait)]
+    async fn submit_batch_query(
+        &mut self,
+        batch: BatchQuery,
+    ) -> impl Future<Output = ServerJobResult>;
+}

--- a/iris-mpc-common/src/lib.rs
+++ b/iris-mpc-common/src/lib.rs
@@ -6,10 +6,12 @@ pub mod galois_engine;
 pub mod helpers;
 pub mod id;
 pub mod iris_db;
+pub mod job;
 pub mod shamir;
 
 pub const IRIS_CODE_LENGTH: usize = 12_800;
 pub const MASK_CODE_LENGTH: usize = 6_400;
+pub const ROTATIONS: usize = 31;
 
 /// Iris code database type; .0 = iris code, .1 = mask
 pub type IrisCodeDb = (Vec<u16>, Vec<u16>);

--- a/iris-mpc-common/tests/statistics.rs
+++ b/iris-mpc-common/tests/statistics.rs
@@ -1,6 +1,9 @@
 mod tests {
     use chrono::{TimeZone, Utc};
-    use iris_mpc_common::helpers::statistics::{BucketResult, BucketStatistics, Eye};
+    use iris_mpc_common::{
+        helpers::statistics::{BucketResult, BucketStatistics},
+        job::Eye,
+    };
     use serde_json::{json, Value};
 
     #[test]

--- a/iris-mpc-gpu/Cargo.toml
+++ b/iris-mpc-gpu/Cargo.toml
@@ -9,10 +9,7 @@ repository.workspace = true
 
 [dependencies]
 bincode = "1.3.3"
-cudarc = { version = "0.13.4", features = [
-    "cuda-12020",
-    "nccl",
-] }
+cudarc = { version = "0.13.4", features = ["cuda-12020", "nccl"] }
 eyre.workspace = true
 tracing.workspace = true
 bytemuck.workspace = true
@@ -47,9 +44,9 @@ uuid.workspace = true
 default = []
 gpu_dependent = []
 
-#[[bench]]
-#name = "chacha"
-#harness = false
+[[bench]]
+name = "preprocessing"
+harness = false
 
 [[bench]]
 name = "matmul"

--- a/iris-mpc-gpu/benches/preprocessing.rs
+++ b/iris-mpc-gpu/benches/preprocessing.rs
@@ -1,0 +1,77 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use iris_mpc_common::{
+    galois_engine::degree4::{
+        FullGaloisRingIrisCodeShare, GaloisRingIrisCodeShare, GaloisRingTrimmedMaskCodeShare,
+    },
+    helpers::smpc_request::UNIQUENESS_MESSAGE_TYPE,
+    iris_db::iris::IrisCode,
+    job::BatchQuery,
+};
+use iris_mpc_gpu::server::PreprocessedBatchQuery;
+use rand::thread_rng;
+use uuid::Uuid;
+
+pub fn criterion_benchmark_preprocessing(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Preprocessing");
+    for batch_size in [1, 4, 16, 64] {
+        let mut batch_query = BatchQuery::default();
+        for _ in 0..batch_size {
+            let iris = IrisCode::random_rng(&mut thread_rng());
+            let [shares, _, _] =
+                FullGaloisRingIrisCodeShare::encode_iris_code(&iris, &mut thread_rng());
+            let code_shares_store = shares.code;
+            let mask_shares_store = shares.mask;
+            let mut code_shares_query = code_shares_store.clone();
+            let mut mask_shares_query = mask_shares_store.clone();
+            GaloisRingIrisCodeShare::preprocess_iris_code_query_share(&mut code_shares_query);
+            GaloisRingTrimmedMaskCodeShare::preprocess_mask_code_query_share(
+                &mut mask_shares_query,
+            );
+            let code_shares_query = code_shares_query.all_rotations();
+            let mask_shares_query = mask_shares_query.all_rotations();
+            let code_shares_db = code_shares_store.all_rotations();
+            let mask_shares_db = mask_shares_store.all_rotations();
+            batch_query.request_ids.push(Uuid::new_v4().to_string());
+            batch_query
+                .request_types
+                .push(UNIQUENESS_MESSAGE_TYPE.to_owned());
+            batch_query
+                .query_left
+                .code
+                .extend(code_shares_query.clone());
+            batch_query.query_right.code.extend(code_shares_query);
+            batch_query
+                .query_left
+                .mask
+                .extend(mask_shares_query.clone());
+            batch_query.query_right.mask.extend(mask_shares_query);
+
+            batch_query.store_left.code.push(code_shares_store.clone());
+            batch_query.store_right.code.push(code_shares_store);
+            batch_query.store_left.mask.push(mask_shares_store.clone());
+            batch_query.store_right.mask.push(mask_shares_store);
+
+            batch_query.db_left.code.extend(code_shares_db.clone());
+            batch_query.db_right.code.extend(code_shares_db);
+            batch_query.db_left.mask.extend(mask_shares_db.clone());
+            batch_query.db_right.mask.extend(mask_shares_db);
+        }
+
+        group.bench_function(format!("batch_size={}", batch_size), |b| {
+            b.iter_batched(
+                || batch_query.clone(),
+                |batch| {
+                    let _ = PreprocessedBatchQuery::from(batch);
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+    }
+}
+
+criterion_group!(
+    name = preprocessing;
+    config = Criterion::default();
+    targets = criterion_benchmark_preprocessing
+);
+criterion_main!(preprocessing);

--- a/iris-mpc-gpu/src/dot/mod.rs
+++ b/iris-mpc-gpu/src/dot/mod.rs
@@ -1,6 +1,6 @@
 pub mod distance_comparator;
 pub mod share_db;
 
-pub const IRIS_CODE_LENGTH: usize = 12_800;
-pub const MASK_CODE_LENGTH: usize = 6_400;
-pub const ROTATIONS: usize = 31;
+pub const IRIS_CODE_LENGTH: usize = iris_mpc_common::IRIS_CODE_LENGTH;
+pub const MASK_CODE_LENGTH: usize = iris_mpc_common::MASK_CODE_LENGTH;
+pub const ROTATIONS: usize = iris_mpc_common::ROTATIONS;

--- a/iris-mpc-gpu/src/dot/share_db.rs
+++ b/iris-mpc-gpu/src/dot/share_db.rs
@@ -54,7 +54,7 @@ pub fn preprocess_query(query: &[u16]) -> Vec<Vec<u8>> {
         }
     }
 
-    result.to_vec()
+    result
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/iris-mpc-gpu/src/server/mod.rs
+++ b/iris-mpc-gpu/src/server/mod.rs
@@ -6,7 +6,7 @@ use iris_mpc_common::job::{BatchMetadata, BatchQuery, BatchQueryEntries};
 use std::collections::{HashMap, HashSet};
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) struct BatchQueryEntriesPreprocessed {
+pub struct BatchQueryEntriesPreprocessed {
     pub code: Vec<Vec<u8>>,
     pub mask: Vec<Vec<u8>>,
 }
@@ -39,6 +39,9 @@ impl BatchQueryEntriesPreprocessed {
         } else {
             self.code[0].len() / IRIS_CODE_LENGTH
         }
+    }
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 }
 
@@ -75,7 +78,7 @@ macro_rules! filter_by_indices_with_rotations_and_code_length {
     };
 }
 
-pub(crate) struct PreprocessedBatchQuery {
+pub struct PreprocessedBatchQuery {
     // Enrollment and reauth specific fields
     pub request_ids:          Vec<String>,
     pub request_types:        Vec<String>,

--- a/iris-mpc-gpu/src/server/mod.rs
+++ b/iris-mpc-gpu/src/server/mod.rs
@@ -2,21 +2,11 @@ mod actor;
 
 use crate::dot::{share_db::preprocess_query, IRIS_CODE_LENGTH, MASK_CODE_LENGTH, ROTATIONS};
 pub use actor::{generate_luc_records, prepare_or_policy_bitmap, ServerActor, ServerActorHandle};
-use iris_mpc_common::{
-    galois_engine::degree4::{GaloisRingIrisCodeShare, GaloisRingTrimmedMaskCodeShare},
-    helpers::statistics::BucketStatistics,
-};
+use iris_mpc_common::job::{BatchMetadata, BatchQuery, BatchQueryEntries};
 use std::collections::{HashMap, HashSet};
-use tokio::sync::oneshot;
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
-pub struct BatchQueryEntries {
-    pub code: Vec<GaloisRingIrisCodeShare>,
-    pub mask: Vec<GaloisRingTrimmedMaskCodeShare>,
-}
-
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
-pub struct BatchQueryEntriesPreprocessed {
+pub(crate) struct BatchQueryEntriesPreprocessed {
     pub code: Vec<Vec<u8>>,
     pub mask: Vec<Vec<u8>>,
 }
@@ -50,47 +40,6 @@ impl BatchQueryEntriesPreprocessed {
             self.code[0].len() / IRIS_CODE_LENGTH
         }
     }
-
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-}
-
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
-pub struct BatchMetadata {
-    pub node_id:  String,
-    pub trace_id: String,
-    pub span_id:  String,
-}
-
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
-pub struct BatchQuery {
-    // Enrollment and reauth specific fields
-    pub request_ids:              Vec<String>,
-    pub request_types:            Vec<String>,
-    pub metadata:                 Vec<BatchMetadata>,
-    pub query_left:               BatchQueryEntries,
-    pub db_left:                  BatchQueryEntries,
-    pub store_left:               BatchQueryEntries,
-    pub query_left_preprocessed:  BatchQueryEntriesPreprocessed,
-    pub db_left_preprocessed:     BatchQueryEntriesPreprocessed,
-    pub query_right:              BatchQueryEntries,
-    pub db_right:                 BatchQueryEntries,
-    pub store_right:              BatchQueryEntries,
-    pub query_right_preprocessed: BatchQueryEntriesPreprocessed,
-    pub db_right_preprocessed:    BatchQueryEntriesPreprocessed,
-    pub or_rule_indices:          Vec<Vec<u32>>,
-    pub luc_lookback_records:     usize,
-    pub valid_entries:            Vec<bool>,
-
-    // Only reauth specific fields
-    // Map from reauth request id to the index of the target entry to be matched
-    pub reauth_target_indices: HashMap<String, u32>,
-    pub reauth_use_or_rule:    HashMap<String, bool>,
-
-    // Only deletion specific fields
-    pub deletion_requests_indices:  Vec<u32>, // 0-indexed indices of entries to be deleted
-    pub deletion_requests_metadata: Vec<BatchMetadata>,
 }
 
 macro_rules! filter_by_indices {
@@ -126,7 +75,73 @@ macro_rules! filter_by_indices_with_rotations_and_code_length {
     };
 }
 
-impl BatchQuery {
+pub(crate) struct PreprocessedBatchQuery {
+    // Enrollment and reauth specific fields
+    pub request_ids:          Vec<String>,
+    pub request_types:        Vec<String>,
+    pub metadata:             Vec<BatchMetadata>,
+    pub query_left:           BatchQueryEntries,
+    pub db_left:              BatchQueryEntries,
+    pub store_left:           BatchQueryEntries,
+    pub query_right:          BatchQueryEntries,
+    pub db_right:             BatchQueryEntries,
+    pub store_right:          BatchQueryEntries,
+    pub or_rule_indices:      Vec<Vec<u32>>,
+    pub luc_lookback_records: usize,
+    pub valid_entries:        Vec<bool>,
+
+    // Only reauth specific fields
+    // Map from reauth request id to the index of the target entry to be matched
+    pub reauth_target_indices: HashMap<String, u32>,
+    pub reauth_use_or_rule:    HashMap<String, bool>,
+
+    // Only deletion specific fields
+    pub deletion_requests_indices: Vec<u32>, // 0-indexed indices of entries to be deleted
+
+    // this one is not needed for the GPU actor
+    // pub deletion_requests_metadata: Vec<BatchMetadata>,
+
+    // additional fields which are GPU specific
+    pub query_left_preprocessed:  BatchQueryEntriesPreprocessed,
+    pub db_left_preprocessed:     BatchQueryEntriesPreprocessed,
+    pub query_right_preprocessed: BatchQueryEntriesPreprocessed,
+    pub db_right_preprocessed:    BatchQueryEntriesPreprocessed,
+}
+
+impl From<BatchQuery> for PreprocessedBatchQuery {
+    fn from(value: BatchQuery) -> Self {
+        let query_left_preprocessed = BatchQueryEntriesPreprocessed::from(value.query_left.clone());
+        let query_right_preprocessed =
+            BatchQueryEntriesPreprocessed::from(value.query_right.clone());
+        let db_left_preprocessed = BatchQueryEntriesPreprocessed::from(value.db_left.clone());
+        let db_right_preprocessed = BatchQueryEntriesPreprocessed::from(value.db_right.clone());
+
+        Self {
+            request_ids: value.request_ids,
+            request_types: value.request_types,
+            metadata: value.metadata,
+            query_left: value.query_left,
+            db_left: value.db_left,
+            store_left: value.store_left,
+            query_right: value.query_right,
+            db_right: value.db_right,
+            store_right: value.store_right,
+            or_rule_indices: value.or_rule_indices,
+            luc_lookback_records: value.luc_lookback_records,
+            valid_entries: value.valid_entries,
+            reauth_target_indices: value.reauth_target_indices,
+            reauth_use_or_rule: value.reauth_use_or_rule,
+            deletion_requests_indices: value.deletion_requests_indices,
+            // deletion_requests_metadata: value.deletion_requests_metadata,
+            query_left_preprocessed,
+            db_left_preprocessed,
+            query_right_preprocessed,
+            db_right_preprocessed,
+        }
+    }
+}
+
+impl PreprocessedBatchQuery {
     pub fn retain(&mut self, indices: &[usize]) {
         let indices_set: HashSet<usize> = indices.iter().cloned().collect();
         filter_by_indices!(self.request_ids, indices_set);
@@ -169,36 +184,4 @@ impl BatchQuery {
             );
         }
     }
-}
-
-#[derive(Debug)]
-pub struct ServerJob {
-    batch:          BatchQuery,
-    return_channel: oneshot::Sender<ServerJobResult>,
-}
-
-#[derive(Debug, Clone)]
-pub struct ServerJobResult {
-    pub merged_results: Vec<u32>,
-    pub request_ids: Vec<String>,
-    pub request_types: Vec<String>,
-    pub metadata: Vec<BatchMetadata>,
-    pub matches: Vec<bool>,
-    pub match_ids: Vec<Vec<u32>>,
-    pub partial_match_ids_left: Vec<Vec<u32>>,
-    pub partial_match_ids_right: Vec<Vec<u32>>,
-    pub store_left: BatchQueryEntries,
-    pub store_right: BatchQueryEntries,
-    pub deleted_ids: Vec<u32>,
-    pub matched_batch_request_ids: Vec<Vec<String>>,
-    pub anonymized_bucket_statistics_left: BucketStatistics,
-    pub anonymized_bucket_statistics_right: BucketStatistics,
-    pub successful_reauths: Vec<bool>, // true if request type is reauth and it's successful
-    pub reauth_target_indices: HashMap<String, u32>,
-    pub reauth_or_rule_used: HashMap<String, bool>,
-}
-
-enum Eye {
-    Left,
-    Right,
 }

--- a/iris-mpc-gpu/src/server/mod.rs
+++ b/iris-mpc-gpu/src/server/mod.rs
@@ -113,33 +113,52 @@ pub struct PreprocessedBatchQuery {
 
 impl From<BatchQuery> for PreprocessedBatchQuery {
     fn from(value: BatchQuery) -> Self {
-        let query_left_preprocessed = BatchQueryEntriesPreprocessed::from(value.query_left.clone());
-        let query_right_preprocessed =
-            BatchQueryEntriesPreprocessed::from(value.query_right.clone());
-        let db_left_preprocessed = BatchQueryEntriesPreprocessed::from(value.db_left.clone());
-        let db_right_preprocessed = BatchQueryEntriesPreprocessed::from(value.db_right.clone());
+        let mut query_left_preprocessed = None;
+        let mut query_right_preprocessed = None;
+        let mut db_left_preprocessed = None;
+        let mut db_right_preprocessed = None;
+        rayon::scope(|s| {
+            s.spawn(|_| {
+                query_left_preprocessed = Some(BatchQueryEntriesPreprocessed::from(
+                    value.query_left.clone(),
+                ));
+            });
+            s.spawn(|_| {
+                query_right_preprocessed = Some(BatchQueryEntriesPreprocessed::from(
+                    value.query_right.clone(),
+                ));
+            });
+            s.spawn(|_| {
+                db_left_preprocessed =
+                    Some(BatchQueryEntriesPreprocessed::from(value.db_left.clone()));
+            });
+            s.spawn(|_| {
+                db_right_preprocessed =
+                    Some(BatchQueryEntriesPreprocessed::from(value.db_right.clone()));
+            });
+        });
 
         Self {
-            request_ids: value.request_ids,
-            request_types: value.request_types,
-            metadata: value.metadata,
-            query_left: value.query_left,
-            db_left: value.db_left,
-            store_left: value.store_left,
-            query_right: value.query_right,
-            db_right: value.db_right,
-            store_right: value.store_right,
-            or_rule_indices: value.or_rule_indices,
-            luc_lookback_records: value.luc_lookback_records,
-            valid_entries: value.valid_entries,
-            reauth_target_indices: value.reauth_target_indices,
-            reauth_use_or_rule: value.reauth_use_or_rule,
+            request_ids:               value.request_ids,
+            request_types:             value.request_types,
+            metadata:                  value.metadata,
+            query_left:                value.query_left,
+            db_left:                   value.db_left,
+            store_left:                value.store_left,
+            query_right:               value.query_right,
+            db_right:                  value.db_right,
+            store_right:               value.store_right,
+            or_rule_indices:           value.or_rule_indices,
+            luc_lookback_records:      value.luc_lookback_records,
+            valid_entries:             value.valid_entries,
+            reauth_target_indices:     value.reauth_target_indices,
+            reauth_use_or_rule:        value.reauth_use_or_rule,
             deletion_requests_indices: value.deletion_requests_indices,
             // deletion_requests_metadata: value.deletion_requests_metadata,
-            query_left_preprocessed,
-            db_left_preprocessed,
-            query_right_preprocessed,
-            db_right_preprocessed,
+            query_left_preprocessed:   query_left_preprocessed.unwrap(),
+            db_left_preprocessed:      db_left_preprocessed.unwrap(),
+            query_right_preprocessed:  query_right_preprocessed.unwrap(),
+            db_right_preprocessed:     db_right_preprocessed.unwrap(),
         }
     }
 }

--- a/iris-mpc/src/bin/server.rs
+++ b/iris-mpc/src/bin/server.rs
@@ -39,10 +39,9 @@ use iris_mpc_common::{
         task_monitor::TaskMonitor,
     },
     iris_db::get_dummy_shares_for_deletion,
+    job::{BatchMetadata, BatchQuery, JobSubmissionHandle, ServerJobResult},
 };
-use iris_mpc_gpu::server::{
-    BatchMetadata, BatchQuery, BatchQueryEntriesPreprocessed, ServerActor, ServerJobResult,
-};
+use iris_mpc_gpu::server::ServerActor;
 use iris_mpc_store::{
     fetch_and_parse_chunks, last_snapshot_timestamp, DbStoredIris, ObjectStore, S3Store,
     S3StoredIris, Store, StoredIrisRef,
@@ -574,16 +573,6 @@ async fn receive_batch(
             .zip(batch_query.request_types.iter())
             .collect::<Vec<_>>()
     );
-
-    // Preprocess query shares here already to avoid blocking the actor
-    batch_query.query_left_preprocessed =
-        BatchQueryEntriesPreprocessed::from(batch_query.query_left.clone());
-    batch_query.query_right_preprocessed =
-        BatchQueryEntriesPreprocessed::from(batch_query.query_right.clone());
-    batch_query.db_left_preprocessed =
-        BatchQueryEntriesPreprocessed::from(batch_query.db_left.clone());
-    batch_query.db_right_preprocessed =
-        BatchQueryEntriesPreprocessed::from(batch_query.db_right.clone());
 
     Ok(Some(batch_query))
 }


### PR DESCRIPTION
This is the final step to address #985. This PR moves the GPU-relevant part of the preprocessing completely into the GPU Actor.
This step might cause slight performance regressions since this part was previously handled by the main server loop, so this should be cross-examined.

I also moved the BatchQuery structs and its relevant child structs into the common crate and created a trait that provides an interface to submit jobs to whatever implementation is backing the Iris Uniqueness service.
This means that there is only a single import leftover from the `iris_mpc_gpu` crate, which is the concrete implementation of the actor itself, which can now more easily be switched out.
