### PR TITLE
feat: upgrade NCCL to latest supported

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -4,7 +4,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends pkg-config wget
 RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb \
     && dpkg -i cuda-keyring_1.1-1_all.deb \
     && apt-get update \
-    && apt-get install -y--no-install-recommends cuda-toolkit-12-2 libnccl2=2.23.4-1+cuda12.2 libnccl-dev=2.23.4-1+cuda12.2 git curl build-essential debhelper libhwloc-dev
+    && apt-get install -y --no-install-recommends cuda-toolkit-12-2 libnccl2=2.23.4-1+cuda12.2 libnccl-dev=2.23.4-1+cuda12.2 git curl build-essential debhelper libhwloc-dev
 
 ARG GDRCOPY_VERSION=v2.4.1
 ARG EFA_INSTALLER_VERSION=1.39.0

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -4,11 +4,11 @@ RUN apt-get update && apt-get install -y pkg-config wget libssl-dev ca-certifica
 RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb \
     && dpkg -i cuda-keyring_1.1-1_all.deb \
     && apt-get update \
-    && apt-get install -y cuda-toolkit-12-2 libnccl2=2.22.3-1+cuda12.2 libnccl-dev=2.22.3-1+cuda12.2 git curl build-essential debhelper libhwloc-dev
+    && apt-get install -y cuda-toolkit-12-2 libnccl2=2.23.4-1+cuda12.2 libnccl-dev=2.23.4-1+cuda12.2 git curl build-essential debhelper libhwloc-dev
 
 ARG GDRCOPY_VERSION=v2.4.1
 ARG EFA_INSTALLER_VERSION=1.39.0
-ARG NCCL_INSTALL_VERSION=v2.22.3-1
+ARG NCCL_INSTALL_VERSION=v2.23.4-1
 ARG AWS_OFI_NCCL_VERSION=v1.13.2-aws
 
 ENV LD_LIBRARY_PATH=/usr/local/cuda/extras/CUPTI/lib64:/opt/amazon/openmpi/lib:/opt/nccl/build/lib:/opt/amazon/efa/lib:/opt/aws-ofi-nccl/install/lib:/usr/local/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
Update NCCL to 2.23.4-1 (https://github.com/NVIDIA/nccl/releases/tag/v2.23.4-1 and https://docs.nvidia.com/deeplearning/nccl/release-notes/rel_2-23-4.html#rel_2-23-4) which is the latest supported by AWS OFI NCCL https://github.com/aws/aws-ofi-nccl/releases/tag/v1.13.2-aws