### PR TITLE
Add metrics host

### DIFF
--- a/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw.yaml
@@ -71,6 +71,11 @@ env:
   - name: SMPC__HEARTBEAT_INITIAL_RETRIES
     value: "65"
 
+  - name: SMPC__SERVICE__METRICS__HOST
+    valueFrom:
+      fieldRef:
+        fieldPath: status.hostIP
+
   - name: SMPC__SERVICE__METRICS__PORT
     value: "8125"
 

--- a/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw.yaml
@@ -71,6 +71,11 @@ env:
   - name: SMPC__HEARTBEAT_INITIAL_RETRIES
     value: "65"
 
+  - name: SMPC__SERVICE__METRICS__HOST
+    valueFrom:
+      fieldRef:
+        fieldPath: status.hostIP
+
   - name: SMPC__SERVICE__METRICS__PORT
     value: "8125"
 

--- a/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw.yaml
@@ -71,6 +71,11 @@ env:
   - name: SMPC__HEARTBEAT_INITIAL_RETRIES
     value: "65"
 
+  - name: SMPC__SERVICE__METRICS__HOST
+    valueFrom:
+      fieldRef:
+        fieldPath: status.hostIP
+
   - name: SMPC__SERVICE__METRICS__PORT
     value: "8125"
 


### PR DESCRIPTION
Missing:
```
Init config
thread 'main' panicked at iris-mpc/bin/server/iris_mpc_hawk.rs:13:58:
called `Result::unwrap()` on an `Err` value: missing field `host`

Location:
    iris-mpc-common/src/config/mod.rs:305:30
stack backtrace:
   0:     0x55bc7f7508f5 - std::backtrace_rs::backtrace::libunwind::trace::h649ab3318d3445c5
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/../../backtrace/src/backtrace/libunwind.rs:116:5
   1:     0x55bc7f7508f5 - std::backtrace_rs::backtrace::trace_unsynchronized::hf4bb60c3387150c3
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2:     0x55bc7f7508f5 - std::sys::backtrace::_print_fmt::hd9186c800e44bd00
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/sys/backtrace.rs:65:5
   3:     0x55bc7f7508f5 - <std::sys::backtrace::BacktraceLock::print::DisplayBacktrace as core::fmt::Display>::fmt::h1b9dad2a88e955ff
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/sys/backtrace.rs:40:26
   4:     0x55bc7f77c5cb - core::fmt::rt::Argument::fmt::h351a7824f737a6a0
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/core/src/fmt/rt.rs:173:76
   5:     0x55bc7f77c5cb - core::fmt::write::h4b5a1270214bc4a7
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/core/src/fmt/mod.rs:1182:21
   6:     0x55bc7f74d21f - std::io::Write::write_fmt::hd04af345a50c312d
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/io/mod.rs:1827:15```