### PR TITLE
chore(deploy/stage/smpcv2-eu-central-1): reduce memory request for `iris-mpc`

### DIFF
--- a/deploy/stage/smpcv2-0-stage-eu-central-1/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage-eu-central-1/values-iris-mpc.yaml
@@ -7,7 +7,7 @@ resources:
     vpc.amazonaws.com/efa: 4
   requests:
     cpu: 94
-    memory: 1100Gi
+    memory: 1000Gi
     nvidia.com/gpu: 8
     hugepages-2Mi: 5Gi
     vpc.amazonaws.com/efa: 4

--- a/deploy/stage/smpcv2-1-stage-eu-central-1/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage-eu-central-1/values-iris-mpc.yaml
@@ -7,7 +7,7 @@ resources:
     vpc.amazonaws.com/efa: 4
   requests:
     cpu: 94
-    memory: 1100Gi
+    memory: 1000Gi
     nvidia.com/gpu: 8
     hugepages-2Mi: 5Gi
     vpc.amazonaws.com/efa: 4

--- a/deploy/stage/smpcv2-2-stage-eu-central-1/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage-eu-central-1/values-iris-mpc.yaml
@@ -7,7 +7,7 @@ resources:
     vpc.amazonaws.com/efa: 4
   requests:
     cpu: 94
-    memory: 1100Gi
+    memory: 1000Gi
     nvidia.com/gpu: 8
     hugepages-2Mi: 5Gi
     vpc.amazonaws.com/efa: 4


### PR DESCRIPTION
Requestor/Issue: https://linear.app/worldcoin/issue/INFRA-4414/push-common-charts-to-eu-central-1
Tested (yes/no): no
Description/Why: the previous value was too high, causing scheduling issues due to insufficient memory left on the node... since other pods also require memory, we need to consider the overall memory usage and avoid requesting excessive resources for the `iris-mpc` pod
```sh
I> kubectl get node $(kubectl get nodes -l beta.kubernetes.io/instance-type=p4d.24xlarge -o jsonpath='{.items[*].metadata.name}') -o json | jq -r '.status.allocatable.memory,.status.capacity.memory'
1146004700Ki
1176298716Ki
```
![image](https://github.com/user-attachments/assets/4d94f346-841f-48ca-9be4-e25d6d0f85db)
