### PR TITLE
fix nocuda workflow name

### DIFF
--- a/.github/workflows/build-and-push-no-cuda.yaml
+++ b/.github/workflows/build-and-push-no-cuda.yaml
@@ -1,4 +1,4 @@
-name: [nocuda] Build and push image from a branch
+name: "[nocuda] Build and push image from a branch"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
### Description
In the previous commit, we altered a github workflow for the nocuda case and the name was malformed. It fails with:
<img width="668" alt="Screenshot 2025-02-27 at 15 57 53" src="https://github.com/user-attachments/assets/99f47004-2694-4d8e-9299-2b1f193a71ea" />

### Solution
wrap the name name into "" to avoid brackets parsing error