### PR TITLE
refactor batch processor into something more sensible

### DIFF
--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -3,7 +3,7 @@ mod utils;
 use crate::server::utils::get_check_addresses;
 use crate::services::aws::clients::AwsClients;
 use crate::services::init::initialize_chacha_seeds;
-use crate::services::processors::batch::{receive_batch, BatchProcessor};
+use crate::services::processors::batch::receive_batch;
 use crate::services::processors::job::process_job_result;
 use crate::services::processors::process_identity_deletions;
 use crate::services::processors::result_message::send_results_to_sns;

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -3,7 +3,7 @@ mod utils;
 use crate::server::utils::get_check_addresses;
 use crate::services::aws::clients::AwsClients;
 use crate::services::init::initialize_chacha_seeds;
-use crate::services::processors::batch::receive_batch;
+use crate::services::processors::batch::BatchProcessor;
 use crate::services::processors::job::process_job_result;
 use crate::services::processors::process_identity_deletions;
 use crate::services::processors::result_message::send_results_to_sns;
@@ -705,7 +705,8 @@ pub async fn server_main(config: Config) -> eyre::Result<()> {
         let shares_encryption_key_pair = shares_encryption_key_pair.clone();
         // This batch can consist of N sets of iris_share + mask
         // It also includes a vector of request ids, mapping to the sets above
-        let mut next_batch = receive_batch(
+
+        let mut processor = BatchProcessor::new(
             party_id,
             &aws_clients.sqs_client,
             &aws_clients.sns_client,
@@ -718,6 +719,8 @@ pub async fn server_main(config: Config) -> eyre::Result<()> {
             &uniqueness_error_result_attribute,
             &reauth_error_result_attribute,
         );
+
+        let mut next_batch = processor.receive_batch();
 
         let dummy_shares_for_deletions = get_dummy_shares_for_deletion(party_id);
 
@@ -760,19 +763,7 @@ pub async fn server_main(config: Config) -> eyre::Result<()> {
 
             let result_future = hawk_handle.submit_batch_query(batch.clone());
 
-            next_batch = receive_batch(
-                party_id,
-                &aws_clients.sqs_client,
-                &aws_clients.sns_client,
-                &aws_clients.s3_client,
-                &config,
-                &store,
-                &skip_request_ids,
-                shares_encryption_key_pair.clone(),
-                &shutdown_handler,
-                &uniqueness_error_result_attribute,
-                &reauth_error_result_attribute,
-            );
+            next_batch = processor.receive_batch();
 
             // await the result
             let result = timeout(processing_timeout, result_future.await)

--- a/iris-mpc/src/services/processors/batch.rs
+++ b/iris-mpc/src/services/processors/batch.rs
@@ -29,6 +29,37 @@ use std::sync::Arc;
 use tokio::sync::Semaphore;
 use tokio::task::JoinHandle;
 
+#[allow(clippy::too_many_arguments)]
+pub async fn receive_batch(
+    party_id: usize,
+    client: &Client,
+    sns_client: &SNSClient,
+    s3_client: &S3Client,
+    config: &Config,
+    store: &Store,
+    skip_request_ids: &[String],
+    shares_encryption_key_pairs: SharesEncryptionKeyPairs,
+    shutdown_handler: &ShutdownHandler,
+    uniqueness_error_result_attributes: &HashMap<String, MessageAttributeValue>,
+    reauth_error_result_attributes: &HashMap<String, MessageAttributeValue>,
+) -> eyre::Result<Option<BatchQuery>, ReceiveRequestError> {
+    let mut processor = BatchProcessor::new(
+        party_id,
+        client,
+        sns_client,
+        s3_client,
+        config,
+        store,
+        skip_request_ids,
+        shares_encryption_key_pairs,
+        shutdown_handler,
+        uniqueness_error_result_attributes,
+        reauth_error_result_attributes,
+    );
+
+    processor.receive_batch().await
+}
+
 pub struct BatchProcessor<'a> {
     party_id: usize,
     client: &'a Client,

--- a/iris-mpc/src/services/processors/batch.rs
+++ b/iris-mpc/src/services/processors/batch.rs
@@ -1,14 +1,10 @@
+use crate::server::{CURRENT_BATCH_SIZE, MAX_CONCURRENT_REQUESTS, SQS_POLLING_INTERVAL};
+use crate::services::processors::get_iris_shares_parse_task;
+use crate::services::processors::result_message::send_error_results_to_sns;
 use aws_sdk_s3::Client as S3Client;
 use aws_sdk_sns::types::MessageAttributeValue;
 use aws_sdk_sns::Client as SNSClient;
 use aws_sdk_sqs::Client;
-use std::collections::HashMap;
-use std::sync::Arc;
-use tokio::sync::Semaphore;
-
-use crate::server::{CURRENT_BATCH_SIZE, MAX_CONCURRENT_REQUESTS, SQS_POLLING_INTERVAL};
-use crate::services::processors::get_iris_shares_parse_task;
-use crate::services::processors::result_message::send_error_results_to_sns;
 use iris_mpc_common::config::Config;
 use iris_mpc_common::galois_engine::degree4::{
     GaloisRingIrisCodeShare, GaloisRingTrimmedMaskCodeShare, GaloisShares,
@@ -28,429 +24,542 @@ use iris_mpc_common::helpers::smpc_response::{
 };
 use iris_mpc_common::job::{BatchMetadata, BatchQuery};
 use iris_mpc_store::Store;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::Semaphore;
+use tokio::task::JoinHandle;
 
-#[allow(clippy::too_many_arguments)]
-pub async fn receive_batch(
+pub struct BatchProcessor<'a> {
     party_id: usize,
-    client: &Client,
-    sns_client: &SNSClient,
-    s3_client: &S3Client,
-    config: &Config,
-    store: &Store,
-    skip_request_ids: &[String],
+    client: &'a Client,
+    sns_client: &'a SNSClient,
+    s3_client: &'a S3Client,
+    config: &'a Config,
+    store: &'a Store,
+    skip_request_ids: &'a [String],
     shares_encryption_key_pairs: SharesEncryptionKeyPairs,
-    shutdown_handler: &ShutdownHandler,
-    uniqueness_error_result_attributes: &HashMap<String, MessageAttributeValue>,
-    reauth_error_result_attributes: &HashMap<String, MessageAttributeValue>,
-) -> eyre::Result<Option<BatchQuery>, ReceiveRequestError> {
-    let max_batch_size = config.clone().max_batch_size;
-    let queue_url = &config.clone().requests_queue_url;
-    if shutdown_handler.is_shutting_down() {
-        tracing::info!("Stopping batch receive due to shutdown signal...");
-        return Ok(None);
-    }
+    shutdown_handler: &'a ShutdownHandler,
+    uniqueness_error_result_attributes: &'a HashMap<String, MessageAttributeValue>,
+    reauth_error_result_attributes: &'a HashMap<String, MessageAttributeValue>,
+    batch_query: BatchQuery,
+    semaphore: Arc<Semaphore>,
+    handles: Vec<JoinHandle<Result<(GaloisShares, GaloisShares), eyre::Error>>>,
+    msg_counter: usize,
+}
 
-    let mut batch_query = BatchQuery::default();
-
-    let semaphore = Arc::new(Semaphore::new(MAX_CONCURRENT_REQUESTS));
-    let mut handles = vec![];
-    let mut msg_counter = 0;
-
-    // temporary hack for staging to only process 1 message at a time
-    // this helps with the correctness test
-    while msg_counter < 1 {
-        let rcv_message_output = client
-            .receive_message()
-            .max_number_of_messages(1)
-            .queue_url(queue_url)
-            .send()
-            .await
-            .map_err(ReceiveRequestError::FailedToReadFromSQS)?;
-
-        if let Some(messages) = rcv_message_output.messages {
-            for sqs_message in messages {
-                let message: SQSMessage = serde_json::from_str(sqs_message.body().unwrap())
-                    .map_err(|e| ReceiveRequestError::json_parse_error("SQS body", e))?;
-
-                // messages arrive to SQS through SNS. So, all the attributes set in SNS are
-                // moved into the SQS body.
-                let message_attributes = message.message_attributes;
-
-                let mut batch_metadata = BatchMetadata::default();
-
-                if let Some(trace_id) = message_attributes.get(TRACE_ID_MESSAGE_ATTRIBUTE_NAME) {
-                    let trace_id = trace_id.string_value().unwrap();
-                    batch_metadata.trace_id = trace_id.to_string();
-                }
-                if let Some(span_id) = message_attributes.get(SPAN_ID_MESSAGE_ATTRIBUTE_NAME) {
-                    let span_id = span_id.string_value().unwrap();
-                    batch_metadata.span_id = span_id.to_string();
-                }
-
-                let request_type = message_attributes
-                    .get(SMPC_MESSAGE_TYPE_ATTRIBUTE)
-                    .ok_or(ReceiveRequestError::NoMessageTypeAttribute)?
-                    .string_value()
-                    .ok_or(ReceiveRequestError::NoMessageTypeAttribute)?;
-
-                match request_type {
-                    IDENTITY_DELETION_MESSAGE_TYPE => {
-                        if config.hawk_server_deletions_enabled {
-                            // If it's a deletion request, we just store the serial_id and continue.
-                            // Deletion will take place when batch process starts.
-                            let identity_deletion_request: IdentityDeletionRequest =
-                                serde_json::from_str(&message.message).map_err(|e| {
-                                    ReceiveRequestError::json_parse_error(
-                                        "Identity deletion request",
-                                        e,
-                                    )
-                                })?;
-                            metrics::counter!("request.received", "type" => "identity_deletion")
-                                .increment(1);
-                            batch_query
-                                .deletion_requests_indices
-                                .push(identity_deletion_request.serial_id - 1); // serial_id is 1-indexed
-                            batch_query.deletion_requests_metadata.push(batch_metadata);
-                        } else {
-                            tracing::warn!("Identity deletions are disabled");
-                        }
-                        // We still delete if the deletion is disabled, so that the queue doesn't
-                        // build up
-                        client
-                            .delete_message()
-                            .queue_url(queue_url)
-                            .receipt_handle(sqs_message.receipt_handle.unwrap())
-                            .send()
-                            .await
-                            .map_err(ReceiveRequestError::FailedToDeleteFromSQS)?;
-                    }
-
-                    UNIQUENESS_MESSAGE_TYPE => {
-                        msg_counter += 1;
-
-                        let shares_encryption_key_pairs = shares_encryption_key_pairs.clone();
-
-                        let uniqueness_request: UniquenessRequest =
-                            serde_json::from_str(&message.message).map_err(|e| {
-                                ReceiveRequestError::json_parse_error("Uniqueness request", e)
-                            })?;
-                        metrics::counter!("request.received", "type" => "uniqueness_verification")
-                            .increment(1);
-                        store
-                            .mark_requests_deleted(&[uniqueness_request.signup_id.clone()])
-                            .await
-                            .map_err(ReceiveRequestError::FailedToMarkRequestAsDeleted)?;
-
-                        client
-                            .delete_message()
-                            .queue_url(queue_url)
-                            .receipt_handle(sqs_message.receipt_handle.unwrap())
-                            .send()
-                            .await
-                            .map_err(ReceiveRequestError::FailedToDeleteFromSQS)?;
-
-                        if skip_request_ids.contains(&uniqueness_request.signup_id) {
-                            // Some party (maybe us) already meant to delete this request, so we
-                            // skip it. Ignore this message when calculating the batch size.
-                            msg_counter -= 1;
-                            metrics::counter!("skip.request.deleted.sqs.request").increment(1);
-                            tracing::warn!(
-                                "Skipping request due to it being from synced deleted ids: {}",
-                                uniqueness_request.signup_id
-                            );
-                            let message = UniquenessResult::new_error_result(
-                                config.party_id,
-                                uniqueness_request.signup_id,
-                                ERROR_SKIPPED_REQUEST_PREVIOUS_NODE_BATCH,
-                            );
-                            // shares
-                            send_error_results_to_sns(
-                                serde_json::to_string(&message).unwrap(),
-                                &batch_metadata,
-                                sns_client,
-                                config,
-                                uniqueness_error_result_attributes,
-                                UNIQUENESS_MESSAGE_TYPE,
-                            )
-                            .await?;
-                            if config.enable_sync_queues_on_sns_sequence_number {
-                                tracing::error!("Skip requests were used while SQS sync is enabled. This should not happen.");
-                            }
-                            continue;
-                        }
-
-                        if let Some(batch_size) = uniqueness_request.batch_size {
-                            // Updating the batch size instantly makes it a bit unpredictable, since
-                            // if we're already above the new limit, we'll still process the current
-                            // batch at the higher limit. On the other
-                            // hand, updating it after the batch is
-                            // processed would not let us "unblock" the protocol if we're stuck with
-                            // low throughput.
-                            *CURRENT_BATCH_SIZE.lock().unwrap() =
-                                batch_size.clamp(1, max_batch_size);
-                            tracing::info!("Updating batch size to {}", batch_size);
-                        }
-                        if config.luc_enabled {
-                            if config.luc_lookback_records > 0 {
-                                batch_query.luc_lookback_records = config.luc_lookback_records;
-                            }
-                            if config.luc_serial_ids_from_smpc_request {
-                                if let Some(serial_ids) =
-                                    uniqueness_request.or_rule_serial_ids.clone()
-                                {
-                                    // convert from 1-based serial id to 0-based index in actor
-                                    batch_query
-                                        .or_rule_indices
-                                        .push(serial_ids.iter().map(|x| x - 1).collect());
-                                } else {
-                                    tracing::error!(
-                                        "Received a uniqueness request without serial_ids"
-                                    );
-                                }
-                            }
-                        }
-
-                        batch_query
-                            .request_ids
-                            .push(uniqueness_request.signup_id.clone());
-                        batch_query
-                            .request_types
-                            .push(UNIQUENESS_MESSAGE_TYPE.to_string());
-                        batch_query.metadata.push(batch_metadata);
-
-                        let semaphore = Arc::clone(&semaphore);
-                        let s3_client_arc = s3_client.clone();
-                        let bucket_name = config.shares_bucket_name.clone();
-                        let s3_key = uniqueness_request.s3_key.clone();
-                        let handle = get_iris_shares_parse_task(
-                            party_id,
-                            shares_encryption_key_pairs,
-                            semaphore,
-                            s3_client_arc,
-                            bucket_name,
-                            s3_key,
-                        )?;
-
-                        handles.push(handle);
-                    }
-
-                    REAUTH_MESSAGE_TYPE => {
-                        let shares_encryption_key_pairs = shares_encryption_key_pairs.clone();
-
-                        let reauth_request: ReAuthRequest = serde_json::from_str(&message.message)
-                            .map_err(|e| {
-                                ReceiveRequestError::json_parse_error("Reauth request", e)
-                            })?;
-                        metrics::counter!("request.received", "type" => "reauth").increment(1);
-
-                        tracing::debug!("Received reauth request: {:?}", reauth_request);
-
-                        // TODO: populate sync mechanism table (TBD: rollback or rollforward)
-
-                        client
-                            .delete_message()
-                            .queue_url(queue_url)
-                            .receipt_handle(sqs_message.receipt_handle.unwrap())
-                            .send()
-                            .await
-                            .map_err(ReceiveRequestError::FailedToDeleteFromSQS)?;
-
-                        if config.hawk_server_reauths_enabled {
-                            if reauth_request.use_or_rule
-                                && !(config.luc_enabled && config.luc_serial_ids_from_smpc_request)
-                            {
-                                tracing::error!(
-                                    "Received a reauth request with use_or_rule set to true, but LUC \
-                                     is not enabled. Skipping request."
-                                );
-                                continue;
-                            }
-
-                            if config.enable_reauth {
-                                msg_counter += 1;
-
-                                if let Some(batch_size) = reauth_request.batch_size {
-                                    // Updating the batch size instantly makes it a bit unpredictable,
-                                    // since if we're already above the
-                                    // new limit, we'll still process the current
-                                    // batch at the higher limit. On the other
-                                    // hand, updating it after the batch is
-                                    // processed would not let us "unblock" the protocol if we're stuck
-                                    // with low throughput.
-                                    *CURRENT_BATCH_SIZE.lock().unwrap() =
-                                        batch_size.clamp(1, max_batch_size);
-                                    tracing::info!("Updating batch size to {}", batch_size);
-                                }
-
-                                batch_query
-                                    .request_ids
-                                    .push(reauth_request.reauth_id.clone());
-                                batch_query
-                                    .request_types
-                                    .push(REAUTH_MESSAGE_TYPE.to_string());
-                                batch_query.metadata.push(batch_metadata);
-                                batch_query.reauth_target_indices.insert(
-                                    reauth_request.reauth_id.clone(),
-                                    reauth_request.serial_id - 1,
-                                );
-                                batch_query.reauth_use_or_rule.insert(
-                                    reauth_request.reauth_id.clone(),
-                                    reauth_request.use_or_rule,
-                                );
-
-                                let or_rule_indices = if reauth_request.use_or_rule {
-                                    vec![reauth_request.serial_id - 1]
-                                } else {
-                                    vec![]
-                                };
-                                batch_query.or_rule_indices.push(or_rule_indices);
-
-                                let semaphore = Arc::clone(&semaphore);
-                                let s3_client_clone = s3_client.clone();
-                                let bucket_name = config.shares_bucket_name.clone();
-                                let s3_key = reauth_request.s3_key.clone();
-                                let handle = get_iris_shares_parse_task(
-                                    party_id,
-                                    shares_encryption_key_pairs,
-                                    semaphore,
-                                    s3_client_clone,
-                                    bucket_name,
-                                    s3_key,
-                                )?;
-
-                                handles.push(handle);
-                            } else {
-                                tracing::warn!("Reauth is disabled, skipping reauth request");
-                            }
-                        } else {
-                            tracing::warn!("Reauth is disabled, skipping reauth request");
-                        }
-                    }
-
-                    _ => {
-                        client
-                            .delete_message()
-                            .queue_url(queue_url)
-                            .receipt_handle(sqs_message.receipt_handle.unwrap())
-                            .send()
-                            .await
-                            .map_err(ReceiveRequestError::FailedToDeleteFromSQS)?;
-                        tracing::error!("Error: {}", ReceiveRequestError::InvalidMessageType);
-                    }
-                }
-            }
-        } else {
-            tokio::time::sleep(SQS_POLLING_INTERVAL).await;
+impl<'a> BatchProcessor<'a> {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        party_id: usize,
+        client: &'a Client,
+        sns_client: &'a SNSClient,
+        s3_client: &'a S3Client,
+        config: &'a Config,
+        store: &'a Store,
+        skip_request_ids: &'a [String],
+        shares_encryption_key_pairs: SharesEncryptionKeyPairs,
+        shutdown_handler: &'a ShutdownHandler,
+        uniqueness_error_result_attributes: &'a HashMap<String, MessageAttributeValue>,
+        reauth_error_result_attributes: &'a HashMap<String, MessageAttributeValue>,
+    ) -> Self {
+        Self {
+            party_id,
+            client,
+            sns_client,
+            s3_client,
+            config,
+            store,
+            skip_request_ids,
+            shares_encryption_key_pairs,
+            shutdown_handler,
+            uniqueness_error_result_attributes,
+            reauth_error_result_attributes,
+            batch_query: BatchQuery::default(),
+            semaphore: Arc::new(Semaphore::new(MAX_CONCURRENT_REQUESTS)),
+            handles: vec![],
+            msg_counter: 0,
         }
     }
-    for (index, handle) in handles.into_iter().enumerate() {
-        let ((share_left, share_right), valid_entry) = match handle
-            .await
-            .map_err(ReceiveRequestError::FailedToJoinHandle)?
-        {
-            Ok(res) => (res, true),
-            Err(e) => {
-                tracing::error!("Failed to process iris shares: {:?}", e);
-                // Return error message back to the signup-service if failed to process iris
-                // shares
-                let request_id = batch_query.request_ids[index].clone();
-                let (result_attributes, message) = match batch_query.request_types[index].as_str() {
-                    UNIQUENESS_MESSAGE_TYPE => {
-                        let message = UniquenessResult::new_error_result(
-                            config.party_id,
-                            request_id,
-                            ERROR_FAILED_TO_PROCESS_IRIS_SHARES,
-                        );
-                        let serialized = serde_json::to_string(&message).unwrap();
-                        (uniqueness_error_result_attributes, serialized)
-                    }
-                    REAUTH_MESSAGE_TYPE => {
-                        let message = ReAuthResult::new_error_result(
-                            request_id.clone(),
-                            config.party_id,
-                            *batch_query.reauth_target_indices.get(&request_id).unwrap(),
-                            ERROR_FAILED_TO_PROCESS_IRIS_SHARES,
-                        );
-                        let serialized = serde_json::to_string(&message).unwrap();
-                        (reauth_error_result_attributes, serialized)
-                    }
-                    _ => unreachable!(), // we don't push a handle for unknown message types
-                };
 
-                send_error_results_to_sns(
-                    message,
-                    &batch_query.metadata[index],
-                    sns_client,
-                    config,
-                    result_attributes,
-                    batch_query.request_types[index].as_str(),
-                )
-                .await?;
-                // If we failed to process the iris shares, we include a dummy entry in the
-                // batch in order to keep the same order across nodes
-                let dummy_code_share = GaloisRingIrisCodeShare::default_for_party(party_id);
-                let dummy_mask_share = GaloisRingTrimmedMaskCodeShare::default_for_party(party_id);
-                let dummy = GaloisShares {
-                    code: dummy_code_share.clone(),
-                    mask: dummy_mask_share.clone(),
-                    code_rotated: dummy_code_share.all_rotations(),
-                    mask_rotated: dummy_mask_share.all_rotations(),
-                    code_interpolated: dummy_code_share.all_rotations(),
-                    mask_interpolated: dummy_mask_share.all_rotations(),
-                };
-                ((dummy.clone(), dummy), false)
+    pub async fn receive_batch(&mut self) -> eyre::Result<Option<BatchQuery>, ReceiveRequestError> {
+        if self.shutdown_handler.is_shutting_down() {
+            tracing::info!("Stopping batch receive due to shutdown signal...");
+            return Ok(None);
+        }
+
+        // Poll messages until we have enough or timeout
+        self.poll_messages().await?;
+
+        // Process all parse tasks
+        self.process_parse_tasks().await?;
+
+        tracing::info!(
+            "Batch requests: {:?}",
+            self.batch_query
+                .request_ids
+                .iter()
+                .zip(self.batch_query.request_types.iter())
+                .collect::<Vec<_>>()
+        );
+
+        Ok(Some(self.batch_query.clone()))
+    }
+
+    async fn poll_messages(&mut self) -> Result<(), ReceiveRequestError> {
+        let max_batch_size = self.config.max_batch_size;
+        let queue_url = &self.config.requests_queue_url;
+
+        // Poll until we have enough messages
+        while self.msg_counter < max_batch_size {
+            let rcv_message_output = self
+                .client
+                .receive_message()
+                .max_number_of_messages(1)
+                .queue_url(queue_url)
+                .send()
+                .await
+                .map_err(ReceiveRequestError::FailedToReadFromSQS)?;
+
+            if let Some(messages) = rcv_message_output.messages {
+                for sqs_message in messages {
+                    self.process_message(sqs_message).await?;
+                }
+            } else {
+                tokio::time::sleep(SQS_POLLING_INTERVAL).await;
             }
+        }
+
+        Ok(())
+    }
+
+    async fn process_message(
+        &mut self,
+        sqs_message: aws_sdk_sqs::types::Message,
+    ) -> Result<(), ReceiveRequestError> {
+        let message: SQSMessage = serde_json::from_str(sqs_message.body().unwrap())
+            .map_err(|e| ReceiveRequestError::json_parse_error("SQS body", e))?;
+
+        let message_attributes = message.message_attributes.clone();
+        let batch_metadata = self.extract_batch_metadata(&message_attributes);
+
+        let request_type = message_attributes
+            .get(SMPC_MESSAGE_TYPE_ATTRIBUTE)
+            .ok_or(ReceiveRequestError::NoMessageTypeAttribute)?
+            .string_value()
+            .ok_or(ReceiveRequestError::NoMessageTypeAttribute)?;
+
+        match request_type {
+            IDENTITY_DELETION_MESSAGE_TYPE => {
+                self.process_identity_deletion(&message, batch_metadata, &sqs_message)
+                    .await
+            }
+            UNIQUENESS_MESSAGE_TYPE => {
+                self.process_uniqueness_request(&message, batch_metadata, &sqs_message)
+                    .await
+            }
+            REAUTH_MESSAGE_TYPE => {
+                self.process_reauth_request(&message, batch_metadata, &sqs_message)
+                    .await
+            }
+            _ => {
+                self.delete_message(&sqs_message).await?;
+                tracing::error!("Error: {}", ReceiveRequestError::InvalidMessageType);
+                Ok(())
+            }
+        }
+    }
+
+    async fn process_identity_deletion(
+        &mut self,
+        message: &SQSMessage,
+        batch_metadata: BatchMetadata,
+        sqs_message: &aws_sdk_sqs::types::Message,
+    ) -> Result<(), ReceiveRequestError> {
+        if self.config.hawk_server_deletions_enabled {
+            let identity_deletion_request: IdentityDeletionRequest =
+                serde_json::from_str(&message.message).map_err(|e| {
+                    ReceiveRequestError::json_parse_error("Identity deletion request", e)
+                })?;
+
+            metrics::counter!("request.received", "type" => "identity_deletion").increment(1);
+
+            self.batch_query
+                .deletion_requests_indices
+                .push(identity_deletion_request.serial_id - 1);
+            self.batch_query
+                .deletion_requests_metadata
+                .push(batch_metadata);
+        } else {
+            tracing::warn!("Identity deletions are disabled");
+        }
+
+        self.delete_message(sqs_message).await
+    }
+
+    async fn process_uniqueness_request(
+        &mut self,
+        message: &SQSMessage,
+        batch_metadata: BatchMetadata,
+        sqs_message: &aws_sdk_sqs::types::Message,
+    ) -> Result<(), ReceiveRequestError> {
+        self.msg_counter += 1;
+
+        let uniqueness_request: UniquenessRequest = serde_json::from_str(&message.message)
+            .map_err(|e| ReceiveRequestError::json_parse_error("Uniqueness request", e))?;
+
+        metrics::counter!("request.received", "type" => "uniqueness_verification").increment(1);
+
+        self.store
+            .mark_requests_deleted(&[uniqueness_request.signup_id.clone()])
+            .await
+            .map_err(ReceiveRequestError::FailedToMarkRequestAsDeleted)?;
+
+        self.delete_message(sqs_message).await?;
+
+        if self
+            .skip_request_ids
+            .contains(&uniqueness_request.signup_id)
+        {
+            self.msg_counter -= 1;
+            metrics::counter!("skip.request.deleted.sqs.request").increment(1);
+
+            tracing::warn!(
+                "Skipping request due to synced deleted id: {}",
+                uniqueness_request.signup_id
+            );
+
+            let message = UniquenessResult::new_error_result(
+                self.config.party_id,
+                uniqueness_request.signup_id,
+                ERROR_SKIPPED_REQUEST_PREVIOUS_NODE_BATCH,
+            );
+
+            send_error_results_to_sns(
+                serde_json::to_string(&message).unwrap(),
+                &batch_metadata,
+                self.sns_client,
+                self.config,
+                self.uniqueness_error_result_attributes,
+                UNIQUENESS_MESSAGE_TYPE,
+            )
+            .await?;
+            if self.config.enable_sync_queues_on_sns_sequence_number {
+                tracing::error!(
+                    "Skip requests were used while SQS sync is enabled. This should not happen."
+                );
+            }
+            return Ok(());
+        }
+
+        self.update_batch_size_if_needed(&uniqueness_request);
+        self.update_luc_config_if_needed(&uniqueness_request);
+
+        self.batch_query
+            .request_ids
+            .push(uniqueness_request.signup_id.clone());
+        self.batch_query
+            .request_types
+            .push(UNIQUENESS_MESSAGE_TYPE.to_string());
+        self.batch_query.metadata.push(batch_metadata);
+
+        self.add_iris_shares_task(uniqueness_request.s3_key)?;
+
+        Ok(())
+    }
+
+    async fn process_reauth_request(
+        &mut self,
+        message: &SQSMessage,
+        batch_metadata: BatchMetadata,
+        sqs_message: &aws_sdk_sqs::types::Message,
+    ) -> Result<(), ReceiveRequestError> {
+        let reauth_request: ReAuthRequest = serde_json::from_str(&message.message)
+            .map_err(|e| ReceiveRequestError::json_parse_error("Reauth request", e))?;
+
+        metrics::counter!("request.received", "type" => "reauth").increment(1);
+        tracing::debug!("Received reauth request: {:?}", reauth_request);
+
+        self.delete_message(sqs_message).await?;
+
+        if !self.config.hawk_server_reauths_enabled {
+            tracing::warn!("Reauth is disabled, skipping reauth request");
+            return Ok(());
+        }
+
+        if reauth_request.use_or_rule
+            && !(self.config.luc_enabled && self.config.luc_serial_ids_from_smpc_request)
+        {
+            tracing::error!(
+                "Received a reauth request with use_or_rule set to true, but LUC is not enabled. Skipping request."
+            );
+            return Ok(());
+        }
+
+        if !self.config.enable_reauth {
+            tracing::warn!("Reauth processing is disabled, skipping reauth request");
+            return Ok(());
+        }
+
+        self.msg_counter += 1;
+        self.update_batch_size_if_needed_from_reauth(&reauth_request);
+
+        self.batch_query
+            .request_ids
+            .push(reauth_request.reauth_id.clone());
+        self.batch_query
+            .request_types
+            .push(REAUTH_MESSAGE_TYPE.to_string());
+        self.batch_query.metadata.push(batch_metadata);
+
+        self.batch_query.reauth_target_indices.insert(
+            reauth_request.reauth_id.clone(),
+            reauth_request.serial_id - 1,
+        );
+
+        self.batch_query
+            .reauth_use_or_rule
+            .insert(reauth_request.reauth_id.clone(), reauth_request.use_or_rule);
+
+        let or_rule_indices = if reauth_request.use_or_rule {
+            vec![reauth_request.serial_id - 1]
+        } else {
+            vec![]
         };
 
-        batch_query.valid_entries.push(valid_entry);
+        self.batch_query.or_rule_indices.push(or_rule_indices);
+        self.add_iris_shares_task(reauth_request.s3_key)?;
 
-        batch_query.left_iris_requests.code.push(share_left.code);
-        batch_query.left_iris_requests.mask.push(share_left.mask);
-        batch_query
+        Ok(())
+    }
+
+    async fn process_parse_tasks(&mut self) -> Result<(), ReceiveRequestError> {
+        // Use std::mem::take to take ownership of handles while leaving an empty vector in self
+        let handles = std::mem::take(&mut self.handles);
+        for (index, handle) in handles.into_iter().enumerate() {
+            let result = handle
+                .await
+                .map_err(ReceiveRequestError::FailedToJoinHandle)?;
+
+            match result {
+                Ok((share_left, share_right)) => {
+                    self.batch_query.valid_entries.push(true);
+                    self.add_shares_to_batch_query(share_left, share_right);
+                }
+                Err(e) => {
+                    tracing::error!("Failed to process iris shares: {:?}", e);
+                    self.handle_share_processing_error(index).await?;
+
+                    // Create dummy shares for invalid entry
+                    let ((dummy_left, dummy_right), valid) = self.create_dummy_shares();
+                    self.batch_query.valid_entries.push(valid);
+                    self.add_shares_to_batch_query(dummy_left, dummy_right);
+                }
+            }
+        }
+
+        Ok(())
+    }
+    async fn handle_share_processing_error(&self, index: usize) -> eyre::Result<()> {
+        let request_id = self.batch_query.request_ids[index].clone();
+        let request_type = &self.batch_query.request_types[index];
+
+        let (result_attributes, message) = match request_type.as_str() {
+            UNIQUENESS_MESSAGE_TYPE => {
+                let message = UniquenessResult::new_error_result(
+                    self.config.party_id,
+                    request_id,
+                    ERROR_FAILED_TO_PROCESS_IRIS_SHARES,
+                );
+                (
+                    self.uniqueness_error_result_attributes,
+                    serde_json::to_string(&message).unwrap(),
+                )
+            }
+            REAUTH_MESSAGE_TYPE => {
+                let message = ReAuthResult::new_error_result(
+                    request_id.clone(),
+                    self.config.party_id,
+                    *self
+                        .batch_query
+                        .reauth_target_indices
+                        .get(&request_id)
+                        .unwrap(),
+                    ERROR_FAILED_TO_PROCESS_IRIS_SHARES,
+                );
+                (
+                    self.reauth_error_result_attributes,
+                    serde_json::to_string(&message).unwrap(),
+                )
+            }
+            _ => unreachable!(),
+        };
+
+        send_error_results_to_sns(
+            message,
+            &self.batch_query.metadata[index],
+            self.sns_client,
+            self.config,
+            result_attributes,
+            request_type.as_str(),
+        )
+        .await
+    }
+
+    // Helper methods
+    fn extract_batch_metadata(
+        &self,
+        message_attributes: &HashMap<String, MessageAttributeValue>,
+    ) -> BatchMetadata {
+        let mut batch_metadata = BatchMetadata::default();
+
+        if let Some(trace_id) = message_attributes.get(TRACE_ID_MESSAGE_ATTRIBUTE_NAME) {
+            if let Some(trace_id_str) = trace_id.string_value() {
+                batch_metadata.trace_id = trace_id_str.to_string();
+            }
+        }
+
+        if let Some(span_id) = message_attributes.get(SPAN_ID_MESSAGE_ATTRIBUTE_NAME) {
+            if let Some(span_id_str) = span_id.string_value() {
+                batch_metadata.span_id = span_id_str.to_string();
+            }
+        }
+
+        batch_metadata
+    }
+
+    async fn delete_message(
+        &self,
+        sqs_message: &aws_sdk_sqs::types::Message,
+    ) -> Result<(), ReceiveRequestError> {
+        self.client
+            .delete_message()
+            .queue_url(&self.config.requests_queue_url)
+            .receipt_handle(sqs_message.receipt_handle.as_ref().unwrap())
+            .send()
+            .await
+            .map_err(ReceiveRequestError::FailedToDeleteFromSQS)?;
+        tracing::debug!("Deleted message: {:?}", sqs_message.message_id);
+        Ok(())
+    }
+
+    fn update_batch_size_if_needed(&self, uniqueness_request: &UniquenessRequest) {
+        if let Some(batch_size) = uniqueness_request.batch_size {
+            let max_batch_size = self.config.max_batch_size;
+            *CURRENT_BATCH_SIZE.lock().unwrap() = batch_size.clamp(1, max_batch_size);
+            tracing::info!("Updating batch size to {}", batch_size);
+        }
+    }
+
+    fn update_batch_size_if_needed_from_reauth(&self, reauth_request: &ReAuthRequest) {
+        if let Some(batch_size) = reauth_request.batch_size {
+            let max_batch_size = self.config.max_batch_size;
+            *CURRENT_BATCH_SIZE.lock().unwrap() = batch_size.clamp(1, max_batch_size);
+            tracing::info!("Updating batch size to {} from reauth", batch_size);
+        }
+    }
+
+    fn update_luc_config_if_needed(&mut self, uniqueness_request: &UniquenessRequest) {
+        if self.config.luc_enabled {
+            if self.config.luc_lookback_records > 0 {
+                self.batch_query.luc_lookback_records = self.config.luc_lookback_records;
+            }
+
+            if self.config.luc_serial_ids_from_smpc_request {
+                if let Some(serial_ids) = &uniqueness_request.or_rule_serial_ids {
+                    self.batch_query
+                        .or_rule_indices
+                        .push(serial_ids.iter().map(|x| x - 1).collect());
+                } else {
+                    tracing::error!("Received a uniqueness request without serial_ids");
+                }
+            }
+        }
+    }
+
+    fn add_iris_shares_task(&mut self, s3_key: String) -> Result<(), ReceiveRequestError> {
+        let semaphore = Arc::clone(&self.semaphore);
+        let s3_client = self.s3_client.clone();
+        let bucket_name = self.config.shares_bucket_name.clone();
+        let shares_encryption_key_pairs = self.shares_encryption_key_pairs.clone();
+
+        let handle = get_iris_shares_parse_task(
+            self.party_id,
+            shares_encryption_key_pairs,
+            semaphore,
+            s3_client,
+            bucket_name,
+            s3_key,
+        )?;
+
+        self.handles.push(handle);
+        Ok(())
+    }
+
+    fn create_dummy_shares(&self) -> ((GaloisShares, GaloisShares), bool) {
+        let dummy_code_share = GaloisRingIrisCodeShare::default_for_party(self.party_id);
+        let dummy_mask_share = GaloisRingTrimmedMaskCodeShare::default_for_party(self.party_id);
+
+        let dummy = GaloisShares {
+            code: dummy_code_share.clone(),
+            mask: dummy_mask_share.clone(),
+            code_rotated: dummy_code_share.all_rotations(),
+            mask_rotated: dummy_mask_share.all_rotations(),
+            code_interpolated: dummy_code_share.all_rotations(),
+            mask_interpolated: dummy_mask_share.all_rotations(),
+        };
+
+        ((dummy.clone(), dummy), false)
+    }
+
+    fn add_shares_to_batch_query(&mut self, share_left: GaloisShares, share_right: GaloisShares) {
+        self.batch_query
+            .left_iris_requests
+            .code
+            .push(share_left.code);
+        self.batch_query
+            .left_iris_requests
+            .mask
+            .push(share_left.mask);
+        self.batch_query
             .left_iris_rotated_requests
             .code
             .extend(share_left.code_rotated);
-        batch_query
+        self.batch_query
             .left_iris_rotated_requests
             .mask
             .extend(share_left.mask_rotated);
-        batch_query
+        self.batch_query
             .left_iris_interpolated_requests
             .code
             .extend(share_left.code_interpolated);
-        batch_query
+        self.batch_query
             .left_iris_interpolated_requests
             .mask
             .extend(share_left.mask_interpolated);
 
-        batch_query.right_iris_requests.code.push(share_right.code);
-        batch_query.right_iris_requests.mask.push(share_right.mask);
-        batch_query
+        self.batch_query
+            .right_iris_requests
+            .code
+            .push(share_right.code);
+        self.batch_query
+            .right_iris_requests
+            .mask
+            .push(share_right.mask);
+        self.batch_query
             .right_iris_rotated_requests
             .code
             .extend(share_right.code_rotated);
-        batch_query
+        self.batch_query
             .right_iris_rotated_requests
             .mask
             .extend(share_right.mask_rotated);
-        batch_query
+        self.batch_query
             .right_iris_interpolated_requests
             .code
             .extend(share_right.code_interpolated);
-        batch_query
+        self.batch_query
             .right_iris_interpolated_requests
             .mask
             .extend(share_right.mask_interpolated);
     }
-
-    tracing::info!(
-        "Batch requests: {:?}",
-        batch_query
-            .request_ids
-            .iter()
-            .zip(batch_query.request_types.iter())
-            .collect::<Vec<_>>()
-    );
-
-    Ok(Some(batch_query))
 }

--- a/iris-mpc/src/services/processors/batch.rs
+++ b/iris-mpc/src/services/processors/batch.rs
@@ -106,11 +106,13 @@ impl<'a> BatchProcessor<'a> {
     }
 
     async fn poll_messages(&mut self) -> Result<(), ReceiveRequestError> {
-        let max_batch_size = self.config.max_batch_size;
+        // let max_batch_size = self.config.max_batch_size;
         let queue_url = &self.config.requests_queue_url;
 
         // Poll until we have enough messages
-        while self.msg_counter < max_batch_size {
+        // temporary hack for staging to only process 1 message at a time
+        // this helps with the correctness test
+        while self.msg_counter < 1 {
             let rcv_message_output = self
                 .client
                 .receive_message()


### PR DESCRIPTION
Preparation for the work needed to poll sqs messages without using the current mechanics of `CURRENT_BATCH_SIZE` + batch size coming `UniquenessRequest`.

Next step is implementing the mechanic by which we take batches as follows:

- Poll from SQS until a timeout is reached
- Once timeout is reached, communicate to other parties your latest sequence number
- If your sequence number < max(other parties sequence numbers) continue polling messages until the max is reached
- Process batch

WIP for this is happening here: https://github.com/worldcoin/iris-mpc/pull/1207