### PR TITLE
test/db-max-conn: More postgres connections for tests

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -4,6 +4,7 @@ services:
     ports:
       - "5432:5432"
     user: "postgres"
+    command: -c 'max_connections=300'
     environment:
       POSTGRES_USER: "postgres"
       POSTGRES_PASSWORD: "postgres"


### PR DESCRIPTION
Tests regularly fail locally due to too few connections in the docker postgres.