### PR TITLE
chore: Bump the init size of the staging db

### DIFF
--- a/deploy/stage/smpcv2-0-stage-eu-central-1/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage-eu-central-1/values-iris-mpc.yaml
@@ -115,7 +115,7 @@ env:
     value: "1200000"
 
   - name: SMPC__MAX_DB_SIZE
-    value: "2000000"
+    value: "1400000"
 
   - name: SMPC__MAX_BATCH_SIZE
     value: "64"

--- a/deploy/stage/smpcv2-0-stage-eu-central-1/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage-eu-central-1/values-iris-mpc.yaml
@@ -112,10 +112,10 @@ env:
     value: "true"
 
   - name: SMPC__INIT_DB_SIZE
-    value: "1000"
+    value: "1200000"
 
   - name: SMPC__MAX_DB_SIZE
-    value: "1300000"
+    value: "2000000"
 
   - name: SMPC__MAX_BATCH_SIZE
     value: "64"

--- a/deploy/stage/smpcv2-1-stage-eu-central-1/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage-eu-central-1/values-iris-mpc.yaml
@@ -115,7 +115,7 @@ env:
     value: "1200000"
 
   - name: SMPC__MAX_DB_SIZE
-    value: "2000000"
+    value: "1400000"
 
   - name: SMPC__MAX_BATCH_SIZE
     value: "64"

--- a/deploy/stage/smpcv2-1-stage-eu-central-1/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage-eu-central-1/values-iris-mpc.yaml
@@ -112,10 +112,10 @@ env:
     value: "true"
 
   - name: SMPC__INIT_DB_SIZE
-    value: "1000"
+    value: "1200000"
 
   - name: SMPC__MAX_DB_SIZE
-    value: "1300000"
+    value: "2000000"
 
   - name: SMPC__MAX_BATCH_SIZE
     value: "64"

--- a/deploy/stage/smpcv2-2-stage-eu-central-1/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage-eu-central-1/values-iris-mpc.yaml
@@ -115,7 +115,7 @@ env:
     value: "1200000"
 
   - name: SMPC__MAX_DB_SIZE
-    value: "2000000"
+    value: "1400000"
 
   - name: SMPC__MAX_BATCH_SIZE
     value: "64"

--- a/deploy/stage/smpcv2-2-stage-eu-central-1/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage-eu-central-1/values-iris-mpc.yaml
@@ -112,10 +112,10 @@ env:
     value: "true"
 
   - name: SMPC__INIT_DB_SIZE
-    value: "1000"
+    value: "1200000"
 
   - name: SMPC__MAX_DB_SIZE
-    value: "1300000"
+    value: "2000000"
 
   - name: SMPC__MAX_BATCH_SIZE
     value: "64"


### PR DESCRIPTION
To run a test on a bigger dataset