### PR TITLE
aurel/mirror-results: Results engine with `select(Filter)`

### DIFF
--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -849,7 +849,7 @@ impl HawkResult {
     }
 
     fn job_result(self) -> ServerJobResult {
-        use Orientation::Mirror;
+        use Orientation::{Mirror, Normal};
         use StoreId::{Left, Right};
 
         let n_requests = self.is_matches.len();
@@ -860,12 +860,12 @@ impl HawkResult {
 
         let (partial_match_ids_left, partial_match_counters_left) = self.select(Filter {
             eyes: Only(Left),
-            orient: Both,
+            orient: Only(Normal),
         });
 
         let (partial_match_ids_right, partial_match_counters_right) = self.select(Filter {
             eyes: Only(Right),
-            orient: Both,
+            orient: Only(Normal),
         });
 
         let (full_face_mirror_match_ids, _) = self.select(Filter {

--- a/iris-mpc-cpu/src/execution/hawk_main/matching.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/matching.rs
@@ -4,7 +4,6 @@ use super::{
 };
 use itertools::{chain, izip, Itertools};
 use std::collections::HashMap;
-use tracing_subscriber::filter;
 
 /// Since the two separate HSNW for left and right return separate vectors of matching ids, we
 /// cannot do the trivial AND/OR matching procedure from v2, since the other side might not have
@@ -195,17 +194,6 @@ impl BatchStep3 {
             .map(|step| step.select(filter).collect_vec())
             .collect_vec()
     }
-
-    // TODO: Integrate mirror.
-    pub fn filter_map<F, OUT>(&self, f: F) -> VecRequests<VecEdges<OUT>>
-    where
-        F: Fn(&(VectorId, BothEyes<bool>)) -> Option<OUT>,
-    {
-        self.0
-            .iter()
-            .map(|step| step.normal.filter_map(&f))
-            .collect_vec()
-    }
 }
 
 /// Results for one request.
@@ -266,15 +254,6 @@ impl Step2 {
             .map(|m| MatchId::IntraBatch(m.other_request_i));
 
         chain!(search, luc, intra)
-    }
-
-    fn filter_map<F, OUT>(&self, f: F) -> VecEdges<OUT>
-    where
-        F: Fn(&(VectorId, BothEyes<bool>)) -> Option<OUT>,
-    {
-        chain!(&self.full_join, &self.luc_results)
-            .filter_map(f)
-            .collect_vec()
     }
 }
 


### PR DESCRIPTION
Follow-up to #1307 to process the results.

To support all the kinds of results (AND rule, OR rule, partial, mirrored), this PR introduces a method `select(Filter)` that iterates over the matches for the given filter.