### PR TITLE
Refactor server_main into smaller function calls

### DIFF
--- a/iris-mpc-common/src/helpers/sync.rs
+++ b/iris-mpc-common/src/helpers/sync.rs
@@ -15,7 +15,7 @@ pub struct SyncState {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SyncResult {
-    my_state: SyncState,
+    pub my_state: SyncState,
     all_states: Vec<SyncState>,
 }
 
@@ -103,9 +103,9 @@ impl SyncResult {
     }
 
     /// Returns `None` if all states have equal database length.  If not all
-    /// database lengths are the same, instead returns `Some
-    /// (smallest_len)`, indicating that other databases probably should be
-    /// rolled back to this smallest size.
+    /// database lengths are the same, instead returns `Some(smallest_len)`,
+    /// indicating that other databases probably should be rolled back to this
+    /// smallest size.
     pub fn must_rollback_storage(&self) -> Option<usize> {
         let smallest_len = self.all_states.iter().map(|s| s.db_len).min()?;
         let all_equal = self.all_states.iter().all(|s| s.db_len == smallest_len);
@@ -116,6 +116,7 @@ impl SyncResult {
         }
     }
 
+    /// Check if the common part of the config is the same across all nodes.
     pub fn check_common_config(&self) -> eyre::Result<()> {
         let config = self.my_state.common_config.clone();
         for state in &self.all_states {

--- a/iris-mpc-common/src/helpers/sync.rs
+++ b/iris-mpc-common/src/helpers/sync.rs
@@ -102,6 +102,10 @@ impl SyncResult {
         }
     }
 
+    /// Returns `None` if all states have equal database length.  If not all
+    /// database lengths are the same, instead returns `Some
+    /// (smallest_len)`, indicating that other databases probably should be
+    /// rolled back to this smallest size.
     pub fn must_rollback_storage(&self) -> Option<usize> {
         let smallest_len = self.all_states.iter().map(|s| s.db_len).min()?;
         let all_equal = self.all_states.iter().all(|s| s.db_len == smallest_len);

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -468,7 +468,7 @@ async fn start_coordination_server(
 
     let _health_check_abort = task_monitor.spawn({
         let uuid = uuid::Uuid::new_v4().to_string();
-        let is_ready_flag = is_ready_flag.clone();
+        let is_ready_flag = Arc::clone(&is_ready_flag);
         let ready_probe_response = ReadyProbeResponse {
             image_name: config.image_name.clone(),
             shutting_down: false,

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -7,11 +7,12 @@ use crate::services::processors::job::process_job_result;
 use crate::services::processors::process_identity_deletions;
 use crate::services::processors::result_message::send_results_to_sns;
 use crate::services::store::load_db;
+use aws_sdk_sns::types::MessageAttributeValue;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::routing::get;
 use axum::Router;
-use eyre::{eyre, Report, WrapErr};
+use eyre::{bail, eyre, Error, Report, Result, WrapErr};
 use iris_mpc_common::config::{CommonConfig, Config, ModeOfCompute, ModeOfDeployment};
 use iris_mpc_common::helpers::inmemory_store::InMemoryStore;
 use iris_mpc_common::helpers::key_pair::SharesEncryptionKeyPairs;
@@ -34,10 +35,12 @@ use iris_mpc_cpu::hawkers::aby3::aby3_store::Aby3Store;
 use iris_mpc_cpu::hnsw::graph::graph_store::GraphPg;
 use iris_mpc_store::{S3Store, Store};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::mem;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, LazyLock, Mutex};
 use std::time::{Duration, Instant};
+use tokio::sync::mpsc::Sender;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::timeout;
 
@@ -46,19 +49,109 @@ pub const SQS_POLLING_INTERVAL: Duration = Duration::from_secs(1);
 pub const MAX_CONCURRENT_REQUESTS: usize = 32;
 pub static CURRENT_BATCH_SIZE: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
 
-pub async fn server_main(config: Config) -> eyre::Result<()> {
+/// Main logic for initialization and execution of AMPC iris uniqueness server
+/// nodes.
+pub async fn server_main(config: Config) -> Result<()> {
+    let shutdown_handler = init_shutdown_handler(&config).await;
 
+    process_config(&config);
 
-    // BLOCK: initialize shutdown handler
+    let (store, graph_store) = prepare_stores(&config).await?;
 
+    let aws_clients = init_aws_services(&config).await?;
+    let shares_encryption_key_pair = get_shares_encryption_key_pair(&config, &aws_clients).await?;
+    let sns_attributes_maps = init_sns(&config, &aws_clients, &store).await?;
+
+    maybe_seed_random_shares(&config, &store).await?;
+    check_store_consistency(&config, &store).await?;
+    let my_state = build_sync_state(&config, &aws_clients, &store).await?;
+
+    let mut background_tasks = init_task_monitor();
+
+    let is_ready_flag =
+        start_coordination_server(&config, &mut background_tasks, &shutdown_handler, &my_state)
+            .await;
+
+    background_tasks.check_tasks();
+
+    wait_for_others_unready(&config).await?;
+    init_heartbeat_task(&config, &mut background_tasks, &shutdown_handler).await?;
+
+    background_tasks.check_tasks();
+
+    let sync_result = get_others_sync_state(&config, &my_state).await?;
+    sync_result.check_common_config()?;
+
+    maybe_sync_sqs_queues(&config, &sync_result, &aws_clients).await?;
+    sync_dbs_rollback(&config, &sync_result, &store).await?;
+
+    if shutdown_handler.is_shutting_down() {
+        tracing::warn!("Shutting down has been triggered");
+        return Ok(());
+    }
+
+    let mut hawk_actor = init_hawk_actor(&config).await?;
+
+    load_database(
+        &config,
+        &store,
+        &graph_store,
+        &aws_clients,
+        &shutdown_handler,
+        &mut hawk_actor,
+    )
+    .await?;
+
+    background_tasks.check_tasks();
+
+    let tx_results = start_results_thread(
+        &config,
+        &store,
+        graph_store,
+        &aws_clients,
+        &mut background_tasks,
+        &shutdown_handler,
+        sns_attributes_maps,
+    )
+    .await?;
+
+    background_tasks.check_tasks();
+
+    set_node_ready(is_ready_flag);
+    wait_for_others_ready(&config).await?;
+
+    background_tasks.check_tasks();
+
+    run_main_server_loop(
+        &config,
+        &store,
+        &aws_clients,
+        shares_encryption_key_pair,
+        &sync_result,
+        background_tasks,
+        &shutdown_handler,
+        hawk_actor,
+        tx_results,
+    )
+    .await?;
+
+    Ok(())
+}
+
+/// Initializes shutdown handler, which waits for shutdown signals or function
+/// calls and provides a light mechanism for gracefully finishing ongoing query
+/// batches before exiting.
+async fn init_shutdown_handler(config: &Config) -> Arc<ShutdownHandler> {
     let shutdown_handler = Arc::new(ShutdownHandler::new(
         config.shutdown_last_results_sync_timeout_secs,
     ));
     shutdown_handler.wait_for_shutdown_signal().await;
 
+    shutdown_handler
+}
 
-    // BLOCK: validate modes of compute and deployment, load extra config values
-
+/// Validate server Config input and initialize associated static state
+fn process_config(config: &Config) {
     // Validate modes of compute/deployment.
     if config.mode_of_compute != ModeOfCompute::Cpu {
         panic!(
@@ -81,792 +174,19 @@ pub async fn server_main(config: Config) -> eyre::Result<()> {
 
     // Load batch_size config
     *CURRENT_BATCH_SIZE.lock().unwrap() = config.max_batch_size;
-    let max_sync_lookback: usize = config.max_batch_size * 2;
-    let max_rollback: usize = config.max_batch_size * 2;
     tracing::info!("Set batch size to {}", config.max_batch_size);
-
-
-    // BLOCK: prepare stores
-
-    let (store, graph_store) = prepare_stores(&config).await?;
-
-
-    // BLOCK: initialize AWS services
-
-    tracing::info!("Initialising AWS services");
-    let aws_clients = AwsClients::new(&config.clone()).await?;
-    let next_sns_seq_number_future = get_next_sns_seq_num(&config, &aws_clients.sqs_client);
-
-
-    // SUB-BLOCK: initialize shares encryption key pairs
-
-    let shares_encryption_key_pair = match SharesEncryptionKeyPairs::from_storage(
-        aws_clients.secrets_manager_client,
-        &config.environment,
-        &config.party_id,
-    )
-    .await
-    {
-        Ok(key_pair) => key_pair,
-        Err(e) => {
-            tracing::error!("Failed to initialize shares encryption key pairs: {:?}", e);
-            return Ok(());
-        }
-    };
-
-
-    // SUB-BLOCK: initialize SNS message types
-
-    let party_id = config.party_id; // TODO move to state struct
-    let uniqueness_result_attributes = create_message_type_attribute_map(UNIQUENESS_MESSAGE_TYPE);
-    let reauth_result_attributes = create_message_type_attribute_map(REAUTH_MESSAGE_TYPE);
-    let anonymized_statistics_attributes =
-        create_message_type_attribute_map(ANONYMIZED_STATISTICS_MESSAGE_TYPE);
-    let identity_deletion_result_attributes =
-        create_message_type_attribute_map(IDENTITY_DELETION_MESSAGE_TYPE);
-
-
-    // ITEM: replay previous results for synchronization
-
-    tracing::info!("Replaying results");
-    send_results_to_sns(
-        store.last_results(max_sync_lookback).await?,
-        &Vec::new(),
-        &aws_clients.sns_client,
-        &config,
-        &uniqueness_result_attributes,
-        UNIQUENESS_MESSAGE_TYPE,
-    )
-    .await?;
-
-    let store_len = store.count_irises().await?;
-
-    tracing::info!("Size of the database before init: {}", store_len);
-
-
-    // BLOCK: seed storage with random shares
-
-    // Seed the persistent storage with random shares if configured and db is still
-    // empty.
-    if store_len == 0 && config.init_db_size > 0 {
-        tracing::info!(
-            "Initialize persistent iris DB with {} randomly generated shares",
-            config.init_db_size
-        );
-        tracing::info!("Resetting the db: {}", config.clear_db_before_init);
-        store
-            .init_db_with_random_shares(
-                RNG_SEED_INIT_DB,
-                config.party_id,
-                config.init_db_size,
-                config.clear_db_before_init,
-            )
-            .await?;
-    }
-
-    // Fetch again in case we've just initialized the DB
-    let store_len = store.count_irises().await?;
-
-    tracing::info!("Size of the database after init: {}", store_len);
-
-
-    // BLOCK: Check consistency of database size and sequence ids
-
-    // Check if the sequence id is consistent with the number of irises
-    let max_serial_id = store.get_max_serial_id().await?;
-    if max_serial_id != store_len {
-        tracing::error!(
-            "Detected inconsistency between max serial id {} and db size {}.",
-            max_serial_id,
-            store_len
-        );
-
-        eyre::bail!(
-            "Detected inconsistency between max serial id {} and db size {}.",
-            max_serial_id,
-            store_len
-        );
-    }
-
-    if store_len > config.max_db_size {
-        tracing::error!("Database size exceeds maximum allowed size: {}", store_len);
-        eyre::bail!("Database size exceeds maximum allowed size: {}", store_len);
-    }
-
-
-    // BLOCK: Prepare task monitor and health checks
-
-    tracing::info!("Preparing task monitor");
-    let mut background_tasks = TaskMonitor::new();
-
-    // --------------------------------------------------------------------------
-    // ANCHOR: Starting Healthcheck, Readiness and Sync server
-    // --------------------------------------------------------------------------
-    tracing::info!("⚓️ ANCHOR: Starting Healthcheck, Readiness and Sync server");
-
-    let is_ready_flag = Arc::new(AtomicBool::new(false));
-    let is_ready_flag_cloned = Arc::clone(&is_ready_flag);
-
-    let my_state = SyncState {
-        db_len: store_len as u64,
-        deleted_request_ids: store.last_deleted_requests(max_sync_lookback).await?,
-        modifications: store.last_modifications(max_sync_lookback).await?,
-        next_sns_sequence_num: next_sns_seq_number_future.await?,
-        common_config: CommonConfig::from(config.clone()),
-    };
-
-    #[derive(Debug, Serialize, Deserialize, Clone)]
-    struct ReadyProbeResponse {
-        image_name: String,
-        uuid: String,
-        shutting_down: bool,
-    }
-
-    let health_shutdown_handler = Arc::clone(&shutdown_handler);
-    let health_check_port = config.hawk_server_healthcheck_port;
-
-    let _health_check_abort = background_tasks.spawn({
-        let uuid = uuid::Uuid::new_v4().to_string();
-        let ready_probe_response = ReadyProbeResponse {
-            image_name: config.image_name.clone(),
-            shutting_down: false,
-            uuid: uuid.clone(),
-        };
-        let ready_probe_response_shutdown = ReadyProbeResponse {
-            image_name: config.image_name.clone(),
-            shutting_down: true,
-            uuid: uuid.clone(),
-        };
-        let serialized_response = serde_json::to_string(&ready_probe_response)
-            .expect("Serialization to JSON to probe response failed");
-        let serialized_response_shutdown = serde_json::to_string(&ready_probe_response_shutdown)
-            .expect("Serialization to JSON to probe response failed");
-        tracing::info!("Healthcheck probe response: {}", serialized_response);
-        let my_state = my_state.clone();
-        async move {
-            // Generate a random UUID for each run.
-            let app = Router::new()
-                .route(
-                    "/health",
-                    get(move || {
-                        let shutdown_handler_clone = Arc::clone(&health_shutdown_handler);
-                        async move {
-                            if shutdown_handler_clone.is_shutting_down() {
-                                serialized_response_shutdown.clone()
-                            } else {
-                                serialized_response.clone()
-                            }
-                        }
-                    }),
-                )
-                .route(
-                    "/ready",
-                    get({
-                        // We are only ready once this flag is set to true.
-                        let is_ready_flag = Arc::clone(&is_ready_flag);
-                        move || async move {
-                            if is_ready_flag.load(Ordering::SeqCst) {
-                                "ready".into_response()
-                            } else {
-                                StatusCode::SERVICE_UNAVAILABLE.into_response()
-                            }
-                        }
-                    }),
-                )
-                .route(
-                    "/startup-sync",
-                    get(move || async move { serde_json::to_string(&my_state).unwrap() }),
-                );
-            let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{}", health_check_port))
-                .await
-                .wrap_err("healthcheck listener bind error")?;
-            axum::serve(listener, app)
-                .await
-                .wrap_err("healthcheck listener server launch error")?;
-
-            Ok::<(), eyre::Error>(())
-        }
-    });
-
-    background_tasks.check_tasks();
-    tracing::info!(
-        "Healthcheck and Readiness server running on port {}.",
-        health_check_port.clone()
-    );
-
-
-    // BLOCK: wait for other servers
-
-    tracing::info!("⚓️ ANCHOR: Waiting for other servers to be un-ready (syncing on startup)");
-    // Check other nodes and wait until all nodes are ready.
-    let all_readiness_addresses = get_check_addresses(
-        config.node_hostnames.clone(),
-        config.healthcheck_ports.clone(),
-        "ready",
-    );
-
-    let unready_check = tokio::spawn(async move {
-        let next_node = &all_readiness_addresses[(config.party_id + 1) % 3];
-        let prev_node = &all_readiness_addresses[(config.party_id + 2) % 3];
-        let mut connected_but_unready = [false, false];
-
-        loop {
-            for (i, host) in [next_node, prev_node].iter().enumerate() {
-                let res = reqwest::get(host.as_str()).await;
-
-                if res.is_ok() && res.unwrap().status() == StatusCode::SERVICE_UNAVAILABLE {
-                    connected_but_unready[i] = true;
-                    // If all nodes are connected, notify the main thread.
-                    if connected_but_unready.iter().all(|&c| c) {
-                        return;
-                    }
-                }
-            }
-
-            tokio::time::sleep(Duration::from_secs(1)).await;
-        }
-    });
-
-    tracing::info!("Waiting for all nodes to be unready...");
-    match tokio::time::timeout(
-        Duration::from_secs(config.startup_sync_timeout_secs),
-        unready_check,
-    )
-    .await
-    {
-        Ok(res) => {
-            res?;
-        }
-        Err(_) => {
-            tracing::error!("Timeout waiting for all nodes to be unready.");
-            return Err(eyre!("Timeout waiting for all nodes to be unready."));
-        }
-    };
-    tracing::info!("All nodes are starting up.");
-
-    
-    // BLOCK: initialize heartbeat task
-
-    let (heartbeat_tx, heartbeat_rx) = oneshot::channel();
-    let mut heartbeat_tx = Some(heartbeat_tx);
-
-    let all_health_addresses = get_check_addresses(
-        config.node_hostnames.clone(),
-        config.healthcheck_ports.clone(),
-        "health",
-    );
-
-    let image_name = config.image_name.clone();
-    let heartbeat_shutdown_handler = Arc::clone(&shutdown_handler);
-    let _heartbeat = background_tasks.spawn(async move {
-        let next_node = &all_health_addresses[(config.party_id + 1) % 3];
-        let prev_node = &all_health_addresses[(config.party_id + 2) % 3];
-        let mut last_response = [String::default(), String::default()];
-        let mut connected = [false, false];
-        let mut retries = [0, 0];
-
-        loop {
-            for (i, host) in [next_node, prev_node].iter().enumerate() {
-                let res = reqwest::get(host.as_str()).await;
-                if res.is_err() || !res.as_ref().unwrap().status().is_success() {
-                    // If it's the first time after startup, we allow a few retries to let the other
-                    // nodes start up as well.
-                    if last_response[i] == String::default()
-                        && retries[i] < config.heartbeat_initial_retries
-                    {
-                        retries[i] += 1;
-                        tracing::warn!("Node {} did not respond with success, retrying...", host);
-                        continue;
-                    }
-                    tracing::info!(
-                        "Node {} did not respond with success, starting graceful shutdown",
-                        host
-                    );
-                    // if the nodes are still starting up and they get a failure - we can panic and
-                    // not start graceful shutdown
-                    if last_response[i] == String::default() {
-                        panic!(
-                            "Node {} did not respond with success during heartbeat init phase, \
-                             killing server...",
-                            host
-                        );
-                    }
-
-                    if !heartbeat_shutdown_handler.is_shutting_down() {
-                        heartbeat_shutdown_handler.trigger_manual_shutdown();
-                        tracing::error!(
-                            "Node {} has not completed health check, therefore graceful shutdown \
-                             has been triggered",
-                            host
-                        );
-                    } else {
-                        tracing::info!("Node {} has already started graceful shutdown.", host);
-                    }
-                    continue;
-                }
-
-                let probe_response = res
-                    .unwrap()
-                    .json::<ReadyProbeResponse>()
-                    .await
-                    .expect("Deserialization of probe response failed");
-                if probe_response.image_name != image_name {
-                    // Do not create a panic as we still can continue to process before its
-                    // updated
-                    tracing::error!(
-                        "Host {} is using image {} which differs from current node image: {}",
-                        host,
-                        probe_response.image_name.clone(),
-                        image_name
-                    );
-                }
-                if last_response[i] == String::default() {
-                    last_response[i] = probe_response.uuid;
-                    connected[i] = true;
-
-                    // If all nodes are connected, notify the main thread.
-                    if connected.iter().all(|&c| c) {
-                        if let Some(tx) = heartbeat_tx.take() {
-                            tx.send(()).unwrap();
-                        }
-                    }
-                } else if probe_response.uuid != last_response[i] {
-                    // If the UUID response is different, the node has restarted without us
-                    // noticing. Our main NCCL connections cannot recover from
-                    // this, so we panic.
-                    panic!("Node {} seems to have restarted, killing server...", host);
-                } else if probe_response.shutting_down {
-                    tracing::info!("Node {} has starting graceful shutdown", host);
-
-                    if !heartbeat_shutdown_handler.is_shutting_down() {
-                        heartbeat_shutdown_handler.trigger_manual_shutdown();
-                        tracing::error!(
-                            "Node {} has starting graceful shutdown, therefore triggering \
-                             graceful shutdown",
-                            host
-                        );
-                    }
-                } else {
-                    tracing::info!("Heartbeat: Node {} is healthy", host);
-                }
-            }
-
-            tokio::time::sleep(Duration::from_secs(config.heartbeat_interval_secs)).await;
-        }
-    });
-
-    tracing::info!("Heartbeat starting...");
-    heartbeat_rx.await?;
-    tracing::info!("Heartbeat on all nodes started.");
-
-    background_tasks.check_tasks();
-
-
-    // BLOCK: Sync latest node state
-
-    // --------------------------------------------------------------------------
-    // ANCHOR: Syncing latest node state
-    // --------------------------------------------------------------------------
-    tracing::info!("⚓️ ANCHOR: Syncing latest node state");
-
-    let all_startup_sync_addresses = get_check_addresses(
-        config.node_hostnames.clone(),
-        config.healthcheck_ports.clone(),
-        "startup-sync",
-    );
-
-    let next_node = &all_startup_sync_addresses[(config.party_id + 1) % 3];
-    let prev_node = &all_startup_sync_addresses[(config.party_id + 2) % 3];
-
-    tracing::info!("Database store length is: {}", store_len);
-    let mut states = vec![my_state.clone()];
-    for host in [next_node, prev_node].iter() {
-        let res = reqwest::get(host.as_str()).await;
-        match res {
-            Ok(res) => {
-                let state: SyncState = match res.json().await {
-                    Ok(state) => state,
-                    Err(e) => {
-                        tracing::error!("Failed to parse sync state from party {}: {:?}", host, e);
-                        panic!(
-                            "could not get sync state from party {}, trying to restart",
-                            host
-                        );
-                    }
-                };
-                states.push(state);
-            }
-            Err(e) => {
-                tracing::error!("Failed to fetch sync state from party {}: {:?}", host, e);
-                panic!(
-                    "could not get sync state from party {}, trying to restart",
-                    host
-                );
-            }
-        }
-    }
-    let sync_result = SyncResult::new(my_state.clone(), states);
-
-    // check if common part of the config is the same across all nodes
-    sync_result.check_common_config()?;
-
-
-    // BLOCK: sync SQS queues
-
-    // sync the queues
-    if config.enable_sync_queues_on_sns_sequence_number {
-        let max_sqs_sequence_num = sync_result.max_sns_sequence_num();
-        delete_messages_until_sequence_num(
-            &config,
-            &aws_clients.sqs_client,
-            my_state.next_sns_sequence_num,
-            max_sqs_sequence_num,
-        )
-        .await?;
-    }
-
-    if let Some(db_len) = sync_result.must_rollback_storage() {
-        tracing::error!("Databases are out-of-sync: {:?}", sync_result);
-        if db_len + max_rollback < store_len {
-            return Err(eyre!(
-                "Refusing to rollback so much (from {} to {})",
-                store_len,
-                db_len,
-            ));
-        }
-        tracing::warn!(
-            "Rolling back from database length {} to other nodes length {}",
-            store_len,
-            db_len
-        );
-        store.rollback(db_len).await?;
-        metrics::counter!("db.sync.rollback").increment(1);
-    }
-
-    if shutdown_handler.is_shutting_down() {
-        tracing::warn!("Shutting down has been triggered");
-        return Ok(());
-    }
-
-    // refetch store_len in case we rolled back
-    let store_len = store.count_irises().await?;
-    tracing::info!("Database store length after sync: {}", store_len);
-
-
-    // BLOCK: Initialize Hawk Actor
-
-    // Initialize the HawkActor
-    let node_addresses: Vec<String> = config
-        .node_hostnames
-        .iter()
-        .zip(config.service_ports.iter())
-        .map(|(host, port)| format!("{}:{}", host, port))
-        .collect();
-
-    let hawk_args = HawkArgs {
-        party_index: config.party_id,
-        addresses: node_addresses.clone(),
-        request_parallelism: config.hawk_request_parallelism,
-        connection_parallelism: config.hawk_connection_parallelism,
-        hnsw_prng_seed: config.hawk_prng_seed,
-        disable_persistence: config.cpu_disable_persistence,
-        match_distances_buffer_size: config.match_distances_buffer_size,
-        n_buckets: config.n_buckets,
-    };
-
-    tracing::info!(
-        "Initializing HawkActor with args: party_index: {}, addresses: {:?}",
-        hawk_args.party_index,
-        node_addresses
-    );
-
-    let mut hawk_actor = HawkActor::from_cli(&hawk_args).await?;
-
-
-    // BLOCK: load database
-
-    {
-        // ANCHOR: Load the database
-        tracing::info!("⚓️ ANCHOR: Load the database");
-        let (mut iris_loader, graph_loader) = hawk_actor.as_iris_loader().await;
-
-        let parallelism = config
-            .database
-            .as_ref()
-            .ok_or(eyre!("Missing database config"))?
-            .load_parallelism;
-
-        let s3_load_parallelism = config.load_chunks_parallelism;
-        let s3_chunks_bucket_name = config.db_chunks_bucket_name.clone();
-        let s3_chunks_folder_name = config.db_chunks_folder_name.clone();
-        let s3_load_max_retries = config.load_chunks_max_retries;
-        let s3_load_initial_backoff_ms = config.load_chunks_initial_backoff_ms;
-
-        if config.fake_db_size > 0 {
-            // TODO: not needed?
-            iris_loader.fake_db(config.fake_db_size);
-        } else {
-            tracing::info!(
-                "Initialize iris db: Loading from DB (parallelism: {})",
-                parallelism
-            );
-            let download_shutdown_handler = Arc::clone(&shutdown_handler);
-            let db_chunks_s3_store = S3Store::new(
-                aws_clients.db_chunks_s3_client.clone(),
-                s3_chunks_bucket_name.clone(),
-            );
-
-            load_db(
-                &mut iris_loader,
-                &store,
-                store_len,
-                parallelism,
-                &config,
-                db_chunks_s3_store,
-                aws_clients.db_chunks_s3_client,
-                s3_chunks_folder_name,
-                s3_chunks_bucket_name,
-                s3_load_parallelism,
-                s3_load_max_retries,
-                s3_load_initial_backoff_ms,
-                download_shutdown_handler,
-            )
-            .await
-            .expect("Failed to load DB");
-
-            graph_loader.load_graph_store(&graph_store).await?;
-        }
-    }
-
-    background_tasks.check_tasks();
-
-
-    // BLOCK: Initialize results processing thread
-
-    // Start thread that will be responsible for communicating back the results
-    let (tx, mut rx) = mpsc::channel::<ServerJobResult>(32); // TODO: pick some buffer value
-    let sns_client_bg = aws_clients.sns_client.clone();
-    let config_bg = config.clone();
-    let store_bg = store.clone();
-    let shutdown_handler_bg = Arc::clone(&shutdown_handler);
-    let _result_sender_abort = background_tasks.spawn(async move {
-        while let Some(job_result) = rx.recv().await {
-            if let Err(e) = process_job_result(
-                job_result,
-                party_id,
-                &store_bg,
-                &graph_store,
-                &sns_client_bg,
-                &config_bg,
-                &uniqueness_result_attributes,
-                &reauth_result_attributes,
-                &identity_deletion_result_attributes,
-                &anonymized_statistics_attributes,
-                &shutdown_handler_bg,
-            )
-            .await
-            {
-                tracing::error!("Error processing job result: {:?}", e);
-            }
-        }
-
-        Ok(())
-    });
-    background_tasks.check_tasks();
-
-
-    // BLOCK: enable readiness checks
-
-    // --------------------------------------------------------------------------
-    // ANCHOR: Enable readiness and check all nodes
-    // --------------------------------------------------------------------------
-    tracing::info!("⚓️ ANCHOR: Enable readiness and check all nodes");
-
-    // Set the readiness flag to true, which will make the readiness server return a
-    // 200 status code.
-    is_ready_flag_cloned.store(true, Ordering::SeqCst);
-
-    // Check other nodes and wait until all nodes are ready.
-    let all_readiness_addresses = get_check_addresses(
-        config.node_hostnames.clone(),
-        config.healthcheck_ports.clone(),
-        "ready",
-    );
-
-    let ready_check = tokio::spawn(async move {
-        let next_node = &all_readiness_addresses[(config.party_id + 1) % 3];
-        let prev_node = &all_readiness_addresses[(config.party_id + 2) % 3];
-        let mut connected = [false, false];
-
-        loop {
-            for (i, host) in [next_node, prev_node].iter().enumerate() {
-                let res = reqwest::get(host.as_str()).await;
-
-                if res.is_ok() && res.as_ref().unwrap().status().is_success() {
-                    connected[i] = true;
-                    // If all nodes are connected, notify the main thread.
-                    if connected.iter().all(|&c| c) {
-                        return;
-                    }
-                }
-            }
-
-            tokio::time::sleep(Duration::from_secs(1)).await;
-        }
-    });
-
-    tracing::info!("Waiting for all nodes to be ready...");
-    match tokio::time::timeout(
-        Duration::from_secs(config.startup_sync_timeout_secs),
-        ready_check,
-    )
-    .await
-    {
-        Ok(res) => {
-            res?;
-        }
-        Err(_) => {
-            tracing::error!("Timeout waiting for all nodes to be ready.");
-            return Err(eyre!("Timeout waiting for all nodes to be ready."));
-        }
-    }
-    tracing::info!("All nodes are ready.");
-    background_tasks.check_tasks();
-
-
-    // BLOCK: main loop
-
-    // --------------------------------------------------------------------------
-    // ANCHOR: Start the main loop
-    // --------------------------------------------------------------------------
-    tracing::info!("⚓️ ANCHOR: Start the main loop");
-
-    let mut hawk_handle = HawkHandle::new(hawk_actor).await?;
-
-    let mut skip_request_ids = sync_result.deleted_request_ids();
-
-    let processing_timeout = Duration::from_secs(config.processing_timeout_secs);
-    let uniqueness_error_result_attribute =
-        create_message_type_attribute_map(UNIQUENESS_MESSAGE_TYPE);
-    let reauth_error_result_attribute = create_message_type_attribute_map(REAUTH_MESSAGE_TYPE);
-    let res: eyre::Result<()> = async {
-        tracing::info!("Entering main loop");
-
-        // Skip requests based on the startup sync, only in the first iteration.
-        let skip_request_ids = mem::take(&mut skip_request_ids);
-        let shares_encryption_key_pair = shares_encryption_key_pair.clone();
-        // This batch can consist of N sets of iris_share + mask
-        // It also includes a vector of request ids, mapping to the sets above
-
-        let mut next_batch = receive_batch(
-            party_id,
-            &aws_clients.sqs_client,
-            &aws_clients.sns_client,
-            &aws_clients.s3_client,
-            &config,
-            &store,
-            &skip_request_ids,
-            shares_encryption_key_pair.clone(),
-            &shutdown_handler,
-            &uniqueness_error_result_attribute,
-            &reauth_error_result_attribute,
-        );
-
-        let dummy_shares_for_deletions = get_dummy_shares_for_deletion(party_id);
-
-        loop {
-            let now = Instant::now();
-
-            let _batch = next_batch.await?;
-            if _batch.is_none() {
-                tracing::info!("No more batches to process, exiting main loop");
-                return Ok(());
-            }
-            let batch = _batch.unwrap();
-
-            // start trace span - with single TraceId and single ParentTraceID
-            tracing::info!("Received batch in {:?}", now.elapsed());
-
-            metrics::histogram!("receive_batch_duration").record(now.elapsed().as_secs_f64());
-
-            process_identity_deletions(
-                &batch,
-                &store,
-                &dummy_shares_for_deletions.0,
-                &dummy_shares_for_deletions.1,
-            )
-            .await?;
-
-            // Iterate over a list of tracing payloads, and create logs with mappings to
-            // payloads Log at least a "start" event using a log with trace.id and
-            // parent.trace.id
-            for tracing_payload in batch.metadata.iter() {
-                tracing::info!(
-                    node_id = tracing_payload.node_id,
-                    dd.trace_id = tracing_payload.trace_id,
-                    dd.span_id = tracing_payload.span_id,
-                    "Started processing share",
-                );
-            }
-
-            background_tasks.check_tasks();
-
-            let result_future = hawk_handle.submit_batch_query(batch.clone());
-
-            next_batch = receive_batch(
-                party_id,
-                &aws_clients.sqs_client,
-                &aws_clients.sns_client,
-                &aws_clients.s3_client,
-                &config,
-                &store,
-                &skip_request_ids,
-                shares_encryption_key_pair.clone(),
-                &shutdown_handler,
-                &uniqueness_error_result_attribute,
-                &reauth_error_result_attribute,
-            );
-
-            // await the result
-            let result = timeout(processing_timeout, result_future.await)
-                .await
-                .map_err(|e| eyre!("ServerActor processing timeout: {:?}", e))??;
-
-            tx.send(result).await?;
-
-            shutdown_handler.increment_batches_pending_completion()
-            // wrap up span context
-        }
-    }
-    .await;
-
-    match res {
-        Ok(_) => {
-            tracing::info!(
-                "Main loop exited normally. Waiting for last batch results to be processed before \
-                 shutting down..."
-            );
-
-            shutdown_handler.wait_for_pending_batches_completion().await;
-        }
-        Err(e) => {
-            tracing::error!("ServerActor processing error: {:?}", e);
-            // drop actor handle to initiate shutdown
-            drop(hawk_handle);
-
-            // Clean up server tasks, then wait for them to finish
-            background_tasks.abort_all();
-            tokio::time::sleep(Duration::from_secs(5)).await;
-
-            // Check for background task hangs and shutdown panics
-            background_tasks.check_tasks_finished();
-        }
-    }
-    Ok(())
 }
 
+fn max_sync_lookback(config: &Config) -> usize {
+    config.max_batch_size * 2
+}
 
+fn max_rollback(config: &Config) -> usize {
+    config.max_batch_size * 2
+}
 
+/// Initialize Postgres connections for access to iris share and HNSW graph
+/// databases.
 async fn prepare_stores(config: &Config) -> Result<(Store, GraphPg<Aby3Store>), Report> {
     let schema_name = format!(
         "{}_{}_{}",
@@ -967,4 +287,892 @@ async fn prepare_stores(config: &Config) -> Result<(Store, GraphPg<Aby3Store>), 
             Ok((store, graph_store))
         }
     }
+}
+
+/// Initialize AWS service access for SQS, SNS, S3, and Secrets Manager.
+async fn init_aws_services(config: &Config) -> Result<AwsClients> {
+    tracing::info!("Initialising AWS services");
+    AwsClients::new(config).await
+}
+
+/// Retrieve this node's keypair for decrypting their iris code secret shares
+/// from SQS query inputs.
+async fn get_shares_encryption_key_pair(
+    config: &Config,
+    aws_clients: &AwsClients,
+) -> Result<SharesEncryptionKeyPairs> {
+    let key_pair_result = SharesEncryptionKeyPairs::from_storage(
+        aws_clients.secrets_manager_client.clone(),
+        &config.environment,
+        &config.party_id,
+    )
+    .await;
+
+    if let Err(e) = &key_pair_result {
+        tracing::error!("Failed to initialize shares encryption key pairs: {:?}", e);
+    }
+
+    Ok(key_pair_result?)
+}
+
+struct SnsAttributesMaps {
+    uniqueness_result_attributes: HashMap<String, MessageAttributeValue>,
+    reauth_result_attributes: HashMap<String, MessageAttributeValue>,
+    anonymized_statistics_attributes: HashMap<String, MessageAttributeValue>,
+    identity_deletion_result_attributes: HashMap<String, MessageAttributeValue>,
+}
+
+/// Initialize SNS attribute maps, and replay recent SNS results to ensure
+/// delivery occurred in case of previous server failure.
+async fn init_sns(
+    config: &Config,
+    aws_clients: &AwsClients,
+    store: &Store,
+) -> Result<SnsAttributesMaps> {
+    let uniqueness_result_attributes = create_message_type_attribute_map(UNIQUENESS_MESSAGE_TYPE);
+    let reauth_result_attributes = create_message_type_attribute_map(REAUTH_MESSAGE_TYPE);
+    let anonymized_statistics_attributes =
+        create_message_type_attribute_map(ANONYMIZED_STATISTICS_MESSAGE_TYPE);
+    let identity_deletion_result_attributes =
+        create_message_type_attribute_map(IDENTITY_DELETION_MESSAGE_TYPE);
+
+    tracing::info!("Replaying results");
+    send_results_to_sns(
+        store.last_results(max_sync_lookback(config)).await?,
+        &Vec::new(),
+        &aws_clients.sns_client,
+        config,
+        &uniqueness_result_attributes,
+        UNIQUENESS_MESSAGE_TYPE,
+    )
+    .await?;
+
+    Ok(SnsAttributesMaps {
+        uniqueness_result_attributes,
+        reauth_result_attributes,
+        anonymized_statistics_attributes,
+        identity_deletion_result_attributes,
+    })
+}
+
+/// Seed the iris database with random shares if the store has length 0 and
+/// `config.init_db_size` has value greater than 0.
+async fn maybe_seed_random_shares(config: &Config, store: &Store) -> Result<()> {
+    let store_len = store.count_irises().await?;
+    if store_len == 0 && config.init_db_size > 0 {
+        tracing::info!(
+            "Initialize persistent iris DB with {} randomly generated shares",
+            config.init_db_size
+        );
+        tracing::info!("Resetting the db: {}", config.clear_db_before_init);
+        store
+            .init_db_with_random_shares(
+                RNG_SEED_INIT_DB,
+                config.party_id,
+                config.init_db_size,
+                config.clear_db_before_init,
+            )
+            .await?
+    }
+
+    Ok(())
+}
+
+/// Conduct consistency checks on the iris shares store.
+async fn check_store_consistency(config: &Config, store: &Store) -> Result<()> {
+    let store_len = store.count_irises().await?;
+    tracing::info!("Size of the database after init: {}", store_len);
+
+    // Check if the sequence id is consistent with the number of irises
+    let max_serial_id = store.get_max_serial_id().await?;
+    if max_serial_id != store_len {
+        tracing::error!(
+            "Detected inconsistency between max serial id {} and db size {}.",
+            max_serial_id,
+            store_len
+        );
+
+        bail!(
+            "Detected inconsistency between max serial id {} and db size {}.",
+            max_serial_id,
+            store_len
+        );
+    }
+
+    if store_len > config.max_db_size {
+        tracing::error!("Database size exceeds maximum allowed size: {}", store_len);
+        bail!("Database size exceeds maximum allowed size: {}", store_len);
+    }
+
+    Ok(())
+}
+
+fn init_task_monitor() -> TaskMonitor {
+    tracing::info!("Preparing task monitor");
+    TaskMonitor::new()
+}
+
+/// Build this node's synchronization state, which is compared against the
+/// states provided by the other MPC nodes to reconstruct a consistent initial
+/// state for MPC operation.
+async fn build_sync_state(
+    config: &Config,
+    aws_clients: &AwsClients,
+    store: &Store,
+) -> Result<SyncState> {
+    let db_len = store.count_irises().await? as u64;
+    let deleted_request_ids = store
+        .last_deleted_requests(max_sync_lookback(config))
+        .await?;
+    let modifications = store.last_modifications(max_sync_lookback(config)).await?;
+    let next_sns_sequence_num = get_next_sns_seq_num(config, &aws_clients.sqs_client).await?;
+    let common_config = CommonConfig::from(config.clone());
+
+    Ok(SyncState {
+        db_len,
+        deleted_request_ids,
+        modifications,
+        next_sns_sequence_num,
+        common_config,
+    })
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct ReadyProbeResponse {
+    image_name: String,
+    uuid: String,
+    shutting_down: bool,
+}
+
+/// Initializes and starts HTTP server for coordinating healthcheck, readiness,
+/// and synchronization between MPC nodes.
+///
+/// Returns a reference to the readiness flag, an `AtomicBool`, which can later
+/// be set to indicate to other MPC nodes that this server is ready for
+/// operation.
+async fn start_coordination_server(
+    config: &Config,
+    task_monitor: &mut TaskMonitor,
+    shutdown_handler: &Arc<ShutdownHandler>,
+    my_state: &SyncState,
+) -> Arc<AtomicBool> {
+    // --------------------------------------------------------------------------
+    // ANCHOR: Starting Healthcheck, Readiness and Sync server
+    // --------------------------------------------------------------------------
+    tracing::info!("⚓️ ANCHOR: Starting Healthcheck, Readiness and Sync server");
+
+    let is_ready_flag = Arc::new(AtomicBool::new(false));
+
+    let health_shutdown_handler = Arc::clone(shutdown_handler);
+    let health_check_port = config.hawk_server_healthcheck_port;
+
+    let _health_check_abort = task_monitor.spawn({
+        let uuid = uuid::Uuid::new_v4().to_string();
+        let is_ready_flag = is_ready_flag.clone();
+        let ready_probe_response = ReadyProbeResponse {
+            image_name: config.image_name.clone(),
+            shutting_down: false,
+            uuid: uuid.clone(),
+        };
+        let ready_probe_response_shutdown = ReadyProbeResponse {
+            image_name: config.image_name.clone(),
+            shutting_down: true,
+            uuid: uuid.clone(),
+        };
+        let serialized_response = serde_json::to_string(&ready_probe_response)
+            .expect("Serialization to JSON to probe response failed");
+        let serialized_response_shutdown = serde_json::to_string(&ready_probe_response_shutdown)
+            .expect("Serialization to JSON to probe response failed");
+        tracing::info!("Healthcheck probe response: {}", serialized_response);
+        let my_state = my_state.clone();
+        async move {
+            // Generate a random UUID for each run.
+            let app = Router::new()
+                .route(
+                    "/health",
+                    get(move || {
+                        let shutdown_handler_clone = Arc::clone(&health_shutdown_handler);
+                        async move {
+                            if shutdown_handler_clone.is_shutting_down() {
+                                serialized_response_shutdown.clone()
+                            } else {
+                                serialized_response.clone()
+                            }
+                        }
+                    }),
+                )
+                .route(
+                    "/ready",
+                    get({
+                        // We are only ready once this flag is set to true.
+                        let is_ready_flag = Arc::clone(&is_ready_flag);
+                        move || async move {
+                            if is_ready_flag.load(Ordering::SeqCst) {
+                                "ready".into_response()
+                            } else {
+                                StatusCode::SERVICE_UNAVAILABLE.into_response()
+                            }
+                        }
+                    }),
+                )
+                .route(
+                    "/startup-sync",
+                    get(move || async move { serde_json::to_string(&my_state).unwrap() }),
+                );
+            let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{}", health_check_port))
+                .await
+                .wrap_err("healthcheck listener bind error")?;
+            axum::serve(listener, app)
+                .await
+                .wrap_err("healthcheck listener server launch error")?;
+
+            Ok::<(), Error>(())
+        }
+    });
+
+    tracing::info!(
+        "Healthcheck and Readiness server running on port {}.",
+        health_check_port.clone()
+    );
+
+    is_ready_flag
+}
+
+/// Wait until all other MPC nodes respond to queries against their "ready"
+/// endpoints, indicating that their coordination servers are running.  The
+/// response to this query is expected initially to be `503 Service
+/// Unavailable`.
+async fn wait_for_others_unready(config: &Config) -> Result<()> {
+    tracing::info!("⚓️ ANCHOR: Waiting for other servers to be un-ready (syncing on startup)");
+    // Check other nodes and wait until all nodes are ready.
+    let all_readiness_addresses = get_check_addresses(
+        config.node_hostnames.clone(),
+        config.healthcheck_ports.clone(),
+        "ready",
+    );
+
+    let party_id = config.party_id;
+
+    let unready_check = tokio::spawn(async move {
+        let next_node = &all_readiness_addresses[(party_id + 1) % 3];
+        let prev_node = &all_readiness_addresses[(party_id + 2) % 3];
+        let mut connected_but_unready = [false, false];
+
+        loop {
+            for (i, host) in [next_node, prev_node].iter().enumerate() {
+                let res = reqwest::get(host.as_str()).await;
+
+                if res.is_ok() && res.unwrap().status() == StatusCode::SERVICE_UNAVAILABLE {
+                    connected_but_unready[i] = true;
+                    // If all nodes are connected, notify the main thread.
+                    if connected_but_unready.iter().all(|&c| c) {
+                        return;
+                    }
+                }
+            }
+
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    });
+
+    tracing::info!("Waiting for all nodes to be unready...");
+    match tokio::time::timeout(
+        Duration::from_secs(config.startup_sync_timeout_secs),
+        unready_check,
+    )
+    .await
+    {
+        Ok(res) => {
+            res?;
+        }
+        Err(_) => {
+            tracing::error!("Timeout waiting for all nodes to be unready.");
+            return Err(eyre!("Timeout waiting for all nodes to be unready."));
+        }
+    };
+    tracing::info!("All nodes are starting up.");
+
+    Ok(())
+}
+
+/// Start a heartbeat task which periodically polls the "health" endpoints of
+/// all other MPC nodes to ensure that the other nodes are still running and
+/// responding to network requests.
+async fn init_heartbeat_task(
+    config: &Config,
+    task_monitor: &mut TaskMonitor,
+    shutdown_handler: &Arc<ShutdownHandler>,
+) -> Result<()> {
+    let (heartbeat_tx, heartbeat_rx) = oneshot::channel();
+    let mut heartbeat_tx = Some(heartbeat_tx);
+
+    let all_health_addresses = get_check_addresses(
+        config.node_hostnames.clone(),
+        config.healthcheck_ports.clone(),
+        "health",
+    );
+
+    let party_id = config.party_id;
+    let image_name = config.image_name.clone();
+    let heartbeat_initial_retries = config.heartbeat_initial_retries;
+    let heartbeat_interval_secs = config.heartbeat_interval_secs;
+
+    let heartbeat_shutdown_handler = Arc::clone(shutdown_handler);
+    let _heartbeat = task_monitor.spawn(async move {
+        let next_node = &all_health_addresses[(party_id + 1) % 3];
+        let prev_node = &all_health_addresses[(party_id + 2) % 3];
+        let mut last_response = [String::default(), String::default()];
+        let mut connected = [false, false];
+        let mut retries = [0, 0];
+
+        loop {
+            for (i, host) in [next_node, prev_node].iter().enumerate() {
+                let res = reqwest::get(host.as_str()).await;
+                if res.is_err() || !res.as_ref().unwrap().status().is_success() {
+                    // If it's the first time after startup, we allow a few retries to let the other
+                    // nodes start up as well.
+                    if last_response[i] == String::default()
+                        && retries[i] < heartbeat_initial_retries
+                    {
+                        retries[i] += 1;
+                        tracing::warn!("Node {} did not respond with success, retrying...", host);
+                        continue;
+                    }
+                    tracing::info!(
+                        "Node {} did not respond with success, starting graceful shutdown",
+                        host
+                    );
+                    // if the nodes are still starting up and they get a failure - we can panic and
+                    // not start graceful shutdown
+                    if last_response[i] == String::default() {
+                        panic!(
+                            "Node {} did not respond with success during heartbeat init phase, \
+                             killing server...",
+                            host
+                        );
+                    }
+
+                    if !heartbeat_shutdown_handler.is_shutting_down() {
+                        heartbeat_shutdown_handler.trigger_manual_shutdown();
+                        tracing::error!(
+                            "Node {} has not completed health check, therefore graceful shutdown \
+                             has been triggered",
+                            host
+                        );
+                    } else {
+                        tracing::info!("Node {} has already started graceful shutdown.", host);
+                    }
+                    continue;
+                }
+
+                let probe_response = res
+                    .unwrap()
+                    .json::<ReadyProbeResponse>()
+                    .await
+                    .expect("Deserialization of probe response failed");
+                if probe_response.image_name != image_name {
+                    // Do not create a panic as we still can continue to process before its
+                    // updated
+                    tracing::error!(
+                        "Host {} is using image {} which differs from current node image: {}",
+                        host,
+                        probe_response.image_name.clone(),
+                        image_name
+                    );
+                }
+                if last_response[i] == String::default() {
+                    last_response[i] = probe_response.uuid;
+                    connected[i] = true;
+
+                    // If all nodes are connected, notify the main thread.
+                    if connected.iter().all(|&c| c) {
+                        if let Some(tx) = heartbeat_tx.take() {
+                            tx.send(()).unwrap();
+                        }
+                    }
+                } else if probe_response.uuid != last_response[i] {
+                    // If the UUID response is different, the node has restarted without us
+                    // noticing. Our main NCCL connections cannot recover from
+                    // this, so we panic.
+                    panic!("Node {} seems to have restarted, killing server...", host);
+                } else if probe_response.shutting_down {
+                    tracing::info!("Node {} has starting graceful shutdown", host);
+
+                    if !heartbeat_shutdown_handler.is_shutting_down() {
+                        heartbeat_shutdown_handler.trigger_manual_shutdown();
+                        tracing::error!(
+                            "Node {} has starting graceful shutdown, therefore triggering \
+                             graceful shutdown",
+                            host
+                        );
+                    }
+                } else {
+                    tracing::info!("Heartbeat: Node {} is healthy", host);
+                }
+            }
+
+            tokio::time::sleep(Duration::from_secs(heartbeat_interval_secs)).await;
+        }
+    });
+
+    tracing::info!("Heartbeat starting...");
+    heartbeat_rx.await?;
+    tracing::info!("Heartbeat on all nodes started.");
+
+    Ok(())
+}
+
+/// Retrieve the synchronization state of the other MPC nodes from their
+/// "startup-sync" endpoints.  This data is used to ensure that all nodes are
+/// in a consistent state prior to starting MPC operation.
+async fn get_others_sync_state(config: &Config, my_state: &SyncState) -> Result<SyncResult> {
+    // --------------------------------------------------------------------------
+    // ANCHOR: Syncing latest node state
+    // --------------------------------------------------------------------------
+    tracing::info!("⚓️ ANCHOR: Syncing latest node state");
+
+    let all_startup_sync_addresses = get_check_addresses(
+        config.node_hostnames.clone(),
+        config.healthcheck_ports.clone(),
+        "startup-sync",
+    );
+
+    let next_node = &all_startup_sync_addresses[(config.party_id + 1) % 3];
+    let prev_node = &all_startup_sync_addresses[(config.party_id + 2) % 3];
+
+    tracing::info!("Database store length is: {}", my_state.db_len);
+    let mut states = vec![my_state.clone()];
+    for host in [next_node, prev_node].iter() {
+        let res = reqwest::get(host.as_str()).await;
+        match res {
+            Ok(res) => {
+                let state: SyncState = match res.json().await {
+                    Ok(state) => state,
+                    Err(e) => {
+                        tracing::error!("Failed to parse sync state from party {}: {:?}", host, e);
+                        panic!(
+                            "could not get sync state from party {}, trying to restart",
+                            host
+                        );
+                    }
+                };
+                states.push(state);
+            }
+            Err(e) => {
+                tracing::error!("Failed to fetch sync state from party {}: {:?}", host, e);
+                panic!(
+                    "could not get sync state from party {}, trying to restart",
+                    host
+                );
+            }
+        }
+    }
+    Ok(SyncResult::new(my_state.clone(), states))
+}
+
+/// If enabled in `config.enable_sync_queues_on_sns_sequence_number`, delete SQS
+/// messages in the requests queue with sequence number older than the most
+/// recent sequence number seen by any MPC party.
+async fn maybe_sync_sqs_queues(
+    config: &Config,
+    sync_result: &SyncResult,
+    aws_clients: &AwsClients,
+) -> Result<()> {
+    // sync the queues
+    if config.enable_sync_queues_on_sns_sequence_number {
+        let max_sqs_sequence_num = sync_result.max_sns_sequence_num();
+        delete_messages_until_sequence_num(
+            config,
+            &aws_clients.sqs_client,
+            sync_result.my_state.next_sns_sequence_num,
+            max_sqs_sequence_num,
+        )
+        .await?;
+    }
+
+    Ok(())
+}
+
+/// Synchronize iris databases if needed by rolling back to the smallest length
+/// among the MPC parties.  Rollback fails if the number of rolled back entries
+/// is greater than a fixed maximum rollback amount determined by the
+/// configuration parameters.
+async fn sync_dbs_rollback(config: &Config, sync_result: &SyncResult, store: &Store) -> Result<()> {
+    let my_db_len = store.count_irises().await?;
+
+    if let Some(min_db_len) = sync_result.must_rollback_storage() {
+        tracing::error!("Databases are out-of-sync: {:?}", sync_result);
+        if min_db_len + max_rollback(config) < my_db_len {
+            return Err(eyre!(
+                "Refusing to rollback so much (from {} to {})",
+                my_db_len,
+                min_db_len,
+            ));
+        }
+        tracing::warn!(
+            "Rolling back from database length {} to other nodes length {}",
+            my_db_len,
+            min_db_len
+        );
+        store.rollback(min_db_len).await?;
+        metrics::counter!("db.sync.rollback").increment(1);
+    }
+
+    // refetch store_len in case we rolled back
+    let store_len = store.count_irises().await?;
+    tracing::info!("Size of the database after sync: {}", store_len);
+
+    Ok(())
+}
+
+/// Initialize main Hawk actor process for handling query batches using HNSW
+/// approximate k-nearest neighbors graph search.
+async fn init_hawk_actor(config: &Config) -> Result<HawkActor> {
+    // Initialize the HawkActor
+    let node_addresses: Vec<String> = config
+        .node_hostnames
+        .iter()
+        .zip(config.service_ports.iter())
+        .map(|(host, port)| format!("{}:{}", host, port))
+        .collect();
+
+    let hawk_args = HawkArgs {
+        party_index: config.party_id,
+        addresses: node_addresses.clone(),
+        request_parallelism: config.hawk_request_parallelism,
+        connection_parallelism: config.hawk_connection_parallelism,
+        hnsw_prng_seed: config.hawk_prng_seed,
+        disable_persistence: config.cpu_disable_persistence,
+        match_distances_buffer_size: config.match_distances_buffer_size,
+        n_buckets: config.n_buckets,
+    };
+
+    tracing::info!(
+        "Initializing HawkActor with args: party_index: {}, addresses: {:?}",
+        hawk_args.party_index,
+        node_addresses
+    );
+
+    HawkActor::from_cli(&hawk_args).await
+}
+
+/// Load iris code shares and HNSW graph from Postgres and/or S3.
+async fn load_database(
+    config: &Config,
+    store: &Store,
+    graph_store: &GraphPg<Aby3Store>,
+    aws_clients: &AwsClients,
+    shutdown_handler: &Arc<ShutdownHandler>,
+    hawk_actor: &mut HawkActor,
+) -> Result<()> {
+    // ANCHOR: Load the database
+    tracing::info!("⚓️ ANCHOR: Load the database");
+    let (mut iris_loader, graph_loader) = hawk_actor.as_iris_loader().await;
+
+    let parallelism = config
+        .database
+        .as_ref()
+        .ok_or(eyre!("Missing database config"))?
+        .load_parallelism;
+
+    let s3_load_parallelism = config.load_chunks_parallelism;
+    let s3_chunks_bucket_name = config.db_chunks_bucket_name.clone();
+    let s3_chunks_folder_name = config.db_chunks_folder_name.clone();
+    let s3_load_max_retries = config.load_chunks_max_retries;
+    let s3_load_initial_backoff_ms = config.load_chunks_initial_backoff_ms;
+
+    if config.fake_db_size > 0 {
+        // TODO: not needed?
+        iris_loader.fake_db(config.fake_db_size);
+    } else {
+        tracing::info!(
+            "Initialize iris db: Loading from DB (parallelism: {})",
+            parallelism
+        );
+        let download_shutdown_handler = Arc::clone(shutdown_handler);
+        let db_chunks_s3_store = S3Store::new(
+            aws_clients.db_chunks_s3_client.clone(),
+            s3_chunks_bucket_name.clone(),
+        );
+
+        let store_len = store.count_irises().await?;
+
+        load_db(
+            &mut iris_loader,
+            store,
+            store_len,
+            parallelism,
+            config,
+            db_chunks_s3_store,
+            aws_clients.db_chunks_s3_client.clone(),
+            s3_chunks_folder_name,
+            s3_chunks_bucket_name,
+            s3_load_parallelism,
+            s3_load_max_retries,
+            s3_load_initial_backoff_ms,
+            download_shutdown_handler,
+        )
+        .await
+        .expect("Failed to load DB");
+
+        graph_loader.load_graph_store(graph_store).await?;
+    }
+
+    Ok(())
+}
+
+/// Start thread which is responsible for communicating back the results from
+/// batch query processing.
+async fn start_results_thread(
+    config: &Config,
+    store: &Store,
+    graph_store: GraphPg<Aby3Store>,
+    aws_clients: &AwsClients,
+    task_monitor: &mut TaskMonitor,
+    shutdown_handler: &Arc<ShutdownHandler>,
+    sns_attributes_maps: SnsAttributesMaps,
+) -> Result<Sender<ServerJobResult>> {
+    let (tx, mut rx) = mpsc::channel::<ServerJobResult>(32); // TODO: pick some buffer value
+    let sns_client_bg = aws_clients.sns_client.clone();
+    let config_bg = config.clone();
+    let store_bg = store.clone();
+    let shutdown_handler_bg = Arc::clone(shutdown_handler);
+    let party_id = config.party_id;
+    let _result_sender_abort = task_monitor.spawn(async move {
+        while let Some(job_result) = rx.recv().await {
+            if let Err(e) = process_job_result(
+                job_result,
+                party_id,
+                &store_bg,
+                &graph_store,
+                &sns_client_bg,
+                &config_bg,
+                &sns_attributes_maps.uniqueness_result_attributes,
+                &sns_attributes_maps.reauth_result_attributes,
+                &sns_attributes_maps.identity_deletion_result_attributes,
+                &sns_attributes_maps.anonymized_statistics_attributes,
+                &shutdown_handler_bg,
+            )
+            .await
+            {
+                tracing::error!("Error processing job result: {:?}", e);
+            }
+        }
+
+        Ok(())
+    });
+
+    Ok(tx)
+}
+
+/// Toggle `is_ready_flag` to `true` to signal to other nodes that this node
+/// is ready to execute the main server loop.
+fn set_node_ready(is_ready_flag: Arc<AtomicBool>) {
+    tracing::info!("⚓️ ANCHOR: Enable readiness and check all nodes");
+
+    // Set the readiness flag to true, which will make the readiness server return a
+    // 200 status code.
+    is_ready_flag.store(true, Ordering::SeqCst);
+}
+
+/// Query other nodes at their "ready" endpoints until all other nodes return
+/// a success response, indicating readiness to execute the main server loop.
+async fn wait_for_others_ready(config: &Config) -> Result<()> {
+    // Check other nodes and wait until all nodes are ready.
+    let all_readiness_addresses = get_check_addresses(
+        config.node_hostnames.clone(),
+        config.healthcheck_ports.clone(),
+        "ready",
+    );
+
+    let party_id = config.party_id;
+    let ready_check = tokio::spawn(async move {
+        let next_node = &all_readiness_addresses[(party_id + 1) % 3];
+        let prev_node = &all_readiness_addresses[(party_id + 2) % 3];
+        let mut connected = [false, false];
+
+        loop {
+            for (i, host) in [next_node, prev_node].iter().enumerate() {
+                let res = reqwest::get(host.as_str()).await;
+
+                if res.is_ok() && res.as_ref().unwrap().status().is_success() {
+                    connected[i] = true;
+                    // If all nodes are connected, notify the main thread.
+                    if connected.iter().all(|&c| c) {
+                        return;
+                    }
+                }
+            }
+
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    });
+
+    tracing::info!("Waiting for all nodes to be ready...");
+    match tokio::time::timeout(
+        Duration::from_secs(config.startup_sync_timeout_secs),
+        ready_check,
+    )
+    .await
+    {
+        Ok(res) => {
+            res?;
+        }
+        Err(_) => {
+            tracing::error!("Timeout waiting for all nodes to be ready.");
+            return Err(eyre!("Timeout waiting for all nodes to be ready."));
+        }
+    }
+    tracing::info!("All nodes are ready.");
+
+    Ok(())
+}
+
+/// Run the main processing loop in this thread.  Batches of requests are read
+/// from the SQS input queue, and are passed to a `HawkHandle` processer task,
+/// which distributes tasks among different threads and gRPC network sessions
+/// to execute appropriate computations via MPC.  Once a batch is processed,
+/// the results are passed to the results processing thread to be finalized
+/// and communicated out.
+#[allow(clippy::too_many_arguments)]
+async fn run_main_server_loop(
+    config: &Config,
+    store: &Store,
+    aws_clients: &AwsClients,
+    shares_encryption_key_pair: SharesEncryptionKeyPairs,
+    sync_result: &SyncResult,
+    mut task_monitor: TaskMonitor,
+    shutdown_handler: &Arc<ShutdownHandler>,
+    hawk_actor: HawkActor,
+    tx_results: Sender<ServerJobResult>,
+) -> Result<()> {
+    // --------------------------------------------------------------------------
+    // ANCHOR: Start the main loop
+    // --------------------------------------------------------------------------
+    tracing::info!("⚓️ ANCHOR: Start the main loop");
+
+    let mut hawk_handle = HawkHandle::new(hawk_actor).await?;
+
+    let mut skip_request_ids = sync_result.deleted_request_ids();
+
+    let party_id = config.party_id;
+
+    let processing_timeout = Duration::from_secs(config.processing_timeout_secs);
+    let uniqueness_error_result_attribute =
+        create_message_type_attribute_map(UNIQUENESS_MESSAGE_TYPE);
+    let reauth_error_result_attribute = create_message_type_attribute_map(REAUTH_MESSAGE_TYPE);
+    let res: Result<()> = async {
+        tracing::info!("Entering main loop");
+
+        // Skip requests based on the startup sync, only in the first iteration.
+        let skip_request_ids = mem::take(&mut skip_request_ids);
+
+        // This batch can consist of N sets of iris_share + mask
+        // It also includes a vector of request ids, mapping to the sets above
+
+        let mut next_batch = receive_batch(
+            party_id,
+            &aws_clients.sqs_client,
+            &aws_clients.sns_client,
+            &aws_clients.s3_client,
+            config,
+            store,
+            &skip_request_ids,
+            shares_encryption_key_pair.clone(),
+            shutdown_handler,
+            &uniqueness_error_result_attribute,
+            &reauth_error_result_attribute,
+        );
+
+        let dummy_shares_for_deletions = get_dummy_shares_for_deletion(party_id);
+
+        loop {
+            let now = Instant::now();
+
+            let _batch = next_batch.await?;
+            if _batch.is_none() {
+                tracing::info!("No more batches to process, exiting main loop");
+                return Ok(());
+            }
+            let batch = _batch.unwrap();
+
+            // start trace span - with single TraceId and single ParentTraceID
+            tracing::info!("Received batch in {:?}", now.elapsed());
+
+            metrics::histogram!("receive_batch_duration").record(now.elapsed().as_secs_f64());
+
+            process_identity_deletions(
+                &batch,
+                store,
+                &dummy_shares_for_deletions.0,
+                &dummy_shares_for_deletions.1,
+            )
+            .await?;
+
+            // Iterate over a list of tracing payloads, and create logs with mappings to
+            // payloads Log at least a "start" event using a log with trace.id and
+            // parent.trace.id
+            for tracing_payload in batch.metadata.iter() {
+                tracing::info!(
+                    node_id = tracing_payload.node_id,
+                    dd.trace_id = tracing_payload.trace_id,
+                    dd.span_id = tracing_payload.span_id,
+                    "Started processing share",
+                );
+            }
+
+            task_monitor.check_tasks();
+
+            let result_future = hawk_handle.submit_batch_query(batch.clone());
+
+            next_batch = receive_batch(
+                party_id,
+                &aws_clients.sqs_client,
+                &aws_clients.sns_client,
+                &aws_clients.s3_client,
+                config,
+                store,
+                &skip_request_ids,
+                shares_encryption_key_pair.clone(),
+                shutdown_handler,
+                &uniqueness_error_result_attribute,
+                &reauth_error_result_attribute,
+            );
+
+            // await the result
+            let result = timeout(processing_timeout, result_future.await)
+                .await
+                .map_err(|e| eyre!("HawkActor processing timeout: {:?}", e))??;
+
+            tx_results.send(result).await?;
+
+            shutdown_handler.increment_batches_pending_completion()
+            // wrap up tracing span context
+        }
+    }
+    .await;
+
+    match res {
+        Ok(_) => {
+            tracing::info!(
+                "Main loop exited normally. Waiting for last batch results to be processed before \
+                 shutting down..."
+            );
+
+            shutdown_handler.wait_for_pending_batches_completion().await;
+        }
+        Err(e) => {
+            tracing::error!("HawkActor processing error: {:?}", e);
+            // drop actor handle to initiate shutdown
+            drop(hawk_handle);
+
+            // Clean up server tasks, then wait for them to finish
+            task_monitor.abort_all();
+            tokio::time::sleep(Duration::from_secs(5)).await;
+
+            // Check for background task hangs and shutdown panics
+            task_monitor.check_tasks_finished();
+        }
+    }
+    Ok(())
 }


### PR DESCRIPTION
This PR restructures the primary HNSW `server_main` function by pulling out logical components of the server functionality into individual functional calls.  This restructuring is in preparation for implementing the "genesis" indexer, which will be used to initially construct an HNSW graph from pre-existing secret shared iris shares, and which will share much (but not all) of the functionality of `server_main`.