### PR TITLE
Parallel prefix adder to extract MSB in less-than operation

### DIFF
--- a/iris-mpc-cpu/src/protocol/binary.rs
+++ b/iris-mpc-cpu/src/protocol/binary.rs
@@ -648,7 +648,7 @@ pub(crate) async fn binary_add_3_get_msb_prefix(
         };
 
         // Split the vectors into even and odd indexed elements
-        // Note that we the starting index of temp_p is 1 due to removal of p0 above
+        // Note that the starting index of temp_p is 1 due to removal of p0 above
         let (even_p, odd_p): (Vec<_>, Vec<_>) = temp_p
             .clone()
             .into_iter()


### PR DESCRIPTION
This implements the binary circuit to compute MSB of a binary sum used in [the Brent-Kung adder](https://en.wikipedia.org/wiki/Brent%E2%80%93Kung_adder#Basic_model_outline).
As a result, the number of rounds in the less-than operation is reduced from 33 to 9, at the cost of almost doubling its bandwidth cost.

In the HNSW algorithm, this resulted in halving down the number of rounds for the search-insert at the cost of 20% more bandwidth for dataset sizes up to 2 million vectors.