### PR TITLE
reisntall certs

### DIFF
--- a/.github/workflows/test-gpu.yaml
+++ b/.github/workflows/test-gpu.yaml
@@ -26,6 +26,7 @@ jobs:
             - Cargo.toml
             - deny.toml
             - iris-*/**
+            - .github/workflows/test-gpu.yaml
       
 
       # The following steps will only run if any of the src files have changed

--- a/.github/workflows/test-gpu.yaml
+++ b/.github/workflows/test-gpu.yaml
@@ -40,6 +40,7 @@ jobs:
       - name: Update gcc to version 11
         if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: |
+          sudo apt-get install --reinstall ca-certificates
           sudo apt-get update
           sudo apt-get install -y build-essential manpages-dev software-properties-common
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test


### PR DESCRIPTION
Fixes GPU tests not being able to run due to:

```
Cannot add PPA: 'ppa:~ubuntu-toolchain-r/ubuntu/test'.
The team named '~ubuntu-toolchain-r' has no PPA named 'ubuntu/test'
Please choose from the following available PPAs:
 * 'aarch64':  AArch64
 * 'armhf':  armhf
…
```