### PR TITLE
Add skipping persistance into request query

### DIFF
--- a/.github/workflows/temp-branch-build-and-push.yaml
+++ b/.github/workflows/temp-branch-build-and-push.yaml
@@ -3,7 +3,7 @@ name: Branch - Build and push docker image
 on:
   push:
     branches:
-      - "POP-2078/include-all-message-types-in-batch-hash"
+      - "POP-2119/implement-smpc-logic-for-running-without-an-insertion"
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'

--- a/iris-mpc-common/src/helpers/smpc_request.rs
+++ b/iris-mpc-common/src/helpers/smpc_request.rs
@@ -113,6 +113,7 @@ pub struct UniquenessRequest {
     pub signup_id:          String,
     pub s3_key:             String,
     pub or_rule_serial_ids: Option<Vec<u32>>,
+    pub skip_persistence:   Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/iris-mpc-common/src/job.rs
+++ b/iris-mpc-common/src/job.rs
@@ -53,6 +53,11 @@ pub struct BatchQuery {
     // Also is synced to ensure each node has the same valid entries
     pub valid_entries: Vec<bool>,
 
+    // Skip persistence for not maintaining persistence
+    // This is used to skip the persistence of the iris shares in the database
+    // if it is not a match. This is for testing the flow
+    pub skip_persistence: Vec<bool>,
+
     // Only reauth specific fields
     // Map from reauth request id to the index of the target entry to be matched
     // These can be ignored on the first iterations of HNSW
@@ -83,6 +88,10 @@ pub struct ServerJobResult<A = ()> {
     pub metadata: Vec<BatchMetadata>,
     // Boolean array to indicate if the query was unique or not
     pub matches: Vec<bool>,
+    // Boolean array to indicate if the query was unique which includes the matches that were not
+    // entered into the DB
+    pub matches_with_skip_persistence: Vec<bool>,
+
     // For each query, the serial ids to which the query matched to
     pub match_ids: Vec<Vec<u32>>,
     // For each query, the serial ids to which the query partially matched to

--- a/iris-mpc-common/tests/smpc_request.rs
+++ b/iris-mpc-common/tests/smpc_request.rs
@@ -90,6 +90,7 @@ mod tests {
             signup_id:          "test_signup_id".to_string(),
             s3_key:             key.to_string(),
             or_rule_serial_ids: None,
+            skip_persistence:   None,
         };
 
         let result = get_iris_data_by_party_id(

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -562,11 +562,12 @@ impl JobSubmissionHandle for HawkHandle {
                 request_types: batch.request_types,
                 metadata: batch.metadata,
                 matches: result.matches(),
-                match_ids: vec![],                    // TODO.
-                partial_match_ids_left: vec![],       // TODO.
-                partial_match_ids_right: vec![],      // TODO.
-                partial_match_counters_left: vec![],  // TODO.
-                partial_match_counters_right: vec![], // TODO.
+                matches_with_skip_persistence: result.matches(), // TODO
+                match_ids: vec![],                               // TODO.
+                partial_match_ids_left: vec![],                  // TODO.
+                partial_match_ids_right: vec![],                 // TODO.
+                partial_match_counters_left: vec![],             // TODO.
+                partial_match_counters_right: vec![],            // TODO.
                 store_left: batch.store_left,
                 store_right: batch.store_right,
                 deleted_ids: vec![],                                    // TODO.

--- a/iris-mpc-gpu/src/server/mod.rs
+++ b/iris-mpc-gpu/src/server/mod.rs
@@ -95,6 +95,7 @@ pub struct PreprocessedBatchQuery {
     pub or_rule_indices:      Vec<Vec<u32>>,
     pub luc_lookback_records: usize,
     pub valid_entries:        Vec<bool>,
+    pub skip_persistence:     Vec<bool>,
 
     // Only reauth specific fields
     // Map from reauth request id to the index of the target entry to be matched
@@ -170,6 +171,7 @@ impl From<BatchQuery> for PreprocessedBatchQuery {
             db_right_preprocessed:     db_right_preprocessed.unwrap(),
             modifications:             value.modifications,
             sns_message_ids:           value.sns_message_ids,
+            skip_persistence:          value.skip_persistence,
         }
     }
 }
@@ -185,6 +187,7 @@ impl PreprocessedBatchQuery {
         filter_by_indices!(self.store_right.code, indices_set);
         filter_by_indices!(self.store_right.mask, indices_set);
         filter_by_indices!(self.or_rule_indices, indices_set);
+        filter_by_indices!(self.skip_persistence, indices_set);
         filter_by_indices_with_rotations!(self.query_left.code, indices_set);
         filter_by_indices_with_rotations!(self.query_left.mask, indices_set);
         filter_by_indices_with_rotations!(self.db_left.code, indices_set);

--- a/iris-mpc/bin/server_hawk.rs
+++ b/iris-mpc/bin/server_hawk.rs
@@ -1387,6 +1387,7 @@ async fn server_main(config: Config) -> eyre::Result<()> {
             request_types,
             metadata,
             matches,
+            matches_with_skip_persistence,
             match_ids,
             partial_match_ids_left,
             partial_match_ids_right,
@@ -1419,7 +1420,7 @@ async fn server_main(config: Config) -> eyre::Result<()> {
                             true => None,
                             false => Some(idx_result + 1),
                         },
-                        matches[i],
+                        matches_with_skip_persistence[i],
                         request_ids[i].clone(),
                         match matches[i] {
                             true => Some(match_ids[i].iter().map(|x| x + 1).collect::<Vec<_>>()),

--- a/iris-mpc/src/client.rs
+++ b/iris-mpc/src/client.rs
@@ -370,6 +370,7 @@ pub async fn run_client(opts: Opt) -> eyre::Result<()> {
                     signup_id:          request_id.to_string(),
                     s3_key:             bucket_key,
                     or_rule_serial_ids: None,
+                    skip_persistence:   None,
                 };
 
                 let message_attributes = create_message_type_attribute_map(UNIQUENESS_MESSAGE_TYPE);


### PR DESCRIPTION
### Notes
* before releasing e2e tests in prod - we want to ensure that tests can never result in any insertions
* add skip-persistence flag that ensures if the result is unique it is not inserted into the DB
* the result is sent back with no serial id

### Testing
* tested in staging with both unique and non-unique signups