### PR TITLE
Handle reset check requests

### DIFF
--- a/.github/workflows/temp-branch-build-and-push.yaml
+++ b/.github/workflows/temp-branch-build-and-push.yaml
@@ -3,7 +3,7 @@ name: Branch - Build and push docker image
 on:
   push:
     branches:
-      - "POP-2339/add-iris-share-versions-to-mpc"
+      - "POP-2393/handle-reset-check-requests"
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -110,6 +110,9 @@ env:
   - name: SMPC__ENABLE_REAUTH
     value: "true"
 
+  - name: SMPC__ENABLE_RESET
+    value: "true"
+
   - name: SMPC__LUC_ENABLED
     value: "false"
 

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -110,6 +110,9 @@ env:
   - name: SMPC__ENABLE_REAUTH
     value: "true"
 
+  - name: SMPC__ENABLE_RESET
+    value: "true"
+
   - name: SMPC__LUC_LOOKBACK_RECORDS
     value: "50"
 

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -110,6 +110,9 @@ env:
   - name: SMPC__ENABLE_REAUTH
     value: "true"
 
+  - name: SMPC__ENABLE_RESET
+    value: "true"
+
   - name: SMPC__LUC_ENABLED
     value: "false"
 

--- a/iris-mpc-common/src/config/mod.rs
+++ b/iris-mpc-common/src/config/mod.rs
@@ -172,6 +172,9 @@ pub struct Config {
     #[serde(default)]
     pub enable_reauth: bool,
 
+    #[serde(default)]
+    pub enable_reset: bool,
+
     #[serde(default = "default_hawk_request_parallelism")]
     pub hawk_request_parallelism: usize,
 
@@ -209,6 +212,9 @@ pub struct Config {
 
     #[serde(default = "default_hawk_server_reauths_enabled")]
     pub hawk_server_reauths_enabled: bool,
+
+    #[serde(default = "default_hawk_server_resets_enabled")]
+    pub hawk_server_resets_enabled: bool,
 }
 
 /// Enumeration over set of compute modes.
@@ -324,6 +330,10 @@ fn default_sqs_sync_long_poll_seconds() -> i32 {
 }
 
 fn default_hawk_server_reauths_enabled() -> bool {
+    false
+}
+
+fn default_hawk_server_resets_enabled() -> bool {
     false
 }
 

--- a/iris-mpc-common/src/helpers/smpc_request.rs
+++ b/iris-mpc-common/src/helpers/smpc_request.rs
@@ -106,6 +106,7 @@ pub const ANONYMIZED_STATISTICS_MESSAGE_TYPE: &str = "anonymized_statistics";
 pub const CIRCUIT_BREAKER_MESSAGE_TYPE: &str = "circuit_breaker";
 pub const UNIQUENESS_MESSAGE_TYPE: &str = "uniqueness";
 pub const REAUTH_MESSAGE_TYPE: &str = "reauth";
+pub const RESET_CHECK_MESSAGE_TYPE: &str = "reset_check";
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct UniquenessRequest {
@@ -133,6 +134,13 @@ pub struct ReAuthRequest {
     pub s3_key: String,
     pub serial_id: u32,
     pub use_or_rule: bool,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ResetCheckRequest {
+    pub reset_id: String,
+    pub batch_size: Option<usize>,
+    pub s3_key: String,
 }
 
 #[derive(Error, Debug)]

--- a/iris-mpc-common/src/helpers/smpc_response.rs
+++ b/iris-mpc-common/src/helpers/smpc_response.rs
@@ -106,7 +106,7 @@ impl ReAuthResult {
         node_id: usize,
         serial_id: u32,
         success: bool,
-        and_rule_matched_serial_ids: Vec<u32>,
+        matched_serial_ids: Vec<u32>,
         or_rule_used: bool,
     ) -> Self {
         Self {
@@ -114,7 +114,7 @@ impl ReAuthResult {
             node_id,
             serial_id,
             success,
-            matched_serial_ids: and_rule_matched_serial_ids,
+            matched_serial_ids,
             or_rule_used,
             error: None,
             error_reason: None,
@@ -134,6 +134,62 @@ impl ReAuthResult {
             success: false,
             matched_serial_ids: vec![],
             or_rule_used: false,
+            error: Some(true),
+            error_reason: Some(error_reason.to_string()),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ResetCheckResult {
+    pub reset_id: String,
+    pub node_id: usize,
+    pub matched_serial_ids: Option<Vec<u32>>,
+    pub matched_serial_ids_left: Option<Vec<u32>>,
+    pub matched_serial_ids_right: Option<Vec<u32>>,
+    pub matched_batch_request_ids: Option<Vec<String>>,
+    pub partial_matches_count_right: Option<usize>,
+    pub partial_matches_count_left: Option<usize>,
+    pub error: Option<bool>,
+    pub error_reason: Option<String>,
+}
+
+impl ResetCheckResult {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        reset_id: String,
+        node_id: usize,
+        matched_serial_ids: Option<Vec<u32>>,
+        matched_serial_ids_left: Option<Vec<u32>>,
+        matched_serial_ids_right: Option<Vec<u32>>,
+        matched_batch_request_ids: Option<Vec<String>>,
+        partial_matches_count_right: Option<usize>,
+        partial_matches_count_left: Option<usize>,
+    ) -> Self {
+        Self {
+            reset_id,
+            node_id,
+            matched_serial_ids,
+            matched_serial_ids_left,
+            matched_serial_ids_right,
+            matched_batch_request_ids,
+            partial_matches_count_right,
+            partial_matches_count_left,
+            error: None,
+            error_reason: None,
+        }
+    }
+
+    pub fn new_error_result(reset_id: String, node_id: usize, error_reason: &str) -> Self {
+        Self {
+            reset_id,
+            node_id,
+            matched_serial_ids: None,
+            matched_serial_ids_left: None,
+            matched_serial_ids_right: None,
+            matched_batch_request_ids: None,
+            partial_matches_count_right: None,
+            partial_matches_count_left: None,
             error: Some(true),
             error_reason: Some(error_reason.to_string()),
         }

--- a/iris-mpc-common/src/test.rs
+++ b/iris-mpc-common/src/test.rs
@@ -941,9 +941,12 @@ impl TestCaseGenerator {
             .expect("request id not found");
 
         if is_reset_check {
-            assert!(!was_match);
-            assert!(!was_skip_persistence_match);
+            // assert that we don't report unique for reset_check requests. only enrollment requests can be reported as unique
+            assert!(was_match);
+            assert!(was_skip_persistence_match);
             assert!(!was_reauth_success);
+
+            // assert that we report correct matched indices for reset_check requests
             if expected_idx.is_some() {
                 assert_eq!(idx, expected_idx.unwrap());
             } else {

--- a/iris-mpc-cpu/tests/e2e.rs
+++ b/iris-mpc-cpu/tests/e2e.rs
@@ -136,6 +136,8 @@ async fn e2e_test() -> Result<()> {
     test_case_generator.disable_test_case(TestCase::ReauthNonMatchingTarget);
     test_case_generator.disable_test_case(TestCase::ReauthOrRuleMatchingTarget);
     test_case_generator.disable_test_case(TestCase::ReauthOrRuleNonMatchingTarget);
+    test_case_generator.disable_test_case(TestCase::ResetCheckMatch);
+    test_case_generator.disable_test_case(TestCase::ResetCheckNonMatch);
 
     // TODO: enable this once supported
     // test_case_generator.enable_bucket_statistic_checks(

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -553,10 +553,16 @@ impl ServerActor {
             .iter()
             .filter(|x| *x == REAUTH_MESSAGE_TYPE)
             .count();
+        let n_reset_checks = batch
+            .request_types
+            .iter()
+            .filter(|x| *x == RESET_CHECK_MESSAGE_TYPE)
+            .count();
         tracing::info!(
-            "Started processing batch: {} uniqueness, {} reauth, {} deletion requests",
-            batch.request_types.len() - n_reauths,
+            "Started processing batch: {} uniqueness, {} reauth, {} reset_check, {} deletion requests",
+            batch.request_types.len() - n_reauths - n_reset_checks,
             n_reauths,
+            n_reset_checks,
             batch.deletion_requests_indices.len(),
         );
 

--- a/iris-mpc/bin/server.rs
+++ b/iris-mpc/bin/server.rs
@@ -507,8 +507,8 @@ async fn receive_batch(
                             batch_query.metadata.push(batch_metadata);
                             batch_query.sns_message_ids.push(sns_message_id);
 
-                            // Always skip persistence for reset check requests
-                            batch_query.skip_persistence.push(true);
+                            // skip_persistence is only used for uniqueness requests
+                            batch_query.skip_persistence.push(false);
 
                             // We don't need OR rule for reset check
                             batch_query.or_rule_indices.push(vec![]);

--- a/iris-mpc/bin/server.rs
+++ b/iris-mpc/bin/server.rs
@@ -511,7 +511,7 @@ async fn receive_batch(
                             // skip_persistence is only used for uniqueness requests
                             batch_query.skip_persistence.push(false);
 
-                            // We don't need OR rule for reset check
+                            // We need to use AND rule for reset check requests
                             batch_query.or_rule_indices.push(vec![]);
 
                             let semaphore = Arc::clone(&semaphore);


### PR DESCRIPTION
## Change
- This PR handles `reset_check` messages which are the first communication round to complete a Reset action.
- When received, we conduct a 1-to-N query using AND rule. Note that we skip the OR rule on last N serial_ids too. 
- We skip writing anything into memory or database.

## Side Changes
- Refactor `ExpectedResult` creation in tests to use a builder pattern.
- Move reauth modification logic within feature flag check to not have any action if it's disabled but we still get a request.