### PR TITLE
fix match counters order when reporting results to SNS

### DIFF
--- a/.github/workflows/test-gpu.yaml
+++ b/.github/workflows/test-gpu.yaml
@@ -41,6 +41,7 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
+          sudo apt install -y wget
           wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.1-1_all.deb
           sudo dpkg -i cuda-keyring_1.1-1_all.deb
           sudo apt update

--- a/iris-mpc/bin/server.rs
+++ b/iris-mpc/bin/server.rs
@@ -1774,12 +1774,12 @@ async fn server_main(config: Config) -> eyre::Result<()> {
                             true => None,
                         },
                         Some(matched_batch_request_ids[i].clone()),
-                        match partial_match_counters_left.is_empty() {
-                            false => Some(partial_match_counters_left[i]),
-                            true => None,
-                        },
                         match partial_match_counters_right.is_empty() {
                             false => Some(partial_match_counters_right[i]),
+                            true => None,
+                        },
+                        match partial_match_counters_left.is_empty() {
+                            false => Some(partial_match_counters_left[i]),
                             true => None,
                         },
                         full_face_mirror_attack_detected[i],


### PR DESCRIPTION
## Change
- We used to mix left and right counters when serializing the JSON message sent to SNS. This PR fixes it.