### PR TITLE
aurel/refactor-vector-store: Use references for iris shares

### DIFF
--- a/iris-mpc-cpu/benches/hnsw.rs
+++ b/iris-mpc-cpu/benches/hnsw.rs
@@ -134,7 +134,7 @@ fn bench_gr_primitives(c: &mut Criterion) {
                     y1.mask.preprocess_mask_code_query_share();
                     y2.code.preprocess_iris_code_query_share();
                     y2.mask.preprocess_mask_code_query_share();
-                    let pairs = [(x1, y1), (x2, y2)];
+                    let pairs = [(&x1, &y1), (&x2, &y2)];
                     let ds_and_ts = galois_ring_pairwise_distance(&mut player_session, &pairs)
                         .await
                         .unwrap();

--- a/iris-mpc-cpu/src/database_generators.rs
+++ b/iris-mpc-cpu/src/database_generators.rs
@@ -1,4 +1,5 @@
 use crate::shares::{ring_impl::RingElement, share::Share};
+use eyre::Result;
 use iris_mpc_common::{
     galois_engine::degree4::{GaloisRingIrisCodeShare, GaloisRingTrimmedMaskCodeShare},
     iris_db::iris::IrisCode,
@@ -7,6 +8,7 @@ use iris_mpc_common::{
 use itertools::izip;
 use rand::{CryptoRng, Rng, RngCore};
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 type ShareRing = u16;
 type ShareRingPlain = RingElement<ShareRing>;
@@ -36,6 +38,19 @@ impl GaloisRingSharedIris {
             code: shares.iter().map(|s| s.code.clone()).collect(),
             mask: shares.iter().map(|s| s.mask.clone()).collect(),
         }
+    }
+
+    pub fn try_from_buffers(party_id: usize, code: &[u16], mask: &[u16]) -> Result<Arc<Self>> {
+        Ok(Arc::new(GaloisRingSharedIris {
+            code: GaloisRingIrisCodeShare {
+                id: party_id,
+                coefs: code.try_into()?,
+            },
+            mask: GaloisRingTrimmedMaskCodeShare {
+                id: party_id,
+                coefs: mask.try_into()?,
+            },
+        }))
     }
 }
 

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -385,6 +385,7 @@ impl HawkActor {
                     self.iris_store[0].write().await,
                     self.iris_store[1].write().await,
                 ],
+                empty_iris: Arc::new(GaloisRingSharedIris::default_for_party(0)),
             },
             GraphLoader([
                 self.graph_store[0].write().await,
@@ -398,6 +399,7 @@ pub struct IrisLoader<'a> {
     party_id: usize,
     db_size: &'a mut usize,
     irises: BothEyes<SharedIrisesMut<'a>>,
+    empty_iris: Arc<GaloisRingSharedIris>,
 }
 
 impl<'a> InMemoryStore for IrisLoader<'a> {
@@ -414,14 +416,14 @@ impl<'a> InMemoryStore for IrisLoader<'a> {
             [left_code, right_code],
             [left_mask, right_mask]
         ) {
+            let iris = GaloisRingSharedIris::try_from_buffers(self.party_id, code, mask)
+                .expect("Wrong code or mask size");
             if index >= side.points.len() {
-                side.points.resize(
-                    index + 1,
-                    GaloisRingSharedIris::default_for_party(self.party_id),
-                );
+                side.points.resize_with(index, || self.empty_iris.clone());
+                side.points.push(iris);
+            } else {
+                side.points[index] = iris;
             }
-            side.points[index].code.coefs = code.try_into().unwrap();
-            side.points[index].mask.coefs = mask.try_into().unwrap();
         }
     }
 
@@ -441,9 +443,9 @@ impl<'a> InMemoryStore for IrisLoader<'a> {
 
     fn fake_db(&mut self, size: usize) {
         *self.db_size = size;
+        let iris = Arc::new(GaloisRingSharedIris::default_for_party(self.party_id));
         for side in &mut self.irises {
-            side.points
-                .resize(size, GaloisRingSharedIris::default_for_party(self.party_id));
+            side.points.resize(size, iris.clone());
         }
     }
 }

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -356,7 +356,7 @@ impl HawkActor {
         session: &mut HawkSession,
         insert_plan: InsertPlan,
     ) -> Result<ConnectPlan> {
-        let inserted = session.aby3_store.insert(&insert_plan.query).await;
+        let inserted = session.aby3_store.storage.insert(&insert_plan.query).await;
         let mut graph_store = session.graph_store.write().await;
 
         let connect_plan = self

--- a/iris-mpc-cpu/src/hawkers/plaintext_store.rs
+++ b/iris-mpc-cpu/src/hawkers/plaintext_store.rs
@@ -1,5 +1,6 @@
 use crate::hnsw::{
     metrics::ops_counter::Operation::{CompareDistance, EvaluateDistance},
+    vector_store::VectorStoreMut,
     GraphMem, HnswSearcher, VectorStore,
 };
 use aes_prng::AesRng;
@@ -132,12 +133,6 @@ impl VectorStore for PlaintextStore {
     type VectorRef = PointId; // Vector ID, inserted.
     type DistanceRef = (u16, u16);
 
-    async fn insert(&mut self, query: &Self::QueryRef) -> Self::VectorRef {
-        // The query is now accepted in the store. It keeps the same ID.
-        self.points[*query].is_persistent = true;
-        *query
-    }
-
     async fn eval_distance(
         &mut self,
         query: &Self::QueryRef,
@@ -232,6 +227,14 @@ impl PlaintextStore {
         }
 
         Ok(plaintext_graph_store)
+    }
+}
+
+impl VectorStoreMut for PlaintextStore {
+    async fn insert(&mut self, query: &Self::QueryRef) -> Self::VectorRef {
+        // The query is now accepted in the store. It keeps the same ID.
+        self.points[*query].is_persistent = true;
+        *query
     }
 }
 

--- a/iris-mpc-cpu/src/hnsw/graph/graph_store.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/graph_store.rs
@@ -292,7 +292,7 @@ mod tests {
     use super::{test_utils::TestGraphPg, *};
     use crate::{
         hawkers::plaintext_store::PlaintextStore,
-        hnsw::{GraphMem, HnswSearcher, SortedNeighborhood},
+        hnsw::{vector_store::VectorStoreMut, GraphMem, HnswSearcher, SortedNeighborhood},
     };
     use aes_prng::AesRng;
     use iris_mpc_common::iris_db::db::IrisDB;

--- a/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
@@ -224,7 +224,7 @@ mod tests {
     use super::*;
     use crate::{
         hawkers::plaintext_store::{PlaintextStore, PointId},
-        hnsw::HnswSearcher,
+        hnsw::{vector_store::VectorStoreMut, HnswSearcher},
     };
     use aes_prng::AesRng;
     use iris_mpc_common::iris_db::db::IrisDB;
@@ -253,15 +253,6 @@ mod tests {
         type VectorRef = PointId; // Vector ID, inserted.
         type DistanceRef = u32; // Eager distance representation as fraction.
 
-        async fn insert(&mut self, query: &Self::QueryRef) -> Self::VectorRef {
-            // The query is now accepted in the store. It keeps the same ID.
-            self.points
-                .get_mut(&(query.0 as usize))
-                .unwrap()
-                .is_persistent = true;
-            *query
-        }
-
         async fn eval_distance(
             &mut self,
             query: &Self::QueryRef,
@@ -283,6 +274,17 @@ mod tests {
             distance2: &Self::DistanceRef,
         ) -> bool {
             *distance1 < *distance2
+        }
+    }
+
+    impl VectorStoreMut for TestStore {
+        async fn insert(&mut self, query: &Self::QueryRef) -> Self::VectorRef {
+            // The query is now accepted in the store. It keeps the same ID.
+            self.points
+                .get_mut(&(query.0 as usize))
+                .unwrap()
+                .is_persistent = true;
+            *query
         }
     }
 

--- a/iris-mpc-cpu/src/hnsw/graph/neighborhood.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/neighborhood.rs
@@ -178,7 +178,7 @@ impl<Vector, Distance> From<SortedNeighborhood<Vector, Distance>> for Vec<(Vecto
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::hawkers::plaintext_store::PlaintextStore;
+    use crate::{hawkers::plaintext_store::PlaintextStore, hnsw::vector_store::VectorStoreMut};
     use iris_mpc_common::iris_db::iris::IrisCode;
 
     #[tokio::test]

--- a/iris-mpc-cpu/src/hnsw/searcher.rs
+++ b/iris-mpc-cpu/src/hnsw/searcher.rs
@@ -4,7 +4,7 @@
 //!
 //! (<https://github.com/Inversed-Tech/hawk-pack/>)
 
-use super::graph::neighborhood::SortedNeighborhoodV;
+use super::{graph::neighborhood::SortedNeighborhoodV, vector_store::VectorStoreMut};
 use crate::hnsw::{metrics::ops_counter::Operation, GraphMem, SortedNeighborhood, VectorStore};
 use rand::RngCore;
 use rand_distr::{Distribution, Geometric};
@@ -389,7 +389,7 @@ impl HnswSearcher {
     /// `graph_store`.  Return a `V::VectorRef` representing the inserted
     /// vector.
     #[instrument(level = "trace", skip_all, target = "searcher::cpu_time")]
-    pub async fn insert<V: VectorStore>(
+    pub async fn insert<V: VectorStoreMut>(
         &self,
         vector_store: &mut V,
         graph_store: &mut GraphMem<V>,

--- a/iris-mpc-cpu/src/network/grpc.rs
+++ b/iris-mpc-cpu/src/network/grpc.rs
@@ -647,7 +647,8 @@ mod tests {
                 let mut store = store.clone();
                 let mut graph = graph.clone();
                 let searcher = searcher.clone();
-                let q = store.prepare_query(store.storage.get_vector(&i.into()).await);
+                let q = store.storage.get_vector(&i.into()).await;
+                let q = store.prepare_query((*q).clone());
                 jobs.spawn(async move {
                     let secret_neighbors = searcher.search(&mut store, &mut graph, &q, 1).await;
                     searcher.is_match(&mut store, &[secret_neighbors]).await

--- a/iris-mpc-cpu/src/protocol/ops.rs
+++ b/iris-mpc-cpu/src/protocol/ops.rs
@@ -184,7 +184,7 @@ pub async fn cross_compare(
 /// vector to be able to reshare it later.
 pub async fn galois_ring_pairwise_distance(
     _session: &mut Session,
-    pairs: &[(GaloisRingSharedIris, GaloisRingSharedIris)],
+    pairs: &[(&GaloisRingSharedIris, &GaloisRingSharedIris)],
 ) -> eyre::Result<Vec<RingElement<u16>>> {
     let mut additive_shares = Vec::with_capacity(2 * pairs.len());
     for pair in pairs.iter() {
@@ -252,7 +252,7 @@ pub async fn galois_ring_to_rep3(
 ///   `lift_and_compare_threshold` function.
 pub async fn galois_ring_is_match(
     session: &mut Session,
-    pairs: &[(GaloisRingSharedIris, GaloisRingSharedIris)],
+    pairs: &[(&GaloisRingSharedIris, &GaloisRingSharedIris)],
 ) -> eyre::Result<bool> {
     assert_eq!(pairs.len(), 1);
     let additive_dots = galois_ring_pairwise_distance(session, pairs).await?;
@@ -288,6 +288,7 @@ mod tests {
     };
     use aes_prng::AesRng;
     use iris_mpc_common::iris_db::db::IrisDB;
+    use itertools::Itertools;
     use rand::{Rng, RngCore, SeedableRng};
     use rstest::rstest;
     use std::collections::HashMap;
@@ -568,6 +569,7 @@ mod tests {
                 y.mask.preprocess_mask_code_query_share();
             });
             jobs.spawn(async move {
+                let own_shares = own_shares.iter().map(|(x, y)| (x, y)).collect_vec();
                 let x = galois_ring_pairwise_distance(&mut player_session, &own_shares)
                     .await
                     .unwrap();


### PR DESCRIPTION
Task https://www.notion.so/inversed/Robust-iris-memory-db-loading-1aca3b540bfe80cdacbec02845f62286?pvs=4

- [x] Move `insert` out of the `VectorStore` trait.
    - This clarifies that it is supposed to be read-only.
    - This is a step towards moving the `AbyStore` type to references instead of locks.
- [x] Use references to move around giant structures `GaloisRingSharedIris`.
- [x] Change the iris storage to `Vec<Arc>`.
    - This avoids (potential) allocation limits and copies of a flat `Vec`.
    - This makes it easier to handle shares in async contexts.
    - This introduces a layer of indirection which we will use for deletions and updates; e.g. change `Vec[index]` to `HashMap.get(vector_id)`.