### PR TITLE
Deploy latest main in stage for test, including the missing migration

### DIFF
--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:v0.14.19"
+image: "ghcr.io/worldcoin/iris-mpc:cf5f8f617e15aa6be65960f8ea05a82ddd91ecb7"
 
 environment: stage
 replicaCount: 1


### PR DESCRIPTION
### Description
Latest stage deployment failed due to a missing migration in the v0.14.19 image.
Solution: built new image from latest main https://github.com/worldcoin/iris-mpc/actions/runs/14131099182/job/39591367352 and deploy this