### PR TITLE
Add version id to iris-mpc store

### DIFF
--- a/.github/workflows/temp-branch-build-and-push.yaml
+++ b/.github/workflows/temp-branch-build-and-push.yaml
@@ -3,7 +3,7 @@ name: Branch - Build and push docker image
 on:
   push:
     branches:
-      - "chore/relax-modifications-asserts"
+      - "POP-2339/add-iris-share-versions-to-mpc"
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'

--- a/iris-mpc-store/migrations/20250321144530_add_version_id.down.sql
+++ b/iris-mpc-store/migrations/20250321144530_add_version_id.down.sql
@@ -1,0 +1,3 @@
+DROP TRIGGER IF EXISTS increment_version_id_trigger ON irises;
+DROP FUNCTION IF EXISTS increment_version_id();
+ALTER TABLE irises DROP COLUMN version_id;

--- a/iris-mpc-store/migrations/20250321144530_add_version_id.up.sql
+++ b/iris-mpc-store/migrations/20250321144530_add_version_id.up.sql
@@ -1,0 +1,23 @@
+-- Add version_id column with a default value of 0
+ALTER TABLE irises ADD COLUMN IF NOT EXISTS version_id SMALLINT DEFAULT 0 CHECK (version_id >= 0);
+
+-- Create a function that will be executed by the trigger
+CREATE OR REPLACE FUNCTION increment_version_id()
+RETURNS TRIGGER AS $$
+BEGIN
+    -- Only increment version_id if actual data columns changed
+    IF (OLD.left_code IS DISTINCT FROM NEW.left_code OR
+        OLD.left_mask IS DISTINCT FROM NEW.left_mask OR
+        OLD.right_code IS DISTINCT FROM NEW.right_code OR
+        OLD.right_mask IS DISTINCT FROM NEW.right_mask) THEN
+        NEW.version_id = COALESCE(OLD.version_id, 0) + 1;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create the trigger that calls the function before updates
+CREATE TRIGGER increment_version_id_trigger
+    BEFORE UPDATE ON irises
+    FOR EACH ROW
+    EXECUTE FUNCTION increment_version_id();

--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -92,6 +92,46 @@ impl DbStoredIris {
     }
 }
 
+#[derive(sqlx::FromRow, Debug, Default, PartialEq, Eq)]
+pub struct DbStoredIrisWithVersion {
+    #[allow(dead_code)]
+    id: i64, // BIGSERIAL
+    left_code: Vec<u8>,  // BYTEA
+    left_mask: Vec<u8>,  // BYTEA
+    right_code: Vec<u8>, // BYTEA
+    right_mask: Vec<u8>, // BYTEA
+    version_id: i16,     // SMALLINT
+}
+
+impl DbStoredIrisWithVersion {
+    /// The index which is contiguous and starts from 0.
+    pub fn index(&self) -> usize {
+        self.id as usize
+    }
+
+    pub fn left_code(&self) -> &[u16] {
+        cast_u8_to_u16(&self.left_code)
+    }
+
+    pub fn left_mask(&self) -> &[u16] {
+        cast_u8_to_u16(&self.left_mask)
+    }
+
+    pub fn right_code(&self) -> &[u16] {
+        cast_u8_to_u16(&self.right_code)
+    }
+
+    pub fn right_mask(&self) -> &[u16] {
+        cast_u8_to_u16(&self.right_mask)
+    }
+    pub fn id(&self) -> i64 {
+        self.id
+    }
+    pub fn version_id(&self) -> i16 {
+        self.version_id
+    }
+}
+
 #[derive(Clone)]
 pub struct StoredIrisRef<'a> {
     pub id: i64,
@@ -196,12 +236,22 @@ impl Store {
         Ok(count.0 as usize)
     }
 
-    /// Stream irises in order.
+    /// (only for testing) Stream irises in order.
     pub async fn stream_irises(
         &self,
     ) -> impl Stream<Item = Result<DbStoredIris, sqlx::Error>> + '_ {
         sqlx::query_as::<_, DbStoredIris>("SELECT * FROM irises WHERE id >= 1 ORDER BY id")
             .fetch(&self.pool)
+    }
+
+    /// (only for testing) Stream irises including version in order.
+    pub async fn stream_irises_with_version(
+        &self,
+    ) -> impl Stream<Item = Result<DbStoredIrisWithVersion, sqlx::Error>> + '_ {
+        sqlx::query_as::<_, DbStoredIrisWithVersion>(
+            "SELECT * FROM irises WHERE id >= 1 ORDER BY id",
+        )
+        .fetch(&self.pool)
     }
 
     pub fn stream_irises_in_range(
@@ -358,56 +408,6 @@ WHERE id = $1;
             }
         }
 
-        Ok(())
-    }
-
-    pub async fn insert_or_update_left_iris(
-        &self,
-        id: i64,
-        left_code: &[u16],
-        left_mask: &[u16],
-    ) -> Result<()> {
-        let mut tx = self.pool.begin().await?;
-
-        let query = sqlx::query(
-            r#"
-INSERT INTO irises (id, left_code, left_mask)
-VALUES ( $1, $2, $3 )
-ON CONFLICT (id)
-DO UPDATE SET left_code = EXCLUDED.left_code, left_mask = EXCLUDED.left_mask;
-"#,
-        )
-        .bind(id)
-        .bind(cast_slice::<u16, u8>(left_code))
-        .bind(cast_slice::<u16, u8>(left_mask));
-
-        query.execute(&mut *tx).await?;
-        tx.commit().await?;
-        Ok(())
-    }
-
-    pub async fn insert_or_update_right_iris(
-        &self,
-        id: i64,
-        right_code: &[u16],
-        right_mask: &[u16],
-    ) -> Result<()> {
-        let mut tx = self.pool.begin().await?;
-
-        let query = sqlx::query(
-            r#"
-INSERT INTO irises (id, right_code, right_mask)
-VALUES ( $1, $2, $3 )
-ON CONFLICT (id)
-DO UPDATE SET right_code = EXCLUDED.right_code, right_mask = EXCLUDED.right_mask;
-"#,
-        )
-        .bind(id)
-        .bind(cast_slice::<u16, u8>(right_code))
-        .bind(cast_slice::<u16, u8>(right_mask));
-
-        query.execute(&mut *tx).await?;
-        tx.commit().await?;
         Ok(())
     }
 
@@ -771,13 +771,21 @@ pub mod tests {
         assert_eq!(got, got_par);
 
         assert_eq!(got_len, 3);
+        assert_eq!(got_par.len(), 3);
         assert_eq!(got.len(), 3);
+
+        let got_versions: Vec<DbStoredIrisWithVersion> = store
+            .stream_irises_with_version()
+            .await
+            .try_collect()
+            .await?;
         for i in 0..3 {
-            assert_eq!(got[i].id, (i + 1) as i64);
-            assert_eq!(got[i].left_code(), codes_and_masks[i].left_code);
-            assert_eq!(got[i].left_mask(), codes_and_masks[i].left_mask);
-            assert_eq!(got[i].right_code(), codes_and_masks[i].right_code);
-            assert_eq!(got[i].right_mask(), codes_and_masks[i].right_mask);
+            assert_eq!(got_versions[i].id, (i + 1) as i64);
+            assert_eq!(got_versions[i].left_code(), codes_and_masks[i].left_code);
+            assert_eq!(got_versions[i].left_mask(), codes_and_masks[i].left_mask);
+            assert_eq!(got_versions[i].right_code(), codes_and_masks[i].right_code);
+            assert_eq!(got_versions[i].right_mask(), codes_and_masks[i].right_mask);
+            assert_eq!(got_versions[i].version_id(), 0);
         }
 
         // Clean up on success.
@@ -947,71 +955,6 @@ pub mod tests {
     }
 
     #[tokio::test]
-    async fn test_insert_left_right() -> Result<()> {
-        let schema_name = temporary_name();
-        let store = Store::new(&test_db_url()?, &schema_name).await?;
-
-        for i in 0..10u16 {
-            if i % 2 == 0 {
-                store
-                    .insert_or_update_left_iris(
-                        (i + 1) as i64,
-                        &[i * 100 + 1, i * 100 + 2, i * 100 + 3, i * 100 + 4],
-                        &[i * 100 + 5, i * 100 + 6, i * 100 + 7, i * 100 + 8],
-                    )
-                    .await?;
-                store
-                    .insert_or_update_right_iris(
-                        (i + 1) as i64,
-                        &[i * 100 + 9, i * 100 + 10, i * 100 + 11, i * 100 + 12],
-                        &[i * 100 + 13, i * 100 + 14, i * 100 + 15, i * 100 + 16],
-                    )
-                    .await?;
-            } else {
-                store
-                    .insert_or_update_right_iris(
-                        (i + 1) as i64,
-                        &[i * 100 + 9, i * 100 + 10, i * 100 + 11, i * 100 + 12],
-                        &[i * 100 + 13, i * 100 + 14, i * 100 + 15, i * 100 + 16],
-                    )
-                    .await?;
-                store
-                    .insert_or_update_left_iris(
-                        (i + 1) as i64,
-                        &[i * 100 + 1, i * 100 + 2, i * 100 + 3, i * 100 + 4],
-                        &[i * 100 + 5, i * 100 + 6, i * 100 + 7, i * 100 + 8],
-                    )
-                    .await?;
-            }
-        }
-
-        let got: Vec<DbStoredIris> = store.stream_irises().await.try_collect().await?;
-
-        for i in 0..10u16 {
-            assert_eq!(got[i as usize].id, (i + 1) as i64);
-            assert_eq!(
-                got[i as usize].left_code(),
-                &[i * 100 + 1, i * 100 + 2, i * 100 + 3, i * 100 + 4]
-            );
-            assert_eq!(
-                got[i as usize].left_mask(),
-                &[i * 100 + 5, i * 100 + 6, i * 100 + 7, i * 100 + 8]
-            );
-            assert_eq!(
-                got[i as usize].right_code(),
-                &[i * 100 + 9, i * 100 + 10, i * 100 + 11, i * 100 + 12]
-            );
-            assert_eq!(
-                got[i as usize].right_mask(),
-                &[i * 100 + 13, i * 100 + 14, i * 100 + 15, i * 100 + 16]
-            );
-        }
-
-        cleanup(&store, &schema_name).await?;
-        Ok(())
-    }
-
-    #[tokio::test]
     async fn test_update_iris() -> Result<()> {
         let schema_name = temporary_name();
         let store = Store::new(&test_db_url()?, &schema_name).await?;
@@ -1062,18 +1005,60 @@ pub mod tests {
             .await?;
 
         // assert iris updated in db with new values
-        let got: Vec<DbStoredIris> = store.stream_irises().await.try_collect().await?;
+        let got: Vec<DbStoredIrisWithVersion> = store
+            .stream_irises_with_version()
+            .await
+            .try_collect()
+            .await?;
         assert_eq!(got.len(), 2);
         assert_eq!(cast_u8_to_u16(&got[0].left_code), updated_left_code.coefs);
         assert_eq!(cast_u8_to_u16(&got[0].left_mask), updated_left_mask.coefs);
         assert_eq!(cast_u8_to_u16(&got[0].right_code), updated_right_code.coefs);
         assert_eq!(cast_u8_to_u16(&got[0].right_mask), updated_right_mask.coefs);
+        assert_eq!(got[0].version_id(), 1);
 
         // assert the other iris in db is not updated
         assert_eq!(cast_u8_to_u16(&got[1].left_code), iris2.left_code);
         assert_eq!(cast_u8_to_u16(&got[1].left_mask), iris2.left_mask);
         assert_eq!(cast_u8_to_u16(&got[1].right_code), iris2.right_code);
         assert_eq!(cast_u8_to_u16(&got[1].right_mask), iris2.right_mask);
+        assert_eq!(got[1].version_id(), 0);
+
+        // update with the same values and expect the version not to change
+        store
+            .update_iris(
+                None,
+                1,
+                &updated_left_code,
+                &updated_left_mask,
+                &updated_right_code,
+                &updated_right_mask,
+            )
+            .await?;
+
+        let got_second_update: Vec<DbStoredIrisWithVersion> = store
+            .stream_irises_with_version()
+            .await
+            .try_collect()
+            .await?;
+        assert_eq!(got_second_update.len(), 2);
+        assert_eq!(
+            cast_u8_to_u16(&got_second_update[0].left_code),
+            updated_left_code.coefs
+        );
+        assert_eq!(
+            cast_u8_to_u16(&got_second_update[0].left_mask),
+            updated_left_mask.coefs
+        );
+        assert_eq!(
+            cast_u8_to_u16(&got_second_update[0].right_code),
+            updated_right_code.coefs
+        );
+        assert_eq!(
+            cast_u8_to_u16(&got_second_update[0].right_mask),
+            updated_right_mask.coefs
+        );
+        assert_eq!(got_second_update[0].version_id(), 1);
 
         cleanup(&store, &schema_name).await?;
         Ok(())


### PR DESCRIPTION
### Notes
* add versioning to irises
* the trigger checks if the values actual values change - so for re-running modifications the version would not update
* we introduce a new type of iris db version - this way GPU and CPU can use what they need (it also stops GPU from streaming the version into memory)
* remove unused methods `insert_or_update_left_iris` and `insert_or_update_right_iris`