### PR TITLE
fix: client_max_body_size limit

### DIFF
--- a/deploy/stage/common-values-reshare-server.yaml
+++ b/deploy/stage/common-values-reshare-server.yaml
@@ -121,6 +121,8 @@ nginxSidecar:
           # Enable session resumption to improve performance
           ssl_session_cache shared:SSL:10m;
           ssl_session_timeout 1h;
+
+          client_max_body_size 100M;
       
           location / {
             # Forward gRPC traffic to the gRPC server on port 7000


### PR DESCRIPTION
Increase max_body_size because currently we are hitting the maximum payload limit. 