### PR TITLE
INFRA-4536: Part4 - update timeout-minutes to 40 for jobs where large runners are used

### DIFF
--- a/.github/workflows/build-all-targets.yml
+++ b/.github/workflows/build-all-targets.yml
@@ -38,7 +38,7 @@ jobs:
         run: cargo build --release --all-features --tests
 
   build-bins:
-    timeout-minutes: 20
+    timeout-minutes: 40
     runs-on:
       labels: ubuntu-22.04-64core
     steps:

--- a/.github/workflows/build-all-targets.yml
+++ b/.github/workflows/build-all-targets.yml
@@ -38,6 +38,7 @@ jobs:
         run: cargo build --release --all-features --tests
 
   build-bins:
+    timeout-minutes: 20
     runs-on:
       labels: ubuntu-22.04-64core
     steps:

--- a/.github/workflows/build-and-push-base.yaml
+++ b/.github/workflows/build-and-push-base.yaml
@@ -15,7 +15,7 @@ env:
   NCCL_VERSION: 2_22_3_1
 jobs:
   docker:
-    timeout-minutes: 20
+    timeout-minutes: 40
     runs-on:
       labels: ubuntu-22.04-64core
     permissions:

--- a/.github/workflows/build-and-push-base.yaml
+++ b/.github/workflows/build-and-push-base.yaml
@@ -15,6 +15,7 @@ env:
   NCCL_VERSION: 2_22_3_1
 jobs:
   docker:
+    timeout-minutes: 20
     runs-on:
       labels: ubuntu-22.04-64core
     permissions:

--- a/.github/workflows/build-and-push-debug.yaml
+++ b/.github/workflows/build-and-push-debug.yaml
@@ -13,6 +13,7 @@ env:
 
 jobs:
   docker:
+    timeout-minutes: 20
     runs-on:
       labels: ubuntu-22.04-64core
     permissions:

--- a/.github/workflows/build-and-push-debug.yaml
+++ b/.github/workflows/build-and-push-debug.yaml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   docker:
-    timeout-minutes: 20
+    timeout-minutes: 40
     runs-on:
       labels: ubuntu-22.04-64core
     permissions:

--- a/.github/workflows/build-and-push-hawk-server.yaml
+++ b/.github/workflows/build-and-push-hawk-server.yaml
@@ -15,6 +15,7 @@ env:
 
 jobs:
   docker:
+    timeout-minutes: 20
     runs-on:
       labels: ubuntu-22.04-64core
     permissions:

--- a/.github/workflows/build-and-push-hawk-server.yaml
+++ b/.github/workflows/build-and-push-hawk-server.yaml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   docker:
-    timeout-minutes: 20
+    timeout-minutes: 40
     runs-on:
       labels: ubuntu-22.04-64core
     permissions:

--- a/.github/workflows/build-and-push-nccl.yaml
+++ b/.github/workflows/build-and-push-nccl.yaml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   docker:
+    timeout-minutes: 20
     runs-on:
       labels: ubuntu-22.04-64core
     permissions:

--- a/.github/workflows/build-and-push-nccl.yaml
+++ b/.github/workflows/build-and-push-nccl.yaml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   docker:
-    timeout-minutes: 20
+    timeout-minutes: 40
     runs-on:
       labels: ubuntu-22.04-64core
     permissions:

--- a/.github/workflows/build-and-push-no-cuda.yaml
+++ b/.github/workflows/build-and-push-no-cuda.yaml
@@ -19,6 +19,7 @@ env:
 
 jobs:
   docker:
+    timeout-minutes: 20
     runs-on:
       labels: ubuntu-22.04-64core
     permissions:

--- a/.github/workflows/build-and-push-no-cuda.yaml
+++ b/.github/workflows/build-and-push-no-cuda.yaml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   docker:
-    timeout-minutes: 20
+    timeout-minutes: 40
     runs-on:
       labels: ubuntu-22.04-64core
     permissions:

--- a/.github/workflows/build-and-push-reshare-protocol.yaml
+++ b/.github/workflows/build-and-push-reshare-protocol.yaml
@@ -26,6 +26,7 @@ env:
 
 jobs:
   docker:
+    timeout-minutes: 20
     runs-on:
       labels: ubuntu-22.04-64core
     permissions:

--- a/.github/workflows/build-and-push-reshare-protocol.yaml
+++ b/.github/workflows/build-and-push-reshare-protocol.yaml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   docker:
-    timeout-minutes: 20
+    timeout-minutes: 40
     runs-on:
       labels: ubuntu-22.04-64core
     permissions:

--- a/.github/workflows/build-and-push-shares-encoding.yaml
+++ b/.github/workflows/build-and-push-shares-encoding.yaml
@@ -14,6 +14,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}-shares-encoding
 jobs:
   docker:
+    timeout-minutes: 20
     runs-on:
       labels: ubuntu-22.04-64core
     permissions:

--- a/.github/workflows/build-and-push-shares-encoding.yaml
+++ b/.github/workflows/build-and-push-shares-encoding.yaml
@@ -14,7 +14,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}-shares-encoding
 jobs:
   docker:
-    timeout-minutes: 20
+    timeout-minutes: 40
     runs-on:
       labels: ubuntu-22.04-64core
     permissions:

--- a/.github/workflows/build-and-push-upgrade-hawk.yaml
+++ b/.github/workflows/build-and-push-upgrade-hawk.yaml
@@ -15,6 +15,7 @@ env:
 
 jobs:
   docker:
+    timeout-minutes: 20
     runs-on:
       labels: ubuntu-22.04-64core
     permissions:

--- a/.github/workflows/build-and-push-upgrade-hawk.yaml
+++ b/.github/workflows/build-and-push-upgrade-hawk.yaml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   docker:
-    timeout-minutes: 20
+    timeout-minutes: 40
     runs-on:
       labels: ubuntu-22.04-64core
     permissions:

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -15,6 +15,7 @@ env:
 
 jobs:
   docker:
+    timeout-minutes: 20
     runs-on:
       labels: ubuntu-22.04-64core
     permissions:

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   docker:
-    timeout-minutes: 20
+    timeout-minutes: 40
     runs-on:
       labels: ubuntu-22.04-64core
     permissions:

--- a/.github/workflows/cpu-integration-tests.yaml
+++ b/.github/workflows/cpu-integration-tests.yaml
@@ -12,6 +12,7 @@ env:
 
 jobs:
   integration-tests:
+    timeout-minutes: 20
     runs-on:
       labels: ubuntu-22.04-64core
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,7 @@ permissions:
 
 jobs:
   update_release_draft:
+    timeout-minutes: 20
     name: Update Release Draft
     runs-on:
       labels: ubuntu-22.04-64core

--- a/.github/workflows/run-unit-tests.yaml
+++ b/.github/workflows/run-unit-tests.yaml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   unit-tests:
+    timeout-minutes: 20
     runs-on:
       labels: ubuntu-22.04-64core
 

--- a/.github/workflows/temp-branch-build-and-push-hawk.yaml
+++ b/.github/workflows/temp-branch-build-and-push-hawk.yaml
@@ -15,6 +15,7 @@ env:
 
 jobs:
   docker:
+    timeout-minutes: 20
     runs-on:
       labels: ubuntu-22.04-64core
     permissions:

--- a/.github/workflows/temp-branch-build-and-push-hawk.yaml
+++ b/.github/workflows/temp-branch-build-and-push-hawk.yaml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   docker:
-    timeout-minutes: 20
+    timeout-minutes: 40
     runs-on:
       labels: ubuntu-22.04-64core
     permissions:

--- a/.github/workflows/temp-branch-build-and-push.yaml
+++ b/.github/workflows/temp-branch-build-and-push.yaml
@@ -15,6 +15,7 @@ env:
 
 jobs:
   docker:
+    timeout-minutes: 20
     runs-on:
       labels: ubuntu-22.04-64core
     permissions:

--- a/.github/workflows/temp-branch-build-and-push.yaml
+++ b/.github/workflows/temp-branch-build-and-push.yaml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   docker:
-    timeout-minutes: 20
+    timeout-minutes: 40
     runs-on:
       labels: ubuntu-22.04-64core
     permissions:


### PR DESCRIPTION
Requestor/Issue: https://linear.app/worldcoin/issue/INFRA-4536/review-workflows-for-iris-mpc-repository
Tested (yes/no): yes, this PR is a test
Description/Why: Cost savings for repository iris-mpc with use timout-minute set to 20 minutes when large 64core runners is used. Change of this timeout preserve against us long live runners.

From time to time workflow with integration test hang and didn't end, github cancel that workflow after 6h and bill us for time when runner is working.

![Screenshot 2025-05-16 at 14 26 27](https://github.com/user-attachments/assets/4df802d6-23e0-4e79-9a09-e17924759af1)

![Screenshot 2025-05-16 at 14 27 36](https://github.com/user-attachments/assets/88771d26-2a2d-4a31-9fbb-7e5d63e3dfab)

![Screenshot 2025-05-16 at 14 29 21](https://github.com/user-attachments/assets/878d1ffd-5b11-45c4-9716-aed0dc7e2fa3)

Link to links: https://github.com/worldcoin/iris-mpc/actions/workflows/cpu-integration-tests.yaml?page=6
