### PR TITLE
fix: use parameter --ca-root-file-path

### DIFF
--- a/scripts/reshare-client.sh
+++ b/scripts/reshare-client.sh
@@ -134,7 +134,7 @@ COMMAND="reshare-client \
     --my-kms-key-arn $MY_KMS_KEY_ARN \
     --other-kms-key-arn $OTHER_KMS_KEY_ARN \
     --reshare-run-session-id $RESHARE_RUN_SESSION_ID \
-    --client-tls-cert-path $CLIENT_TLS_CERT_PATH"
+    --ca-root-file-path $CLIENT_TLS_CERT_PATH"
 
 # Display or execute command
 echo "Generated command:"


### PR DESCRIPTION
`error: unexpected argument '--client-tls-cert-path' found `. This should fix that problem. 
```
nobody@e01e098a0fce:/$ reshare-client
error: the following required arguments were not provided:
  --db-start <DB_START>
  --db-end <DB_END>
  --party-id <PARTY_ID>
  --other-party-id <OTHER_PARTY_ID>
  --target-party-id <TARGET_PARTY_ID>
  --batch-size <BATCH_SIZE>
  --db-url <DB_URL>
  --environment <ENVIRONMENT>
  --my-kms-key-arn <MY_KMS_KEY_ARN>
  --other-kms-key-arn <OTHER_KMS_KEY_ARN>
  --reshare-run-session-id <RESHARE_RUN_SESSION_ID>
  --ca-root-file-path <CA_ROOT_FILE_PATH>
```