### PR TITLE
Update e2e tests with mirror checks not being persisted

### DIFF
--- a/iris-mpc-common/src/test.rs
+++ b/iris-mpc-common/src/test.rs
@@ -1126,13 +1126,14 @@ impl TestCaseGenerator {
     ) {
         tracing::info!(
             "Checking result for request_id: {}, idx: {}, was_match: {}, matched_batch_req_ids: \
-             {:?}, was_reauth_success: {}, was_skip_persistence_match: {}",
+             {:?}, was_reauth_success: {}, was_skip_persistence_match: {}, full_face_mirror_attack: {}",
             req_id,
             idx,
             was_match,
             matched_batch_req_ids,
             was_reauth_success,
-            was_skip_persistence_match
+            was_skip_persistence_match,
+            full_face_mirror_attack_detected
         );
         let &ExpectedResult {
             db_index: expected_idx,
@@ -1157,6 +1158,7 @@ impl TestCaseGenerator {
             assert!(was_match);
             assert!(was_skip_persistence_match);
             assert!(!was_reauth_success);
+            assert!(!full_face_mirror_attack_detected);
 
             // assert that we report correct matched indices upon reset_check requests
             if expected_idx.is_some() {
@@ -1174,6 +1176,7 @@ impl TestCaseGenerator {
 
         // if the request is a reauth, we only check the reauth success
         if let Some(is_reauth_successful) = is_reauth_successful {
+            assert!(!full_face_mirror_attack_detected);
             assert_eq!(
                 is_reauth_successful, was_reauth_success,
                 "expected reauth success status to be as expected"
@@ -1182,6 +1185,7 @@ impl TestCaseGenerator {
         }
 
         if let Some(expected_idx) = expected_idx {
+            assert!(!full_face_mirror_attack_detected);
             assert!(
                 was_match,
                 "expected this request to be a match, but it was not"

--- a/iris-mpc-common/src/test.rs
+++ b/iris-mpc-common/src/test.rs
@@ -1031,7 +1031,6 @@ impl TestCaseGenerator {
 
                     // send a mirrored template as our test case
                     // this will ensure that the original template will be mirrored
-                    // let mirrored_template = original_template.clone().mirrored();
                     E2ETemplate {
                         // This is swapped on purpose due to the mirror attack flow
                         left: original_template[RIGHT].mirrored(),

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -1183,8 +1183,7 @@ impl ServerActor {
                 let attack_detected = (0..request_count)
                     .map(|i| {
                         // Here we check that the normal merged result is non-match while the mirrored merged result shows a match.
-                        batch.request_types[i] == UNIQUENESS_MESSAGE_TYPE
-                            && merged_results[i] == NON_MATCH_ID
+                        merged_results[i] == NON_MATCH_ID
                             && mirror_results.matches_with_skip_persistence[i]
                     })
                     .collect();

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -1183,7 +1183,8 @@ impl ServerActor {
                 let attack_detected = (0..request_count)
                     .map(|i| {
                         // Here we check that the normal merged result is non-match while the mirrored merged result shows a match.
-                        merged_results[i] == NON_MATCH_ID
+                        batch.request_types[i] == UNIQUENESS_MESSAGE_TYPE
+                            && merged_results[i] == NON_MATCH_ID
                             && mirror_results.matches_with_skip_persistence[i]
                     })
                     .collect();

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -1185,6 +1185,7 @@ impl ServerActor {
                         // Here we check that the normal merged result is non-match while the mirrored merged result shows a match.
                         merged_results[i] == NON_MATCH_ID
                             && mirror_results.matches_with_skip_persistence[i]
+                            && batch.request_types[i] == UNIQUENESS_MESSAGE_TYPE
                     })
                     .collect();
                 full_face_mirror_match_ids = mirror_results.match_ids;


### PR DESCRIPTION
### Notes
* ensure no mirror checks are flagged for non-mirror tests