### PR TITLE
Aurel/state check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2378,6 +2378,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
+ "siphasher",
  "sqlx",
  "static_assertions",
  "tokio",
@@ -4235,6 +4236,12 @@ dependencies = [
  "digest",
  "rand_core",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "sketches-ddsketch"

--- a/iris-mpc-cpu/Cargo.toml
+++ b/iris-mpc-cpu/Cargo.toml
@@ -31,6 +31,7 @@ rand_distr = "0.4.3"
 rstest = "0.23.0"
 serde.workspace = true
 serde_json.workspace = true
+siphasher = "1"
 static_assertions.workspace = true
 sqlx.workspace = true
 tokio.workspace = true

--- a/iris-mpc-cpu/Cargo.toml
+++ b/iris-mpc-cpu/Cargo.toml
@@ -58,6 +58,10 @@ db_dependent = []
 name = "hnsw"
 harness = false
 
+[[bench]]
+name = "set_hash"
+harness = false
+
 [[example]]
 name = "hnsw-ex"
 

--- a/iris-mpc-cpu/benches/set_hash.rs
+++ b/iris-mpc-cpu/benches/set_hash.rs
@@ -1,0 +1,35 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use iris_mpc_common::vector_id::VectorId;
+use iris_mpc_cpu::{
+    execution::hawk_main::state_check::SetHash, hnsw::graph::neighborhood::SortedEdgeIds,
+};
+
+/// Benchmark that repeatedly calls insert on SharedIrises.
+fn bench_set_hash(c: &mut Criterion) {
+    c.bench_function("set_hash_vector_id", |b| {
+        let mut set_hash = SetHash::default();
+        let v = black_box(VectorId::from_serial_id(1111));
+
+        b.iter(|| {
+            set_hash.add_unordered(v);
+            set_hash.digest()
+        });
+    });
+
+    c.bench_function("set_hash_250_links", |b| {
+        let mut set_hash = SetHash::default();
+
+        let lc = 1_u8;
+        let v = VectorId::from_serial_id(1);
+        let links = &SortedEdgeIds::from_ascending_vec(vec![VectorId::from_serial_id(2); 250]);
+        let item = black_box((lc, v, links));
+
+        b.iter(|| {
+            set_hash.add_unordered(item);
+            set_hash.digest()
+        });
+    });
+}
+
+criterion_group! {benches, bench_set_hash}
+criterion_main!(benches);

--- a/iris-mpc-cpu/benches/set_hash.rs
+++ b/iris-mpc-cpu/benches/set_hash.rs
@@ -12,7 +12,7 @@ fn bench_set_hash(c: &mut Criterion) {
 
         b.iter(|| {
             set_hash.add_unordered(v);
-            set_hash.digest()
+            set_hash.checksum()
         });
     });
 
@@ -26,7 +26,7 @@ fn bench_set_hash(c: &mut Criterion) {
 
         b.iter(|| {
             set_hash.add_unordered(item);
-            set_hash.digest()
+            set_hash.checksum()
         });
     });
 }

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -799,8 +799,8 @@ impl HawkHandle {
 
         // Validate the common state before starting.
         try_join!(
-            HawkSession::sync(&sessions[LEFT][0]),
-            HawkSession::sync(&sessions[RIGHT][0]),
+            HawkSession::state_check(&sessions[LEFT][0]),
+            HawkSession::state_check(&sessions[RIGHT][0]),
         )?;
 
         let (tx, mut rx) = mpsc::channel::<HawkJob>(1);

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -870,6 +870,14 @@ impl HawkHandle {
                 } else {
                     tracing::info!("Persistence is disabled, not writing to DB");
                 }
+
+                // Validate the common state after processing the requests.
+                try_join!(
+                    HawkSession::state_check(&sessions[LEFT][0]),
+                    HawkSession::state_check(&sessions[RIGHT][0]),
+                )
+                .expect("Party states diverged after processing requests");
+
                 metrics::histogram!("job_duration").record(now.elapsed().as_secs_f64());
                 metrics::gauge!("db_size").set(hawk_actor.db_size as f64);
                 let left_query_count = search_queries[LEFT].len();

--- a/iris-mpc-cpu/src/execution/hawk_main/state_check.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/state_check.rs
@@ -1,0 +1,51 @@
+use eyre::{eyre, Result};
+use serde::{Deserialize, Serialize};
+use siphasher::sip::SipHasher13;
+use std::hash::{Hash, Hasher};
+
+use super::{HawkSession, HawkSessionRef};
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct SetHash {
+    hash: u64,
+}
+
+impl SetHash {
+    pub fn add(&mut self, value: &impl Hash) {
+        let mut hasher = SipHasher13::default();
+        value.hash(&mut hasher);
+
+        self.hash ^= hasher.finish();
+    }
+
+    pub fn digest(&self) -> u64 {
+        self.hash
+    }
+}
+
+impl HawkSession {
+    pub async fn sync(session: &HawkSessionRef) -> Result<()> {
+        let mut session = session.write().await;
+
+        let my_state = session
+            .aby3_store
+            .storage
+            .digest()
+            .await
+            .to_le_bytes()
+            .to_vec();
+
+        let net = &mut session.aby3_store.session.network_session;
+        net.send_prev(my_state.clone()).await?;
+        net.send_next(my_state.clone()).await?;
+        let prev_state = net.receive_prev().await?;
+        let next_state = net.receive_next().await?;
+
+        if prev_state != my_state || next_state != my_state {
+            return Err(eyre!(
+                "Out-of-sync: my_state={my_state:?} prev_state={prev_state:?} next_state={next_state:?}"
+            ));
+        }
+        Ok(())
+    }
+}

--- a/iris-mpc-cpu/src/execution/hawk_main/state_check.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/state_check.rs
@@ -52,3 +52,33 @@ impl HawkSession {
         chain(iris_digest.to_le_bytes(), graph_digest.to_le_bytes()).collect_vec()
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::hnsw::graph::neighborhood::SortedEdgeIds;
+    use iris_mpc_common::vector_id::VectorId;
+
+    #[test]
+    fn test_set_hash() {
+        let mut digests = vec![];
+
+        let mut set_hash = SetHash::default();
+        digests.push(set_hash.digest());
+
+        set_hash.add_unordered(VectorId::from_serial_id(1));
+        digests.push(set_hash.digest());
+
+        set_hash.add_unordered(VectorId::from_serial_id(111));
+        digests.push(set_hash.digest());
+
+        set_hash.add_unordered((
+            1_u8,
+            VectorId::from_serial_id(1),
+            SortedEdgeIds::from_ascending_vec(vec![VectorId::from_serial_id(2); 10]),
+        ));
+        digests.push(set_hash.digest());
+
+        assert!(digests.iter().all_unique());
+    }
+}

--- a/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
@@ -73,7 +73,7 @@ impl SharedIrises {
         self.next_id = self.next_id.max(vector_id.serial_id() + 1);
 
         if was_there.is_none() {
-            self.set_hash.add(&vector_id);
+            self.set_hash.add_unordered(vector_id);
         }
     }
 

--- a/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
@@ -159,8 +159,8 @@ impl SharedIrisesRef {
         new_id
     }
 
-    pub async fn digest(&self) -> u64 {
-        self.body.read().await.set_hash.digest()
+    pub async fn checksum(&self) -> u64 {
+        self.body.read().await.set_hash.checksum()
     }
 }
 

--- a/iris-mpc-cpu/src/hawkers/aby3/test_utils.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3/test_utils.rs
@@ -131,7 +131,7 @@ async fn graph_from_plain(graph_store: &GraphMem<PlaintextStore>) -> GraphMem<Ab
     let mut shared_layers = vec![];
     for layer in layers {
         let links = layer.get_links_map();
-        let mut shared_links = HashMap::new();
+        let mut shared_layer = Layer::new();
         for (source_v, queue) in links {
             let source_v = VectorId::from(*source_v);
             let mut shared_queue = vec![];
@@ -139,9 +139,9 @@ async fn graph_from_plain(graph_store: &GraphMem<PlaintextStore>) -> GraphMem<Ab
                 let target_v = VectorId::from(*target_v);
                 shared_queue.push(target_v);
             }
-            shared_links.insert(source_v, SortedEdgeIds::from_ascending_vec(shared_queue));
+            shared_layer.set_links(source_v, SortedEdgeIds::from_ascending_vec(shared_queue));
         }
-        shared_layers.push(Layer::from_links(shared_links));
+        shared_layers.push(shared_layer);
     }
     GraphMem::from_precomputed(new_ep, shared_layers)
 }

--- a/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
@@ -149,13 +149,13 @@ impl<V: VectorStore> GraphMem<V> {
         self.layers.len()
     }
 
-    pub fn digest(&self) -> u64 {
+    pub fn checksum(&self) -> u64 {
         let mut set_hash = SetHash::default();
         set_hash.add_unordered(&self.entry_point);
         for (lc, layer) in self.layers.iter().enumerate() {
-            set_hash.add_unordered((lc as u64, layer.set_hash.digest()));
+            set_hash.add_unordered((lc as u64, layer.set_hash.checksum()));
         }
-        set_hash.digest()
+        set_hash.checksum()
     }
 }
 

--- a/iris-mpc-cpu/src/hnsw/graph/neighborhood.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/neighborhood.rs
@@ -15,7 +15,7 @@ use std::ops::{Deref, DerefMut};
 use tracing::{debug, instrument};
 
 /// A sorted list of edge IDs (without distances).
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct SortedEdgeIds<V>(pub Vec<V>);
 
 impl<V> SortedEdgeIds<V> {


### PR DESCRIPTION
Continuing the spirit of validating the state that is supposed to stay in sync across nodes.

- [x] Introduce a hasher for sets (ignoring order).
- [x] Hash the iris store.
- [x] Hash the graph, with efficient mutations.
- [x] Compare notes with the other parties on startup.
- [x] Compare again after each batch.

Benchmark (laptop): `350ns` to hash the largest graph node; expecting a few seconds total on startup.