### PR TITLE
Rust toolchain upgrade

### DIFF
--- a/.github/workflows/build-all-targets.yml
+++ b/.github/workflows/build-all-targets.yml
@@ -3,9 +3,9 @@ name: Build All Targets
 on:
   push:
     paths-ignore:
-      - 'adr/**'
-      - 'deploy/**'
-      - '.github/**'
+      - "adr/**"
+      - "deploy/**"
+      - ".github/**"
 
 concurrency:
   group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
@@ -28,10 +28,10 @@ jobs:
           key: "test"
 
       - name: Install Rust
-        run: rustup toolchain install 1.81.0
+        run: rustup toolchain install 1.85.0
 
       - name: Set Rust  as default
-        run: rustup default 1.81.0
+        run: rustup default 1.85.0
 
       # Building tests in release mode checks warnings and compiler errors that depend on optimisations
       - name: Build Tests
@@ -54,10 +54,10 @@ jobs:
           key: "bench"
 
       - name: Install Rust
-        run: rustup toolchain install 1.81.0
+        run: rustup toolchain install 1.85.0
 
       - name: Set Rust  as default
-        run: rustup default 1.81.0
+        run: rustup default 1.85.0
 
       - name: Build All Targets
         run: cargo build --release --all-features --lib --bins --benches --examples

--- a/.github/workflows/check-licenses.yaml
+++ b/.github/workflows/check-licenses.yaml
@@ -7,7 +7,7 @@ on:
       - main
       - prod
     tags:
-      - '**'
+      - "**"
 
 jobs:
   cargo-deny:
@@ -16,4 +16,4 @@ jobs:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # pin@v4.2.1
       - uses: EmbarkStudios/cargo-deny-action@8371184bd11e21dcf8ac82ebf8c9c9f74ebf7268
         with:
-          rust-version: "1.81.0"
+          rust-version: "1.85.0"

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -3,9 +3,9 @@ name: Check Doc Syntax
 on:
   push:
     paths-ignore:
-      - 'adr/**'
-      - 'deploy/**'
-      - '.github/**'
+      - "adr/**"
+      - "deploy/**"
+      - ".github/**"
 
 concurrency:
   group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
@@ -25,10 +25,10 @@ jobs:
         uses: r7kamura/rust-problem-matchers@v1
 
       - name: Install Rust
-        run: rustup toolchain install 1.81.0
+        run: rustup toolchain install 1.85.0
 
       - name: Set Rust  as default
-        run: rustup default 1.81.0
+        run: rustup default 1.85.0
 
       - name: Build Docs
         run: cargo doc --all-features --no-deps --document-private-items

--- a/.github/workflows/lint-clippy.yaml
+++ b/.github/workflows/lint-clippy.yaml
@@ -27,10 +27,10 @@ jobs:
         run: sudo apt install protobuf-compiler
 
       - name: Install Rust
-        run: rustup toolchain install 1.81.0
+        run: rustup toolchain install 1.85.0
 
       - name: Set Rust  as default
-        run: rustup default 1.81.0
+        run: rustup default 1.85.0
 
       - name: Install Rust clippy for checking clippy errors
         run: rustup component add clippy

--- a/.github/workflows/lint-rustfmt.yaml
+++ b/.github/workflows/lint-rustfmt.yaml
@@ -4,7 +4,7 @@ on:
   push:
 
 concurrency:
-  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
   cancel-in-progress: true
 
 jobs:
@@ -17,9 +17,9 @@ jobs:
       - name: Show errors inline
         uses: r7kamura/rust-problem-matchers@v1
       - name: Install Rust
-        run: rustup toolchain install 1.81.0
+        run: rustup toolchain install 1.85.0
       - name: Set Rust as default
-        run: rustup default 1.81.0
+        run: rustup default 1.85.0
       - name: Install Rustfmt for formatting
         run: rustup component add rustfmt
       - name: Run Rustfmt

--- a/.github/workflows/run-unit-tests.yaml
+++ b/.github/workflows/run-unit-tests.yaml
@@ -40,10 +40,10 @@ jobs:
           key: "test"
 
       - name: Install Rust
-        run: rustup toolchain install 1.81.0
+        run: rustup toolchain install 1.85.0
 
       - name: Set Rust  as default
-        run: rustup default 1.81.0
+        run: rustup default 1.85.0
 
       - name: Run Tests
         run: cargo test --release -- --test-threads=1

--- a/.github/workflows/test-gpu.yaml
+++ b/.github/workflows/test-gpu.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.81.0
+          toolchain: 1.85.0
 
       - name: GPU Dependent Tests
         timeout-minutes: 10

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3487,9 +3487,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.22.6"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f402062616ab18202ae8319da13fa4279883a2b8a9d9f83f20dbade813ce1884"
+checksum = "7f1c6c3591120564d64db2261bec5f910ae454f01def849b9c22835a84695e86"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -3505,9 +3505,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.22.6"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b14b5775b5ff446dd1056212d778012cbe8a0fbffd368029fd9e25b514479c38"
+checksum = "e9b6c2b34cf71427ea37c7001aefbaeb85886a074795e35f161f5aecc7620a7a"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -3515,9 +3515,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.22.6"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab5bcf04a2cdcbb50c7d6105de943f543f9ed92af55818fd17b660390fc8636"
+checksum = "5507651906a46432cdda02cd02dd0319f6064f1374c9147c45b978621d2c3a9c"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -3525,9 +3525,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.22.6"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd24d897903a9e6d80b968368a34e1525aeb719d568dba8b3d4bfa5dc67d453"
+checksum = "b0d394b5b4fd8d97d48336bb0dd2aebabad39f1d294edd6bcd2cccf2eefe6f42"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -3537,9 +3537,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.22.6"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c011a03ba1e50152b4b394b479826cad97e7a21eb52df179cd91ac411cbfbe"
+checksum = "fd72da09cfa943b1080f621f024d2ef7e2773df7badd51aa30a2be1f8caa7c8e"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -4587,9 +4587,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
 
 [[package]]
 name = "telemetry-batteries"

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH "/root/.cargo/bin:${PATH}"
 ENV RUSTUP_HOME "/root/.rustup"
 ENV CARGO_HOME "/root/.cargo"
-RUN rustup toolchain install 1.81.0
-RUN rustup default 1.81.0
+RUN rustup toolchain install 1.85.0
+RUN rustup default 1.85.0
 RUN rustup component add cargo
 RUN cargo install cargo-build-deps \
     && cargo install cargo-edit

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -21,8 +21,8 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH "/root/.cargo/bin:${PATH}"
 ENV RUSTUP_HOME "/root/.rustup"
 ENV CARGO_HOME "/root/.cargo"
-RUN rustup toolchain install 1.81.0
-RUN rustup default 1.81.0
+RUN rustup toolchain install 1.85.0
+RUN rustup default 1.85.0
 RUN rustup component add cargo
 RUN cargo install cargo-build-deps && cargo install cargo-edit
 

--- a/Dockerfile.dev.hawk
+++ b/Dockerfile.dev.hawk
@@ -19,8 +19,8 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 ENV RUSTUP_HOME="/root/.rustup"
 ENV CARGO_HOME="/root/.cargo"
-RUN rustup toolchain install 1.81.0
-RUN rustup default 1.81.0
+RUN rustup toolchain install 1.85.0
+RUN rustup default 1.85.0
 RUN rustup component add cargo
 RUN cargo install cargo-build-deps \
     && cargo install cargo-edit

--- a/Dockerfile.hawk
+++ b/Dockerfile.hawk
@@ -19,8 +19,8 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 ENV RUSTUP_HOME="/root/.rustup"
 ENV CARGO_HOME="/root/.cargo"
-RUN rustup toolchain install 1.81.0
-RUN rustup default 1.81.0
+RUN rustup toolchain install 1.85.0
+RUN rustup default 1.85.0
 RUN rustup component add cargo
 RUN cargo install cargo-build-deps \
     && cargo install cargo-edit

--- a/Dockerfile.nocuda
+++ b/Dockerfile.nocuda
@@ -19,8 +19,8 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH "/root/.cargo/bin:${PATH}"
 ENV RUSTUP_HOME "/root/.rustup"
 ENV CARGO_HOME "/root/.cargo"
-RUN rustup toolchain install 1.81.0
-RUN rustup default 1.81.0
+RUN rustup toolchain install 1.85.0
+RUN rustup default 1.85.0
 RUN rustup component add cargo
 RUN cargo install cargo-build-deps \
     && cargo install cargo-edit

--- a/Dockerfile.reshare-protocol
+++ b/Dockerfile.reshare-protocol
@@ -19,8 +19,8 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH "/root/.cargo/bin:${PATH}"
 ENV RUSTUP_HOME "/root/.rustup"
 ENV CARGO_HOME "/root/.cargo"
-RUN rustup toolchain install 1.81.0
-RUN rustup default 1.81.0
+RUN rustup toolchain install 1.85.0
+RUN rustup default 1.85.0
 RUN rustup component add cargo
 RUN cargo install cargo-build-deps \
     && cargo install cargo-edit

--- a/Dockerfile.shares-encoding
+++ b/Dockerfile.shares-encoding
@@ -19,8 +19,8 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH "/root/.cargo/bin:${PATH}"
 ENV RUSTUP_HOME "/root/.rustup"
 ENV CARGO_HOME "/root/.cargo"
-RUN rustup toolchain install 1.81.0
-RUN rustup default 1.81.0
+RUN rustup toolchain install 1.85.0
+RUN rustup default 1.85.0
 RUN rustup component add cargo
 RUN cargo install cargo-build-deps \
     && cargo install cargo-edit

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -450,6 +450,7 @@ pub struct IrisLoader<'a> {
     irises: BothEyes<SharedIrisesMut<'a>>,
 }
 
+#[allow(clippy::needless_lifetimes)]
 impl<'a> InMemoryStore for IrisLoader<'a> {
     fn load_single_record_from_db(
         &mut self,
@@ -498,6 +499,7 @@ impl<'a> InMemoryStore for IrisLoader<'a> {
 
 pub struct GraphLoader<'a>(BothEyes<GraphMut<'a>>);
 
+#[allow(clippy::needless_lifetimes)]
 impl<'a> GraphLoader<'a> {
     pub async fn load_graph_store(self, graph_store: &GraphStore) -> Result<()> {
         let mut graph_tx = graph_store.tx().await?;

--- a/iris-mpc-cpu/src/shares/vecshare.rs
+++ b/iris-mpc-cpu/src/shares/vecshare.rs
@@ -47,6 +47,7 @@ pub struct SliceShare<'a, T: IntRing2k> {
     shares: &'a [Share<T>],
 }
 
+#[allow(clippy::needless_lifetimes)]
 impl<'a, T: IntRing2k> SliceShare<'a, T> {
     pub fn split_at(&self, mid: usize) -> (SliceShare<T>, SliceShare<T>) {
         let (a, b) = self.shares.split_at(mid);
@@ -78,6 +79,7 @@ pub struct SliceShareMut<'a, T: IntRing2k> {
     shares: &'a mut [Share<T>],
 }
 
+#[allow(clippy::needless_lifetimes)]
 impl<'a, T: IntRing2k> SliceShareMut<'a, T> {
     pub fn to_vec(&self) -> VecShare<T> {
         VecShare {
@@ -228,6 +230,7 @@ impl<T: IntRing2k> VecShare<T> {
 }
 
 impl VecShare<Bit> {
+    #[allow(clippy::manual_div_ceil)]
     pub fn pack<T: IntRing2k>(self) -> VecShare<T> {
         let outlen = (self.shares.len() + T::K - 1) / T::K;
         let mut out = VecShare::with_capacity(outlen);
@@ -362,6 +365,7 @@ impl<T: IntRing2k> BitXorAssign<Self> for VecShare<T> {
     }
 }
 
+#[allow(clippy::needless_lifetimes)]
 impl<'a, T: IntRing2k> Deref for SliceShare<'a, T> {
     type Target = [Share<T>];
 
@@ -370,6 +374,7 @@ impl<'a, T: IntRing2k> Deref for SliceShare<'a, T> {
     }
 }
 
+#[allow(clippy::needless_lifetimes)]
 impl<'a, T: IntRing2k> Deref for SliceShareMut<'a, T> {
     type Target = [Share<T>];
 
@@ -378,6 +383,7 @@ impl<'a, T: IntRing2k> Deref for SliceShareMut<'a, T> {
     }
 }
 
+#[allow(clippy::needless_lifetimes)]
 impl<'a, T: IntRing2k> DerefMut for SliceShareMut<'a, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.shares

--- a/iris-mpc-gpu/benches/transpose.rs
+++ b/iris-mpc-gpu/benches/transpose.rs
@@ -5,6 +5,7 @@ use cudarc::{
 };
 use std::sync::Arc;
 
+#[allow(clippy::manual_div_ceil)]
 fn lauch_config(num_threads: u32, num_total: u32) -> LaunchConfig {
     let num_blocks = (num_total + num_threads - 1) / num_threads;
     LaunchConfig {

--- a/iris-mpc-gpu/src/helpers/comm.rs
+++ b/iris-mpc-gpu/src/helpers/comm.rs
@@ -51,9 +51,9 @@ impl NcclComm {
     /// let mut slice_receive = dev.alloc_zeros::<f32>(n).unwrap();
     /// comm.all_reduce(&slice, &mut slice_receive, &ReduceOp::Sum)
     ///     .unwrap();
-
+    ///
     /// let out = dev.dtoh_sync_copy(&slice_receive).unwrap();
-
+    ///
     /// assert_eq!(out, vec![(n_devices * (n_devices + 1)) as f32 / 2.0; n]);
     /// ```
     pub fn from_rank(

--- a/iris-mpc-gpu/src/threshold_ring/protocol.rs
+++ b/iris-mpc-gpu/src/threshold_ring/protocol.rs
@@ -84,6 +84,7 @@ pub struct ChunkShareViewMut<'a, T> {
     pub b: CudaViewMut<'a, T>,
 }
 
+#[allow(clippy::needless_lifetimes)]
 impl<'a, T> ChunkShareView<'a, T> {
     pub fn get_offset(&self, i: usize, chunk_size: usize) -> ChunkShareView<T> {
         ChunkShareView {

--- a/iris-mpc-gpu/tests/bucket_threshold.rs
+++ b/iris-mpc-gpu/tests/bucket_threshold.rs
@@ -105,6 +105,7 @@ mod bucket_threshold_test {
         res
     }
 
+    #[allow(clippy::precedence)]
     fn real_result_msb(code_input: Vec<u16>, mask_input: Vec<u16>) -> Vec<u64> {
         assert_eq!(code_input.len(), mask_input.len());
         let mod_ = 1u64 << (16 + B_BITS);

--- a/iris-mpc-gpu/tests/buckets.rs
+++ b/iris-mpc-gpu/tests/buckets.rs
@@ -91,6 +91,7 @@ mod buckets_test {
         result
     }
 
+    #[allow(clippy::precedence)]
     fn real_result_msb(code_input: Vec<u16>, mask_input: Vec<u16>) -> Vec<u32> {
         assert_eq!(code_input.len(), mask_input.len());
         let mod_ = 1u64 << (16 + B_BITS);

--- a/iris-mpc-gpu/tests/extract_msb_mod.rs
+++ b/iris-mpc-gpu/tests/extract_msb_mod.rs
@@ -105,6 +105,7 @@ mod extract_msb_mod_test {
         res
     }
 
+    #[allow(clippy::precedence)]
     fn real_result_msb(input: Vec<u16>) -> Vec<u64> {
         let mod_ = 1u64 << (16 + B_BITS);
         let mut res = Vec::with_capacity(input.len());

--- a/iris-mpc-gpu/tests/one_bucket.rs
+++ b/iris-mpc-gpu/tests/one_bucket.rs
@@ -89,6 +89,7 @@ mod one_bucket_test {
         result
     }
 
+    #[allow(clippy::precedence)]
     fn real_result_msb(code_input: Vec<u16>, mask_input: Vec<u16>) -> u32 {
         assert_eq!(code_input.len(), mask_input.len());
         let mod_ = 1u64 << (16 + B_BITS);

--- a/iris-mpc-gpu/tests/threshold.rs
+++ b/iris-mpc-gpu/tests/threshold.rs
@@ -105,6 +105,7 @@ mod threshold_test {
         res
     }
 
+    #[allow(clippy::precedence)]
     fn real_result_msb(code_input: Vec<u16>, mask_input: Vec<u16>) -> Vec<u64> {
         assert_eq!(code_input.len(), mask_input.len());
         let mod_ = 1u64 << (16 + B_BITS);

--- a/iris-mpc-gpu/tests/threshold_and_or_tree.rs
+++ b/iris-mpc-gpu/tests/threshold_and_or_tree.rs
@@ -88,6 +88,7 @@ mod test_threshold_and_or_tree_test {
         result
     }
 
+    #[allow(clippy::precedence)]
     fn real_result_msb_reduce(code_input: Vec<u16>, mask_input: Vec<u16>) -> bool {
         assert_eq!(code_input.len(), mask_input.len());
         let mod_ = 1u64 << (16 + B_BITS);

--- a/iris-mpc-py/Cargo.toml
+++ b/iris-mpc-py/Cargo.toml
@@ -14,5 +14,5 @@ crate-type = ["cdylib"]
 [dependencies]
 iris-mpc-common = { path = "../iris-mpc-common" }
 iris-mpc-cpu = { path = "../iris-mpc-cpu" }
-pyo3 = { version = "0.22.0", features = ["extension-module"] }
+pyo3 = { version = "0.24.0", features = ["extension-module"] }
 rand.workspace = true

--- a/iris-mpc-py/src/py_hnsw/pyclasses/graph_store.rs
+++ b/iris-mpc-py/src/py_hnsw/pyclasses/graph_store.rs
@@ -18,6 +18,7 @@ impl PyGraphStore {
     pub fn read_from_bin(filename: String) -> PyResult<Self> {
         let result = py_bindings::io::read_bin(&filename)
             .map_err(|_| PyIOError::new_err("Unable to read from file"))?;
+
         Ok(Self(result))
     }
 

--- a/iris-mpc-py/src/py_hnsw/pyclasses/iris_code.rs
+++ b/iris-mpc-py/src/py_hnsw/pyclasses/iris_code.rs
@@ -39,7 +39,7 @@ impl PyIrisCode {
         py: Python<'py>,
         version: Option<String>,
     ) -> PyResult<Bound<'py, PyDict>> {
-        let dict = PyDict::new_bound(py);
+        let dict = PyDict::new(py);
 
         dict.set_item("iris_codes", self.0.code.to_base64().unwrap())?;
         dict.set_item("mask_codes", self.0.mask.to_base64().unwrap())?;

--- a/iris-mpc/bin/server.rs
+++ b/iris-mpc/bin/server.rs
@@ -1899,6 +1899,7 @@ async fn server_main(config: Config) -> eyre::Result<()> {
 }
 
 // Helper function to load Aurora db records from the stream into memory
+#[allow(clippy::needless_lifetimes)]
 async fn load_db_records<'a>(
     actor: &mut impl InMemoryStore,
     mut record_counter: i32,

--- a/iris-mpc/src/services/store/mod.rs
+++ b/iris-mpc/src/services/store/mod.rs
@@ -15,6 +15,7 @@ use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 
 // Helper function to load Aurora db records from the stream into memory
+#[allow(clippy::needless_lifetimes)]
 async fn load_db_records<'a>(
     actor: &mut impl InMemoryStore,
     mut record_counter: i32,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.81.0"
+channel = "1.85.0"


### PR DESCRIPTION
Bumps rust toolchain from 1.81.0 -> 1.85.0

- Updated GH actions + Docker files
- Added various new clippy warnings (to be resolved in a follow up ?)
- Bumped py03 lib