### PR TITLE
aurel/share-id-0-mini: Fix 1-based party index

### DIFF
--- a/iris-mpc-common/src/galois_engine.rs
+++ b/iris-mpc-common/src/galois_engine.rs
@@ -46,6 +46,8 @@ pub mod degree4 {
 
     #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
     pub struct GaloisRingTrimmedMaskCodeShare {
+        /// The 1-based ID of the Lagrange evaluation point. This id = party_id + 1.
+        /// This field appears in serializations.
         pub id: usize,
         #[serde(with = "BigArray")]
         pub coefs: [u16; MASK_CODE_LENGTH],
@@ -76,9 +78,19 @@ pub mod degree4 {
     }
 
     impl GaloisRingTrimmedMaskCodeShare {
+        /// Wrap a mask share. party_id is 0-based.
+        #[inline(always)]
+        pub fn new(coefs: [u16; MASK_CODE_LENGTH], party_id: usize) -> Self {
+            Self {
+                id: party_id + 1,
+                coefs,
+            }
+        }
+
+        /// Empty mask share. party_id is 0-based.
         pub fn default_for_party(party_id: usize) -> Self {
             GaloisRingTrimmedMaskCodeShare {
-                id: party_id,
+                id: party_id + 1,
                 coefs: [0u16; MASK_CODE_LENGTH],
             }
         }
@@ -108,6 +120,8 @@ pub mod degree4 {
 
     #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
     pub struct GaloisRingIrisCodeShare {
+        /// The 1-based ID of the Lagrange evaluation point. This id = party_id + 1.
+        /// This field appears in serializations.
         pub id: usize,
         #[serde(with = "BigArray")]
         pub coefs: [u16; IRIS_CODE_LENGTH],
@@ -130,13 +144,19 @@ pub mod degree4 {
             800 * r + c * 4 + w * 2 + b
         }
 
-        pub fn new(id: usize, coefs: [u16; IRIS_CODE_LENGTH]) -> Self {
-            Self { id, coefs }
+        /// Wrap a code share. party_id is 0-based.
+        #[inline(always)]
+        pub fn new(coefs: [u16; IRIS_CODE_LENGTH], party_id: usize) -> Self {
+            Self {
+                id: party_id + 1,
+                coefs,
+            }
         }
 
+        /// Empty code share. party_id is 0-based.
         pub fn default_for_party(party_id: usize) -> Self {
             GaloisRingIrisCodeShare {
-                id: party_id,
+                id: party_id + 1,
                 coefs: [0u16; IRIS_CODE_LENGTH],
             }
         }

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -778,6 +778,7 @@ mod tests {
     use crate::{
         execution::local::get_free_local_addresses, protocol::shared_iris::GaloisRingSharedIris,
     };
+    use futures::future::JoinAll;
     use iris_mpc_common::{
         helpers::smpc_request::UNIQUENESS_MESSAGE_TYPE, iris_db::db::IrisDB, job::BatchMetadata,
     };
@@ -799,7 +800,7 @@ mod tests {
                 // Make the test async.
                 sleep(Duration::from_millis(100 * index as u64)).await;
 
-                hawk_main(args).await
+                hawk_main(args).await.unwrap()
             }
         };
 
@@ -808,11 +809,11 @@ mod tests {
 
         let handles = (0..n_parties)
             .map(|i| go(addresses.clone(), i))
-            .collect::<JoinSet<_>>()
-            .join_all()
+            .map(tokio::spawn)
+            .collect::<JoinAll<_>>()
             .await
             .into_iter()
-            .collect::<Result<Vec<HawkHandle>>>()?;
+            .collect::<Result<Vec<HawkHandle>, _>>()?;
 
         // ---- Send requests ----
 

--- a/iris-mpc-cpu/src/protocol/shared_iris.rs
+++ b/iris-mpc-cpu/src/protocol/shared_iris.rs
@@ -16,6 +16,7 @@ pub struct GaloisRingSharedIris {
 }
 
 impl GaloisRingSharedIris {
+    /// Empty code and mask share. party_id is 0-based.
     pub fn default_for_party(party_id: usize) -> Self {
         GaloisRingSharedIris {
             code: GaloisRingIrisCodeShare::default_for_party(party_id),
@@ -38,14 +39,8 @@ impl GaloisRingSharedIris {
 
     pub fn try_from_buffers(party_id: usize, code: &[u16], mask: &[u16]) -> Result<Arc<Self>> {
         Ok(Arc::new(GaloisRingSharedIris {
-            code: GaloisRingIrisCodeShare {
-                id: party_id,
-                coefs: code.try_into()?,
-            },
-            mask: GaloisRingTrimmedMaskCodeShare {
-                id: party_id,
-                coefs: mask.try_into()?,
-            },
+            code: GaloisRingIrisCodeShare::new(code.try_into()?, party_id),
+            mask: GaloisRingTrimmedMaskCodeShare::new(mask.try_into()?, party_id),
         }))
     }
 


### PR DESCRIPTION
- [x] Fix incorrect `party_id` in `hawk_main`. Convert to 1-based.
- [x] Fix test flakiness (`JoinAll` instead of unordered `JoinSet`).

_Optional follow-up refactoring: #1102_ 