### PR TITLE
[POP-2329] Refactor actor to compute for both normal and mirrored case

### DIFF
--- a/iris-mpc-common/src/helpers/smpc_response.rs
+++ b/iris-mpc-common/src/helpers/smpc_response.rs
@@ -21,6 +21,7 @@ pub struct UniquenessResult {
     pub matched_batch_request_ids: Option<Vec<String>>,
     pub error: Option<bool>,
     pub error_reason: Option<String>,
+    pub full_face_mirror_attack_detected: bool,
 }
 
 impl UniquenessResult {
@@ -36,6 +37,7 @@ impl UniquenessResult {
         matched_batch_request_ids: Option<Vec<String>>,
         partial_matches_count_right: Option<usize>,
         partial_matches_count_left: Option<usize>,
+        full_face_mirror_attack_detected: bool,
     ) -> Self {
         Self {
             node_id,
@@ -50,6 +52,7 @@ impl UniquenessResult {
             partial_matches_count_left,
             error: None,
             error_reason: None,
+            full_face_mirror_attack_detected,
         }
     }
 
@@ -67,6 +70,7 @@ impl UniquenessResult {
             partial_matches_count_left: None,
             error: Some(true),
             error_reason: Some(error_reason.to_string()),
+            full_face_mirror_attack_detected: false,
         }
     }
 }

--- a/iris-mpc-common/src/iris_db/iris.rs
+++ b/iris-mpc-common/src/iris_db/iris.rs
@@ -208,17 +208,6 @@ impl IrisCode {
         res
     }
 
-    pub fn flipped_codes_and_mask(&self) -> IrisCode {
-        let mut flipped = self.clone();
-        flipped.code = self.code;
-        flipped.mask = self.mask;
-        for i in 0..IrisCode::IRIS_CODE_SIZE {
-            flipped.code.flip_bit(i);
-            flipped.mask.flip_bit(i);
-        }
-        flipped
-    }
-
     pub fn mirrored(&mut self) -> IrisCode {
         let mut mirrored = IrisCode::default();
 

--- a/iris-mpc-common/src/iris_db/iris.rs
+++ b/iris-mpc-common/src/iris_db/iris.rs
@@ -315,10 +315,7 @@ mod tests {
 
         // Check that the mirrored flipped iris matches the original
         let mirrored_iris = flipped_iris.mirrored();
-        let combined_mask = original_iris.mask & mirrored_iris.mask;
-        let code_distance =
-            ((original_iris.code ^ mirrored_iris.code) & combined_mask).count_ones();
-        let distance = code_distance as f64 / combined_mask.count_ones() as f64;
+        let distance = original_iris.get_distance(&mirrored_iris);
         assert_float_eq!(distance, 0.0, abs <= 1e-6);
     }
     pub fn parse_test_data(s: &str) -> eyre::Result<(&str, HashMap<i32, String>)> {

--- a/iris-mpc-common/src/iris_db/iris.rs
+++ b/iris-mpc-common/src/iris_db/iris.rs
@@ -208,13 +208,13 @@ impl IrisCode {
         res
     }
 
-    pub fn mirrored(&mut self) -> IrisCode {
+    pub fn mirrored(&self) -> IrisCode {
         let mut mirrored = IrisCode::default();
 
         // Process each bit position
         for i in 0..IrisCode::IRIS_CODE_SIZE {
             let mirrored_new_i = GaloisRingIrisCodeShare::remap_new_to_mirrored_index(i);
-            self.mask.set_bit(mirrored_new_i, self.mask.get_bit(i));
+            mirrored.mask.set_bit(mirrored_new_i, self.mask.get_bit(i));
             let w = (i % 4) / 2; // channel
             let code_bit = self.code.get_bit(i);
             mirrored
@@ -308,7 +308,7 @@ mod tests {
 
         // Create IrisCode objects
         let original_iris = IrisCode { code, mask };
-        let mut flipped_iris = IrisCode {
+        let flipped_iris = IrisCode {
             code: flipped_code,
             mask: flipped_mask,
         };

--- a/iris-mpc-common/src/job.rs
+++ b/iris-mpc-common/src/job.rs
@@ -114,7 +114,6 @@ pub struct ServerJobResult<A = ()> {
     // Boolean array to indicate if the query was unique which includes the matches that were not
     // entered into the DB
     pub matches_with_skip_persistence: Vec<bool>,
-
     // For each query, the serial ids to which the query matched to
     pub match_ids: Vec<Vec<u32>>,
     // For each query, the serial ids to which the query partially matched to
@@ -147,13 +146,14 @@ pub struct ServerJobResult<A = ()> {
     // Keeping track of updates & deletions for sync mechanism. Mapping: Serial id -> Modification
     // Used for roll forward in the case of needing to r-run mutations
     pub modifications: HashMap<u32, Modification>,
-    /// Actor-specific data (e.g. graph mutations).
+    // Actor-specific data (e.g. graph mutations).
     pub actor_data: A,
-
     // Reset Update specific fields
     pub reset_update_indices: Vec<u32>,
     pub reset_update_request_ids: Vec<String>,
     pub reset_update_shares: Vec<GaloisSharesBothSides>,
+    // Boolean array to indicate if the query is a full face mirror attack attempt.
+    pub full_face_mirror_attack_detected: Vec<bool>,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]

--- a/iris-mpc-common/src/test.rs
+++ b/iris-mpc-common/src/test.rs
@@ -673,8 +673,12 @@ impl TestCaseGenerator {
             TestCase::NonMatchSkipPersistence,
             TestCase::ResetCheckMatch,
             TestCase::ResetCheckNonMatch,
-            TestCase::FullFaceMirrorAttack,
         ];
+
+        if !self.is_cpu {
+            options.push(TestCase::FullFaceMirrorAttack);
+        }
+
         if !self.inserted_responses.is_empty() {
             options.push(TestCase::PreviouslyInserted);
         }

--- a/iris-mpc-common/src/test.rs
+++ b/iris-mpc-common/src/test.rs
@@ -1404,10 +1404,11 @@ fn check_bucket_statistics(
         .map(|b| b.count)
         .sum::<usize>();
     tracing::info!("Total count for bucket: {}", total_count);
-    assert_eq!(
-        total_count,
-        match_distances_buffer_size * num_gpus_per_party
-    );
+    // TODO: reenable when I fix the bucket statistics
+    // assert_eq!(
+    //     total_count,
+    //     match_distances_buffer_size * num_gpus_per_party
+    // );
     Ok(())
 }
 

--- a/iris-mpc-common/src/test.rs
+++ b/iris-mpc-common/src/test.rs
@@ -1386,9 +1386,9 @@ fn prepare_batch(
 
 fn check_bucket_statistics(
     bucket_statistics: &BucketStatistics,
-    num_gpus_per_party: usize,
+    _num_gpus_per_party: usize,
     num_buckets: usize,
-    match_distances_buffer_size: usize,
+    _match_distances_buffer_size: usize,
 ) -> Result<()> {
     if bucket_statistics.is_empty() {
         assert_eq!(bucket_statistics.buckets.len(), 0);

--- a/iris-mpc-common/src/test.rs
+++ b/iris-mpc-common/src/test.rs
@@ -1510,9 +1510,9 @@ fn prepare_batch(
 
 fn check_bucket_statistics(
     bucket_statistics: &BucketStatistics,
-    _num_gpus_per_party: usize,
+    num_gpus_per_party: usize,
     num_buckets: usize,
-    _match_distances_buffer_size: usize,
+    match_distances_buffer_size: usize,
 ) -> Result<()> {
     if bucket_statistics.is_empty() {
         assert_eq!(bucket_statistics.buckets.len(), 0);
@@ -1528,11 +1528,10 @@ fn check_bucket_statistics(
         .map(|b| b.count)
         .sum::<usize>();
     tracing::info!("Total count for bucket: {}", total_count);
-    // TODO: reenable when I fix the bucket statistics
-    // assert_eq!(
-    //     total_count,
-    //     match_distances_buffer_size * num_gpus_per_party
-    // );
+    assert_eq!(
+        total_count,
+        match_distances_buffer_size * num_gpus_per_party
+    );
     Ok(())
 }
 

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -757,6 +757,7 @@ impl HawkResult {
             reset_update_shares: vec![],                 // TODO.
             modifications: batch.modifications,
             actor_data: self.connect_plans,
+            full_face_mirror_attack_detected: vec![false; n_requests], // TODO.
         }
     }
 }

--- a/iris-mpc-cpu/tests/e2e.rs
+++ b/iris-mpc-cpu/tests/e2e.rs
@@ -118,6 +118,7 @@ async fn e2e_test() -> Result<()> {
     // Disable test cases that are not yet supported
     // TODO: enable these once supported
 
+    test_case_generator.disable_test_case(TestCase::FullFaceMirrorAttack);
     test_case_generator.disable_test_case(TestCase::MatchSkipPersistence);
     test_case_generator.disable_test_case(TestCase::NonMatchSkipPersistence);
     test_case_generator.disable_test_case(TestCase::CloseToThreshold);

--- a/iris-mpc-gpu/src/dot/distance_comparator.rs
+++ b/iris-mpc-gpu/src/dot/distance_comparator.rs
@@ -183,6 +183,7 @@ impl DistanceComparator {
         batch_size: usize,
         max_bucket_distances: usize,
         streams: &[CudaStream],
+        is_mirror_orientation: bool,
     ) {
         for i in 0..self.device_manager.device_count() {
             // Those correspond to 0 length dbs, which were just artificially increased to
@@ -227,6 +228,7 @@ impl DistanceComparator {
                             &mask_dots[i].a,
                             &mask_dots[i].b,
                             max_bucket_distances,
+                            is_mirror_orientation,
                         ),
                     )
                     .unwrap();

--- a/iris-mpc-gpu/src/dot/kernel.cu
+++ b/iris-mpc-gpu/src/dot/kernel.cu
@@ -51,7 +51,7 @@ extern "C" __global__ void openResultsBatch(unsigned long long *result1, unsigne
     }
 }
 
-extern "C" __global__ void openResults(unsigned long long *result1, unsigned long long *result2, unsigned long long *result3, unsigned long long *output, size_t chunkLength, size_t queryLength, size_t offset, size_t numElements, size_t realChunkLen, size_t totalDbLen, unsigned short *match_distances_buffer_codes_a, unsigned short *match_distances_buffer_codes_b, unsigned short *match_distances_buffer_masks_a, unsigned short *match_distances_buffer_masks_b, unsigned int *match_distances_counter, unsigned int *match_distances_indices, unsigned short *code_dots_a, unsigned short *code_dots_b, unsigned short *mask_dots_a, unsigned short *mask_dots_b, size_t max_bucket_distances)
+extern "C" __global__ void openResults(unsigned long long *result1, unsigned long long *result2, unsigned long long *result3, unsigned long long *output, size_t chunkLength, size_t queryLength, size_t offset, size_t numElements, size_t realChunkLen, size_t totalDbLen, unsigned short *match_distances_buffer_codes_a, unsigned short *match_distances_buffer_codes_b, unsigned short *match_distances_buffer_masks_a, unsigned short *match_distances_buffer_masks_b, unsigned int *match_distances_counter, unsigned int *match_distances_indices, unsigned short *code_dots_a, unsigned short *code_dots_b, unsigned short *mask_dots_a, unsigned short *mask_dots_b, size_t max_bucket_distances, bool is_mirror_orientation)
 {
     size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx < numElements)
@@ -69,15 +69,19 @@ extern "C" __global__ void openResults(unsigned long long *result1, unsigned lon
                 continue;
             }
 
-            // Save the corresponding code and mask dots for later (match distributions)
-            unsigned int match_distances_counter_idx = atomicAdd(&match_distances_counter[0], 1);
-            if (match_distances_counter_idx < max_bucket_distances)
+
+            if (!is_mirror_orientation)
             {
-                match_distances_indices[match_distances_counter_idx] = idx * 64 + i;
-                match_distances_buffer_codes_a[match_distances_counter_idx] = code_dots_a[idx * 64 + i];
-                match_distances_buffer_codes_b[match_distances_counter_idx] = code_dots_b[idx * 64 + i];
-                match_distances_buffer_masks_a[match_distances_counter_idx] = mask_dots_a[idx * 64 + i];
-                match_distances_buffer_masks_b[match_distances_counter_idx] = mask_dots_b[idx * 64 + i];
+                // Save the corresponding code and mask dots for later (match distributions)
+                unsigned int match_distances_counter_idx = atomicAdd(&match_distances_counter[0], 1);
+                if (match_distances_counter_idx < max_bucket_distances)
+                {
+                    match_distances_indices[match_distances_counter_idx] = idx * 64 + i;
+                    match_distances_buffer_codes_a[match_distances_counter_idx] = code_dots_a[idx * 64 + i];
+                    match_distances_buffer_codes_b[match_distances_counter_idx] = code_dots_b[idx * 64 + i];
+                    match_distances_buffer_masks_a[match_distances_counter_idx] = mask_dots_a[idx * 64 + i];
+                    match_distances_buffer_masks_b[match_distances_counter_idx] = mask_dots_b[idx * 64 + i];
+                }
             }
 
             // Mark which results are matches with a bit in the output

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -1378,7 +1378,7 @@ impl ServerActor {
             if case == Case::Normal && previous_results.is_some() {
                 let mirror_results = previous_results.unwrap();
                 (0..request_count)
-                    .map(|i| matches[i] == false && mirror_results.matches[i] == true)
+                    .map(|i| !matches[i] && mirror_results.matches[i])
                     .collect()
             } else {
                 vec![false; request_count]

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -2116,7 +2116,6 @@ impl ServerActor {
                 .await_event(request_streams, &self.phase1_events[db_chunk_idx % 2]);
 
             // ---- START PHASE 1 ----
-            // Dot product = hamming distance against the database(chunk)
             record_stream_time!(
                 &self.device_manager,
                 request_streams,

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -754,7 +754,6 @@ impl ServerActor {
             }
         }
 
-        // TODO: patch the compact query creation to work with the mirror case
         ///////////////////////////////////////////////////////////////////
         // PERFORM RESET UPDATES (IF ANY)
         ///////////////////////////////////////////////////////////////////
@@ -1967,13 +1966,10 @@ impl ServerActor {
         batch_size: usize,
     ) {
         // we try to calculate the bucket stats here if we have collected enough of them
-        // TODO: design decision on how to handle bucket stats in the mirrored case
         self.try_calculate_bucket_stats(eye_db);
 
         // ---- START BATCH DEDUP ----
-        // TODO: needs modification to be able to check mirrored against the normal in the batch
         self.compare_query_against_self(
-            // TODO: refactor to be able to add mirrored query to check against
             compact_device_queries,
             compact_device_sums,
             events,

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -2279,6 +2279,7 @@ impl ServerActor {
                                 * (100 + self.match_distances_buffer_size_extra_percent)
                                 / 100,
                             request_streams,
+                            orientation == Orientation::Mirror,
                         );
                         self.phase2.return_result_buffer(res);
                     }
@@ -2532,6 +2533,7 @@ fn open(
     batch_size: usize,
     max_bucket_distances: usize,
     streams: &[CudaStream],
+    is_mirror_orientation: bool,
 ) {
     let n_devices = x.len();
     let mut a = Vec::with_capacity(n_devices);
@@ -2576,6 +2578,7 @@ fn open(
         batch_size,
         max_bucket_distances,
         streams,
+        is_mirror_orientation,
     );
 }
 

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -868,6 +868,7 @@ impl ServerActor {
             &mut events,
             self.full_scan_side,
             batch_size,
+            orientation,
         );
 
         ///////////////////////////////////////////////////////////////////
@@ -972,6 +973,7 @@ impl ServerActor {
                 &mut events,
                 other_side,
                 batch_size,
+                orientation,
             );
         } else {
             tracing::info!("Comparing right eye queries against DB subset");
@@ -982,6 +984,7 @@ impl ServerActor {
                 other_side,
                 batch_size,
                 &partial_matches_side1,
+                orientation,
             );
         }
 
@@ -1826,6 +1829,7 @@ impl ServerActor {
         eye_db: Eye,
         batch_size: usize,
         db_subset_idx: &[Vec<u32>],
+        orientation: Orientation,
     ) {
         assert!(
             eye_db == Eye::Right,
@@ -1833,7 +1837,9 @@ impl ServerActor {
         );
 
         // we try to calculate the bucket stats here if we have collected enough of them
-        self.try_calculate_bucket_stats(eye_db);
+        if orientation == Orientation::Normal {
+            self.try_calculate_bucket_stats(eye_db);
+        }
 
         // ---- START BATCH DEDUP ----
         self.compare_query_against_self(
@@ -2007,9 +2013,12 @@ impl ServerActor {
         events: &mut HashMap<&str, Vec<Vec<CUevent>>>,
         eye_db: Eye,
         batch_size: usize,
+        orientation: Orientation,
     ) {
         // we try to calculate the bucket stats here if we have collected enough of them
-        self.try_calculate_bucket_stats(eye_db);
+        if orientation == Orientation::Normal {
+            self.try_calculate_bucket_stats(eye_db);
+        }
 
         // ---- START BATCH DEDUP ----
         self.compare_query_against_self(

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -808,11 +808,11 @@ impl ServerActor {
         // *Query* variant including Lagrange interpolation.
         let compact_query_side1 = CompactQuery {
             code_query: batch
-                .get_iris_interpolated_requests_preprocessed(self.full_scan_side)
+                .get_iris_interpolated_requests_preprocessed(self.full_scan_side, case)
                 .code
                 .clone(),
             mask_query: batch
-                .get_iris_interpolated_requests_preprocessed(self.full_scan_side)
+                .get_iris_interpolated_requests_preprocessed(self.full_scan_side, case)
                 .mask
                 .clone(),
             code_query_insert: batch
@@ -904,11 +904,11 @@ impl ServerActor {
         // *Query* variant including Lagrange interpolation.
         let compact_query_side2 = CompactQuery {
             code_query: batch
-                .get_iris_interpolated_requests_preprocessed(other_side)
+                .get_iris_interpolated_requests_preprocessed(other_side, case)
                 .code
                 .clone(),
             mask_query: batch
-                .get_iris_interpolated_requests_preprocessed(other_side)
+                .get_iris_interpolated_requests_preprocessed(other_side, case)
                 .mask
                 .clone(),
             code_query_insert: batch

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -1821,6 +1821,7 @@ impl ServerActor {
         tracing::info!(party_id = self.party_id, "Finished batch deduplication");
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn compare_query_against_db_subset_and_self(
         &mut self,
         compact_device_queries: &DeviceCompactQuery,

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -1226,7 +1226,7 @@ impl ServerActor {
                         (Orientation::Normal, Some(mirror_results)) => {
                             basic_condition && !mirror_results.matches_with_skip_persistence[idx]
                         }
-                        _ => basic_condition, // In mirror mode or without previous results, just use basic condition (should not happen)
+                        _ => basic_condition, // In mirror mode or without previous results
                     }
                 })
                 .map(|(idx, _num)| idx)

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -541,10 +541,6 @@ impl ServerActor {
                         Some(mirrored_results),
                     ) {
                         Ok(combined_results) => {
-                            tracing::info!(
-                                "Combined_results.full_face_mirror_attack_detected: {:?}",
-                                combined_results.full_face_mirror_attack_detected
-                            );
                             // Send the combined results to the return channel
                             let _ = return_channel.send(combined_results);
                         }
@@ -1446,7 +1442,6 @@ impl ServerActor {
             right_iris_requests: batch.right_iris_requests,
             deleted_ids: batch.deletion_requests_indices,
             matched_batch_request_ids,
-            // TODO: if the bucket is not empty (from the mirrored case) then just place it here, for both
             anonymized_bucket_statistics_left: self.anonymized_bucket_statistics_left.clone(),
             anonymized_bucket_statistics_right: self.anonymized_bucket_statistics_right.clone(),
             successful_reauths,

--- a/iris-mpc-gpu/src/server/mod.rs
+++ b/iris-mpc-gpu/src/server/mod.rs
@@ -94,6 +94,8 @@ pub struct PreprocessedBatchQuery {
     pub right_iris_rotated_requests: IrisQueryBatchEntries,
     pub left_iris_interpolated_requests: IrisQueryBatchEntries,
     pub right_iris_interpolated_requests: IrisQueryBatchEntries,
+    pub left_mirrored_iris_interpolated_requests: IrisQueryBatchEntries,
+    pub right_mirrored_iris_interpolated_requests: IrisQueryBatchEntries,
 
     pub or_rule_indices: Vec<Vec<u32>>,
     pub luc_lookback_records: usize,
@@ -121,6 +123,8 @@ pub struct PreprocessedBatchQuery {
     pub right_iris_interpolated_requests_preprocessed: BatchQueryEntriesPreprocessed,
     pub left_iris_rotated_requests_preprocessed: BatchQueryEntriesPreprocessed,
     pub right_iris_rotated_requests_preprocessed: BatchQueryEntriesPreprocessed,
+    pub left_mirrored_iris_interpolated_requests_preprocessed: BatchQueryEntriesPreprocessed,
+    pub right_mirrored_iris_interpolated_requests_preprocessed: BatchQueryEntriesPreprocessed,
 
     // Keeping track of updates & deletions for sync mechanism. Mapping: Serial id -> Modification
     pub modifications: HashMap<u32, Modification>,
@@ -171,6 +175,9 @@ impl From<BatchQuery> for PreprocessedBatchQuery {
         let mut right_iris_interpolated_requests_preprocessed = None;
         let mut left_iris_rotated_requests_preprocessed = None;
         let mut right_iris_rotated_requests_preprocessed = None;
+        let mut left_mirrored_iris_interpolated_requests_preprocessed = None;
+        let mut right_mirrored_iris_interpolated_requests_preprocessed = None;
+
         rayon::scope(|s| {
             s.spawn(|_| {
                 left_iris_interpolated_requests_preprocessed =
@@ -194,6 +201,18 @@ impl From<BatchQuery> for PreprocessedBatchQuery {
                     BatchQueryEntriesPreprocessed::from(value.right_iris_rotated_requests.clone()),
                 );
             });
+            s.spawn(|_| {
+                left_mirrored_iris_interpolated_requests_preprocessed =
+                    Some(BatchQueryEntriesPreprocessed::from(
+                        value.left_mirrored_iris_interpolated_requests.clone(),
+                    ));
+            });
+            s.spawn(|_| {
+                right_mirrored_iris_interpolated_requests_preprocessed =
+                    Some(BatchQueryEntriesPreprocessed::from(
+                        value.right_mirrored_iris_interpolated_requests.clone(),
+                    ));
+            });
         });
 
         Self {
@@ -206,6 +225,10 @@ impl From<BatchQuery> for PreprocessedBatchQuery {
             right_iris_rotated_requests: value.right_iris_rotated_requests,
             left_iris_interpolated_requests: value.left_iris_interpolated_requests,
             right_iris_interpolated_requests: value.right_iris_interpolated_requests,
+            left_mirrored_iris_interpolated_requests: value
+                .left_mirrored_iris_interpolated_requests,
+            right_mirrored_iris_interpolated_requests: value
+                .right_mirrored_iris_interpolated_requests,
             or_rule_indices: value.or_rule_indices,
             luc_lookback_records: value.luc_lookback_records,
             valid_entries: value.valid_entries,
@@ -224,6 +247,10 @@ impl From<BatchQuery> for PreprocessedBatchQuery {
                 right_iris_interpolated_requests_preprocessed.unwrap(),
             right_iris_rotated_requests_preprocessed: right_iris_rotated_requests_preprocessed
                 .unwrap(),
+            left_mirrored_iris_interpolated_requests_preprocessed:
+                left_mirrored_iris_interpolated_requests_preprocessed.unwrap(),
+            right_mirrored_iris_interpolated_requests_preprocessed:
+                right_mirrored_iris_interpolated_requests_preprocessed.unwrap(),
             modifications: value.modifications,
             sns_message_ids: value.sns_message_ids,
             skip_persistence: value.skip_persistence,
@@ -251,6 +278,23 @@ impl PreprocessedBatchQuery {
         filter_by_indices_with_rotations!(self.right_iris_interpolated_requests.mask, indices_set);
         filter_by_indices_with_rotations!(self.right_iris_rotated_requests.code, indices_set);
         filter_by_indices_with_rotations!(self.right_iris_rotated_requests.mask, indices_set);
+        filter_by_indices_with_rotations!(
+            self.left_mirrored_iris_interpolated_requests.code,
+            indices_set
+        );
+        filter_by_indices_with_rotations!(
+            self.left_mirrored_iris_interpolated_requests.mask,
+            indices_set
+        );
+        filter_by_indices_with_rotations!(
+            self.right_mirrored_iris_interpolated_requests.code,
+            indices_set
+        );
+        filter_by_indices_with_rotations!(
+            self.right_mirrored_iris_interpolated_requests.mask,
+            indices_set
+        );
+
         Self::filter_preprocessed_entry(
             &mut self.left_iris_interpolated_requests_preprocessed,
             &indices_set,
@@ -265,6 +309,14 @@ impl PreprocessedBatchQuery {
         );
         Self::filter_preprocessed_entry(
             &mut self.right_iris_rotated_requests_preprocessed,
+            &indices_set,
+        );
+        Self::filter_preprocessed_entry(
+            &mut self.left_mirrored_iris_interpolated_requests_preprocessed,
+            &indices_set,
+        );
+        Self::filter_preprocessed_entry(
+            &mut self.right_mirrored_iris_interpolated_requests_preprocessed,
             &indices_set,
         );
         filter_by_indices!(self.valid_entries, indices_set);

--- a/iris-mpc-gpu/src/server/mod.rs
+++ b/iris-mpc-gpu/src/server/mod.rs
@@ -2,7 +2,7 @@ pub(crate) mod actor;
 
 use crate::dot::{share_db::preprocess_query, IRIS_CODE_LENGTH, MASK_CODE_LENGTH, ROTATIONS};
 pub use actor::{
-    generate_luc_records, prepare_or_policy_bitmap, Case, ServerActor, ServerActorHandle,
+    generate_luc_records, prepare_or_policy_bitmap, Orientation, ServerActor, ServerActorHandle,
 };
 use iris_mpc_common::job::GaloisSharesBothSides;
 use iris_mpc_common::{
@@ -146,9 +146,9 @@ impl PreprocessedBatchQuery {
     pub fn get_iris_interpolated_requests_preprocessed(
         &self,
         eye: Eye,
-        case: Case,
+        orientation: Orientation,
     ) -> &BatchQueryEntriesPreprocessed {
-        if case == Case::Mirror {
+        if orientation == Orientation::Mirror {
             match eye {
                 Eye::Left => &self.right_mirrored_iris_interpolated_requests_preprocessed,
                 Eye::Right => &self.left_mirrored_iris_interpolated_requests_preprocessed,

--- a/iris-mpc-gpu/src/server/mod.rs
+++ b/iris-mpc-gpu/src/server/mod.rs
@@ -149,6 +149,10 @@ impl PreprocessedBatchQuery {
         orientation: Orientation,
     ) -> &BatchQueryEntriesPreprocessed {
         if orientation == Orientation::Mirror {
+            // To handle the full-face mirror attack, we want to use:
+            // left_mirrored VS right_db
+            // right_mirrored VS left_db
+            // Hence we need to swap the left and right iris interpolated requests
             match eye {
                 Eye::Left => &self.right_mirrored_iris_interpolated_requests_preprocessed,
                 Eye::Right => &self.left_mirrored_iris_interpolated_requests_preprocessed,

--- a/iris-mpc-gpu/src/server/mod.rs
+++ b/iris-mpc-gpu/src/server/mod.rs
@@ -1,7 +1,9 @@
 pub(crate) mod actor;
 
 use crate::dot::{share_db::preprocess_query, IRIS_CODE_LENGTH, MASK_CODE_LENGTH, ROTATIONS};
-pub use actor::{generate_luc_records, prepare_or_policy_bitmap, ServerActor, ServerActorHandle};
+pub use actor::{
+    generate_luc_records, prepare_or_policy_bitmap, Case, ServerActor, ServerActorHandle,
+};
 use iris_mpc_common::job::GaloisSharesBothSides;
 use iris_mpc_common::{
     helpers::sync::Modification,
@@ -144,10 +146,18 @@ impl PreprocessedBatchQuery {
     pub fn get_iris_interpolated_requests_preprocessed(
         &self,
         eye: Eye,
+        case: Case,
     ) -> &BatchQueryEntriesPreprocessed {
-        match eye {
-            Eye::Left => &self.left_iris_interpolated_requests_preprocessed,
-            Eye::Right => &self.right_iris_interpolated_requests_preprocessed,
+        if case == Case::Mirror {
+            match eye {
+                Eye::Left => &self.right_mirrored_iris_interpolated_requests_preprocessed,
+                Eye::Right => &self.left_mirrored_iris_interpolated_requests_preprocessed,
+            }
+        } else {
+            match eye {
+                Eye::Left => &self.left_iris_interpolated_requests_preprocessed,
+                Eye::Right => &self.right_iris_interpolated_requests_preprocessed,
+            }
         }
     }
 

--- a/iris-mpc-gpu/tests/e2e.rs
+++ b/iris-mpc-gpu/tests/e2e.rs
@@ -15,7 +15,7 @@ mod e2e_test {
 
     const DB_SIZE: usize = 8 * 1000;
     const DB_BUFFER: usize = 8 * 1000;
-    const NUM_BATCHES: usize = 40;
+    const NUM_BATCHES: usize = 30;
     const MAX_BATCH_SIZE: usize = 64;
     const N_BUCKETS: usize = 10;
     const MATCH_DISTANCES_BUFFER_SIZE: usize = 1 << 7;

--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -751,6 +751,7 @@ pub mod tests {
             None,
             None,
             None,
+            false,
         ))?;
         let result_events = vec![result_event; count];
 

--- a/iris-mpc/bin/server.rs
+++ b/iris-mpc/bin/server.rs
@@ -1782,6 +1782,7 @@ async fn server_main(config: Config) -> eyre::Result<()> {
                             false => Some(partial_match_counters_right[i]),
                             true => None,
                         },
+                        full_face_mirror_attack_detected[i],
                     );
 
                     serde_json::to_string(&result_event).wrap_err("failed to serialize result")
@@ -1794,7 +1795,27 @@ async fn server_main(config: Config) -> eyre::Result<()> {
                 .enumerate()
                 .filter_map(
                     // Find the indices of non-matching queries in the batch.
-                    |(query_idx, is_match)| if !is_match { Some(query_idx) } else { None },
+                    // BUT ALSO filter out any detected full face mirror attacks.
+                    |(query_idx, is_match)| {
+                        if !is_match {
+                            // Check for full face mirror attack (only for UNIQUENESS requests)
+                            if request_types[query_idx] == UNIQUENESS_MESSAGE_TYPE && full_face_mirror_attack_detected[query_idx]
+                            {
+                                tracing::warn!(
+                                    "Mirror attack detected for request_id {} - Not persisting to database",
+                                    request_ids[query_idx]
+                                );
+                                metrics::counter!("mirror.attack.rejected").increment(1);
+                                None
+                            } else {
+                                // Otherwise it's a legitimate non-match, include it.
+                                Some(query_idx)
+                            }
+                        } else {
+                            // It matched, don't include.
+                            None
+                        }
+                    },
                 )
                 .map(|query_idx| {
                     let serial_id = (merged_results[query_idx] + 1) as i64;

--- a/iris-mpc/bin/server.rs
+++ b/iris-mpc/bin/server.rs
@@ -1732,6 +1732,7 @@ async fn server_main(config: Config) -> eyre::Result<()> {
             reset_update_shares,
             mut modifications,
             actor_data: _,
+            full_face_mirror_attack_detected,
         }) = rx.recv().await
         {
             let dummy_deletion_shares = get_dummy_shares_for_deletion(party_id);

--- a/iris-mpc/src/services/processors/job.rs
+++ b/iris-mpc/src/services/processors/job.rs
@@ -108,6 +108,7 @@ pub async fn process_job_result(
                     false => Some(partial_match_counters_right[i]),
                     true => None,
                 },
+                false, // not applicable for hnsw
             );
 
             serde_json::to_string(&result_event).wrap_err("failed to serialize result")

--- a/iris-mpc/src/services/processors/job.rs
+++ b/iris-mpc/src/services/processors/job.rs
@@ -61,6 +61,7 @@ pub async fn process_job_result(
     let now = Instant::now();
 
     let _modifications = modifications;
+    let _full_face_mirror_attack_detected = full_face_mirror_attack_detected;
 
     // returned serial_ids are 0 indexed, but we want them to be 1 indexed
     let uniqueness_results = merged_results

--- a/iris-mpc/src/services/processors/job.rs
+++ b/iris-mpc/src/services/processors/job.rs
@@ -55,6 +55,7 @@ pub async fn process_job_result(
         reauth_or_rule_used,
         modifications,
         actor_data: hawk_mutation,
+        full_face_mirror_attack_detected,
         ..
     } = job_result;
     let now = Instant::now();


### PR DESCRIPTION
### Description
To implement the Full-Face Mirror attack mechanism we need a way to check for both normal and mirrored shares,masks for each request.

### Implementation Details
Preparation related work: https://github.com/worldcoin/iris-mpc/pull/1187 (mirrored shares available to the actor)

After co-ordination with @dkales we selected the following approach:
- refactor `process_batch_query()` to be able to return the ServerJobResult and to also be able to receive it in the signature
- goal of the above refactor was to make sure we can run `process_batch_query()` twice for each batch.
         - One for the mirrored case (use the mirrored shares and masks when comparing against the batch and the db)
         - One for the normal case (use the actual shares)
- ~~use the mirrored_results.matches vector to perform the mirror attack prevention during the normal flow~~
- [Edit] The above approach with the matches vector, does not work since the merged_results and matches are manipulated during the calculation of the uniquess insertion list. It is wiser to calculate the `full_face_mirror_attack_detected` vector using the merged_results


### Pending Work
- [x] Check if the db insert from the server.rs is OK or if it needs modification to handle mirror attacks
-> handled in this [commit](https://github.com/worldcoin/iris-mpc/pull/1212/commits/99f5606f6e76b7bee51799df402250c0e3f94fec) 
- [x] Introduce Mirror Attack test case in the e2e suite
- [x] Handle bucket statistics in actor