### PR TITLE
Feature-gate `iris-mpc-common/src/test.rs`

### DIFF
--- a/iris-mpc-common/src/lib.rs
+++ b/iris-mpc-common/src/lib.rs
@@ -8,6 +8,7 @@ pub mod id;
 pub mod iris_db;
 pub mod job;
 pub mod shamir;
+#[cfg(feature = "helpers")]
 pub mod test;
 
 pub const IRIS_CODE_LENGTH: usize = 12_800;


### PR DESCRIPTION
This is a follow up to https://github.com/worldcoin/iris-mpc/pull/1112

We need to put another feature gate for a new file `iris-mpc-common/src/test.rs` introduced by https://github.com/worldcoin/iris-mpc/pull/1075. Because the main branch is currently broken if we use `iris-mpc-common` with `default-features = false`.