### PR TITLE
[POP-2506] Alternate full scan side per batch

### DIFF
--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -965,7 +965,10 @@ impl ServerActor {
         ///////////////////////////////////////////////////////////////////
         tracing::info!("Fetching partial {} results", self.full_scan_side);
         let mut partial_matches_side1 = self.distance_comparator.get_partial_results(
-            &self.db_match_list_left,
+            match self.full_scan_side {
+                Eye::Left => &self.db_match_list_left,
+                Eye::Right => &self.db_match_list_right,
+            },
             &self.current_db_sizes,
             &self.streams[0],
         );

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -637,6 +637,10 @@ impl ServerActor {
             );
 
             metrics::histogram!("full_batch_duration").record(now.elapsed().as_secs_f64());
+
+            // Alternate the full scan side for the next batch
+            self.full_scan_side = self.full_scan_side.other();
+            tracing::info!("Switching full scan side to {}", self.full_scan_side);
         }
         tracing::info!("Server Actor finished due to all job queues being closed");
     }

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -2017,11 +2017,6 @@ impl ServerActor {
         db_subset_idx: &[Vec<u32>],
         orientation: Orientation,
     ) {
-        assert!(
-            eye_db == Eye::Right,
-            "We expect this to be called for the right eye only"
-        );
-
         // we try to calculate the bucket stats here if we have collected enough of them
         self.try_calculate_bucket_stats(eye_db, orientation);
 


### PR DESCRIPTION
FYI: all done by codex from my phone

## Summary
- alternate the full scan side after every batch

## Testing
- `cargo fmt --all` *(fails: could not download file)*
- `cargo test --workspace -- --test-threads=1` *(fails: could not download file)*