### PR TITLE
Add eval_distance with batches of queries

### DIFF
--- a/iris-mpc-cpu/src/execution/hawk_main/is_match_batch.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/is_match_batch.rs
@@ -79,20 +79,20 @@ async fn per_session(
 
     let mut out = Vec::with_capacity(tasks.len());
     for (query, vectors) in tasks {
-        let matches = per_query(query, &vectors, &mut session).await;
+        let matches = per_query(&[query], &vectors, &mut session).await;
         out.push(matches);
     }
     out
 }
 
 async fn per_query(
-    query: QueryRef,
+    queries: &[QueryRef],
     vector_ids: &[VectorId],
     session: &mut HawkSession,
 ) -> MapEdges<bool> {
     let distances = session
         .aby3_store
-        .eval_distance_batch(&query, vector_ids)
+        .eval_distance_batch(queries, vector_ids)
         .await;
 
     let is_matches = session.aby3_store.is_match_batch(&distances).await;

--- a/iris-mpc-cpu/src/execution/hawk_main/is_match_batch.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/is_match_batch.rs
@@ -79,20 +79,20 @@ async fn per_session(
 
     let mut out = Vec::with_capacity(tasks.len());
     for (query, vectors) in tasks {
-        let matches = per_query(&[query], &vectors, &mut session).await;
+        let matches = per_query(query, &vectors, &mut session).await;
         out.push(matches);
     }
     out
 }
 
 async fn per_query(
-    queries: &[QueryRef],
+    query: QueryRef,
     vector_ids: &[VectorId],
     session: &mut HawkSession,
 ) -> MapEdges<bool> {
     let distances = session
         .aby3_store
-        .eval_distance_batch(queries, vector_ids)
+        .eval_distance_batch(&[query], vector_ids)
         .await;
 
     let is_matches = session.aby3_store.is_match_batch(&distances).await;

--- a/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
@@ -285,19 +285,24 @@ impl VectorStore for Aby3Store {
         self.lift_distances(dist).await.unwrap()[0].clone()
     }
 
-    #[instrument(level = "trace", target = "searcher::network", skip_all, fields(batch_size = vectors.len()))]
+    #[instrument(level = "trace", target = "searcher::network", skip_all, fields(queries = queries.len(), batch_size = vectors.len()))]
     async fn eval_distance_batch(
         &mut self,
-        query: &Self::QueryRef,
+        queries: &[Self::QueryRef],
         vectors: &[Self::VectorRef],
     ) -> Vec<Self::DistanceRef> {
         if vectors.is_empty() {
             return vec![];
         }
         let vectors = self.storage.iter_vectors(vectors).await;
-        let pairs = vectors
+        let pairs = queries
             .iter()
-            .map(|vector| (&query.processed_query, &**vector))
+            .flat_map(|q| {
+                vectors
+                    .iter()
+                    .map(|vector| (&q.processed_query, &**vector))
+                    .collect::<Vec<_>>()
+            })
             .collect::<Vec<_>>();
 
         let dist = self.eval_pairwise_distances(pairs).await;
@@ -611,10 +616,10 @@ mod tests {
 
         // compute distances in plaintext
         let dist1_plain = plaintext_store
-            .eval_distance_batch(&plaintext_inserts[0], &plaintext_inserts)
+            .eval_distance_batch(&[plaintext_inserts[0]], &plaintext_inserts)
             .await;
         let dist2_plain = plaintext_store
-            .eval_distance_batch(&plaintext_inserts[1], &plaintext_inserts)
+            .eval_distance_batch(&[plaintext_inserts[1]], &plaintext_inserts)
             .await;
         let dist_plain = dist1_plain
             .into_iter()
@@ -645,10 +650,10 @@ mod tests {
             let mut store = store.clone();
             jobs.spawn(async move {
                 let dist1_aby3 = store
-                    .eval_distance_batch(&player_preps[0], &player_inserts)
+                    .eval_distance_batch(&[player_preps[0].clone()], &player_inserts)
                     .await;
                 let dist2_aby3 = store
-                    .eval_distance_batch(&player_preps[1], &player_inserts)
+                    .eval_distance_batch(&[player_preps[1].clone()], &player_inserts)
                     .await;
                 let dist_aby3 = dist1_aby3
                     .into_iter()

--- a/iris-mpc-cpu/src/hnsw/searcher.rs
+++ b/iris-mpc-cpu/src/hnsw/searcher.rs
@@ -748,7 +748,9 @@ impl HnswSearcher {
             .filter(|e| visited.insert(e.clone()))
             .collect();
 
-        let distances = store.eval_distance_batch(query, &unvisited_neighbors).await;
+        let distances = store
+            .eval_distance_batch(&[query.clone()], &unvisited_neighbors)
+            .await;
 
         unvisited_neighbors
             .into_iter()

--- a/iris-mpc-cpu/src/hnsw/vector_store.rs
+++ b/iris-mpc-cpu/src/hnsw/vector_store.rs
@@ -66,7 +66,7 @@ pub trait VectorStore: Clone + Debug {
         queries: &[Self::QueryRef],
         vectors: &[Self::VectorRef],
     ) -> Vec<Self::DistanceRef> {
-        let mut results = Vec::with_capacity(vectors.len());
+        let mut results = Vec::with_capacity(queries.len() * vectors.len());
         for query in queries {
             for vector in vectors {
                 results.push(self.eval_distance(query, vector).await);

--- a/iris-mpc-cpu/src/hnsw/vector_store.rs
+++ b/iris-mpc-cpu/src/hnsw/vector_store.rs
@@ -63,12 +63,14 @@ pub trait VectorStore: Clone + Debug {
     /// Override for more efficient batch distance evaluations.
     async fn eval_distance_batch(
         &mut self,
-        query: &Self::QueryRef,
+        queries: &[Self::QueryRef],
         vectors: &[Self::VectorRef],
     ) -> Vec<Self::DistanceRef> {
         let mut results = Vec::with_capacity(vectors.len());
-        for vector in vectors {
-            results.push(self.eval_distance(query, vector).await);
+        for query in queries {
+            for vector in vectors {
+                results.push(self.eval_distance(query, vector).await);
+            }
         }
         results
     }


### PR DESCRIPTION
This PR changes only `VectorStore` API and its `Aby3Store` implementation. The actual batching of queries in `is_match_batch.rs` should be implemented in a follow-up PR depending on the decision made around [this comment](https://github.com/worldcoin/iris-mpc/pull/1117#discussion_r1989898788).