### PR TITLE
fix: specify region to get files from bucket in different region

### DIFF
--- a/deploy/stage/smpcv2-0-stage-eu-central-1/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage-eu-central-1/values-iris-mpc.yaml
@@ -219,6 +219,7 @@ initContainer:
       # Execute AWS CLI command with the generated JSON
       aws route53 change-resource-record-sets --hosted-zone-id "$HOSTED_ZONE_ID" --change-batch "$BATCH_JSON"
 
+      # region is set to eu-north-1 beacause the bucket is in that region
       cd /libs
-      aws s3 cp s3://wf-smpcv2-stage-libs/libcublas.so.12.2.5.6 .
-      aws s3 cp s3://wf-smpcv2-stage-libs/libcublasLt.so.12.2.5.6 .
+      aws s3 cp --region eu-north-1 s3://wf-smpcv2-stage-libs/libcublas.so.12.2.5.6 .
+      aws s3 cp --region eu-north-1 s3://wf-smpcv2-stage-libs/libcublasLt.so.12.2.5.6 .

--- a/deploy/stage/smpcv2-1-stage-eu-central-1/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage-eu-central-1/values-iris-mpc.yaml
@@ -219,6 +219,7 @@ initContainer:
       # Execute AWS CLI command with the generated JSON
       aws route53 change-resource-record-sets --hosted-zone-id "$HOSTED_ZONE_ID" --change-batch "$BATCH_JSON"
       
+      # region is set to eu-north-1 beacause the bucket is in that region
       cd /libs
-      aws s3 cp s3://wf-smpcv2-stage-libs/libcublas.so.12.2.5.6 .
-      aws s3 cp s3://wf-smpcv2-stage-libs/libcublasLt.so.12.2.5.6 .
+      aws s3 cp --region eu-north-1 s3://wf-smpcv2-stage-libs/libcublas.so.12.2.5.6 .
+      aws s3 cp --region eu-north-1 s3://wf-smpcv2-stage-libs/libcublasLt.so.12.2.5.6 .

--- a/deploy/stage/smpcv2-2-stage-eu-central-1/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage-eu-central-1/values-iris-mpc.yaml
@@ -219,6 +219,7 @@ initContainer:
       # Execute AWS CLI command with the generated JSON
       aws route53 change-resource-record-sets --hosted-zone-id "$HOSTED_ZONE_ID" --change-batch "$BATCH_JSON"
 
+      # region is set to eu-north-1 beacause the bucket is in that region
       cd /libs
-      aws s3 cp s3://wf-smpcv2-stage-libs/libcublas.so.12.2.5.6 .
-      aws s3 cp s3://wf-smpcv2-stage-libs/libcublasLt.so.12.2.5.6 .
+      aws s3 cp --region eu-north-1 s3://wf-smpcv2-stage-libs/libcublas.so.12.2.5.6 .
+      aws s3 cp --region eu-north-1 s3://wf-smpcv2-stage-libs/libcublasLt.so.12.2.5.6 .


### PR DESCRIPTION
We must specify the region when downloading files from a different region. 