### PR TITLE
INFRA-4536: part 1 - cost savings for repository iris-mpc with use smaller runner

### DIFF
--- a/.github/workflows/build-all-targets.yml
+++ b/.github/workflows/build-all-targets.yml
@@ -39,7 +39,7 @@ jobs:
 
   build-bins:
     runs-on:
-      labels: ubuntu-22.04-64core
+      labels: ubuntu-22.04-32core
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/build-and-push-base.yaml
+++ b/.github/workflows/build-and-push-base.yaml
@@ -16,7 +16,7 @@ env:
 jobs:
   docker:
     runs-on:
-      labels: ubuntu-22.04-64core
+      labels: ubuntu-22.04-32core
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/build-and-push-debug.yaml
+++ b/.github/workflows/build-and-push-debug.yaml
@@ -14,7 +14,7 @@ env:
 jobs:
   docker:
     runs-on:
-      labels: ubuntu-22.04-64core
+      labels: ubuntu-22.04-32core
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/build-and-push-hawk-server.yaml
+++ b/.github/workflows/build-and-push-hawk-server.yaml
@@ -16,7 +16,7 @@ env:
 jobs:
   docker:
     runs-on:
-      labels: ubuntu-22.04-64core
+      labels: ubuntu-22.04-32core
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/build-and-push-nccl.yaml
+++ b/.github/workflows/build-and-push-nccl.yaml
@@ -17,7 +17,7 @@ env:
 jobs:
   docker:
     runs-on:
-      labels: ubuntu-22.04-64core
+      labels: ubuntu-22.04-32core
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/build-and-push-no-cuda.yaml
+++ b/.github/workflows/build-and-push-no-cuda.yaml
@@ -20,7 +20,7 @@ env:
 jobs:
   docker:
     runs-on:
-      labels: ubuntu-22.04-64core
+      labels: ubuntu-22.04-32core
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/build-and-push-reshare-protocol.yaml
+++ b/.github/workflows/build-and-push-reshare-protocol.yaml
@@ -27,7 +27,7 @@ env:
 jobs:
   docker:
     runs-on:
-      labels: ubuntu-22.04-64core
+      labels: ubuntu-22.04-32core
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/build-and-push-shares-encoding.yaml
+++ b/.github/workflows/build-and-push-shares-encoding.yaml
@@ -15,7 +15,7 @@ env:
 jobs:
   docker:
     runs-on:
-      labels: ubuntu-22.04-64core
+      labels: ubuntu-22.04-32core
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/build-and-push-upgrade-hawk.yaml
+++ b/.github/workflows/build-and-push-upgrade-hawk.yaml
@@ -16,7 +16,7 @@ env:
 jobs:
   docker:
     runs-on:
-      labels: ubuntu-22.04-64core
+      labels: ubuntu-22.04-32core
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -16,7 +16,7 @@ env:
 jobs:
   docker:
     runs-on:
-      labels: ubuntu-22.04-64core
+      labels: ubuntu-22.04-32core
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/cpu-integration-tests.yaml
+++ b/.github/workflows/cpu-integration-tests.yaml
@@ -13,7 +13,7 @@ env:
 jobs:
   integration-tests:
     runs-on:
-      labels: ubuntu-22.04-64core
+      labels: ubuntu-22.04-32core
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
   update_release_draft:
     name: Update Release Draft
     runs-on:
-      labels: ubuntu-22.04-64core
+      labels: ubuntu-22.04-32core
 
     permissions:
       contents: write

--- a/.github/workflows/run-unit-tests.yaml
+++ b/.github/workflows/run-unit-tests.yaml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   unit-tests:
     runs-on:
-      labels: ubuntu-22.04-64core
+      labels: ubuntu-22.04-32core
 
     services:
       postgres:

--- a/.github/workflows/temp-branch-build-and-push-hawk.yaml
+++ b/.github/workflows/temp-branch-build-and-push-hawk.yaml
@@ -16,7 +16,7 @@ env:
 jobs:
   docker:
     runs-on:
-      labels: ubuntu-22.04-64core
+      labels: ubuntu-22.04-32core
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/temp-branch-build-and-push.yaml
+++ b/.github/workflows/temp-branch-build-and-push.yaml
@@ -16,7 +16,7 @@ env:
 jobs:
   docker:
     runs-on:
-      labels: ubuntu-22.04-64core
+      labels: ubuntu-22.04-32core
     permissions:
       packages: write
       contents: read


### PR DESCRIPTION
Requestor/Issue: https://linear.app/worldcoin/issue/INFRA-4536/review-workflows-for-iris-mpc-repository
Tested (yes/no): yes, this PR is a test
Description/Why: Cost savings for repository iris-mpc with use smaller runners, 32 core machine should be enough for all rust workflows.
