### PR TITLE
Audit March '25: Issue A

### DIFF
--- a/iris-mpc-cpu/src/network/value.rs
+++ b/iris-mpc-cpu/src/network/value.rs
@@ -91,6 +91,9 @@ impl NetworkValue {
 
     pub fn from_network(serialized: eyre::Result<Vec<u8>>) -> eyre::Result<Self> {
         let serialized = serialized?;
+        if serialized.is_empty() {
+            return Err(eyre!("Empty serialized data"));
+        }
         let descriptor = serialized[0];
         match descriptor {
             0x01 => {
@@ -341,6 +344,14 @@ mod tests {
         let result_vec = NetworkValue::vec_from_network(Ok(serialized))?;
         assert_eq!(network_values, result_vec);
 
+        Ok(())
+    }
+
+    /// Test from_network with empty data
+    #[test]
+    fn test_from_network_empty() -> eyre::Result<()> {
+        let result = NetworkValue::from_network(Ok(vec![]));
+        assert_eq!(result.unwrap_err().to_string(), "Empty serialized data");
         Ok(())
     }
 }


### PR DESCRIPTION
The code operates under the assumption that serialized contains at least one byte. However,
networking protocols allow for empty packet payloads. If an empty packet arrives, the code in question
will panic. Furthermore, this panic propagates to the server’s main function, causing the server software
to crash.

This panic cannot be triggered by honest nodes, as they remain consistent with the protocol. While a
malicious node could exploit this attack vector, this scenario can be excluded from consideration, as the
system operates under an honest-but-curious threat model. Nevertheless, an external attacker may still be
able to exploit it, depending on the permissiveness of the network configuration.