### PR TITLE
INFRA-4536: part 2 - migrate gpu runner to runner managed by ARCv2

### DIFF
--- a/.github/workflows/test-gpu.yaml
+++ b/.github/workflows/test-gpu.yaml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   e2e:
-    runs-on: gpu
+    runs-on: arc-gpu-amd64-runner
     timeout-minutes: 20
     steps:
       - name: Checkout code


### PR DESCRIPTION
Requestor/Issue: https://linear.app/worldcoin/issue/INFRA-4536/review-workflows-for-iris-mpc-repository
Tested (yes/no): yes, this PR is a test
Description/Why:Infra team is migrationg self-hosted runners from ARCv1 to ARCv2. This PR change runners.