### PR TITLE
Handle reset update requests

### DIFF
--- a/.github/workflows/temp-branch-build-and-push.yaml
+++ b/.github/workflows/temp-branch-build-and-push.yaml
@@ -3,7 +3,7 @@ name: Branch - Build and push docker image
 on:
   push:
     branches:
-      - "POP-2393/handle-reset-check-requests"
+      - "POP-2394/handle-reset-update-requests"
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2599,9 +2599,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libloading"
@@ -2610,7 +2610,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4740,9 +4740,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.41.0"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4758,9 +4758,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/iris-mpc-common/src/helpers/smpc_request.rs
+++ b/iris-mpc-common/src/helpers/smpc_request.rs
@@ -107,6 +107,7 @@ pub const CIRCUIT_BREAKER_MESSAGE_TYPE: &str = "circuit_breaker";
 pub const UNIQUENESS_MESSAGE_TYPE: &str = "uniqueness";
 pub const REAUTH_MESSAGE_TYPE: &str = "reauth";
 pub const RESET_CHECK_MESSAGE_TYPE: &str = "reset_check";
+pub const RESET_UPDATE_MESSAGE_TYPE: &str = "reset_update";
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct UniquenessRequest {
@@ -140,6 +141,13 @@ pub struct ReAuthRequest {
 pub struct ResetCheckRequest {
     pub reset_id: String,
     pub batch_size: Option<usize>,
+    pub s3_key: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ResetUpdateRequest {
+    pub reset_id: String,
+    pub serial_id: u32,
     pub s3_key: String,
 }
 

--- a/iris-mpc-common/src/helpers/smpc_response.rs
+++ b/iris-mpc-common/src/helpers/smpc_response.rs
@@ -196,6 +196,23 @@ impl ResetCheckResult {
     }
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ResetUpdateAckResult {
+    pub reset_id: String,
+    pub node_id: usize,
+    pub serial_id: u32,
+}
+
+impl ResetUpdateAckResult {
+    pub fn new(reset_id: String, node_id: usize, serial_id: u32) -> Self {
+        Self {
+            reset_id,
+            node_id,
+            serial_id,
+        }
+    }
+}
+
 pub fn create_message_type_attribute_map(
     message_type: &str,
 ) -> HashMap<String, MessageAttributeValue> {

--- a/iris-mpc-common/src/job.rs
+++ b/iris-mpc-common/src/job.rs
@@ -22,6 +22,14 @@ pub struct BatchMetadata {
     pub span_id: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct GaloisSharesBothSides {
+    pub code_left: GaloisRingIrisCodeShare,
+    pub mask_left: GaloisRingTrimmedMaskCodeShare,
+    pub code_right: GaloisRingIrisCodeShare,
+    pub mask_right: GaloisRingTrimmedMaskCodeShare,
+}
+
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct BatchQuery {
     // Enrollment and reauth specific fields
@@ -85,6 +93,11 @@ pub struct BatchQuery {
 
     // SNS message ids to assert identical batch processing across parties
     pub sns_message_ids: Vec<String>,
+
+    // Reset Update specific fields
+    pub reset_update_indices: Vec<u32>,
+    pub reset_update_request_ids: Vec<String>,
+    pub reset_update_shares: Vec<GaloisSharesBothSides>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -136,6 +149,10 @@ pub struct ServerJobResult<A = ()> {
     pub modifications: HashMap<u32, Modification>,
     /// Actor-specific data (e.g. graph mutations).
     pub actor_data: A,
+
+    // Reset Update specific fields
+    pub reset_update_indices: Vec<u32>,
+    pub reset_update_request_ids: Vec<String>,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -752,6 +752,8 @@ impl HawkResult {
             successful_reauths: vec![false; n_requests], // TODO.
             reauth_target_indices: Default::default(),   // TODO.
             reauth_or_rule_used: Default::default(),     // TODO.
+            reset_update_indices: vec![],                // TODO.
+            reset_update_request_ids: vec![],            // TODO.
             modifications: batch.modifications,
             actor_data: self.connect_plans,
         }

--- a/iris-mpc-cpu/tests/e2e.rs
+++ b/iris-mpc-cpu/tests/e2e.rs
@@ -24,6 +24,7 @@ const MAX_BATCH_SIZE: usize = 5;
 const HAWK_REQUEST_PARALLELISM: usize = 1;
 const HAWK_CONNECTION_PARALLELISM: usize = 1;
 const MAX_DELETIONS_PER_BATCH: usize = 0; // TODO: set back to 10 or so once deletions are supported
+const MAX_RESET_UPDATES_PER_BATCH: usize = 0; // TODO: set back to 10 or so once reset is supported
 
 fn install_tracing() {
     tracing_subscriber::registry()
@@ -141,6 +142,7 @@ async fn e2e_test() -> Result<()> {
             NUM_BATCHES,
             MAX_BATCH_SIZE,
             MAX_DELETIONS_PER_BATCH,
+            MAX_RESET_UPDATES_PER_BATCH,
             [&mut handle0, &mut handle1, &mut handle2],
         )
         .await?;

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -720,7 +720,7 @@ impl ServerActor {
             // Overwrite the in-memory db
             for (reset_index, shares) in izip!(
                 batch.reset_update_indices.clone(),
-                batch.reset_update_shares
+                batch.reset_update_shares.clone()
             ) {
                 let (queries_left, sums_left) =
                     self.prepare_device_query_for_shares(&shares.code_left, &shares.mask_left)?;

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -27,6 +27,9 @@ use cudarc::{
 };
 use eyre::eyre;
 use futures::{Future, FutureExt};
+use iris_mpc_common::galois_engine::degree4::{
+    GaloisRingIrisCodeShare, GaloisRingTrimmedMaskCodeShare,
+};
 use iris_mpc_common::{
     helpers::{
         inmemory_store::InMemoryStore,
@@ -574,10 +577,11 @@ impl ServerActor {
             .filter(|x| *x == RESET_CHECK_MESSAGE_TYPE)
             .count();
         tracing::info!(
-            "Started processing batch: {} uniqueness, {} reauth, {} reset_check, {} deletion requests",
+            "Started processing batch: {} uniqueness, {} reauth, {} reset_check, {} reset_update, {} deletion requests",
             batch.request_types.len() - n_reauths - n_reset_checks,
             n_reauths,
             n_reset_checks,
+            batch.reset_update_request_ids.len(),
             batch.deletion_requests_indices.len(),
         );
 
@@ -608,6 +612,14 @@ impl ServerActor {
                 && batch_size == batch.skip_persistence.len(),
             "Query batch sizes mismatch"
         );
+
+        let n_reset_updates = batch.reset_update_request_ids.len();
+        assert!(
+            n_reset_updates == batch.reset_update_shares.len()
+                && n_reset_updates == batch.reset_update_indices.len(),
+            "Reset update batch sizes mismatch"
+        );
+
         if !batch.or_rule_indices.is_empty() || batch.luc_lookback_records > 0 {
             assert!(
                 (batch.or_rule_indices.len() == batch_size) || (batch.luc_lookback_records > 0)
@@ -662,7 +674,9 @@ impl ServerActor {
         if !batch.deletion_requests_indices.is_empty() {
             tracing::info!("Performing deletions");
             // Prepare dummy deletion shares
-            let (dummy_queries, dummy_sums) = self.prepare_deletion_shares()?;
+            let (dummy_code_share, dummy_mask_share) = get_dummy_shares_for_deletion(self.party_id);
+            let (dummy_queries, dummy_sums) =
+                self.prepare_device_query_for_shares(&dummy_code_share, &dummy_mask_share)?;
 
             // Overwrite the in-memory db
             for deletion_index in batch.deletion_requests_indices.clone() {
@@ -689,6 +703,53 @@ impl ServerActor {
                     &dummy_sums,
                     &dummy_queries,
                     &dummy_sums,
+                    0,
+                    device_db_index as usize,
+                    device_index as usize,
+                    &self.streams[0],
+                );
+            }
+        }
+
+        ///////////////////////////////////////////////////////////////////
+        // PERFORM RESET UPDATES (IF ANY)
+        ///////////////////////////////////////////////////////////////////
+        if !batch.reset_update_request_ids.is_empty() {
+            tracing::info!("Performing reset updates");
+
+            // Overwrite the in-memory db
+            for (reset_index, shares) in izip!(
+                batch.reset_update_indices.clone(),
+                batch.reset_update_shares
+            ) {
+                let (queries_left, sums_left) =
+                    self.prepare_device_query_for_shares(&shares.code_left, &shares.mask_left)?;
+                let (queries_right, sums_right) =
+                    self.prepare_device_query_for_shares(&shares.code_right, &shares.mask_right)?;
+
+                let device_index = reset_index % self.device_manager.device_count() as u32;
+                let device_db_index = reset_index / self.device_manager.device_count() as u32;
+                if device_db_index as usize >= self.current_db_sizes[device_index as usize] {
+                    tracing::warn!(
+                        "Reset index {} is out of bounds for device {}",
+                        reset_index,
+                        device_index
+                    );
+                    continue;
+                }
+                self.device_manager
+                    .device(device_index as usize)
+                    .bind_to_thread()
+                    .unwrap();
+                write_db_at_index(
+                    &self.left_code_db_slices,
+                    &self.left_mask_db_slices,
+                    &self.right_code_db_slices,
+                    &self.right_mask_db_slices,
+                    &queries_left,
+                    &sums_left,
+                    &queries_right,
+                    &sums_right,
                     0,
                     device_db_index as usize,
                     device_index as usize,
@@ -1278,6 +1339,8 @@ impl ServerActor {
                 successful_reauths,
                 reauth_target_indices: batch.reauth_target_indices,
                 reauth_or_rule_used: batch.reauth_use_or_rule,
+                reset_update_indices: batch.reset_update_indices,
+                reset_update_request_ids: batch.reset_update_request_ids,
                 modifications: batch.modifications,
                 actor_data: (),
             })
@@ -2236,18 +2299,21 @@ impl ServerActor {
         Ok(valid_merged)
     }
 
-    fn prepare_deletion_shares(&self) -> eyre::Result<(DeviceCompactQuery, DeviceCompactSums)> {
-        let (dummy_code_share, dummy_mask_share) = get_dummy_shares_for_deletion(self.party_id);
+    fn prepare_device_query_for_shares(
+        &self,
+        code_share: &GaloisRingIrisCodeShare,
+        mask_share: &GaloisRingTrimmedMaskCodeShare,
+    ) -> eyre::Result<(DeviceCompactQuery, DeviceCompactSums)> {
         let compact_query = {
             let code = preprocess_query(
-                &dummy_code_share
+                &code_share
                     .all_rotations()
                     .into_iter()
                     .flat_map(|e| e.coefs)
                     .collect::<Vec<_>>(),
             );
             let mask = preprocess_query(
-                &dummy_mask_share
+                &mask_share
                     .all_rotations()
                     .into_iter()
                     .flat_map(|e| e.coefs)
@@ -2260,7 +2326,6 @@ impl ServerActor {
                 mask_query_insert: mask,
             }
         };
-
         let compact_device_queries = compact_query.htod_transfer(
             &self.device_manager,
             &self.streams[0],

--- a/iris-mpc-gpu/src/server/mod.rs
+++ b/iris-mpc-gpu/src/server/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod actor;
 
 use crate::dot::{share_db::preprocess_query, IRIS_CODE_LENGTH, MASK_CODE_LENGTH, ROTATIONS};
 pub use actor::{generate_luc_records, prepare_or_policy_bitmap, ServerActor, ServerActorHandle};
+use iris_mpc_common::job::GaloisSharesBothSides;
 use iris_mpc_common::{
     helpers::sync::Modification,
     job::{BatchMetadata, BatchQuery, Eye, IrisQueryBatchEntries},
@@ -110,6 +111,11 @@ pub struct PreprocessedBatchQuery {
     // this one is not needed for the GPU actor
     // pub deletion_requests_metadata: Vec<BatchMetadata>,
 
+    // Reset Update specific fields
+    pub reset_update_indices: Vec<u32>,
+    pub reset_update_request_ids: Vec<String>,
+    pub reset_update_shares: Vec<GaloisSharesBothSides>,
+
     // additional fields which are GPU specific
     pub left_iris_interpolated_requests_preprocessed: BatchQueryEntriesPreprocessed,
     pub right_iris_interpolated_requests_preprocessed: BatchQueryEntriesPreprocessed,
@@ -205,6 +211,9 @@ impl From<BatchQuery> for PreprocessedBatchQuery {
             valid_entries: value.valid_entries,
             reauth_target_indices: value.reauth_target_indices,
             reauth_use_or_rule: value.reauth_use_or_rule,
+            reset_update_indices: value.reset_update_indices,
+            reset_update_request_ids: value.reset_update_request_ids,
+            reset_update_shares: value.reset_update_shares,
             deletion_requests_indices: value.deletion_requests_indices,
             // deletion_requests_metadata: value.deletion_requests_metadata,
             left_iris_interpolated_requests_preprocessed:

--- a/iris-mpc-gpu/tests/e2e.rs
+++ b/iris-mpc-gpu/tests/e2e.rs
@@ -21,6 +21,7 @@ mod e2e_test {
     const MATCH_DISTANCES_BUFFER_SIZE: usize = 1 << 7;
     const MATCH_DISTANCES_BUFFER_SIZE_EXTRA_PERCENT: usize = 100;
     const MAX_DELETIONS_PER_BATCH: usize = 10;
+    const MAX_RESET_UPDATES_PER_BATCH: usize = 10;
 
     fn install_tracing() {
         tracing_subscriber::registry()
@@ -206,6 +207,7 @@ mod e2e_test {
                 NUM_BATCHES,
                 MAX_BATCH_SIZE,
                 MAX_DELETIONS_PER_BATCH,
+                MAX_RESET_UPDATES_PER_BATCH,
                 [&mut handle0, &mut handle1, &mut handle2],
             )
             .await?;

--- a/iris-mpc-gpu/tests/e2e.rs
+++ b/iris-mpc-gpu/tests/e2e.rs
@@ -8,14 +8,13 @@ mod e2e_test {
         test::{load_test_db, TestCaseGenerator},
     };
     use iris_mpc_gpu::{helpers::device_manager::DeviceManager, server::ServerActor};
+    use rand::random;
     use std::{env, sync::Arc};
     use tokio::sync::oneshot;
     use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
     const DB_SIZE: usize = 8 * 1000;
     const DB_BUFFER: usize = 8 * 1000;
-    const DB_RNG_SEED: u64 = 0xdeadbeef;
-    const INTERNAL_RNG_SEED: u64 = 0xdeadbeef;
     const NUM_BATCHES: usize = 40;
     const MAX_BATCH_SIZE: usize = 64;
     const N_BUCKETS: usize = 10;
@@ -64,6 +63,32 @@ mod e2e_test {
         let ids1 = ids0.clone();
         let ids2 = ids0.clone();
 
+        let internal_seed = match env::var("INTERNAL_SEED") {
+            Ok(seed) => {
+                tracing::info!("Internal SEED was passed: {}", seed);
+                seed.parse::<u64>()?
+            }
+            Err(_) => {
+                tracing::info!("Internal SEED not set, using random seed");
+                random()
+            }
+        };
+        let db_seed = match env::var("DB_SEED") {
+            Ok(seed) => {
+                tracing::info!("DB SEED was passed: {}", seed);
+                seed.parse::<u64>()?
+            }
+            Err(_) => {
+                tracing::info!("DB SEED not set, using random seed");
+                random()
+            }
+        };
+        tracing::info!(
+            "Seeds for this test run. DB: {}, Internal: {}",
+            db_seed,
+            internal_seed
+        );
+
         let actor0_task = tokio::task::spawn_blocking(move || {
             let comms0 = device_manager0
                 .instantiate_network_from_ids(0, &ids0)
@@ -85,7 +110,7 @@ mod e2e_test {
                 Eye::Left,
             ) {
                 Ok((mut actor, handle)) => {
-                    load_test_db(0, DB_SIZE, DB_RNG_SEED, &mut actor).unwrap();
+                    load_test_db(0, DB_SIZE, db_seed, &mut actor).unwrap();
                     actor.preprocess_db();
                     tx0.send(Ok(handle)).unwrap();
                     actor
@@ -118,7 +143,7 @@ mod e2e_test {
                 Eye::Left,
             ) {
                 Ok((mut actor, handle)) => {
-                    load_test_db(1, DB_SIZE, DB_RNG_SEED, &mut actor).unwrap();
+                    load_test_db(1, DB_SIZE, db_seed, &mut actor).unwrap();
                     actor.preprocess_db();
                     tx1.send(Ok(handle)).unwrap();
                     actor
@@ -151,7 +176,7 @@ mod e2e_test {
                 Eye::Left,
             ) {
                 Ok((mut actor, handle)) => {
-                    load_test_db(2, DB_SIZE, DB_RNG_SEED, &mut actor).unwrap();
+                    load_test_db(2, DB_SIZE, db_seed, &mut actor).unwrap();
                     actor.preprocess_db();
                     tx2.send(Ok(handle)).unwrap();
                     actor
@@ -168,7 +193,7 @@ mod e2e_test {
         let mut handle2 = rx2.await??;
 
         let mut test_case_generator =
-            TestCaseGenerator::new_seeded(DB_SIZE, DB_RNG_SEED, INTERNAL_RNG_SEED, false);
+            TestCaseGenerator::new_seeded(DB_SIZE, db_seed, internal_seed, false);
 
         test_case_generator.enable_bucket_statistic_checks(
             N_BUCKETS,

--- a/iris-mpc-gpu/tests/e2e.rs
+++ b/iris-mpc-gpu/tests/e2e.rs
@@ -16,7 +16,7 @@ mod e2e_test {
     const DB_BUFFER: usize = 8 * 1000;
     const DB_RNG_SEED: u64 = 0xdeadbeef;
     const INTERNAL_RNG_SEED: u64 = 0xdeadbeef;
-    const NUM_BATCHES: usize = 30;
+    const NUM_BATCHES: usize = 40;
     const MAX_BATCH_SIZE: usize = 64;
     const N_BUCKETS: usize = 10;
     const MATCH_DISTANCES_BUFFER_SIZE: usize = 1 << 7;

--- a/iris-mpc/bin/server.rs
+++ b/iris-mpc/bin/server.rs
@@ -14,8 +14,8 @@ use iris_mpc::services::processors::result_message::{
     send_error_results_to_sns, send_results_to_sns,
 };
 use iris_mpc_common::helpers::sqs::{delete_messages_until_sequence_num, get_next_sns_seq_num};
-use iris_mpc_common::postgres::{AccessMode, PostgresClient};
 use iris_mpc_common::job::GaloisSharesBothSides;
+use iris_mpc_common::postgres::{AccessMode, PostgresClient};
 use iris_mpc_common::{
     config::{Config, ModeOfCompute, ModeOfDeployment, Opt},
     galois_engine::degree4::{GaloisRingIrisCodeShare, GaloisRingTrimmedMaskCodeShare},
@@ -231,8 +231,9 @@ async fn receive_batch(
                             .increment(1);
                         if modifications.contains_key(&identity_deletion_request.serial_id) {
                             tracing::warn!(
-                                "Received multiple modification operations in batch on a serial id: {}. Skipping identity deletion request",
-                                identity_deletion_request.serial_id
+                                "Received multiple modification operations in batch on serial id: {}. Skipping {:?}",
+                                identity_deletion_request.serial_id,
+                                identity_deletion_request,
                             );
                             continue;
                         }
@@ -405,8 +406,9 @@ async fn receive_batch(
 
                             if modifications.contains_key(&reauth_request.serial_id) {
                                 tracing::warn!(
-                                "Received multiple modification operations in batch on a serial id: {}. Skipping reauth request",
-                                reauth_request.serial_id
+                                "Received multiple modification operations in batch on serial id: {}. Skipping {:?}",
+                                reauth_request.serial_id,
+                                reauth_request,
                             );
                                 continue;
                             }
@@ -591,8 +593,9 @@ async fn receive_batch(
 
                             if modifications.contains_key(&reset_update_request.serial_id) {
                                 tracing::warn!(
-                                "Received multiple modification operations in batch on a serial id: {}. Skipping reset update request",
-                                reset_update_request.serial_id
+                                "Received multiple modification operations in batch on serial id: {}. Skipping {:?}",
+                                reset_update_request.serial_id,
+                                reset_update_request,
                             );
                                 continue;
                             }

--- a/iris-mpc/bin/server.rs
+++ b/iris-mpc/bin/server.rs
@@ -15,6 +15,7 @@ use iris_mpc::services::processors::result_message::{
 };
 use iris_mpc_common::helpers::sqs::{delete_messages_until_sequence_num, get_next_sns_seq_num};
 use iris_mpc_common::postgres::{AccessMode, PostgresClient};
+use iris_mpc_common::job::GaloisSharesBothSides;
 use iris_mpc_common::{
     config::{Config, ModeOfCompute, ModeOfDeployment, Opt},
     galois_engine::degree4::{GaloisRingIrisCodeShare, GaloisRingTrimmedMaskCodeShare},
@@ -26,14 +27,16 @@ use iris_mpc_common::{
         smpc_request::{
             decrypt_iris_share, get_iris_data_by_party_id, validate_iris_share,
             CircuitBreakerRequest, IdentityDeletionRequest, ReAuthRequest, ReceiveRequestError,
-            ResetCheckRequest, SQSMessage, UniquenessRequest, ANONYMIZED_STATISTICS_MESSAGE_TYPE,
-            CIRCUIT_BREAKER_MESSAGE_TYPE, IDENTITY_DELETION_MESSAGE_TYPE, REAUTH_MESSAGE_TYPE,
-            RESET_CHECK_MESSAGE_TYPE, UNIQUENESS_MESSAGE_TYPE,
+            ResetCheckRequest, ResetUpdateRequest, SQSMessage, UniquenessRequest,
+            ANONYMIZED_STATISTICS_MESSAGE_TYPE, CIRCUIT_BREAKER_MESSAGE_TYPE,
+            IDENTITY_DELETION_MESSAGE_TYPE, REAUTH_MESSAGE_TYPE, RESET_CHECK_MESSAGE_TYPE,
+            RESET_UPDATE_MESSAGE_TYPE, UNIQUENESS_MESSAGE_TYPE,
         },
         smpc_response::{
             create_message_type_attribute_map, IdentityDeletionResult, ReAuthResult,
-            ResetCheckResult, UniquenessResult, ERROR_FAILED_TO_PROCESS_IRIS_SHARES,
-            ERROR_SKIPPED_REQUEST_PREVIOUS_NODE_BATCH, SMPC_MESSAGE_TYPE_ATTRIBUTE,
+            ResetCheckResult, ResetUpdateAckResult, UniquenessResult,
+            ERROR_FAILED_TO_PROCESS_IRIS_SHARES, ERROR_SKIPPED_REQUEST_PREVIOUS_NODE_BATCH,
+            SMPC_MESSAGE_TYPE_ATTRIBUTE,
         },
         sync::{Modification, SyncResult, SyncState},
         task_monitor::TaskMonitor,
@@ -46,6 +49,7 @@ use iris_mpc_store::{
     fetch_and_parse_chunks, last_snapshot_timestamp, DbStoredIris, ObjectStore, S3Store,
     S3StoredIris, Store, StoredIrisRef,
 };
+use itertools::izip;
 use metrics_exporter_statsd::StatsdBuilder;
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
@@ -532,6 +536,57 @@ async fn receive_batch(
                         }
                     }
 
+                    RESET_UPDATE_MESSAGE_TYPE => {
+                        let shares_encryption_key_pairs = shares_encryption_key_pairs.clone();
+
+                        let reset_update_request: ResetUpdateRequest =
+                            serde_json::from_str(&message.message).map_err(|e| {
+                                ReceiveRequestError::json_parse_error("Reset update request", e)
+                            })?;
+                        metrics::counter!("request.received", "type" => "reset_update")
+                            .increment(1);
+
+                        client
+                            .delete_message()
+                            .queue_url(queue_url)
+                            .receipt_handle(sqs_message.receipt_handle.unwrap())
+                            .send()
+                            .await
+                            .map_err(ReceiveRequestError::FailedToDeleteFromSQS)?;
+
+                        if config.enable_reset {
+                            // Fetch new iris shares from S3
+                            let semaphore = Arc::clone(&semaphore);
+                            let s3_client_arc = s3_client.clone();
+                            let bucket_name = config.shares_bucket_name.clone();
+                            let s3_key = reset_update_request.s3_key.clone();
+
+                            // TODO handle errors better here.
+                            let (left_shares, right_shares) = get_iris_shares_parse_task(
+                                party_id,
+                                shares_encryption_key_pairs,
+                                semaphore,
+                                s3_client_arc,
+                                bucket_name,
+                                s3_key,
+                            )?
+                            .await??;
+
+                            batch_query
+                                .reset_update_indices
+                                .push(reset_update_request.serial_id - 1);
+                            batch_query
+                                .request_ids
+                                .push(reset_update_request.reset_id.clone());
+                            batch_query.reset_update_shares.push(GaloisSharesBothSides {
+                                code_left: left_shares.0,
+                                mask_left: left_shares.1,
+                                code_right: right_shares.0,
+                                mask_right: right_shares.1,
+                            });
+                        }
+                    }
+
                     _ => {
                         client
                             .delete_message()
@@ -1006,7 +1061,9 @@ async fn server_main(config: Config) -> eyre::Result<()> {
 
     let uniqueness_result_attributes = create_message_type_attribute_map(UNIQUENESS_MESSAGE_TYPE);
     let reauth_result_attributes = create_message_type_attribute_map(REAUTH_MESSAGE_TYPE);
-    let reset_result_attributes = create_message_type_attribute_map(RESET_CHECK_MESSAGE_TYPE);
+    let reset_check_result_attributes = create_message_type_attribute_map(RESET_CHECK_MESSAGE_TYPE);
+    let reset_update_result_attributes =
+        create_message_type_attribute_map(RESET_UPDATE_MESSAGE_TYPE);
     let anonymized_statistics_attributes =
         create_message_type_attribute_map(ANONYMIZED_STATISTICS_MESSAGE_TYPE);
     let identity_deletion_result_attributes =
@@ -1460,6 +1517,19 @@ async fn server_main(config: Config) -> eyre::Result<()> {
                     .unwrap();
                     (left_shares.0, left_shares.1, right_shares.0, right_shares.1)
                 }
+                RESET_UPDATE_MESSAGE_TYPE => {
+                    let (left_shares, right_shares) = get_iris_shares_parse_task(
+                        party_id,
+                        shares_encryption_key_pair.clone(),
+                        Arc::clone(&semaphore),
+                        aws_clients.s3_client.clone(),
+                        config.shares_bucket_name.clone(),
+                        modification.clone().s3_url.unwrap(),
+                    )?
+                    .await?
+                    .unwrap();
+                    (left_shares.0, left_shares.1, right_shares.0, right_shares.1)
+                }
                 _ => {
                     panic!("Unknown modification type: {:?}", modification);
                 }
@@ -1607,6 +1677,8 @@ async fn server_main(config: Config) -> eyre::Result<()> {
             successful_reauths,
             reauth_target_indices,
             reauth_or_rule_used,
+            reset_update_indices,
+            reset_update_request_ids,
             mut modifications,
             actor_data: _,
         }) = rx.recv().await
@@ -1761,6 +1833,25 @@ async fn server_main(config: Config) -> eyre::Result<()> {
                 })
                 .collect::<Vec<String>>();
 
+            // reset update results
+            let reset_update_results = reset_update_request_ids
+                .iter()
+                .enumerate()
+                .map(|(i, _)| {
+                    let reset_id = reset_update_request_ids[i].clone();
+                    let serial_id = reset_update_indices[i] + 1;
+                    let result_event =
+                        ResetUpdateAckResult::new(reset_id.clone(), party_id, serial_id);
+                    let result_string = serde_json::to_string(&result_event)
+                        .expect("failed to serialize reset update result");
+                    modifications
+                        .get_mut(&serial_id)
+                        .unwrap()
+                        .mark_completed(true, &result_string);
+                    result_string
+                })
+                .collect::<Vec<String>>();
+
             let mut tx = store_bg.tx().await?;
 
             store_bg
@@ -1867,8 +1958,24 @@ async fn server_main(config: Config) -> eyre::Result<()> {
                     &metadata,
                     &sns_client_bg,
                     &config_bg,
-                    &reset_result_attributes,
+                    &reset_check_result_attributes,
                     RESET_CHECK_MESSAGE_TYPE,
+                )
+                .await?;
+            }
+
+            if !reset_update_results.is_empty() {
+                tracing::info!(
+                    "Sending {} reset update results",
+                    reset_update_results.len()
+                );
+                send_results_to_sns(
+                    reset_update_results,
+                    &metadata,
+                    &sns_client_bg,
+                    &config_bg,
+                    &reset_update_result_attributes,
+                    RESET_UPDATE_MESSAGE_TYPE,
                 )
                 .await?;
             }
@@ -1969,7 +2076,10 @@ async fn server_main(config: Config) -> eyre::Result<()> {
     let uniqueness_error_result_attribute =
         create_message_type_attribute_map(UNIQUENESS_MESSAGE_TYPE);
     let reauth_error_result_attribute = create_message_type_attribute_map(REAUTH_MESSAGE_TYPE);
-    let reset_error_result_attribute = create_message_type_attribute_map(RESET_CHECK_MESSAGE_TYPE);
+    let reset_check_error_result_attribute =
+        create_message_type_attribute_map(RESET_CHECK_MESSAGE_TYPE);
+    let reset_update_error_result_attribute =
+        create_message_type_attribute_map(RESET_UPDATE_MESSAGE_TYPE);
     let res: eyre::Result<()> = async {
         tracing::info!("Entering main loop");
         // **Tensor format of queries**
@@ -2002,7 +2112,7 @@ async fn server_main(config: Config) -> eyre::Result<()> {
             &shutdown_handler,
             &uniqueness_error_result_attribute,
             &reauth_error_result_attribute,
-            &reset_error_result_attribute,
+            &reset_check_error_result_attribute,
         );
 
         loop {
@@ -2020,13 +2130,16 @@ async fn server_main(config: Config) -> eyre::Result<()> {
 
             metrics::histogram!("receive_batch_duration").record(now.elapsed().as_secs_f64());
 
-            process_identity_deletions(
+            // Persist deletions and updates to postgres db before the actor processes the batch.
+            // This way, there is no need to pass shares back from actor to the server
+            persist_identity_deletions(
                 &batch,
                 &store,
                 &dummy_shares_for_deletions.0,
                 &dummy_shares_for_deletions.1,
             )
             .await?;
+            persist_reset_updates(&batch, &store).await?;
 
             // Iterate over a list of tracing payloads, and create logs with mappings to
             // payloads Log at least a "start" event using a log with trace.id and
@@ -2056,7 +2169,7 @@ async fn server_main(config: Config) -> eyre::Result<()> {
                 &shutdown_handler,
                 &uniqueness_error_result_attribute,
                 &reauth_error_result_attribute,
-                &reset_error_result_attribute,
+                &reset_check_error_result_attribute,
             );
 
             // await the result
@@ -2146,7 +2259,7 @@ async fn load_db_records<'a>(
     );
 }
 
-async fn process_identity_deletions(
+async fn persist_identity_deletions(
     batch: &BatchQuery,
     store: &Store,
     dummy_iris_share: &GaloisRingIrisCodeShare,
@@ -2187,6 +2300,40 @@ async fn process_identity_deletions(
             dd.trace_id = tracing_payload.trace_id,
             dd.span_id = tracing_payload.span_id,
             "Deleted identity with serial id {}",
+            serial_id,
+        );
+    }
+
+    Ok(())
+}
+
+async fn persist_reset_updates(batch: &BatchQuery, store: &Store) -> eyre::Result<()> {
+    if batch.reset_update_indices.is_empty() {
+        return Ok(());
+    }
+
+    assert_eq!(
+        batch.reset_update_shares.len(),
+        batch.reset_update_indices.len()
+    );
+    for (entry_idx, shares) in izip!(&batch.reset_update_indices, &batch.reset_update_shares) {
+        let serial_id = entry_idx + 1; // DB serial_id is 1-indexed
+
+        // overwrite postgres db with reset update shares.
+        // note that both serial_id and postgres db are 1-indexed.
+        store
+            .update_iris(
+                None,
+                serial_id as i64,
+                &shares.code_left,
+                &shares.mask_left,
+                &shares.code_right,
+                &shares.mask_right,
+            )
+            .await?;
+
+        tracing::info!(
+            "Updated ResetUpdate shares in Postgres on serial id {}",
             serial_id,
         );
     }

--- a/iris-mpc/src/services/processors/job.rs
+++ b/iris-mpc/src/services/processors/job.rs
@@ -55,6 +55,7 @@ pub async fn process_job_result(
         reauth_or_rule_used,
         modifications,
         actor_data: hawk_mutation,
+        ..
     } = job_result;
     let now = Instant::now();
 


### PR DESCRIPTION
## Change
- This is the second part on reset logic. The first one was https://github.com/worldcoin/iris-mpc/pull/1219
- In this one, we replace the iris code shares for successful reset requests sent from signup-service.
- We don't increment batch counter for this type of message and treat it like deletion messages. The reason is because we do not need a comparison, we just update without checks.
- Since this is a new modification on db and memory, we leverage current modifications table and sync mechanism to sync and replay reset_update changes.