### PR TITLE
relax modification asserts

### DIFF
--- a/.github/workflows/temp-branch-build-and-push.yaml
+++ b/.github/workflows/temp-branch-build-and-push.yaml
@@ -3,7 +3,7 @@ name: Branch - Build and push docker image
 on:
   push:
     branches:
-      - "POP-2179/replay-modification-results-upon-startup"
+      - "chore/relax-modifications-asserts"
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:v0.14.17"
+image: "ghcr.io/worldcoin/iris-mpc:6ee4eabc41b5c9a3e5f9cf23d3dc12300d69583c"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:6ee4eabc41b5c9a3e5f9cf23d3dc12300d69583c"
+image: "ghcr.io/worldcoin/iris-mpc:v0.14.18"
 
 environment: stage
 replicaCount: 1


### PR DESCRIPTION
## Change
- This PR relaxes the modification assertion when a local copy is `None` for a completed modification. This can happen in a case where we have more than lookback `(2 x (max_deletions + max_batch_size))` modifications and local mod is `IN_PROGRESS` while other parties could not read from SQS yet. In this case, other parties return a completed modification but local does not see it in its state as it wasn't included due to lookback window. We upsert this modification
- Another aspect is we roll-forward based on the first completed modification in the group mods instead of local one because it means local is in progress and has no sns result body. We copy other completed node's body and update it's `node_id` to replay the result

## Testing
- Added a unit test to mimic having more items than lookback window.
- Tested in stage by inserting 400 modifications and marking the top ones as: IN_PROGRESS, IN_PROGRESS, row removed completely