### PR TITLE
INFRA-4425(deploy/stage/eu-central-1): Update S3 bucket name

### DIFF
--- a/deploy/stage/smpcv2-0-stage-eu-central-1/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage-eu-central-1/values-iris-mpc.yaml
@@ -220,5 +220,5 @@ initContainer:
       aws route53 change-resource-record-sets --hosted-zone-id "$HOSTED_ZONE_ID" --change-batch "$BATCH_JSON"
 
       cd /libs
-      aws s3 cp s3://wf-smpcv2-stage-libs/libcublas.so.12.2.5.6 .
-      aws s3 cp s3://wf-smpcv2-stage-libs/libcublasLt.so.12.2.5.6 .
+      aws s3 cp s3://wf-smpcv2-stage-eu-central-1-libs/libcublas.so.12.2.5.6 .
+      aws s3 cp s3://wf-smpcv2-stage-eu-central-1-libs/libcublasLt.so.12.2.5.6 .

--- a/deploy/stage/smpcv2-1-stage-eu-central-1/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage-eu-central-1/values-iris-mpc.yaml
@@ -218,7 +218,7 @@ initContainer:
 
       # Execute AWS CLI command with the generated JSON
       aws route53 change-resource-record-sets --hosted-zone-id "$HOSTED_ZONE_ID" --change-batch "$BATCH_JSON"
-      
+
       cd /libs
-      aws s3 cp s3://wf-smpcv2-stage-libs/libcublas.so.12.2.5.6 .
-      aws s3 cp s3://wf-smpcv2-stage-libs/libcublasLt.so.12.2.5.6 .
+      aws s3 cp s3://wf-smpcv2-stage-eu-central-1-libs/libcublas.so.12.2.5.6 .
+      aws s3 cp s3://wf-smpcv2-stage-eu-central-1-libs/libcublasLt.so.12.2.5.6 .

--- a/deploy/stage/smpcv2-2-stage-eu-central-1/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage-eu-central-1/values-iris-mpc.yaml
@@ -220,5 +220,5 @@ initContainer:
       aws route53 change-resource-record-sets --hosted-zone-id "$HOSTED_ZONE_ID" --change-batch "$BATCH_JSON"
 
       cd /libs
-      aws s3 cp s3://wf-smpcv2-stage-libs/libcublas.so.12.2.5.6 .
-      aws s3 cp s3://wf-smpcv2-stage-libs/libcublasLt.so.12.2.5.6 .
+      aws s3 cp s3://wf-smpcv2-stage-eu-central-1-libs/libcublas.so.12.2.5.6 .
+      aws s3 cp s3://wf-smpcv2-stage-eu-central-1-libs/libcublasLt.so.12.2.5.6 .


### PR DESCRIPTION
Requestor/Issue: https://linear.app/worldcoin/issue/INFRA-4425/investigate-and-fix-errors-in-init-container
Tested (yes/no): no
Description/Why: we should use the s3 bucket created in the eu-central-1 region because it's the only one we have access to
```sh
I> kubectl logs iris-mpc-58bdf5f4d6-mt8lg -c iri-mpc-dns-records-updater|grep error
fatal error: An error occurred (403) when calling the HeadObject operation: Forbidden
fatal error: An error occurred (403) when calling the HeadObject operation: Forbidden
```