### PR TITLE
fix: trigger to build reshare-protocol image

### DIFF
--- a/.github/workflows/build-and-push-reshare-protocol.yaml
+++ b/.github/workflows/build-and-push-reshare-protocol.yaml
@@ -8,6 +8,7 @@ on:
       - Dockerfile.reshare-protocol
       - iris-mpc-upgrade/**
       - scripts/reshare-client.sh
+      - .github/workflows/build-and-push-reshare-protocol.yaml
 
   workflow_dispatch:
 

--- a/.github/workflows/build-and-push-reshare-protocol.yaml
+++ b/.github/workflows/build-and-push-reshare-protocol.yaml
@@ -7,6 +7,8 @@ on:
     paths:
       - Dockerfile.reshare-protocol
       - iris-mpc-upgrade/**
+      - scripts/reshare-client.sh
+
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Added new path to trigger to build reshare-protocol image with gh actions.