### PR TITLE
parameters for bucket statistics

### DIFF
--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -1067,11 +1067,20 @@ mod tests {
             all_results[i].right_iris_requests = all_results[0].right_iris_requests.clone();
             // Same for specific fields of the bucket statistics.
             // TODO: specific assertions for the bucket statistics results
-            all_results[i].anonymized_bucket_statistics_left.party_id = all_results[0].anonymized_bucket_statistics_left.party_id;
-            all_results[i].anonymized_bucket_statistics_right.party_id = all_results[0].anonymized_bucket_statistics_right.party_id;
-            all_results[i].anonymized_bucket_statistics_left.start_time_utc_timestamp = all_results[0].anonymized_bucket_statistics_left.start_time_utc_timestamp;
-            all_results[i].anonymized_bucket_statistics_right.start_time_utc_timestamp = all_results[0].anonymized_bucket_statistics_right.start_time_utc_timestamp;
-
+            all_results[i].anonymized_bucket_statistics_left.party_id =
+                all_results[0].anonymized_bucket_statistics_left.party_id;
+            all_results[i].anonymized_bucket_statistics_right.party_id =
+                all_results[0].anonymized_bucket_statistics_right.party_id;
+            all_results[i]
+                .anonymized_bucket_statistics_left
+                .start_time_utc_timestamp = all_results[0]
+                .anonymized_bucket_statistics_left
+                .start_time_utc_timestamp;
+            all_results[i]
+                .anonymized_bucket_statistics_right
+                .start_time_utc_timestamp = all_results[0]
+                .anonymized_bucket_statistics_right
+                .start_time_utc_timestamp;
         }
 
         assert!(

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -688,6 +688,8 @@ impl HawkResult {
         let partial_match_counters_right = partial_match_ids_right.iter().map(Vec::len).collect();
 
         let merged_results = self.merged_results();
+        let anonymized_bucket_statistics_left = self.anonymized_bucket_statistics[LEFT].clone();
+        let anonymized_bucket_statistics_right = self.anonymized_bucket_statistics[RIGHT].clone();
 
         ServerJobResult {
             merged_results,
@@ -705,8 +707,8 @@ impl HawkResult {
             right_iris_requests: batch.right_iris_requests,
             deleted_ids: vec![],                                 // TODO.
             matched_batch_request_ids: vec![vec![]; n_requests], // TODO.
-            anonymized_bucket_statistics_left: self.anonymized_bucket_statistics[0].clone(),
-            anonymized_bucket_statistics_right: self.anonymized_bucket_statistics[1].clone(),
+            anonymized_bucket_statistics_left,
+            anonymized_bucket_statistics_right,
             successful_reauths: vec![false; n_requests], // TODO.
             reauth_target_indices: Default::default(),   // TODO.
             reauth_or_rule_used: Default::default(),     // TODO.
@@ -1063,7 +1065,15 @@ mod tests {
         for i in 1..all_results.len() {
             all_results[i].left_iris_requests = all_results[0].left_iris_requests.clone();
             all_results[i].right_iris_requests = all_results[0].right_iris_requests.clone();
+            // Same for specific fields of the bucket statistics.
+            // TODO: specific assertions for the bucket statistics results
+            all_results[i].anonymized_bucket_statistics_left.party_id = all_results[0].anonymized_bucket_statistics_left.party_id;
+            all_results[i].anonymized_bucket_statistics_right.party_id = all_results[0].anonymized_bucket_statistics_right.party_id;
+            all_results[i].anonymized_bucket_statistics_left.start_time_utc_timestamp = all_results[0].anonymized_bucket_statistics_left.start_time_utc_timestamp;
+            all_results[i].anonymized_bucket_statistics_right.start_time_utc_timestamp = all_results[0].anonymized_bucket_statistics_right.start_time_utc_timestamp;
+
         }
+
         assert!(
             all_results.iter().all_equal(),
             "All parties must agree on the results"

--- a/iris-mpc-cpu/tests/e2e.rs
+++ b/iris-mpc-cpu/tests/e2e.rs
@@ -102,6 +102,8 @@ async fn e2e_test() -> Result<()> {
         request_parallelism: HAWK_REQUEST_PARALLELISM,
         connection_parallelism: HAWK_CONNECTION_PARALLELISM,
         disable_persistence: false,
+        match_distances_buffer_size: 64,
+        n_buckets: 10,
     };
     let args1 = HawkArgs {
         party_index: 1,

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -530,6 +530,7 @@ pub async fn server_main(config: Config) -> eyre::Result<()> {
         request_parallelism: config.hawk_request_parallelism,
         connection_parallelism: config.hawk_connection_parallelism,
         disable_persistence: config.disable_persistence,
+        match_distances_buffer_size: config.match_distances_buffer_size,
     };
 
     tracing::info!(

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -531,6 +531,7 @@ pub async fn server_main(config: Config) -> eyre::Result<()> {
         connection_parallelism: config.hawk_connection_parallelism,
         disable_persistence: config.disable_persistence,
         match_distances_buffer_size: config.match_distances_buffer_size,
+        n_buckets: config.n_buckets,
     };
 
     tracing::info!(


### PR DESCRIPTION
Enabling passing the bucket statistics results to the server job results. The actual calculation needs to perform in an analogous manner as it was in done iris-mpc with `compare_multiple_thresholds`. 