### PR TITLE
Fix logging leftover

### DIFF
--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -991,7 +991,7 @@ impl ServerActor {
                 DB_CHUNK_SIZE
             );
 
-            tracing::info!("Comparing right eye queries against DB and self");
+            tracing::info!("Comparing {} eye queries against DB and self", other_side);
             self.compare_query_against_db_and_self(
                 &compact_device_queries_side2,
                 &compact_device_sums_side2,
@@ -1001,7 +1001,7 @@ impl ServerActor {
                 orientation,
             );
         } else {
-            tracing::info!("Comparing right eye queries against DB subset");
+            tracing::info!("Comparing {} eye queries against DB subset", other_side);
             self.compare_query_against_db_subset_and_self(
                 &compact_device_queries_side2,
                 &compact_device_sums_side2,


### PR DESCRIPTION
### Description

There is a leftover incorrect logging in the code that performs the 'other' side comparison. The logging was left as hardcoded `right` side.

This could lead to frustration during debugging potential issues in the future, when we decide to change the order of the checks (first right and then left).

Minor and straightforward fix