### PR TITLE
accept reauth and rule if target serial id matched

### DIFF
--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:v0.14.13"
+image: "ghcr.io/worldcoin/iris-mpc:v0.14.14"
 
 environment: stage
 replicaCount: 1

--- a/iris-mpc-common/src/helpers/smpc_response.rs
+++ b/iris-mpc-common/src/helpers/smpc_response.rs
@@ -96,7 +96,6 @@ pub struct ReAuthResult {
     pub success: bool,
     pub and_rule_matched_serial_ids: Vec<u32>,
     pub or_rule_used: bool,
-    pub or_rule_matched: Option<bool>,
     pub error: Option<bool>,
     pub error_reason: Option<String>,
 }
@@ -109,7 +108,6 @@ impl ReAuthResult {
         success: bool,
         and_rule_matched_serial_ids: Vec<u32>,
         or_rule_used: bool,
-        or_rule_matched: Option<bool>,
     ) -> Self {
         Self {
             reauth_id,
@@ -118,7 +116,6 @@ impl ReAuthResult {
             success,
             and_rule_matched_serial_ids,
             or_rule_used,
-            or_rule_matched,
             error: None,
             error_reason: None,
         }
@@ -137,7 +134,6 @@ impl ReAuthResult {
             success: false,
             and_rule_matched_serial_ids: vec![],
             or_rule_used: false,
-            or_rule_matched: None,
             error: Some(true),
             error_reason: Some(error_reason.to_string()),
         }

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -1021,14 +1021,8 @@ impl ServerActor {
                     return false;
                 }
                 let reauth_id = batch.request_ids[idx].clone();
-                if *batch.reauth_use_or_rule.get(&reauth_id).unwrap() {
-                    // OR rule used. Expect a match with target reauth index
-                    matches.contains(batch.reauth_target_indices.get(&reauth_id).unwrap())
-                } else {
-                    // AND rule used. Expect exactly one match to the target reauth index
-                    matches.len() == 1
-                        && matches[0] == *batch.reauth_target_indices.get(&reauth_id).unwrap()
-                }
+                // Expect a match with target reauth index
+                matches.contains(batch.reauth_target_indices.get(&reauth_id).unwrap())
             })
             .collect::<Vec<bool>>();
         let mut reauth_updates_per_device = vec![vec![]; self.device_manager.device_count()];

--- a/iris-mpc/bin/server.rs
+++ b/iris-mpc/bin/server.rs
@@ -1462,12 +1462,6 @@ async fn server_main(config: Config) -> eyre::Result<()> {
                 .map(|(i, _)| {
                     let reauth_id = request_ids[i].clone();
                     let or_rule_used = reauth_or_rule_used.get(&reauth_id).unwrap();
-                    let or_rule_matched = if *or_rule_used {
-                        // if or rule was used and reauth was successful, then or rule was matched
-                        Some(successful_reauths[i])
-                    } else {
-                        None
-                    };
                     let serial_id = reauth_target_indices.get(&reauth_id).unwrap() + 1;
                     let success = successful_reauths[i];
                     modifications
@@ -1481,7 +1475,6 @@ async fn server_main(config: Config) -> eyre::Result<()> {
                         success,
                         match_ids[i].iter().map(|x| x + 1).collect::<Vec<_>>(),
                         *reauth_or_rule_used.get(&reauth_id).unwrap(),
-                        or_rule_matched,
                     );
                     serde_json::to_string(&result_event)
                         .wrap_err("failed to serialize reauth result")

--- a/iris-mpc/src/services/processors/job.rs
+++ b/iris-mpc/src/services/processors/job.rs
@@ -139,13 +139,6 @@ pub async fn process_job_result(
         .filter(|(_, request_type)| *request_type == REAUTH_MESSAGE_TYPE)
         .map(|(i, _)| {
             let reauth_id = request_ids[i].clone();
-            let or_rule_used = reauth_or_rule_used.get(&reauth_id).unwrap();
-            let or_rule_matched = if *or_rule_used {
-                // if or rule was used and reauth was successful, then or rule was matched
-                Some(successful_reauths[i])
-            } else {
-                None
-            };
             let result_event = ReAuthResult::new(
                 reauth_id.clone(),
                 party_id,
@@ -153,7 +146,6 @@ pub async fn process_job_result(
                 successful_reauths[i],
                 match_ids[i].iter().map(|x| x + 1).collect::<Vec<_>>(),
                 *reauth_or_rule_used.get(&reauth_id).unwrap(),
-                or_rule_matched,
             );
             serde_json::to_string(&result_event).wrap_err("failed to serialize reauth result")
         })


### PR DESCRIPTION
## Change
- To simplify debugging later, reauth team would like to apply the same logic both in `AND` and `OR` rules