### PR TITLE
persist updates into postgres after actor processing

### DIFF
--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:cf5f8f617e15aa6be65960f8ea05a82ddd91ecb7"
+image: "ghcr.io/worldcoin/iris-mpc:v0.15.0"
 
 environment: stage
 replicaCount: 1

--- a/iris-mpc-common/src/job.rs
+++ b/iris-mpc-common/src/job.rs
@@ -153,6 +153,7 @@ pub struct ServerJobResult<A = ()> {
     // Reset Update specific fields
     pub reset_update_indices: Vec<u32>,
     pub reset_update_request_ids: Vec<String>,
+    pub reset_update_shares: Vec<GaloisSharesBothSides>,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -754,6 +754,7 @@ impl HawkResult {
             reauth_or_rule_used: Default::default(),     // TODO.
             reset_update_indices: vec![],                // TODO.
             reset_update_request_ids: vec![],            // TODO.
+            reset_update_shares: vec![],                 // TODO.
             modifications: batch.modifications,
             actor_data: self.connect_plans,
         }

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -1341,6 +1341,7 @@ impl ServerActor {
                 reauth_or_rule_used: batch.reauth_use_or_rule,
                 reset_update_indices: batch.reset_update_indices,
                 reset_update_request_ids: batch.reset_update_request_ids,
+                reset_update_shares: batch.reset_update_shares,
                 modifications: batch.modifications,
                 actor_data: (),
             })

--- a/iris-mpc/bin/server.rs
+++ b/iris-mpc/bin/server.rs
@@ -1724,10 +1724,13 @@ async fn server_main(config: Config) -> eyre::Result<()> {
             reauth_or_rule_used,
             reset_update_indices,
             reset_update_request_ids,
+            reset_update_shares,
             mut modifications,
             actor_data: _,
         }) = rx.recv().await
         {
+            let dummy_deletion_shares = get_dummy_shares_for_deletion(party_id);
+
             // returned serial_ids are 0 indexed, but we want them to be 1 indexed
             let uniqueness_results = merged_results
                 .iter()
@@ -1926,8 +1929,8 @@ async fn server_main(config: Config) -> eyre::Result<()> {
                 }
             }
 
-            // persist reauth results into db
             if !config_bg.disable_persistence {
+                // persist reauth results into db
                 for (i, success) in successful_reauths.iter().enumerate() {
                     if !success {
                         continue;
@@ -1950,6 +1953,44 @@ async fn server_main(config: Config) -> eyre::Result<()> {
                             &right_iris_requests.mask[i],
                         )
                         .await?;
+                }
+
+                // persist deletion results into db
+                for idx in deleted_ids.iter() {
+                    // overwrite postgres db with dummy shares.
+                    // note that both serial_id and postgres db are 1-indexed.
+                    let serial_id = *idx + 1;
+                    tracing::info!(
+                        "Persisting identity deletion into postgres on serial id {}",
+                        serial_id
+                    );
+                    store_bg.update_iris(
+                        Some(&mut tx),
+                        serial_id as i64,
+                        &dummy_deletion_shares.0,
+                        &dummy_deletion_shares.1,
+                        &dummy_deletion_shares.0,
+                        &dummy_deletion_shares.1,
+                    );
+                }
+
+                // persist reset_update results into db
+                for (idx, shares) in izip!(reset_update_indices, reset_update_shares) {
+                    // overwrite postgres db with reset update shares.
+                    // note that both serial_id and postgres db are 1-indexed.
+                    let serial_id = idx + 1;
+                    tracing::info!(
+                        "Persisting reset update into postgres on serial id {}",
+                        serial_id
+                    );
+                    store_bg.update_iris(
+                        Some(&mut tx),
+                        serial_id as i64,
+                        &shares.code_left,
+                        &shares.mask_left,
+                        &shares.code_right,
+                        &shares.mask_right,
+                    );
                 }
             }
 
@@ -2175,17 +2216,6 @@ async fn server_main(config: Config) -> eyre::Result<()> {
 
             metrics::histogram!("receive_batch_duration").record(now.elapsed().as_secs_f64());
 
-            // Persist deletions and updates to postgres db before the actor processes the batch.
-            // This way, there is no need to pass shares back from actor to the server
-            persist_identity_deletions(
-                &batch,
-                &store,
-                &dummy_shares_for_deletions.0,
-                &dummy_shares_for_deletions.1,
-            )
-            .await?;
-            persist_reset_updates(&batch, &store).await?;
-
             // Iterate over a list of tracing payloads, and create logs with mappings to
             // payloads Log at least a "start" event using a log with trace.id and
             // parent.trace.id
@@ -2302,88 +2332,6 @@ async fn load_db_records<'a>(
         time_waiting_for_stream,
         time_loading_into_memory,
     );
-}
-
-async fn persist_identity_deletions(
-    batch: &BatchQuery,
-    store: &Store,
-    dummy_iris_share: &GaloisRingIrisCodeShare,
-    dummy_mask_share: &GaloisRingTrimmedMaskCodeShare,
-) -> eyre::Result<()> {
-    if batch.deletion_requests_indices.is_empty() {
-        return Ok(());
-    }
-
-    for (&entry_idx, tracing_payload) in batch
-        .deletion_requests_indices
-        .iter()
-        .zip(batch.deletion_requests_metadata.iter())
-    {
-        let serial_id = entry_idx + 1; // DB serial_id is 1-indexed
-        tracing::info!(
-            node_id = tracing_payload.node_id,
-            dd.trace_id = tracing_payload.trace_id,
-            dd.span_id = tracing_payload.span_id,
-            "Started processing deletion request",
-        );
-
-        // overwrite postgres db with dummy values.
-        // note that both serial_id and postgres db are 1-indexed.
-        store
-            .update_iris(
-                None,
-                serial_id as i64,
-                dummy_iris_share,
-                dummy_mask_share,
-                dummy_iris_share,
-                dummy_mask_share,
-            )
-            .await?;
-
-        tracing::info!(
-            node_id = tracing_payload.node_id,
-            dd.trace_id = tracing_payload.trace_id,
-            dd.span_id = tracing_payload.span_id,
-            "Deleted identity with serial id {}",
-            serial_id,
-        );
-    }
-
-    Ok(())
-}
-
-async fn persist_reset_updates(batch: &BatchQuery, store: &Store) -> eyre::Result<()> {
-    if batch.reset_update_indices.is_empty() {
-        return Ok(());
-    }
-
-    assert_eq!(
-        batch.reset_update_shares.len(),
-        batch.reset_update_indices.len()
-    );
-    for (entry_idx, shares) in izip!(&batch.reset_update_indices, &batch.reset_update_shares) {
-        let serial_id = entry_idx + 1; // DB serial_id is 1-indexed
-
-        // overwrite postgres db with reset update shares.
-        // note that both serial_id and postgres db are 1-indexed.
-        store
-            .update_iris(
-                None,
-                serial_id as i64,
-                &shares.code_left,
-                &shares.mask_left,
-                &shares.code_right,
-                &shares.mask_right,
-            )
-            .await?;
-
-        tracing::info!(
-            "Updated ResetUpdate shares in Postgres on serial id {}",
-            serial_id,
-        );
-    }
-
-    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
## Change
- As a follow-up mentioned [here](https://github.com/worldcoin/iris-mpc/pull/1224#discussion_r2031928136), we unify the place where we handle postgres persistence.
- Previously, for batch items that don't require any uniqueness check (deletion, reset_update), we opted for updating shares in postgres before submitting batch to query. But this can cause issues when some nodes crash during actor processing. Because we can end up with updated row in irises table but modification record could still be in_progress as we only mark them after the actor processing. 
- With current change, if we crash during actor processing, we'll end up with in_progress modification but irises table won't be modified as well. So, it'll be a valid db state.