### PR TITLE
Add checking mirror attacks previous results based on match boolean

### DIFF
--- a/.github/workflows/temp-branch-build-and-push.yaml
+++ b/.github/workflows/temp-branch-build-and-push.yaml
@@ -3,7 +3,7 @@ name: Branch - Build and push docker image
 on:
   push:
     branches:
-      - "enable-debug-timing"
+      - "fix-mirror-attacks-using-wrong-matching-value"
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:v0.15.1"
+image: "ghcr.io/worldcoin/iris-mpc:2b68b10c5a4ab525147608342b616e2ab891737b"
 
 environment: stage
 replicaCount: 1

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -1171,7 +1171,7 @@ impl ServerActor {
                     .map(|i| {
                         // Here we check that the normal merged result is non-match while the mirrored merged result shows a match.
                         merged_results[i] == NON_MATCH_ID
-                            && mirror_results.merged_results[i] != NON_MATCH_ID
+                            && mirror_results.matches_with_skip_persistence[i]
                     })
                     .collect();
 
@@ -1181,7 +1181,7 @@ impl ServerActor {
                 let both_matched_count = (0..request_count)
                     .filter(|&i| {
                         merged_results[i] != NON_MATCH_ID
-                            && mirror_results.merged_results[i] != NON_MATCH_ID
+                            && mirror_results.matches_with_skip_persistence[i]
                     })
                     .count();
 


### PR DESCRIPTION
### Notes
* fix mirror attacks
* merged results are altered https://github.com/worldcoin/iris-mpc/blob/main/iris-mpc-gpu/src/server/actor.rs#L2814. Therefore we cannot use it to infer if the previous request is a mirror attack