### PR TITLE
use shares from s3

### DIFF
--- a/iris-mpc/src/bin/client.rs
+++ b/iris-mpc/src/bin/client.rs
@@ -10,7 +10,7 @@ use iris_mpc_common::{
     helpers::{
         key_pair::download_public_key,
         sha256::sha256_as_hex_string,
-        smpc_request::{IrisCodesJSON, UniquenessRequest, UNIQUENESS_MESSAGE_TYPE},
+        smpc_request::{IrisCodeSharesJSON, UniquenessRequest, UNIQUENESS_MESSAGE_TYPE},
         smpc_response::create_message_type_attribute_map,
         sqs_s3_helper::upload_file_and_generate_presigned_url,
     },
@@ -324,7 +324,7 @@ async fn main() -> eyre::Result<()> {
                 let mut iris_codes_shares_base64: [String; 3] = Default::default();
 
                 for i in 0..3 {
-                    let iris_codes_json = IrisCodesJSON {
+                    let iris_code_shares_json = IrisCodeSharesJSON {
                         iris_version:           "1.0".to_string(),
                         iris_shares_version:    "1.3".to_string(),
                         right_iris_code_shares: shared_code[i].to_base64(),
@@ -332,7 +332,7 @@ async fn main() -> eyre::Result<()> {
                         left_iris_code_shares:  shared_code[i].to_base64(),
                         left_mask_code_shares:  shared_mask[i].to_base64(),
                     };
-                    let serialized_iris_codes_json = to_string(&iris_codes_json)
+                    let serialized_iris_codes_json = to_string(&iris_code_shares_json)
                         .expect("Serialization failed")
                         .clone();
 
@@ -368,10 +368,9 @@ async fn main() -> eyre::Result<()> {
                 };
 
                 let request_message = UniquenessRequest {
-                    batch_size: None,
-                    signup_id: request_id.to_string(),
-                    s3_key: presigned_url,
-                    iris_shares_file_hashes,
+                    batch_size:         None,
+                    signup_id:          request_id.to_string(),
+                    s3_key:             presigned_url,
                     or_rule_serial_ids: None,
                 };
 

--- a/iris-mpc/src/bin/server_hawk.rs
+++ b/iris-mpc/src/bin/server_hawk.rs
@@ -336,7 +336,6 @@ async fn receive_batch(
                         let s3_client_arc = s3_client.clone();
                         let bucket_name = config.shares_bucket_name.clone();
                         let s3_key = uniqueness_request.s3_key.clone();
-                        let iris_shares_file_hashes = uniqueness_request.iris_shares_file_hashes;
                         let handle = get_iris_shares_parse_task(
                             party_id,
                             shares_encryption_key_pairs,
@@ -344,7 +343,6 @@ async fn receive_batch(
                             s3_client_arc,
                             bucket_name,
                             s3_key,
-                            iris_shares_file_hashes,
                         )?;
 
                         handles.push(handle);
@@ -424,7 +422,6 @@ async fn receive_batch(
                             let s3_client_clone = s3_client.clone();
                             let bucket_name = config.shares_bucket_name.clone();
                             let s3_key = reauth_request.s3_key.clone();
-                            let iris_shares_file_hashes = reauth_request.iris_shares_file_hashes;
                             let handle = get_iris_shares_parse_task(
                                 party_id,
                                 shares_encryption_key_pairs,
@@ -432,7 +429,6 @@ async fn receive_batch(
                                 s3_client_clone,
                                 bucket_name,
                                 s3_key,
-                                iris_shares_file_hashes,
                             )?;
 
                             handles.push(handle);
@@ -584,13 +580,12 @@ fn get_iris_shares_parse_task(
     s3_client_arc: S3Client,
     bucket_name: String,
     s3_key: String,
-    iris_shares_file_hashes: [String; 3],
 ) -> Result<JoinHandle<ParseSharesTaskResult>, ReceiveRequestError> {
     let handle =
         tokio::spawn(async move {
             let _ = semaphore.acquire().await?;
 
-            let base_64_encoded_message_payload =
+            let (share_b64, hash) =
                 match get_iris_data_by_party_id(&s3_key, party_id, &bucket_name, &s3_client_arc)
                     .await
                 {
@@ -601,22 +596,16 @@ fn get_iris_shares_parse_task(
                     }
                 };
 
-            let iris_message_share = match decrypt_iris_share(
-                base_64_encoded_message_payload,
-                shares_encryption_key_pairs.clone(),
-            ) {
-                Ok(iris_data) => iris_data,
-                Err(e) => {
-                    tracing::error!("Failed to decrypt iris shares: {:?}", e);
-                    eyre::bail!("Failed to decrypt iris shares: {:?}", e);
-                }
-            };
+            let iris_message_share =
+                match decrypt_iris_share(share_b64, shares_encryption_key_pairs.clone()) {
+                    Ok(iris_data) => iris_data,
+                    Err(e) => {
+                        tracing::error!("Failed to decrypt iris shares: {:?}", e);
+                        eyre::bail!("Failed to decrypt iris shares: {:?}", e);
+                    }
+                };
 
-            match validate_iris_share(
-                iris_shares_file_hashes,
-                party_id,
-                iris_message_share.clone(),
-            ) {
+            match validate_iris_share(hash, iris_message_share.clone()) {
                 Ok(_) => {}
                 Err(e) => {
                     tracing::error!("Failed to validate iris shares: {:?}", e);


### PR DESCRIPTION
## Change
- As a follow-up from https://github.com/worldcoin/iris-mpc/pull/1034, this PR makes use of the shares from s3 instead of the ones from SNS payload.
- We'll keep sending both S3 + SNS until this change is deployed. After that, we'll abandon SNS

## Side Change
- Rename `IrisCodesJSON` to `IrisCodeSharesJSON` to better represent underlying data