### PR TITLE
aurel/pipeline-receive-batch

### DIFF
--- a/iris-mpc/src/services/processors/batch.rs
+++ b/iris-mpc/src/services/processors/batch.rs
@@ -5,6 +5,7 @@ use aws_sdk_s3::Client as S3Client;
 use aws_sdk_sns::types::MessageAttributeValue;
 use aws_sdk_sns::Client as SNSClient;
 use aws_sdk_sqs::Client;
+use eyre::Result;
 use iris_mpc_common::config::Config;
 use iris_mpc_common::galois_engine::degree4::{
     GaloisRingIrisCodeShare, GaloisRingTrimmedMaskCodeShare, GaloisShares,
@@ -25,9 +26,65 @@ use iris_mpc_common::helpers::smpc_response::{
 use iris_mpc_common::job::{BatchMetadata, BatchQuery};
 use iris_mpc_store::Store;
 use std::collections::HashMap;
+use std::mem;
 use std::sync::Arc;
-use tokio::sync::Semaphore;
+use tokio::sync::mpsc::Receiver;
+use tokio::sync::{mpsc, Semaphore};
 use tokio::task::JoinHandle;
+
+#[allow(clippy::too_many_arguments)]
+pub fn receive_batch_stream(
+    party_id: usize,
+    client: Client,
+    sns_client: SNSClient,
+    s3_client: S3Client,
+    config: Config,
+    store: Store,
+    mut skip_request_ids: Vec<String>,
+    shares_encryption_key_pairs: SharesEncryptionKeyPairs,
+    shutdown_handler: Arc<ShutdownHandler>,
+    uniqueness_error_result_attributes: HashMap<String, MessageAttributeValue>,
+    reauth_error_result_attributes: HashMap<String, MessageAttributeValue>,
+) -> Receiver<Result<Option<BatchQuery>, ReceiveRequestError>> {
+    let (tx, rx) = mpsc::channel(1);
+
+    tokio::spawn(async move {
+        loop {
+            let permit = match tx.reserve().await {
+                Ok(p) => p,
+                Err(_) => break,
+            };
+
+            // Skip requests based on the startup sync, only in the first iteration.
+            let skip_request_ids = mem::take(&mut skip_request_ids);
+
+            let batch = receive_batch(
+                party_id,
+                &client,
+                &sns_client,
+                &s3_client,
+                &config,
+                &store,
+                &skip_request_ids,
+                shares_encryption_key_pairs.clone(),
+                &shutdown_handler,
+                &uniqueness_error_result_attributes,
+                &reauth_error_result_attributes,
+            )
+            .await;
+
+            let stop = matches!(batch, Err(_) | Ok(None));
+            permit.send(batch);
+
+            if stop {
+                break;
+            }
+        }
+        tracing::info!("Stopping batch receiver.");
+    });
+
+    rx
+}
 
 #[allow(clippy::too_many_arguments)]
 pub async fn receive_batch(


### PR DESCRIPTION
Receive the next batch in parallel to processing the current batch.

With `channel(1)`, when the main takes the ready batch (`batch_stream.recv()`), a `permit` is given to start receiving the next batch in the background.