### PR TITLE
SEC-1406: dockerignore patch

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,7 @@ target
 # Added by SEC-1406 patch
 .git
 .gitignore
+
+# Added by SEC-1406 patch
+.git
+.gitignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -30,3 +30,7 @@ target
 # Added by SEC-1406 patch
 .git
 .gitignore
+
+# Added by SEC-1406 patch
+.git
+.gitignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -14,3 +14,7 @@ target
 # Added by SEC-1406 patch
 .git
 .gitignore
+
+# Added by SEC-1406 patch
+.git
+.gitignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -22,3 +22,7 @@ target
 # Added by SEC-1406 patch
 .git
 .gitignore
+
+# Added by SEC-1406 patch
+.git
+.gitignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,4 @@
 target
+# Added by SEC-1406 patch
+.git
+.gitignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -26,3 +26,7 @@ target
 # Added by SEC-1406 patch
 .git
 .gitignore
+
+# Added by SEC-1406 patch
+.git
+.gitignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,7 @@ target
 # Added by SEC-1406 patch
 .git
 .gitignore
+
+# Added by SEC-1406 patch
+.git
+.gitignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,35 +2,3 @@ target
 # Added by SEC-1406 patch
 .git
 .gitignore
-
-# Added by SEC-1406 patch
-.git
-.gitignore
-
-# Added by SEC-1406 patch
-.git
-.gitignore
-
-# Added by SEC-1406 patch
-.git
-.gitignore
-
-# Added by SEC-1406 patch
-.git
-.gitignore
-
-# Added by SEC-1406 patch
-.git
-.gitignore
-
-# Added by SEC-1406 patch
-.git
-.gitignore
-
-# Added by SEC-1406 patch
-.git
-.gitignore
-
-# Added by SEC-1406 patch
-.git
-.gitignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -18,3 +18,7 @@ target
 # Added by SEC-1406 patch
 .git
 .gitignore
+
+# Added by SEC-1406 patch
+.git
+.gitignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,7 @@ target
 # Added by SEC-1406 patch
 .git
 .gitignore
+
+# Added by SEC-1406 patch
+.git
+.gitignore

--- a/iris-mpc-upgrade/src/bin/.dockerignore
+++ b/iris-mpc-upgrade/src/bin/.dockerignore
@@ -1,0 +1,2 @@
+.git
+.gitignore


### PR DESCRIPTION
- Ensure .git and .gitignore are properly ignored
- Prevent sensitive files from being included in Docker builds