### PR TITLE
use sns message id to calculate batch hash

### DIFF
--- a/.github/workflows/temp-branch-build-and-push.yaml
+++ b/.github/workflows/temp-branch-build-and-push.yaml
@@ -3,7 +3,7 @@ name: Branch - Build and push docker image
 on:
   push:
     branches:
-      - "fix/modifications-on-server"
+      - "POP-2078/include-all-message-types-in-batch-hash"
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:v0.14.6"
+image: "ghcr.io/worldcoin/iris-mpc:735b135e6eab91427c2813397d55b61076fe851b"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -110,6 +110,12 @@ env:
   - name: SMPC__ENABLE_REAUTH
     value: "true"
 
+  - name: SMPC__LUC_ENABLED
+    value: "true"
+
+  - name: SMPC__LUC_SERIAL_IDS_FROM_SMPC_REQUEST
+    value: "true"
+
   - name: SMPC__SERVICE__METRICS__HOST
     valueFrom:
       fieldRef:

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -110,6 +110,12 @@ env:
   - name: SMPC__ENABLE_REAUTH
     value: "true"
 
+  - name: SMPC__LUC_ENABLED
+    value: "true"
+
+  - name: SMPC__LUC_SERIAL_IDS_FROM_SMPC_REQUEST
+    value: "true"
+
   - name: SMPC__SERVICE__METRICS__HOST
     valueFrom:
       fieldRef:

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -110,6 +110,12 @@ env:
   - name: SMPC__ENABLE_REAUTH
     value: "true"
 
+  - name: SMPC__LUC_ENABLED
+    value: "true"
+
+  - name: SMPC__LUC_SERIAL_IDS_FROM_SMPC_REQUEST
+    value: "true"
+
   - name: SMPC__SERVICE__METRICS__HOST
     valueFrom:
       fieldRef:

--- a/iris-mpc-common/src/job.rs
+++ b/iris-mpc-common/src/job.rs
@@ -44,6 +44,9 @@ pub struct BatchQuery {
 
     // Keeping track of updates & deletions for sync mechanism. Mapping: Serial id -> Modification
     pub modifications: HashMap<u32, Modification>,
+
+    // SNS message ids to assert identical batch processing across parties
+    pub sns_message_ids: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -699,8 +699,8 @@ impl ServerActor {
         let tmp_now = Instant::now();
         tracing::info!("Syncing batch entries");
 
-        // Compute hash of the request ids concatenated
-        let batch_hash = sha256_bytes(batch.request_ids.join(""));
+        // Compute hash of the SNS message ids concatenated
+        let batch_hash = sha256_bytes(batch.sns_message_ids.join(""));
         tracing::info!("Current batch hash: {}", hex::encode(&batch_hash[0..4]));
 
         let valid_entries =

--- a/iris-mpc-gpu/src/server/mod.rs
+++ b/iris-mpc-gpu/src/server/mod.rs
@@ -115,6 +115,9 @@ pub struct PreprocessedBatchQuery {
 
     // Keeping track of updates & deletions for sync mechanism. Mapping: Serial id -> Modification
     pub modifications: HashMap<u32, Modification>,
+
+    // SNS message ids to assert identical batch processing across parties
+    pub sns_message_ids: Vec<String>,
 }
 
 impl From<BatchQuery> for PreprocessedBatchQuery {
@@ -166,6 +169,7 @@ impl From<BatchQuery> for PreprocessedBatchQuery {
             query_right_preprocessed:  query_right_preprocessed.unwrap(),
             db_right_preprocessed:     db_right_preprocessed.unwrap(),
             modifications:             value.modifications,
+            sns_message_ids:           value.sns_message_ids,
         }
     }
 }


### PR DESCRIPTION
## Change
- We are currently calculating a `batch_hash` in actor.rs out of request_ids. This only encapsulates the enrollment and reauth request ids. It does not contain the deletion request ids.
- To have a generic way of calculating the `batch_hash` across all message types, this PR uses the `sns_message_ids` to calculate the `batch_hash`. This way, for any new message type addition, we just care about populating their sns message id and not change the hashing logic.

## Testing
- Tested in stage