### PR TITLE
feat: remove strict instance type for reshare-server deployment

### DIFF
--- a/deploy/stage/common-values-reshare-server.yaml
+++ b/deploy/stage/common-values-reshare-server.yaml
@@ -45,7 +45,6 @@ imagePullSecrets:
 
 nodeSelector:
   kubernetes.io/arch: amd64
-  beta.kubernetes.io/instance-type: t3.2xlarge
 
 podSecurityContext:
   runAsUser: 405


### PR DESCRIPTION
We have karpenter on this cluster, and we want to use all available instances to deploy this this app