### PR TITLE
Add configuration for using seperate HNSW cluster for staging deployment

### DIFF
--- a/iris-mpc-common/src/config/mod.rs
+++ b/iris-mpc-common/src/config/mod.rs
@@ -41,6 +41,9 @@ pub struct Config {
     pub database: Option<DbConfig>,
 
     #[serde(default)]
+    pub cpu_database: Option<DbConfig>,
+
+    #[serde(default)]
     pub aws: Option<AwsConfig>,
 
     #[serde(default = "default_processing_timeout_secs")]
@@ -194,20 +197,23 @@ pub struct Config {
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub enum ModeOfCompute {
     /// Computation with standard CPUs (see HNSW graph).
-    CPU,
+    Cpu,
     /// Computation with Cuda GPU(s).
     #[default]
-    GPU,
+    Gpu,
 }
 
 /// Enumeration over set of deployment modes.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub enum ModeOfDeployment {
-    // Shadow mode specifically an HNSW test deployment.
-    SHADOW,
+    // shadow mode for when HSNW deployment does not read from the Gpu implementation
+    // it should create and write its own shares DB
+    ShadowIsolation,
+    // Shadow mode for when HNSW test deployment reads from the Gpu Implementation
+    ShadowReadOnly,
     // Standard mode for all other deployments.
     #[default]
-    STANDARD,
+    Standard,
 }
 
 fn default_load_chunks_parallelism() -> usize {

--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -6,6 +6,7 @@ use futures::{
     stream::{self},
     Stream, StreamExt, TryStreamExt,
 };
+use iris_mpc_common::config::ModeOfDeployment;
 use iris_mpc_common::{
     config::Config,
     galois_engine::degree4::{GaloisRingIrisCodeShare, GaloisRingTrimmedMaskCodeShare},
@@ -137,10 +138,19 @@ pub struct Store {
 impl Store {
     /// Connect to a database based on Config URL, environment, and party_id.
     pub async fn new_from_config(config: &Config) -> Result<Self> {
-        let db_config = config
-            .database
-            .as_ref()
-            .ok_or(eyre!("Missing database config"))?;
+        // if running shadow mode in isolation, we should not read from the iris-mpc shares and instead create a new version
+        let db_config = if config.mode_of_deployment == ModeOfDeployment::ShadowIsolation {
+            config
+                .cpu_database
+                .as_ref()
+                .ok_or(eyre!("Missing database config"))?
+        } else {
+            config
+                .database
+                .as_ref()
+                .ok_or(eyre!("Missing database config"))?
+        };
+
         let schema_name = format!("{}_{}_{}", APP_NAME, config.environment, config.party_id);
         Self::new(&db_config.url, &schema_name).await
     }

--- a/iris-mpc/bin/server.rs
+++ b/iris-mpc/bin/server.rs
@@ -752,8 +752,8 @@ async fn server_main(config: Config) -> eyre::Result<()> {
     shutdown_handler.wait_for_shutdown_signal().await;
 
     // Validate compute/deployment modes.
-    if config.mode_of_compute != ModeOfCompute::GPU
-        || config.mode_of_deployment != ModeOfDeployment::STANDARD
+    if config.mode_of_compute != ModeOfCompute::Gpu
+        || config.mode_of_deployment != ModeOfDeployment::Standard
     {
         panic!(
             "Invalid config: Compute/deployment mode combination.  Expected : ModeOfCompute::GPU \

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -51,7 +51,7 @@ pub async fn server_main(config: Config) -> eyre::Result<()> {
     shutdown_handler.wait_for_shutdown_signal().await;
 
     // Validate modes of compute/deployment.
-    if config.mode_of_compute != ModeOfCompute::CPU {
+    if config.mode_of_compute != ModeOfCompute::Cpu {
         panic!(
             "Invalid config setting: compute_mode: actual: {:?} :: expected: ModeOfCompute::CPU",
             config.mode_of_compute
@@ -69,6 +69,7 @@ pub async fn server_main(config: Config) -> eyre::Result<()> {
 
     tracing::info!("Creating new storage from: {:?}", config);
     let store = Store::new_from_config(&config).await?;
+    // TODO: In future, make the Graph store use only the HNSW DB cluster
     let graph_store = GraphStore::from_iris_store(&store);
 
     tracing::info!("Initialising AWS services");


### PR DESCRIPTION
### Notes
* add config for the separate HNSW aurora DB clusters
* for staging isolation deployment, we should use the HNSW aurora DB cluster to separate the GPU and CPU implementations.
   * This will allow us to run testing in CPU that is not dependent on a sync protocol