### PR TITLE
Fix: allow CLI input of RNG seeds in init_test_dbs binary

### DIFF
--- a/iris-mpc-cpu/bin/init_test_dbs.rs
+++ b/iris-mpc-cpu/bin/init_test_dbs.rs
@@ -133,12 +133,12 @@ struct Args {
 
     /// PRNG seed for HNSW insertion, used to select the layer at which new
     /// elements are inserted into the hierarchical graph structure.
-    #[clap(default_value = "0")]
+    #[clap(long, default_value = "0")]
     hnsw_prng_seed: u64,
 
     /// PRNG seed for ABY3 MPC protocols, used for locally generating secret
     /// shares of iris codes.
-    #[clap(default_value = "1")]
+    #[clap(long, default_value = "1")]
     aby3_prng_seed: u64,
 }
 


### PR DESCRIPTION
The `clap` CLI interface for the `init_test_dbs` binary accidentally didn't have either a short or long argument specifier for the RNG seed parameters, so couldn't take them as input.  This PR adds a long argument specifier to each.