### PR TITLE
Revert "fix: align Party ID in domain of reshare-server with account number"

### DIFF
--- a/deploy/stage/smpcv2-0-stage/values-reshare-server.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-reshare-server.yaml
@@ -24,7 +24,7 @@ initContainer:
   name: "reshare-proto-dns-records-updater"
   env:
     - name: PARTY_ID
-      value: "0"
+      value: "1"
     - name: MY_POD_IP
       valueFrom:
         fieldRef:

--- a/deploy/stage/smpcv2-1-stage/values-reshare-server.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-reshare-server.yaml
@@ -24,7 +24,7 @@ initContainer:
   name: "reshare-proto-dns-records-updater"
   env:
     - name: PARTY_ID
-      value: "1"
+      value: "2"
     - name: MY_POD_IP
       valueFrom:
         fieldRef:

--- a/deploy/stage/smpcv2-2-stage/values-reshare-server.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-reshare-server.yaml
@@ -24,7 +24,7 @@ initContainer:
   name: "reshare-proto-dns-records-updater"
   env:
     - name: PARTY_ID
-      value: "2"
+      value: "3"
     - name: MY_POD_IP
       valueFrom:
         fieldRef:


### PR DESCRIPTION
Those subdomains were created, and currently, it is not easy to change them without interrupting iris-mpc. We will handle it differently.