### PR TITLE
Fix route53 registration script

### DIFF
--- a/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw.yaml
@@ -88,7 +88,7 @@ initContainer:
       #!/usr/bin/env bash
 
       # Set up environment variables
-      HOSTED_ZONE_ID=$(aws route53 list-hosted-zones-by-name --dns-name "$PARTY_ID".stage.hnsw.worldcoin.dev --query "HostedZones[].Id" --output text)
+      HOSTED_ZONE_ID=$(aws route53 list-hosted-zones-by-name --dns-name "$PARTY_ID".stage.hnsw.worldcoin.dev --query "HostedZones[0].Id" --output text)
 
       # Generate the JSON content in memory
       BATCH_JSON=$(cat <<EOF
@@ -113,7 +113,3 @@ initContainer:
 
       # Execute AWS CLI command with the generated JSON
       aws route53 change-resource-record-sets --hosted-zone-id "$HOSTED_ZONE_ID" --change-batch "$BATCH_JSON"
-
-      cd /libs
-      aws s3 cp s3://wf-smpcv2-stage-libs/libcublas.so.12.2.5.6 .
-      aws s3 cp s3://wf-smpcv2-stage-libs/libcublasLt.so.12.2.5.6 .

--- a/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw.yaml
@@ -87,7 +87,7 @@ initContainer:
       #!/usr/bin/env bash
 
       # Set up environment variables
-      HOSTED_ZONE_ID=$(aws route53 list-hosted-zones-by-name --dns-name "$PARTY_ID".stage.hnsw.worldcoin.dev --query "HostedZones[].Id" --output text)
+      HOSTED_ZONE_ID=$(aws route53 list-hosted-zones-by-name --dns-name "$PARTY_ID".stage.hnsw.worldcoin.dev --query "HostedZones[0].Id" --output text)
 
       # Generate the JSON content in memory
       BATCH_JSON=$(cat <<EOF
@@ -112,7 +112,3 @@ initContainer:
 
       # Execute AWS CLI command with the generated JSON
       aws route53 change-resource-record-sets --hosted-zone-id "$HOSTED_ZONE_ID" --change-batch "$BATCH_JSON"
-
-      cd /libs
-      aws s3 cp s3://wf-smpcv2-stage-libs/libcublas.so.12.2.5.6 .
-      aws s3 cp s3://wf-smpcv2-stage-libs/libcublasLt.so.12.2.5.6 .

--- a/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw.yaml
@@ -87,7 +87,7 @@ initContainer:
       #!/usr/bin/env bash
 
       # Set up environment variables
-      HOSTED_ZONE_ID=$(aws route53 list-hosted-zones-by-name --dns-name "$PARTY_ID".stage.hnsw.worldcoin.dev --query "HostedZones[].Id" --output text)
+      HOSTED_ZONE_ID=$(aws route53 list-hosted-zones-by-name --dns-name "$PARTY_ID".stage.hnsw.worldcoin.dev --query "HostedZones[0].Id" --output text)
 
       # Generate the JSON content in memory
       BATCH_JSON=$(cat <<EOF
@@ -112,7 +112,3 @@ initContainer:
 
       # Execute AWS CLI command with the generated JSON
       aws route53 change-resource-record-sets --hosted-zone-id "$HOSTED_ZONE_ID" --change-batch "$BATCH_JSON"
-
-      cd /libs
-      aws s3 cp s3://wf-smpcv2-stage-libs/libcublas.so.12.2.5.6 .
-      aws s3 cp s3://wf-smpcv2-stage-libs/libcublasLt.so.12.2.5.6 .

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -164,7 +164,7 @@ initContainer:
       #!/usr/bin/env bash
 
       # Set up environment variables
-      HOSTED_ZONE_ID=$(aws route53 list-hosted-zones-by-name --dns-name "$PARTY_ID".stage.smpcv2.worldcoin.dev --query "HostedZones[].Id" --output text)
+      HOSTED_ZONE_ID=$(aws route53 list-hosted-zones-by-name --dns-name "$PARTY_ID".stage.smpcv2.worldcoin.dev --query "HostedZones[0].Id" --output text)
 
       # Generate the JSON content in memory
       BATCH_JSON=$(cat <<EOF

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -164,7 +164,7 @@ initContainer:
       #!/usr/bin/env bash
 
       # Set up environment variables
-      HOSTED_ZONE_ID=$(aws route53 list-hosted-zones-by-name --dns-name "$PARTY_ID".stage.smpcv2.worldcoin.dev --query "HostedZones[].Id" --output text)
+      HOSTED_ZONE_ID=$(aws route53 list-hosted-zones-by-name --dns-name "$PARTY_ID".stage.smpcv2.worldcoin.dev --query "HostedZones[0].Id" --output text)
 
       # Generate the JSON content in memory
       BATCH_JSON=$(cat <<EOF

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -164,7 +164,7 @@ initContainer:
       #!/usr/bin/env bash
 
       # Set up environment variables
-      HOSTED_ZONE_ID=$(aws route53 list-hosted-zones-by-name --dns-name "$PARTY_ID".stage.smpcv2.worldcoin.dev --query "HostedZones[].Id" --output text)
+      HOSTED_ZONE_ID=$(aws route53 list-hosted-zones-by-name --dns-name "$PARTY_ID".stage.smpcv2.worldcoin.dev --query "HostedZones[0].Id" --output text)
 
       # Generate the JSON content in memory
       BATCH_JSON=$(cat <<EOF


### PR DESCRIPTION
`aws route53 list-hosted-zones-by-name` returns a list of zones, we had 2 zones after adding a 2nd one for hnsw and this script broke