### PR TITLE
fix: align reshare-server version to last iris-mpc

### DIFF
--- a/deploy/stage/common-values-reshare-server.yaml
+++ b/deploy/stage/common-values-reshare-server.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:f44be82030f079b6355c4fb67f3b0154a98df924"
+image: "ghcr.io/worldcoin/iris-mpc:v0.14.6"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/common-values-reshare-server.yaml
+++ b/deploy/stage/common-values-reshare-server.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:v0.14.6"
+image: "ghcr.io/worldcoin/reshare-protocol:e6f14a8a269d42a18c3ff9e89cee414156e8bfad"
 
 environment: stage
 replicaCount: 1


### PR DESCRIPTION
Because of the database version, we have to use the same version of the iris-mpc docker image.