### PR TITLE
bump processing timeout

### DIFF
--- a/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw.yaml
@@ -87,7 +87,7 @@ env:
         name: application
 
   - name: SMPC__PROCESSING_TIMEOUT_SECS
-    value: "120"
+    value: "240"
 
   - name: SMPC__HEARTBEAT_INITIAL_RETRIES
     value: "65"

--- a/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw.yaml
@@ -87,7 +87,7 @@ env:
         name: application
 
   - name: SMPC__PROCESSING_TIMEOUT_SECS
-    value: "120"
+    value: "240"
 
   - name: SMPC__HEARTBEAT_INITIAL_RETRIES
     value: "65"

--- a/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw.yaml
@@ -52,6 +52,7 @@ env:
 
   - name: SMPC__ENABLE_SENDING_ANONYMIZED_STATS_MESSAGE
     value: "false"
+
   - name: SMPC__AWS__REGION
     value: "eu-north-1"
 
@@ -86,7 +87,7 @@ env:
         name: application
 
   - name: SMPC__PROCESSING_TIMEOUT_SECS
-    value: "120"
+    value: "240"
 
   - name: SMPC__HEARTBEAT_INITIAL_RETRIES
     value: "65"


### PR DESCRIPTION
When we get full batches (64 items), HawkActor is exiting with: HawkActor processing error: HawkActor processing timeout: Elapsed(()) ([logs](https://app.datadoghq.com/logs?query=service:ampc-hnsw%20-heartbeat%20env:stage&agg_m=count&agg_m_source=base&agg_t=count&cols=host,service&event=AwAAAZapsoFBQhJ8EQAAABhBWmFwc294WEFBRDRxOENDVUZsQ1FnQUYAAAAkMDE5NmE5YjItOGM0OC00MThiLTg0MjEtZWQ4ZmZkYTgyMWI0AAAA-A&fromUser=true&messageDisplay=inline&storage=hot&stream_sort=desc&viz=stream&from_ts=1746602485984&to_ts=1746603385984&live=true)) . Not entirely sure why, needs investigation. Bumping it so we can proceed with load testing