### PR TITLE
[POP-2447] Introduce anonymized statistics for mirror orientated computation

### DIFF
--- a/iris-mpc-common/src/config/mod.rs
+++ b/iris-mpc-common/src/config/mod.rs
@@ -178,6 +178,9 @@ pub struct Config {
     pub enable_sending_anonymized_stats_message: bool,
 
     #[serde(default)]
+    pub enable_sending_mirror_anonymized_stats_message: bool,
+
+    #[serde(default)]
     pub enable_reauth: bool,
 
     #[serde(default)]
@@ -530,7 +533,9 @@ pub struct CommonConfig {
     match_distances_buffer_size_extra_percent: usize,
     n_buckets: usize,
     enable_sending_anonymized_stats_message: bool,
+    enable_sending_mirror_anonymized_stats_message: bool,
     enable_reauth: bool,
+    enable_reset: bool,
     hawk_request_parallelism: usize,
     hawk_connection_parallelism: usize,
     hnsw_param_ef_constr: usize,
@@ -548,7 +553,6 @@ pub struct CommonConfig {
     hawk_server_reauths_enabled: bool,
     app_name: String,
     cpu_disable_persistence: bool,
-    enable_reset: bool,
     hawk_server_resets_enabled: bool,
     full_scan_side: Eye,
 }
@@ -602,7 +606,9 @@ impl From<Config> for CommonConfig {
             match_distances_buffer_size_extra_percent,
             n_buckets,
             enable_sending_anonymized_stats_message,
+            enable_sending_mirror_anonymized_stats_message,
             enable_reauth,
+            enable_reset,
             hawk_request_parallelism,
             hawk_connection_parallelism,
             hawk_server_healthcheck_port: _, // different for each server
@@ -621,7 +627,6 @@ impl From<Config> for CommonConfig {
             hawk_server_reauths_enabled,
             app_name,
             cpu_disable_persistence,
-            enable_reset,
             hawk_server_resets_enabled,
             full_scan_side,
             override_max_batch_size: _, // for testing purposes only
@@ -653,7 +658,9 @@ impl From<Config> for CommonConfig {
             match_distances_buffer_size_extra_percent,
             n_buckets,
             enable_sending_anonymized_stats_message,
+            enable_sending_mirror_anonymized_stats_message,
             enable_reauth,
+            enable_reset,
             hawk_request_parallelism,
             hawk_connection_parallelism,
             hnsw_param_ef_constr,
@@ -671,7 +678,6 @@ impl From<Config> for CommonConfig {
             hawk_server_reauths_enabled,
             app_name,
             cpu_disable_persistence,
-            enable_reset,
             hawk_server_resets_enabled,
             full_scan_side,
         }

--- a/iris-mpc-common/src/helpers/statistics.rs
+++ b/iris-mpc-common/src/helpers/statistics.rs
@@ -39,6 +39,8 @@ pub struct BucketStatistics {
     #[serde(skip_deserializing)]
     #[serde(with = "ts_seconds_option")]
     pub next_start_time_utc_timestamp: Option<DateTime<Utc>>,
+    // Flag to indicate if these statistics are from mirror orientation processing
+    pub is_mirror_orientation: bool,
 }
 
 impl BucketStatistics {
@@ -84,6 +86,7 @@ impl BucketStatistics {
             start_time_utc_timestamp: Utc::now(),
             end_time_utc_timestamp: None,
             next_start_time_utc_timestamp: None,
+            is_mirror_orientation: false,
         }
     }
 

--- a/iris-mpc-common/src/job.rs
+++ b/iris-mpc-common/src/job.rs
@@ -151,6 +151,9 @@ pub struct ServerJobResult<A = ()> {
     // See struct definition for more details
     pub anonymized_bucket_statistics_left: BucketStatistics,
     pub anonymized_bucket_statistics_right: BucketStatistics,
+    // Mirror orientation bucket statistics
+    pub anonymized_bucket_statistics_left_mirror: BucketStatistics,
+    pub anonymized_bucket_statistics_right_mirror: BucketStatistics,
     // Reauth results, this can be ignored on the first iterations of HNSW
     pub successful_reauths: Vec<bool>, // true if request type is reauth and it's successful
     pub reauth_target_indices: HashMap<String, u32>,

--- a/iris-mpc-common/src/test.rs
+++ b/iris-mpc-common/src/test.rs
@@ -1266,6 +1266,8 @@ impl TestCaseGenerator {
                     matched_batch_request_ids,
                     anonymized_bucket_statistics_left,
                     anonymized_bucket_statistics_right,
+                    anonymized_bucket_statistics_left_mirror,
+                    anonymized_bucket_statistics_right_mirror,
                     successful_reauths,
                     reset_update_indices,
                     reset_update_request_ids,
@@ -1274,6 +1276,17 @@ impl TestCaseGenerator {
                 } = res;
 
                 if let Some(bucket_statistic_parameters) = &self.bucket_statistic_parameters {
+                    // Check that normal orientation statistics have is_mirror_orientation set to false
+                    assert!(!anonymized_bucket_statistics_left.is_mirror_orientation,
+                        "Normal orientation left statistics should have is_mirror_orientation = false");
+                    assert!(!anonymized_bucket_statistics_right.is_mirror_orientation,
+                        "Normal orientation right statistics should have is_mirror_orientation = false");
+                    // Check that mirror orientation statistics have is_mirror_orientation set to true
+                    assert!(anonymized_bucket_statistics_left_mirror.is_mirror_orientation,
+                        "Mirror orientation left statistics should have is_mirror_orientation = true");
+                    assert!(anonymized_bucket_statistics_right_mirror.is_mirror_orientation,
+                        "Mirror orientation right statistics should have is_mirror_orientation = true");
+
                     check_bucket_statistics(
                         anonymized_bucket_statistics_left,
                         bucket_statistic_parameters.num_gpus,
@@ -1282,6 +1295,19 @@ impl TestCaseGenerator {
                     )?;
                     check_bucket_statistics(
                         anonymized_bucket_statistics_right,
+                        bucket_statistic_parameters.num_gpus,
+                        bucket_statistic_parameters.num_buckets,
+                        bucket_statistic_parameters.match_buffer_size,
+                    )?;
+                    // Also check mirror orientation statistics
+                    check_bucket_statistics(
+                        anonymized_bucket_statistics_left_mirror,
+                        bucket_statistic_parameters.num_gpus,
+                        bucket_statistic_parameters.num_buckets,
+                        bucket_statistic_parameters.match_buffer_size,
+                    )?;
+                    check_bucket_statistics(
+                        anonymized_bucket_statistics_right_mirror,
                         bucket_statistic_parameters.num_gpus,
                         bucket_statistic_parameters.num_buckets,
                         bucket_statistic_parameters.match_buffer_size,

--- a/iris-mpc-common/tests/statistics.rs
+++ b/iris-mpc-common/tests/statistics.rs
@@ -121,7 +121,7 @@ mod tests {
         // If your struct allows it in deserialization, it would default to None
         assert_eq!(stats.next_start_time_utc_timestamp, None);
 
-        assert_eq!(stats.is_mirror_orientation, false);
+        assert!(!stats.is_mirror_orientation);
     }
 
     #[test]

--- a/iris-mpc-common/tests/statistics.rs
+++ b/iris-mpc-common/tests/statistics.rs
@@ -73,6 +73,7 @@ mod tests {
         assert_eq!(value["party_id"], json!(999));
         assert_eq!(value["n_buckets"], json!(2));
         assert_eq!(value["match_distances_buffer_size"], json!(128));
+        assert_eq!(value["is_mirror_orientation"], json!(false));
     }
 
     #[test]
@@ -92,7 +93,8 @@ mod tests {
             "party_id": 123,
             "eye": "Left",
             "start_time_utc_timestamp": 1700000000,
-            "end_time_utc_timestamp": null
+            "end_time_utc_timestamp": null,
+            "is_mirror_orientation": false
         })
         .to_string();
 
@@ -118,6 +120,8 @@ mod tests {
         // next_start_time_utc is skip_serializing, so it wouldn't appear in JSON.
         // If your struct allows it in deserialization, it would default to None
         assert_eq!(stats.next_start_time_utc_timestamp, None);
+
+        assert_eq!(stats.is_mirror_orientation, false);
     }
 
     #[test]
@@ -176,5 +180,11 @@ mod tests {
         // next_start_time_utc won't match because it was not serialized
         // So it should come back as None
         assert_eq!(roundtrip_stats.next_start_time_utc_timestamp, None);
+
+        // is_mirror_orientation should be preserved correctly
+        assert_eq!(
+            roundtrip_stats.is_mirror_orientation,
+            original_stats.is_mirror_orientation
+        );
     }
 }

--- a/iris-mpc-common/tests/statistics.rs
+++ b/iris-mpc-common/tests/statistics.rs
@@ -32,6 +32,7 @@ mod tests {
             end_time_utc_timestamp: Some(known_end_time),
             // This field is #[serde(skip_serializing)]
             next_start_time_utc_timestamp: Some(Utc::now()),
+            is_mirror_orientation: false,
         };
 
         // Serialize to JSON
@@ -137,6 +138,7 @@ mod tests {
                     + chrono::Duration::seconds(15),
             ),
             next_start_time_utc_timestamp: None,
+            is_mirror_orientation: false,
         };
 
         // Serialize

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -922,13 +922,14 @@ impl HawkResult {
             matched_batch_request_ids,
             anonymized_bucket_statistics_left,
             anonymized_bucket_statistics_right,
-            successful_reauths: vec![false; n_requests], // TODO.
-            reauth_target_indices: Default::default(),   // TODO.
-            reauth_or_rule_used: Default::default(),     // TODO.
-            reset_update_indices: vec![],                // TODO.
-            reset_update_request_ids: vec![],            // TODO.
-            reset_update_shares: vec![],                 // TODO.
-
+            anonymized_bucket_statistics_left_mirror: BucketStatistics::default(), // TODO.
+            anonymized_bucket_statistics_right_mirror: BucketStatistics::default(), // TODO.
+            successful_reauths: vec![false; n_requests],                           // TODO.
+            reauth_target_indices: Default::default(),                             // TODO.
+            reauth_or_rule_used: Default::default(),                               // TODO.
+            reset_update_indices: vec![],                                          // TODO.
+            reset_update_request_ids: vec![],                                      // TODO.
+            reset_update_shares: vec![],                                           // TODO.
             modifications: batch.modifications,
 
             actor_data: self.connect_plans,

--- a/iris-mpc-gpu/src/dot/distance_comparator.rs
+++ b/iris-mpc-gpu/src/dot/distance_comparator.rs
@@ -183,7 +183,6 @@ impl DistanceComparator {
         batch_size: usize,
         max_bucket_distances: usize,
         streams: &[CudaStream],
-        is_mirror_orientation: bool,
     ) {
         for i in 0..self.device_manager.device_count() {
             // Those correspond to 0 length dbs, which were just artificially increased to
@@ -228,7 +227,6 @@ impl DistanceComparator {
                             &mask_dots[i].a,
                             &mask_dots[i].b,
                             max_bucket_distances,
-                            is_mirror_orientation,
                         ),
                     )
                     .unwrap();

--- a/iris-mpc-gpu/src/dot/kernel.cu
+++ b/iris-mpc-gpu/src/dot/kernel.cu
@@ -51,7 +51,7 @@ extern "C" __global__ void openResultsBatch(unsigned long long *result1, unsigne
     }
 }
 
-extern "C" __global__ void openResults(unsigned long long *result1, unsigned long long *result2, unsigned long long *result3, unsigned long long *output, size_t chunkLength, size_t queryLength, size_t offset, size_t numElements, size_t realChunkLen, size_t totalDbLen, unsigned short *match_distances_buffer_codes_a, unsigned short *match_distances_buffer_codes_b, unsigned short *match_distances_buffer_masks_a, unsigned short *match_distances_buffer_masks_b, unsigned int *match_distances_counter, unsigned int *match_distances_indices, unsigned short *code_dots_a, unsigned short *code_dots_b, unsigned short *mask_dots_a, unsigned short *mask_dots_b, size_t max_bucket_distances, bool is_mirror_orientation)
+extern "C" __global__ void openResults(unsigned long long *result1, unsigned long long *result2, unsigned long long *result3, unsigned long long *output, size_t chunkLength, size_t queryLength, size_t offset, size_t numElements, size_t realChunkLen, size_t totalDbLen, unsigned short *match_distances_buffer_codes_a, unsigned short *match_distances_buffer_codes_b, unsigned short *match_distances_buffer_masks_a, unsigned short *match_distances_buffer_masks_b, unsigned int *match_distances_counter, unsigned int *match_distances_indices, unsigned short *code_dots_a, unsigned short *code_dots_b, unsigned short *mask_dots_a, unsigned short *mask_dots_b, size_t max_bucket_distances)
 {
     size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx < numElements)
@@ -69,19 +69,15 @@ extern "C" __global__ void openResults(unsigned long long *result1, unsigned lon
                 continue;
             }
 
-
-            if (!is_mirror_orientation)
+            // Save the corresponding code and mask dots for later (match distributions)
+            unsigned int match_distances_counter_idx = atomicAdd(&match_distances_counter[0], 1);
+            if (match_distances_counter_idx < max_bucket_distances)
             {
-                // Save the corresponding code and mask dots for later (match distributions)
-                unsigned int match_distances_counter_idx = atomicAdd(&match_distances_counter[0], 1);
-                if (match_distances_counter_idx < max_bucket_distances)
-                {
-                    match_distances_indices[match_distances_counter_idx] = idx * 64 + i;
-                    match_distances_buffer_codes_a[match_distances_counter_idx] = code_dots_a[idx * 64 + i];
-                    match_distances_buffer_codes_b[match_distances_counter_idx] = code_dots_b[idx * 64 + i];
-                    match_distances_buffer_masks_a[match_distances_counter_idx] = mask_dots_a[idx * 64 + i];
-                    match_distances_buffer_masks_b[match_distances_counter_idx] = mask_dots_b[idx * 64 + i];
-                }
+                match_distances_indices[match_distances_counter_idx] = idx * 64 + i;
+                match_distances_buffer_codes_a[match_distances_counter_idx] = code_dots_a[idx * 64 + i];
+                match_distances_buffer_codes_b[match_distances_counter_idx] = code_dots_b[idx * 64 + i];
+                match_distances_buffer_masks_a[match_distances_counter_idx] = mask_dots_a[idx * 64 + i];
+                match_distances_buffer_masks_b[match_distances_counter_idx] = mask_dots_b[idx * 64 + i];
             }
 
             // Mark which results are matches with a bit in the output

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -150,6 +150,7 @@ pub struct ServerActor {
     mask_chunk_buffers: Vec<DBChunkBuffers>,
     phase1_events: Vec<Vec<CUevent>>,
     phase2_events: Vec<Vec<CUevent>>,
+    // Normal orientation buffers
     match_distances_buffer_codes_left: Vec<ChunkShare<u16>>,
     match_distances_buffer_codes_right: Vec<ChunkShare<u16>>,
     match_distances_buffer_masks_left: Vec<ChunkShare<u16>>,
@@ -158,9 +159,20 @@ pub struct ServerActor {
     match_distances_counter_right: Vec<CudaSlice<u32>>,
     match_distances_indices_left: Vec<CudaSlice<u32>>,
     match_distances_indices_right: Vec<CudaSlice<u32>>,
+    // Mirror orientation buffers
+    match_distances_buffer_codes_left_mirror: Vec<ChunkShare<u16>>,
+    match_distances_buffer_codes_right_mirror: Vec<ChunkShare<u16>>,
+    match_distances_buffer_masks_left_mirror: Vec<ChunkShare<u16>>,
+    match_distances_buffer_masks_right_mirror: Vec<ChunkShare<u16>>,
+    match_distances_counter_left_mirror: Vec<CudaSlice<u32>>,
+    match_distances_counter_right_mirror: Vec<CudaSlice<u32>>,
+    match_distances_indices_left_mirror: Vec<CudaSlice<u32>>,
+    match_distances_indices_right_mirror: Vec<CudaSlice<u32>>,
     buckets: ChunkShare<u32>,
     anonymized_bucket_statistics_left: BucketStatistics,
     anonymized_bucket_statistics_right: BucketStatistics,
+    anonymized_bucket_statistics_left_mirror: BucketStatistics,
+    anonymized_bucket_statistics_right_mirror: BucketStatistics,
     full_scan_side: Eye,
 }
 
@@ -460,6 +472,25 @@ impl ServerActor {
             distance_comparator.prepare_match_distances_index(distance_buffer_len);
         let match_distances_indices_right =
             distance_comparator.prepare_match_distances_index(distance_buffer_len);
+
+        // Mirror orientation buffers
+        let match_distances_buffer_codes_left_mirror =
+            distance_comparator.prepare_match_distances_buffer(distance_buffer_len);
+        let match_distances_buffer_codes_right_mirror =
+            distance_comparator.prepare_match_distances_buffer(distance_buffer_len);
+        let match_distances_buffer_masks_left_mirror =
+            distance_comparator.prepare_match_distances_buffer(distance_buffer_len);
+        let match_distances_buffer_masks_right_mirror =
+            distance_comparator.prepare_match_distances_buffer(distance_buffer_len);
+        let match_distances_counter_left_mirror =
+            distance_comparator.prepare_match_distances_counter();
+        let match_distances_counter_right_mirror =
+            distance_comparator.prepare_match_distances_counter();
+        let match_distances_indices_left_mirror =
+            distance_comparator.prepare_match_distances_index(distance_buffer_len);
+        let match_distances_indices_right_mirror =
+            distance_comparator.prepare_match_distances_index(distance_buffer_len);
+
         let buckets = distance_comparator.prepare_match_distances_buckets(n_buckets);
 
         for dev in device_manager.devices() {
@@ -471,6 +502,14 @@ impl ServerActor {
 
         let anonymized_bucket_statistics_right =
             BucketStatistics::new(match_distances_buffer_size, n_buckets, party_id, Eye::Right);
+
+        let mut anonymized_bucket_statistics_left_mirror =
+            BucketStatistics::new(match_distances_buffer_size, n_buckets, party_id, Eye::Left);
+        anonymized_bucket_statistics_left_mirror.is_mirror_orientation = true;
+
+        let mut anonymized_bucket_statistics_right_mirror =
+            BucketStatistics::new(match_distances_buffer_size, n_buckets, party_id, Eye::Right);
+        anonymized_bucket_statistics_right_mirror.is_mirror_orientation = true;
         tracing::info!("GPU actor: Initialized");
 
         Ok(Self {
@@ -522,8 +561,18 @@ impl ServerActor {
             match_distances_counter_right,
             match_distances_indices_left,
             match_distances_indices_right,
+            match_distances_buffer_codes_left_mirror,
+            match_distances_buffer_codes_right_mirror,
+            match_distances_buffer_masks_left_mirror,
+            match_distances_buffer_masks_right_mirror,
+            match_distances_counter_left_mirror,
+            match_distances_counter_right_mirror,
+            match_distances_indices_left_mirror,
+            match_distances_indices_right_mirror,
             anonymized_bucket_statistics_left,
             anonymized_bucket_statistics_right,
+            anonymized_bucket_statistics_left_mirror,
+            anonymized_bucket_statistics_right_mirror,
             full_scan_side,
         })
     }
@@ -1507,6 +1556,12 @@ impl ServerActor {
             matched_batch_request_ids,
             anonymized_bucket_statistics_left: self.anonymized_bucket_statistics_left.clone(),
             anonymized_bucket_statistics_right: self.anonymized_bucket_statistics_right.clone(),
+            anonymized_bucket_statistics_left_mirror: self
+                .anonymized_bucket_statistics_left_mirror
+                .clone(),
+            anonymized_bucket_statistics_right_mirror: self
+                .anonymized_bucket_statistics_right_mirror
+                .clone(),
             successful_reauths,
             reauth_target_indices: batch.reauth_target_indices,
             reauth_or_rule_used: batch.reauth_use_or_rule,
@@ -1520,6 +1575,12 @@ impl ServerActor {
 
         self.anonymized_bucket_statistics_left.buckets.clear();
         self.anonymized_bucket_statistics_right.buckets.clear();
+        self.anonymized_bucket_statistics_left_mirror
+            .buckets
+            .clear();
+        self.anonymized_bucket_statistics_right_mirror
+            .buckets
+            .clear();
 
         // Reset the results buffers for reuse
         for dst in [
@@ -1594,7 +1655,7 @@ impl ServerActor {
         Ok(result)
     }
 
-    fn try_calculate_bucket_stats(&mut self, eye_db: Eye) {
+    fn try_calculate_bucket_stats(&mut self, eye_db: Eye, is_mirror: bool) {
         // we use the batch_streams for this
         let streams = &self.streams[0];
 
@@ -1603,18 +1664,30 @@ impl ServerActor {
             match_distances_buffers_masks,
             match_distances_counters,
             match_distances_indices,
-        ) = match eye_db {
-            Eye::Left => (
+        ) = match (eye_db, is_mirror) {
+            (Eye::Left, false) => (
                 &self.match_distances_buffer_codes_left,
                 &self.match_distances_buffer_masks_left,
                 &self.match_distances_counter_left,
                 &self.match_distances_indices_left,
             ),
-            Eye::Right => (
+            (Eye::Right, false) => (
                 &self.match_distances_buffer_codes_right,
                 &self.match_distances_buffer_masks_right,
                 &self.match_distances_counter_right,
                 &self.match_distances_indices_right,
+            ),
+            (Eye::Left, true) => (
+                &self.match_distances_buffer_codes_left_mirror,
+                &self.match_distances_buffer_masks_left_mirror,
+                &self.match_distances_counter_left_mirror,
+                &self.match_distances_indices_left_mirror,
+            ),
+            (Eye::Right, true) => (
+                &self.match_distances_buffer_codes_right_mirror,
+                &self.match_distances_buffer_masks_right_mirror,
+                &self.match_distances_counter_right_mirror,
+                &self.match_distances_indices_right_mirror,
             ),
         };
         let bucket_distance_counters = self
@@ -1628,7 +1701,9 @@ impl ServerActor {
             .collect::<Vec<_>>();
 
         tracing::info!(
-            "Matching distances collected: {:?}",
+            "Matching distances collected ({} - mirror: {}): {:?}",
+            eye_db,
+            is_mirror,
             bucket_distance_counters
         );
 
@@ -1638,11 +1713,9 @@ impl ServerActor {
         {
             let now = Instant::now();
             tracing::info!(
-                "Collected enough match distances, starting bucket calculation: {} eye",
-                match eye_db {
-                    Eye::Left => "left",
-                    Eye::Right => "right",
-                }
+                "Collected enough match distances, starting bucket calculation: {} eye, is_mirror: {}",
+                eye_db,
+                is_mirror
             );
 
             self.device_manager.await_streams(streams);
@@ -1703,8 +1776,8 @@ impl ServerActor {
 
             tracing::info!("Buckets: {:?}", buckets);
 
-            match eye_db {
-                Eye::Left => {
+            match (eye_db, is_mirror) {
+                (Eye::Left, false) => {
                     self.anonymized_bucket_statistics_left.fill_buckets(
                         &buckets,
                         MATCH_THRESHOLD_RATIO,
@@ -1712,11 +1785,11 @@ impl ServerActor {
                             .next_start_time_utc_timestamp,
                     );
                     tracing::info!(
-                        "Bucket results:\n{}",
+                        "Normal bucket results (left):\n{}",
                         self.anonymized_bucket_statistics_left
                     );
                 }
-                Eye::Right => {
+                (Eye::Right, false) => {
                     self.anonymized_bucket_statistics_right.fill_buckets(
                         &buckets,
                         MATCH_THRESHOLD_RATIO,
@@ -1724,45 +1797,144 @@ impl ServerActor {
                             .next_start_time_utc_timestamp,
                     );
                     tracing::info!(
-                        "Bucket results:\n{}",
+                        "Normal bucket results (right):\n{}",
                         self.anonymized_bucket_statistics_right
                     );
                 }
+                (Eye::Left, true) => {
+                    self.anonymized_bucket_statistics_left_mirror.fill_buckets(
+                        &buckets,
+                        MATCH_THRESHOLD_RATIO,
+                        self.anonymized_bucket_statistics_left_mirror
+                            .next_start_time_utc_timestamp,
+                    );
+                    tracing::info!(
+                        "Mirror bucket results (left):\n{}",
+                        self.anonymized_bucket_statistics_left_mirror
+                    );
+                }
+                (Eye::Right, true) => {
+                    self.anonymized_bucket_statistics_right_mirror.fill_buckets(
+                        &buckets,
+                        MATCH_THRESHOLD_RATIO,
+                        self.anonymized_bucket_statistics_right_mirror
+                            .next_start_time_utc_timestamp,
+                    );
+                    tracing::info!(
+                        "Mirror bucket results (right):\n{}",
+                        self.anonymized_bucket_statistics_right_mirror
+                    );
+                }
             }
 
-            let reset_all_buffers =
-                |counter: &[CudaSlice<u32>],
-                 indices: &[CudaSlice<u32>],
-                 codes: &[ChunkShare<u16>],
-                 masks: &[ChunkShare<u16>],
-                 buckets: &ChunkShare<u32>| {
-                    reset_slice(self.device_manager.devices(), counter, 0, streams);
-                    reset_slice(self.device_manager.devices(), indices, 0xff, streams);
-                    reset_share(self.device_manager.devices(), masks, 0xff, streams);
-                    reset_share(self.device_manager.devices(), codes, 0xff, streams);
-                    reset_single_share(self.device_manager.devices(), buckets, 0, streams, 0);
-                };
-
-            match eye_db {
-                Eye::Left => {
-                    reset_all_buffers(
+            // Reset all buffers used in this calculation
+            match (eye_db, is_mirror) {
+                (Eye::Left, false) => {
+                    reset_slice(
+                        self.device_manager.devices(),
                         &self.match_distances_counter_left,
+                        0,
+                        streams,
+                    );
+                    reset_slice(
+                        self.device_manager.devices(),
                         &self.match_distances_indices_left,
-                        &self.match_distances_buffer_codes_left,
+                        0xff,
+                        streams,
+                    );
+                    reset_share(
+                        self.device_manager.devices(),
                         &self.match_distances_buffer_masks_left,
-                        &self.buckets,
+                        0xff,
+                        streams,
+                    );
+                    reset_share(
+                        self.device_manager.devices(),
+                        &self.match_distances_buffer_codes_left,
+                        0xff,
+                        streams,
                     );
                 }
-                Eye::Right => {
-                    reset_all_buffers(
+                (Eye::Right, false) => {
+                    reset_slice(
+                        self.device_manager.devices(),
                         &self.match_distances_counter_right,
+                        0,
+                        streams,
+                    );
+                    reset_slice(
+                        self.device_manager.devices(),
                         &self.match_distances_indices_right,
-                        &self.match_distances_buffer_codes_right,
+                        0xff,
+                        streams,
+                    );
+                    reset_share(
+                        self.device_manager.devices(),
                         &self.match_distances_buffer_masks_right,
-                        &self.buckets,
+                        0xff,
+                        streams,
+                    );
+                    reset_share(
+                        self.device_manager.devices(),
+                        &self.match_distances_buffer_codes_right,
+                        0xff,
+                        streams,
+                    );
+                }
+                (Eye::Left, true) => {
+                    reset_slice(
+                        self.device_manager.devices(),
+                        &self.match_distances_counter_left_mirror,
+                        0,
+                        streams,
+                    );
+                    reset_slice(
+                        self.device_manager.devices(),
+                        &self.match_distances_indices_left_mirror,
+                        0xff,
+                        streams,
+                    );
+                    reset_share(
+                        self.device_manager.devices(),
+                        &self.match_distances_buffer_masks_left_mirror,
+                        0xff,
+                        streams,
+                    );
+                    reset_share(
+                        self.device_manager.devices(),
+                        &self.match_distances_buffer_codes_left_mirror,
+                        0xff,
+                        streams,
+                    );
+                }
+                (Eye::Right, true) => {
+                    reset_slice(
+                        self.device_manager.devices(),
+                        &self.match_distances_counter_right_mirror,
+                        0,
+                        streams,
+                    );
+                    reset_slice(
+                        self.device_manager.devices(),
+                        &self.match_distances_indices_right_mirror,
+                        0xff,
+                        streams,
+                    );
+                    reset_share(
+                        self.device_manager.devices(),
+                        &self.match_distances_buffer_masks_right_mirror,
+                        0xff,
+                        streams,
+                    );
+                    reset_share(
+                        self.device_manager.devices(),
+                        &self.match_distances_buffer_codes_right_mirror,
+                        0xff,
+                        streams,
                     );
                 }
             }
+            reset_single_share(self.device_manager.devices(), &self.buckets, 0, streams, 0);
 
             self.device_manager.await_streams(streams);
 
@@ -1897,7 +2069,9 @@ impl ServerActor {
 
         // we try to calculate the bucket stats here if we have collected enough of them
         if orientation == Orientation::Normal {
-            self.try_calculate_bucket_stats(eye_db);
+            self.try_calculate_bucket_stats(eye_db, false);
+        } else if orientation == Orientation::Mirror {
+            self.try_calculate_bucket_stats(eye_db, true);
         }
 
         // ---- START BATCH DEDUP ----
@@ -2076,7 +2250,9 @@ impl ServerActor {
     ) {
         // we try to calculate the bucket stats here if we have collected enough of them
         if orientation == Orientation::Normal {
-            self.try_calculate_bucket_stats(eye_db);
+            self.try_calculate_bucket_stats(eye_db, false);
+        } else if orientation == Orientation::Mirror {
+            self.try_calculate_bucket_stats(eye_db, true);
         }
 
         // ---- START BATCH DEDUP ----
@@ -2298,18 +2474,30 @@ impl ServerActor {
                     match_distances_buffers_masks,
                     match_distances_counters,
                     match_distances_indices,
-                ) = match eye_db {
-                    Eye::Left => (
+                ) = match (eye_db, orientation) {
+                    (Eye::Left, Orientation::Normal) => (
                         &self.match_distances_buffer_codes_left,
                         &self.match_distances_buffer_masks_left,
                         &self.match_distances_counter_left,
                         &self.match_distances_indices_left,
                     ),
-                    Eye::Right => (
+                    (Eye::Right, Orientation::Normal) => (
                         &self.match_distances_buffer_codes_right,
                         &self.match_distances_buffer_masks_right,
                         &self.match_distances_counter_right,
                         &self.match_distances_indices_right,
+                    ),
+                    (Eye::Left, Orientation::Mirror) => (
+                        &self.match_distances_buffer_codes_left_mirror,
+                        &self.match_distances_buffer_masks_left_mirror,
+                        &self.match_distances_counter_left_mirror,
+                        &self.match_distances_indices_left_mirror,
+                    ),
+                    (Eye::Right, Orientation::Mirror) => (
+                        &self.match_distances_buffer_codes_right_mirror,
+                        &self.match_distances_buffer_masks_right_mirror,
+                        &self.match_distances_counter_right_mirror,
+                        &self.match_distances_indices_right_mirror,
                     ),
                 };
 
@@ -2342,7 +2530,6 @@ impl ServerActor {
                                 * (100 + self.match_distances_buffer_size_extra_percent)
                                 / 100,
                             request_streams,
-                            orientation == Orientation::Mirror,
                         );
                         self.phase2.return_result_buffer(res);
                     }
@@ -2592,7 +2779,6 @@ fn open(
     batch_size: usize,
     max_bucket_distances: usize,
     streams: &[CudaStream],
-    is_mirror_orientation: bool,
 ) {
     let n_devices = x.len();
     let mut a = Vec::with_capacity(n_devices);
@@ -2637,7 +2823,6 @@ fn open(
         batch_size,
         max_bucket_distances,
         streams,
-        is_mirror_orientation,
     );
 }
 

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -1873,7 +1873,6 @@ impl ServerActor {
                     );
                 }
             }
-            
             reset_single_share(self.device_manager.devices(), &self.buckets, 0, streams, 0);
 
             self.device_manager.await_streams(streams);

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -1827,113 +1827,53 @@ impl ServerActor {
                 }
             }
 
+            let reset_all_buffers =
+                |counter: &[CudaSlice<u32>],
+                 indices: &[CudaSlice<u32>],
+                 codes: &[ChunkShare<u16>],
+                 masks: &[ChunkShare<u16>]| {
+                    reset_slice(self.device_manager.devices(), counter, 0, streams);
+                    reset_slice(self.device_manager.devices(), indices, 0xff, streams);
+                    reset_share(self.device_manager.devices(), masks, 0xff, streams);
+                    reset_share(self.device_manager.devices(), codes, 0xff, streams);
+                };
+
             // Reset all buffers used in this calculation
             match (eye_db, is_mirror) {
                 (Eye::Left, false) => {
-                    reset_slice(
-                        self.device_manager.devices(),
+                    reset_all_buffers(
                         &self.match_distances_counter_left,
-                        0,
-                        streams,
-                    );
-                    reset_slice(
-                        self.device_manager.devices(),
                         &self.match_distances_indices_left,
-                        0xff,
-                        streams,
-                    );
-                    reset_share(
-                        self.device_manager.devices(),
-                        &self.match_distances_buffer_masks_left,
-                        0xff,
-                        streams,
-                    );
-                    reset_share(
-                        self.device_manager.devices(),
                         &self.match_distances_buffer_codes_left,
-                        0xff,
-                        streams,
+                        &self.match_distances_buffer_masks_left,
                     );
                 }
                 (Eye::Right, false) => {
-                    reset_slice(
-                        self.device_manager.devices(),
+                    reset_all_buffers(
                         &self.match_distances_counter_right,
-                        0,
-                        streams,
-                    );
-                    reset_slice(
-                        self.device_manager.devices(),
                         &self.match_distances_indices_right,
-                        0xff,
-                        streams,
-                    );
-                    reset_share(
-                        self.device_manager.devices(),
-                        &self.match_distances_buffer_masks_right,
-                        0xff,
-                        streams,
-                    );
-                    reset_share(
-                        self.device_manager.devices(),
                         &self.match_distances_buffer_codes_right,
-                        0xff,
-                        streams,
+                        &self.match_distances_buffer_masks_right,
                     );
                 }
                 (Eye::Left, true) => {
-                    reset_slice(
-                        self.device_manager.devices(),
+                    reset_all_buffers(
                         &self.match_distances_counter_left_mirror,
-                        0,
-                        streams,
-                    );
-                    reset_slice(
-                        self.device_manager.devices(),
                         &self.match_distances_indices_left_mirror,
-                        0xff,
-                        streams,
-                    );
-                    reset_share(
-                        self.device_manager.devices(),
-                        &self.match_distances_buffer_masks_left_mirror,
-                        0xff,
-                        streams,
-                    );
-                    reset_share(
-                        self.device_manager.devices(),
                         &self.match_distances_buffer_codes_left_mirror,
-                        0xff,
-                        streams,
+                        &self.match_distances_buffer_masks_left_mirror,
                     );
                 }
                 (Eye::Right, true) => {
-                    reset_slice(
-                        self.device_manager.devices(),
+                    reset_all_buffers(
                         &self.match_distances_counter_right_mirror,
-                        0,
-                        streams,
-                    );
-                    reset_slice(
-                        self.device_manager.devices(),
                         &self.match_distances_indices_right_mirror,
-                        0xff,
-                        streams,
-                    );
-                    reset_share(
-                        self.device_manager.devices(),
-                        &self.match_distances_buffer_masks_right_mirror,
-                        0xff,
-                        streams,
-                    );
-                    reset_share(
-                        self.device_manager.devices(),
                         &self.match_distances_buffer_codes_right_mirror,
-                        0xff,
-                        streams,
+                        &self.match_distances_buffer_masks_right_mirror,
                     );
                 }
             }
+            
             reset_single_share(self.device_manager.devices(), &self.buckets, 0, streams, 0);
 
             self.device_manager.await_streams(streams);


### PR DESCRIPTION
### Description
- Replicate the process of collecting and communicating anonymized matching statistics for the mirror orientated computation
- Duplicate the match distances buffers. Keep buffers for normal and mirror orientation
- Introduce env var to control wether we send the mirror anon stats
- Remove the mirror flag from kernel code. Now we want to compute anon stats for both orientations. **actor** is responsible to pass the correct orientation distance buffers to the kernel code

~~Still wip:~~

- [x] Add check for mirror anon stats in the e2e tests