### PR TITLE
remove share hashes from reauth request body

### DIFF
--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:v0.14.7"
+image: "ghcr.io/worldcoin/iris-mpc:v0.14.8"
 
 environment: stage
 replicaCount: 1

--- a/iris-mpc-common/src/helpers/smpc_request.rs
+++ b/iris-mpc-common/src/helpers/smpc_request.rs
@@ -127,12 +127,11 @@ pub struct IdentityDeletionRequest {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ReAuthRequest {
-    pub reauth_id:               String,
-    pub batch_size:              Option<usize>,
-    pub s3_key:                  String,
-    pub iris_shares_file_hashes: [String; 3],
-    pub serial_id:               u32,
-    pub use_or_rule:             bool,
+    pub reauth_id:   String,
+    pub batch_size:  Option<usize>,
+    pub s3_key:      String,
+    pub serial_id:   u32,
+    pub use_or_rule: bool,
 }
 
 #[derive(Error, Debug)]


### PR DESCRIPTION
## Change
- We removed sending shares from SNS body. Let's remove them from reauth body as well