### PR TITLE
Add genesis max height as a string

### DIFF
--- a/Dockerfile.genesis.dev.hawk
+++ b/Dockerfile.genesis.dev.hawk
@@ -44,4 +44,4 @@ COPY scripts/run-server-docker.sh .
 
 USER 65534
 
-ENTRYPOINT ["./run-server-docker.sh genesis"] 
+ENTRYPOINT ["./run-server-docker.sh", "genesis"] 

--- a/iris-mpc-upgrade-hawk/bin/iris_mpc_hawk_genesis.rs
+++ b/iris-mpc-upgrade-hawk/bin/iris_mpc_hawk_genesis.rs
@@ -10,29 +10,36 @@ use iris_mpc_upgrade_hawk::genesis::exec_main;
 
 #[derive(Parser)]
 #[allow(non_snake_case)]
+#[derive(Debug)]
 struct Args {
     // Maximum height of indexation.
     #[clap(long("max-height"))]
-    max_indexation_height: Option<IrisSerialId>,
+    max_indexation_height: Option<String>,
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Set args.
+    println!("Parsing args");
     let args = Args::parse();
-    let max_indexation_height = args.max_indexation_height;
+    println!("Parsed args: {:?}", args);
+    let max_indexation_height_arg = args.max_indexation_height;
 
-    if max_indexation_height.is_none() {
+    if max_indexation_height_arg.is_none() {
         eprintln!("Error: --max-height argument is required.");
         bail!("--max-height argument is required.");
     }
-    let max_indexation_height = max_indexation_height.unwrap();
+    let max_indexation_height_arg = max_indexation_height_arg.unwrap();
+
+    let max_indexation_height: IrisSerialId = max_indexation_height_arg.parse().map_err(|_| {
+        eprintln!("Error: --max-height argument must be a valid u32.");
+        eyre::eyre!("--max-height argument must be a valid u32.")
+    })?;
 
     // Set config.
     println!("Initialising config");
     dotenvy::dotenv().ok();
-    let mut config: Config = Config::load_config("SMPC").unwrap();
-    config.overwrite_defaults_with_cli_args(Opt::parse());
+    let config: Config = Config::load_config("SMPC").unwrap();
 
     // Set tracing.
     println!("Initialising tracing");

--- a/scripts/run-server-docker.sh
+++ b/scripts/run-server-docker.sh
@@ -36,7 +36,7 @@ fi
 export RUST_MIN_STACK=104857600
 
 if [ "$BINARY" == "genesis" ]; then
-    /bin/iris-mpc-hawk-genesis
+    /bin/iris-mpc-hawk-genesis --max-height 100
 else
     /bin/iris-mpc-hawk
 fi


### PR DESCRIPTION
### Notes
* Kubernetes needs all env variables to be strings (https://github.com/worldcoin-foundation/ampc-sync-protocol/actions/runs/14930242145)
* therefore we accept the args as strings and convert within the application