### PR TITLE
INFRA-4536: Part3 - Use common way to preserve Rust Cache

### DIFF
--- a/.github/workflows/build-all-targets.yml
+++ b/.github/workflows/build-all-targets.yml
@@ -21,11 +21,17 @@ jobs:
       - name: Install Dependencies
         run: sudo apt install protobuf-compiler
 
-      - name: Cache build products
-        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
+      - name: Cache Rust build
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        id: cache-rust
         with:
-          # Split the test and bench caches, the have different debug settings
-          key: "test"
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: rust-build-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            rust-build-${{ runner.os }}-
 
       - name: Install Rust
         run: rustup toolchain install 1.85.0
@@ -47,11 +53,17 @@ jobs:
       - name: Install Dependencies
         run: sudo apt install protobuf-compiler
 
-      - name: Cache build products
-        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
+      - name: Cache Rust build
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        id: cache-rust
         with:
-          # Split the test and bench caches, they have different debug settings
-          key: "bench"
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: rust-build-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            rust-build-${{ runner.os }}-
 
       - name: Install Rust
         run: rustup toolchain install 1.85.0

--- a/.github/workflows/cpu-integration-tests.yaml
+++ b/.github/workflows/cpu-integration-tests.yaml
@@ -17,6 +17,18 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
+      - name: Cache Rust build
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        id: cache-rust
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: rust-build-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            rust-build-${{ runner.os }}-
+
       - name: Log in to the Container registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
         with:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -18,6 +18,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
+      - name: Cache Rust build
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        id: cache-rust
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: rust-build-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            rust-build-${{ runner.os }}-
+
       - name: Install Dependencies
         run: sudo apt install protobuf-compiler
 

--- a/.github/workflows/lint-clippy.yaml
+++ b/.github/workflows/lint-clippy.yaml
@@ -22,6 +22,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
+      - name: Cache Rust build
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        id: cache-rust
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: rust-build-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            rust-build-${{ runner.os }}-
+
       # The following steps will only run if any of the src files have changed
       - name: Install Dependencies
         run: sudo apt install protobuf-compiler

--- a/.github/workflows/lint-rustfmt.yaml
+++ b/.github/workflows/lint-rustfmt.yaml
@@ -14,6 +14,17 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Cache Rust build
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        id: cache-rust
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: rust-build-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            rust-build-${{ runner.os }}-
       - name: Show errors inline
         uses: r7kamura/rust-problem-matchers@9fe7ca9f6550e5d6358e179d451cc25ea6b54f98
       - name: Install Rust

--- a/.github/workflows/run-unit-tests.yaml
+++ b/.github/workflows/run-unit-tests.yaml
@@ -33,11 +33,17 @@ jobs:
       - name: Install Dependencies
         run: sudo apt install protobuf-compiler
 
-      - name: Cache build products
-        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
+      - name: Cache Rust build
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        id: cache-rust
         with:
-          # Split the test and bench caches, the have different debug settings
-          key: "test"
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: rust-build-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            rust-build-${{ runner.os }}-
 
       - name: Install Rust
         run: rustup toolchain install 1.85.0


### PR DESCRIPTION
Requestor/Issue: https://linear.app/worldcoin/issue/INFRA-4536/review-workflows-for-iris-mpc-repository
Tested (yes/no): yes, this PR is a test
Description/Why: Cost savings for repository iris-mpc by adding rust cache for some workflows and use common way to preserve rust cache with action/cache.