### PR TITLE
feat: upgrade AWS OFI NCCL version

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -8,9 +8,9 @@ RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86
     && apt-get install -y cuda-toolkit-12-2 libnccl2=2.22.3-1+cuda12.2 libnccl-dev=2.22.3-1+cuda12.2 git curl build-essential debhelper
 
 ARG GDRCOPY_VERSION=v2.4.1
-ARG EFA_INSTALLER_VERSION=1.34.0
+ARG EFA_INSTALLER_VERSION=1.39.0
 ARG NCCL_INSTALL_VERSION=v2.22.3-1
-ARG AWS_OFI_NCCL_VERSION=aws
+ARG AWS_OFI_NCCL_VERSION=v1.13.2-aws
 
 ENV LD_LIBRARY_PATH=/usr/local/cuda/extras/CUPTI/lib64:/opt/amazon/openmpi/lib:/opt/nccl/build/lib:/opt/amazon/efa/lib:/opt/aws-ofi-nccl/install/lib:/usr/local/lib:$LD_LIBRARY_PATH
 ENV PATH=/opt/amazon/openmpi/bin/:/opt/amazon/efa/bin:$PATH

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -4,8 +4,7 @@ RUN apt-get update && apt-get install -y pkg-config wget libssl-dev ca-certifica
 RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb \
     && dpkg -i cuda-keyring_1.1-1_all.deb \
     && apt-get update \
-    && apt-get install -y cuda-toolkit-12-2 libnccl2=2.22.3-1+cuda12.2 libnccl-dev=2.22.3-1+cuda12.2 git curl build-essential debhelper libhwloc-dev \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get install -y cuda-toolkit-12-2 libnccl2=2.22.3-1+cuda12.2 libnccl-dev=2.22.3-1+cuda12.2 git curl build-essential debhelper libhwloc-dev
 
 ARG GDRCOPY_VERSION=v2.4.1
 ARG EFA_INSTALLER_VERSION=1.39.0
@@ -46,3 +45,6 @@ RUN cd /tmp \
     --with-nccl=/tmp/nccl/build \
     --with-mpi=/opt/amazon/openmpi/ \
     && make && make install
+
+# Final cleanup
+RUN rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y pkg-config wget libssl-dev ca-certifica
 RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb \
     && dpkg -i cuda-keyring_1.1-1_all.deb \
     && apt-get update \
-    && apt-get install -y cuda-toolkit-12-2 libnccl2=2.22.3-1+cuda12.2 libnccl-dev=2.22.3-1+cuda12.2 git curl build-essential debhelper
+    && apt-get install -y cuda-toolkit-12-2 libnccl2=2.22.3-1+cuda12.2 libnccl-dev=2.22.3-1+cuda12.2 git curl build-essential debhelper hwloc
 
 ARG GDRCOPY_VERSION=v2.4.1
 ARG EFA_INSTALLER_VERSION=1.39.0

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,11 +1,11 @@
 FROM --platform=linux/amd64 ubuntu:22.04 as build-image
 
-RUN apt-get update && apt-get install -y pkg-config wget libssl-dev ca-certificates protobuf-compiler \
-    && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y pkg-config wget libssl-dev ca-certificates protobuf-compiler
 RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb \
     && dpkg -i cuda-keyring_1.1-1_all.deb \
     && apt-get update \
-    && apt-get install -y cuda-toolkit-12-2 libnccl2=2.22.3-1+cuda12.2 libnccl-dev=2.22.3-1+cuda12.2 git curl build-essential debhelper hwloc
+    && apt-get install -y cuda-toolkit-12-2 libnccl2=2.22.3-1+cuda12.2 libnccl-dev=2.22.3-1+cuda12.2 git curl build-essential debhelper libhwloc-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 ARG GDRCOPY_VERSION=v2.4.1
 ARG EFA_INSTALLER_VERSION=1.39.0


### PR DESCRIPTION
Upgrades to latest AWS OFI NCCL version tested on AWS: https://github.com/aws/aws-ofi-nccl/tree/v1.13.2-aws (this version is compatible with NCCL 2.22.x)
Upgrades to latest EFA installer: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-verify.html

The previous OFI NCCL branch used was `aws` but its content has been merged to `main`.