### PR TITLE
sync queues based on sns sequence number

### DIFF
--- a/.github/workflows/temp-branch-build-and-push.yaml
+++ b/.github/workflows/temp-branch-build-and-push.yaml
@@ -3,7 +3,7 @@ name: Branch - Build and push docker image
 on:
   push:
     branches:
-      - "fix/log-modifications"
+      - "POP-2268/sync-queues-based-on-sns-sequence-number"
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:v0.14.9"
+image: "ghcr.io/worldcoin/iris-mpc:v0.14.13"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -145,6 +145,8 @@ env:
   - name: SMPC__IMAGE_NAME
     value: $(IMAGE_NAME)
 
+  - name: SMPC__ENABLE_SYNC_QUEUES_ON_SNS_SEQUENCE_NUMBER
+    value: "true"
 
 initContainer:
   enabled: true

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -145,6 +145,9 @@ env:
   - name: SMPC__IMAGE_NAME
     value: $(IMAGE_NAME)
 
+  - name: SMPC__ENABLE_SYNC_QUEUES_ON_SNS_SEQUENCE_NUMBER
+    value: "true"
+
 initContainer:
   enabled: true
   image: "amazon/aws-cli:2.17.62"

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -145,6 +145,9 @@ env:
   - name: SMPC__IMAGE_NAME
     value: $(IMAGE_NAME)
 
+  - name: SMPC__ENABLE_SYNC_QUEUES_ON_SNS_SEQUENCE_NUMBER
+    value: "true"
+
 initContainer:
   enabled: true
   image: "amazon/aws-cli:2.17.62"

--- a/iris-mpc-common/src/config/mod.rs
+++ b/iris-mpc-common/src/config/mod.rs
@@ -188,6 +188,12 @@ pub struct Config {
 
     #[serde(default)]
     pub enable_modifications_sync: bool,
+
+    #[serde(default)]
+    pub enable_sync_queues_on_sns_sequence_number: bool,
+
+    #[serde(default = "default_sqs_sync_long_poll_seconds")]
+    pub sqs_sync_long_poll_seconds: i32,
 }
 
 /// Enumeration over set of compute modes.
@@ -289,6 +295,10 @@ fn default_healthcheck_ports() -> Vec<String> {
 
 fn default_max_deletions_per_batch() -> usize {
     100
+}
+
+fn default_sqs_sync_long_poll_seconds() -> i32 {
+    10
 }
 
 impl Config {

--- a/iris-mpc-common/src/helpers/mod.rs
+++ b/iris-mpc-common/src/helpers/mod.rs
@@ -16,6 +16,7 @@ pub mod shutdown_handler;
 pub mod smpc_request;
 #[cfg(feature = "helpers")]
 pub mod smpc_response;
+pub mod sqs;
 #[cfg(feature = "helpers")]
 pub mod sqs_s3_helper;
 pub mod statistics;

--- a/iris-mpc-common/src/helpers/sqs.rs
+++ b/iris-mpc-common/src/helpers/sqs.rs
@@ -139,8 +139,7 @@ pub async fn delete_messages_until_sequence_num(
                 break;
             }
         } else {
-            tracing::info!("No more messages in the queue. Done.");
-            break;
+            tracing::info!("Could not find more messages in the queue. Retrying.");
         }
     }
 

--- a/iris-mpc-common/src/helpers/sqs.rs
+++ b/iris-mpc-common/src/helpers/sqs.rs
@@ -1,0 +1,148 @@
+use crate::config::Config;
+use crate::helpers::smpc_request::SQSMessage;
+use aws_sdk_sqs::Client;
+use eyre::Context;
+
+/// SQS messages contain a sequence number when they originate from SNS and raw message delivery is enabled.
+/// This function reads the top of the requests SQS queue and returns its sequence number.
+pub async fn get_next_sns_seq_num(
+    config: &Config,
+    sqs_client: &Client,
+) -> eyre::Result<Option<u128>> {
+    let sqs_snoop_response = sqs_client
+        .receive_message()
+        .wait_time_seconds(config.sqs_sync_long_poll_seconds)
+        .max_number_of_messages(1)
+        .set_visibility_timeout(Some(0))
+        .queue_url(&config.requests_queue_url)
+        .send()
+        .await
+        .context("while reading from SQS to snoop on the next message")?;
+    if let Some(msgs) = sqs_snoop_response.messages {
+        if msgs.len() != 1 {
+            return Err(eyre::eyre!(
+                "Expected exactly one message in the queue, but found {}",
+                msgs.len()
+            ));
+        }
+        let sqs_message = msgs.first().expect("first sqs message is empty");
+        match serde_json::from_str::<SQSMessage>(sqs_message.body().unwrap_or("")) {
+            Ok(message) => {
+                // found a valid message originating from SNS --> get its sequence number
+                let sequence_number: u128 =
+                    str::parse(&message.sequence_number).expect("sequence number is not a number");
+                Ok(Some(sequence_number))
+            }
+            Err(err) => {
+                tracing::error!(
+                        "Found corrupt message in queue while parsing SNS message from body. The error is: '{}'. The SQS message body is '{}'", err, sqs_message.body().unwrap_or("None")
+                    );
+                Err(err)
+                    .context("Found corrupt message in queue while parsing SNS message from body")
+            }
+        }
+    } else {
+        tracing::info!("Timeout while waiting for a message in the queue. Queue is clean.");
+        Ok(None)
+    }
+}
+
+/// Deletes all messages in the requests SQS queue until the sequence number is reached.
+/// Leaves the message with given sequence number on top of the queue.
+/// <https://docs.aws.amazon.com/sns/latest/dg/fifo-topic-message-ordering.html>
+pub async fn delete_messages_until_sequence_num(
+    config: &Config,
+    sqs_client: &Client,
+    my_sequence_num: Option<u128>,
+    target_sequence_num: Option<u128>,
+) -> eyre::Result<()> {
+    tracing::info!(
+        "Syncing queues. my_sequence_num: {:?}, target_sequence_num: {:?}.",
+        my_sequence_num,
+        target_sequence_num
+    );
+
+    // Exit early if there is no need to delete messages
+    if target_sequence_num.is_none() {
+        return if my_sequence_num.is_some() {
+            Err(eyre::eyre!("SQS target sequence number is None, but my sequence number is Some. This should not happen."))
+        } else {
+            tracing::info!("Target sequence number is None. Queues are in clean state.");
+            Ok(())
+        };
+    }
+
+    let target_sequence_num = target_sequence_num.expect("could not unwrap target sequence number");
+    if my_sequence_num.is_none() {
+        tracing::info!(
+            "My sequence number is None. Deleting all messages until target sequence number."
+        );
+    } else {
+        let my_sequence_num = my_sequence_num.expect("could not unwrap my sequence number");
+        if my_sequence_num == target_sequence_num {
+            tracing::info!("My sequence number is already equal to target sequence number. No need to delete messages.");
+            return Ok(());
+        }
+    }
+
+    // Delete messages until the target sequence number is reached
+    loop {
+        let sqs_snoop_response = sqs_client
+            .receive_message()
+            .wait_time_seconds(config.sqs_sync_long_poll_seconds)
+            .max_number_of_messages(1)
+            .queue_url(&config.requests_queue_url)
+            .send()
+            .await
+            .context("while reading from SQS to delete messages")?;
+        if let Some(msgs) = sqs_snoop_response.messages {
+            if msgs.len() != 1 {
+                return Err(eyre::eyre!(
+                    "Expected exactly one message in the queue, but found {}",
+                    msgs.len()
+                ));
+            }
+            let msg = msgs.first().expect("first sqs message is empty");
+            let sequence_num: u128 = str::parse(
+                &serde_json::from_str::<SQSMessage>(msg.body().unwrap_or(""))
+                    .expect("message is not a valid SQS message")
+                    .sequence_number,
+            )
+            .expect("sequence number is not a number");
+            if sequence_num < target_sequence_num {
+                tracing::warn!(
+                    "Deleting message with sequence number: {}, body: {:?}",
+                    sequence_num,
+                    msg.body
+                );
+                sqs_client
+                    .delete_message()
+                    .queue_url(&config.requests_queue_url)
+                    .receipt_handle(msg.receipt_handle.clone().unwrap_or_default())
+                    .send()
+                    .await
+                    .context("while deleting message from SQS")?;
+            } else {
+                tracing::info!(
+                    "Reached target sequence number. Top of queue has sequence num: {}",
+                    sequence_num
+                );
+                // Leave the message with target sequence number on top of the queue
+                sqs_client
+                    .change_message_visibility()
+                    .queue_url(&config.requests_queue_url)
+                    .receipt_handle(msg.receipt_handle.clone().unwrap_or_default())
+                    .visibility_timeout(0)
+                    .send()
+                    .await
+                    .context("while changing message visibility in SQS")?;
+                break;
+            }
+        } else {
+            tracing::info!("No more messages in the queue. Done.");
+            break;
+        }
+    }
+
+    Ok(())
+}

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -22,6 +22,7 @@ use iris_mpc_common::helpers::smpc_request::{
     UNIQUENESS_MESSAGE_TYPE,
 };
 use iris_mpc_common::helpers::smpc_response::create_message_type_attribute_map;
+use iris_mpc_common::helpers::sqs::{delete_messages_until_sequence_num, get_next_sns_seq_num};
 use iris_mpc_common::helpers::sync::{SyncResult, SyncState};
 use iris_mpc_common::helpers::task_monitor::TaskMonitor;
 use iris_mpc_common::iris_db::get_dummy_shares_for_deletion;
@@ -73,6 +74,7 @@ pub async fn server_main(config: Config) -> eyre::Result<()> {
 
     tracing::info!("Initialising AWS services");
     let aws_clients = AwsClients::new(&config.clone()).await?;
+    let next_sns_seq_number_future = get_next_sns_seq_num(&config, &aws_clients.sqs_client);
 
     let shares_encryption_key_pair = match SharesEncryptionKeyPairs::from_storage(
         aws_clients.secrets_manager_client,
@@ -172,6 +174,7 @@ pub async fn server_main(config: Config) -> eyre::Result<()> {
         db_len: store_len as u64,
         deleted_request_ids: store.last_deleted_requests(max_sync_lookback).await?,
         modifications: store.last_modifications(max_sync_lookback).await?,
+        next_sns_sequence_num: next_sns_seq_number_future.await?,
     };
 
     #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -472,7 +475,19 @@ pub async fn server_main(config: Config) -> eyre::Result<()> {
             }
         }
     }
-    let sync_result = SyncResult::new(my_state, states);
+    let sync_result = SyncResult::new(my_state.clone(), states);
+
+    // sync the queues
+    if config.enable_sync_queues_on_sns_sequence_number {
+        let max_sqs_sequence_num = sync_result.max_sns_sequence_num();
+        delete_messages_until_sequence_num(
+            &config,
+            &aws_clients.sqs_client,
+            my_state.next_sns_sequence_num,
+            max_sqs_sequence_num,
+        )
+        .await?;
+    }
 
     if let Some(db_len) = sync_result.must_rollback_storage() {
         tracing::error!("Databases are out-of-sync: {:?}", sync_result);

--- a/iris-mpc/src/services/processors/batch.rs
+++ b/iris-mpc/src/services/processors/batch.rs
@@ -192,6 +192,9 @@ pub async fn receive_batch(
                                 UNIQUENESS_MESSAGE_TYPE,
                             )
                             .await?;
+                            if config.enable_sync_queues_on_sns_sequence_number {
+                                tracing::error!("Skip requests were used while SQS sync is enabled. This should not happen.");
+                            }
                             continue;
                         }
 


### PR DESCRIPTION
## Change
- This PR is part 1/2 of switching from postgres `sync` table based SQS sync to SNS sequence number based SQS sync.
- In this PR, we keep using the `skip_request_ids` based on sync table and we keep populating this table. The aim is to switch back to this old flow if smt goes wrong with the new SQS sync flow. This is also why it's behind feature flag.
- In an additional PR (after 2-3 weeks), we'll completely drop the `sync` table and only rely on the new SQS sync flow.

## Why this change?
- Currently, we only support skipping uniqueness requests but the queues can be desynced on deletion, reauth, or any future request types.
- Instead of updating our logic for each new request type, syncing on SNS sequence number would be fully generic and future-proof.

## Notes & Refs
- From AWS docs ([link](https://docs.aws.amazon.com/sns/latest/dg/fifo-topic-message-ordering.html)): The sequence number is a large, non-consecutive number that Amazon SNS assigns to each message. The length of the sequence number is 128-bits, and continues to increase for each [Message Group](https://docs.aws.amazon.com/sns/latest/dg/fifo-message-grouping.html).
- As an additional follow-up during part-2, we can parse the message body and write related error results to SNS

## Tests
- Tested in stage several times by deleting various number of items from queues randomly, with empty queues, and with already synced queues