### PR TITLE
handle empty or rule indices

### DIFF
--- a/deploy/e2e/iris-mpc-0.yaml.tpl
+++ b/deploy/e2e/iris-mpc-0.yaml.tpl
@@ -212,7 +212,7 @@ iris-mpc-0:
       value: "true"
 
     - name: SMPC__LUC_LOOKBACK_RECORDS
-      value: "1"
+      value: "0"
 
     - name: SMPC__LUC_SERIAL_IDS_FROM_SMPC_REQUEST
       value: "true"

--- a/deploy/e2e/iris-mpc-1.yaml.tpl
+++ b/deploy/e2e/iris-mpc-1.yaml.tpl
@@ -212,7 +212,7 @@ iris-mpc-1:
       value: "true"
 
     - name: SMPC__LUC_LOOKBACK_RECORDS
-      value: "1"
+      value: "0"
 
     - name: SMPC__LUC_SERIAL_IDS_FROM_SMPC_REQUEST
       value: "true"

--- a/deploy/e2e/iris-mpc-2.yaml.tpl
+++ b/deploy/e2e/iris-mpc-2.yaml.tpl
@@ -212,7 +212,7 @@ iris-mpc-2:
       value: "true"
 
     - name: SMPC__LUC_LOOKBACK_RECORDS
-      value: "1"
+      value: "0"
 
     - name: SMPC__LUC_SERIAL_IDS_FROM_SMPC_REQUEST
       value: "true"

--- a/iris-mpc/bin/server.rs
+++ b/iris-mpc/bin/server.rs
@@ -336,9 +336,10 @@ async fn receive_batch(
                                         .or_rule_indices
                                         .push(serial_ids.iter().map(|x| x - 1).collect());
                                 } else {
-                                    tracing::error!(
-                                        "Received a uniqueness request without serial_ids"
+                                    tracing::warn!(
+                                        "LUC serial ids from request enabled, but no serial_ids were passed"
                                     );
+                                    batch_query.or_rule_indices.push(vec![]);
                                 }
                             }
                         }

--- a/iris-mpc/bin/server_hawk.rs
+++ b/iris-mpc/bin/server_hawk.rs
@@ -309,9 +309,10 @@ async fn receive_batch(
                                         .or_rule_indices
                                         .push(serial_ids.iter().map(|x| x - 1).collect());
                                 } else {
-                                    tracing::error!(
-                                        "Received a uniqueness request without serial_ids"
+                                    tracing::warn!(
+                                        "LUC serial ids from request enabled, but no serial_ids were passed"
                                     );
+                                    batch_query.or_rule_indices.push(vec![]);
                                 }
                             }
                         }


### PR DESCRIPTION
Or rule indices can come empty from the signup service, and should be handled properly without error logs