### PR TITLE
[POP-2507]Only collect min rotation for stats

### DIFF
--- a/iris-mpc-gpu/src/dot/distance_comparator.rs
+++ b/iris-mpc-gpu/src/dot/distance_comparator.rs
@@ -177,7 +177,7 @@ impl DistanceComparator {
         match_distances_buffers_codes: &[ChunkShare<u16>],
         match_distances_buffers_masks: &[ChunkShare<u16>],
         match_distances_counters: &[CudaSlice<u32>],
-        match_distances_indices: &[CudaSlice<u32>],
+        match_distances_indices: &[CudaSlice<u64>],
         code_dots: &[ChunkShareView<u16>],
         mask_dots: &[ChunkShareView<u16>],
         batch_size: usize,
@@ -705,7 +705,7 @@ impl DistanceComparator {
             .collect::<Vec<_>>()
     }
 
-    pub fn prepare_match_distances_index(&self, max_size: usize) -> Vec<CudaSlice<u32>> {
+    pub fn prepare_match_distances_index(&self, max_size: usize) -> Vec<CudaSlice<u64>> {
         (0..self.device_manager.device_count())
             .map(|i| {
                 let a = self.device_manager.device(i).alloc_zeros(max_size).unwrap();

--- a/iris-mpc-gpu/src/dot/distance_comparator.rs
+++ b/iris-mpc-gpu/src/dot/distance_comparator.rs
@@ -178,6 +178,7 @@ impl DistanceComparator {
         match_distances_buffers_masks: &[ChunkShare<u16>],
         match_distances_counters: &[CudaSlice<u32>],
         match_distances_indices: &[CudaSlice<u64>],
+        batch_id: u64,
         code_dots: &[ChunkShareView<u16>],
         mask_dots: &[ChunkShareView<u16>],
         batch_size: usize,
@@ -227,6 +228,8 @@ impl DistanceComparator {
                             &mask_dots[i].a,
                             &mask_dots[i].b,
                             max_bucket_distances,
+                            batch_id,
+                            self.query_length,
                         ),
                     )
                     .unwrap();

--- a/iris-mpc-gpu/src/dot/kernel.cu
+++ b/iris-mpc-gpu/src/dot/kernel.cu
@@ -51,7 +51,7 @@ extern "C" __global__ void openResultsBatch(unsigned long long *result1, unsigne
     }
 }
 
-extern "C" __global__ void openResults(unsigned long long *result1, unsigned long long *result2, unsigned long long *result3, unsigned long long *output, size_t chunkLength, size_t queryLength, size_t offset, size_t numElements, size_t realChunkLen, size_t totalDbLen, unsigned short *match_distances_buffer_codes_a, unsigned short *match_distances_buffer_codes_b, unsigned short *match_distances_buffer_masks_a, unsigned short *match_distances_buffer_masks_b, unsigned int *match_distances_counter, unsigned long long *match_distances_indices, unsigned short *code_dots_a, unsigned short *code_dots_b, unsigned short *mask_dots_a, unsigned short *mask_dots_b, size_t max_bucket_distances)
+extern "C" __global__ void openResults(unsigned long long *result1, unsigned long long *result2, unsigned long long *result3, unsigned long long *output, size_t chunkLength, size_t queryLength, size_t offset, size_t numElements, size_t realChunkLen, size_t totalDbLen, unsigned short *match_distances_buffer_codes_a, unsigned short *match_distances_buffer_codes_b, unsigned short *match_distances_buffer_masks_a, unsigned short *match_distances_buffer_masks_b, unsigned int *match_distances_counter, unsigned long long *match_distances_indices, unsigned short *code_dots_a, unsigned short *code_dots_b, unsigned short *mask_dots_a, unsigned short *mask_dots_b, size_t max_bucket_distances, unsigned long long batch_id, size_t max_batch_size)
 {
     size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx < numElements)
@@ -70,11 +70,13 @@ extern "C" __global__ void openResults(unsigned long long *result1, unsigned lon
                 continue;
             }
 
+
             // Save the corresponding code and mask dots for later (match distributions)
             unsigned int match_distances_counter_idx = atomicAdd(&match_distances_counter[0], 1);
             if (match_distances_counter_idx < max_bucket_distances)
             {
-                match_distances_indices[match_distances_counter_idx] = query_db_rot_idx;
+                unsigned long long match_id = batch_id * (totalDbLen * (ALL_ROTATIONS * max_batch_size)) + queryIdx * totalDbLen + dbIdx + offset;
+                match_distances_indices[match_distances_counter_idx] = match_id;
                 match_distances_buffer_codes_a[match_distances_counter_idx] = code_dots_a[idx * 64 + i];
                 match_distances_buffer_codes_b[match_distances_counter_idx] = code_dots_b[idx * 64 + i];
                 match_distances_buffer_masks_a[match_distances_counter_idx] = mask_dots_a[idx * 64 + i];

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -166,8 +166,8 @@ pub struct ServerActor {
     match_distances_buffer_masks_right: Vec<ChunkShare<u16>>,
     match_distances_counter_left: Vec<CudaSlice<u32>>,
     match_distances_counter_right: Vec<CudaSlice<u32>>,
-    match_distances_indices_left: Vec<CudaSlice<u32>>,
-    match_distances_indices_right: Vec<CudaSlice<u32>>,
+    match_distances_indices_left: Vec<CudaSlice<u64>>,
+    match_distances_indices_right: Vec<CudaSlice<u64>>,
     // Mirror orientation buffers
     match_distances_buffer_codes_left_mirror: Vec<ChunkShare<u16>>,
     match_distances_buffer_codes_right_mirror: Vec<ChunkShare<u16>>,
@@ -175,8 +175,8 @@ pub struct ServerActor {
     match_distances_buffer_masks_right_mirror: Vec<ChunkShare<u16>>,
     match_distances_counter_left_mirror: Vec<CudaSlice<u32>>,
     match_distances_counter_right_mirror: Vec<CudaSlice<u32>>,
-    match_distances_indices_left_mirror: Vec<CudaSlice<u32>>,
-    match_distances_indices_right_mirror: Vec<CudaSlice<u32>>,
+    match_distances_indices_left_mirror: Vec<CudaSlice<u64>>,
+    match_distances_indices_right_mirror: Vec<CudaSlice<u64>>,
     buckets: ChunkShare<u32>,
     anonymized_bucket_statistics_left: BucketStatistics,
     anonymized_bucket_statistics_right: BucketStatistics,
@@ -1838,7 +1838,7 @@ impl ServerActor {
 
             let reset_all_buffers =
                 |counter: &[CudaSlice<u32>],
-                 indices: &[CudaSlice<u32>],
+                 indices: &[CudaSlice<u64>],
                  codes: &[ChunkShare<u16>],
                  masks: &[ChunkShare<u16>]| {
                     reset_slice(self.device_manager.devices(), counter, 0, streams);
@@ -2713,7 +2713,7 @@ fn open(
     match_distances_buffers_codes: &[ChunkShare<u16>],
     match_distances_buffers_masks: &[ChunkShare<u16>],
     match_distances_counters: &[CudaSlice<u32>],
-    match_distances_indices: &[CudaSlice<u32>],
+    match_distances_indices: &[CudaSlice<u64>],
     code_dots: &[ChunkShareView<u16>],
     mask_dots: &[ChunkShareView<u16>],
     batch_size: usize,

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -1767,6 +1767,7 @@ impl ServerActor {
                 .into_iter()
                 .map(|mut x| {
                     x.sort();
+                    x.truncate(self.match_distances_buffer_size);
                     x
                 })
                 .map(|sorted| ids_to_bitvec(&sorted))

--- a/iris-mpc-gpu/src/threshold_ring/cuda/kernel.cu
+++ b/iris-mpc-gpu/src/threshold_ring/cuda/kernel.cu
@@ -583,10 +583,19 @@ extern "C" __global__ void collapse_sum(U32 *inout_a, U32 *inout_b,
 }
 
 extern "C" __global__ void rotate_bitvec(U64 *out_a, U64 *out_b, U64 *in_a,
-                                         U64 *in_b, size_t n) {
+                                         U64 *in_b, size_t rotation, size_t n) {
   size_t i = blockIdx.x * blockDim.x + threadIdx.x;
   if (i < n) {
-    out_a[i] = (in_a[i] >> 1) | (in_a[(i + 1) % n] << 63);
-    out_b[i] = (in_b[i] >> 1) | (in_b[(i + 1) % n] << 63);
+    out_a[i] = (in_a[i] >> rotation) | (in_a[(i + 1) % n] << (64 - rotation));
+    out_b[i] = (in_b[i] >> rotation) | (in_b[(i + 1) % n] << (64 - rotation));
+  }
+}
+
+extern "C" __global__ void mask_bitvec(U64 *inout_a, U64 *inout_b, U64 *mask,
+                                       size_t n) {
+  size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < n) {
+    inout_a[i] = inout_a[i] & mask[i];
+    inout_b[i] = inout_b[i] & mask[i];
   }
 }

--- a/iris-mpc-gpu/src/threshold_ring/cuda/kernel.cu
+++ b/iris-mpc-gpu/src/threshold_ring/cuda/kernel.cu
@@ -581,3 +581,12 @@ extern "C" __global__ void collapse_sum(U32 *inout_a, U32 *inout_b,
     }
   }
 }
+
+extern "C" __global__ void rotate_bitvec(U64 *out_a, U64 *out_b, U64 *in_a,
+                                         U64 *in_b, size_t n) {
+  size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < n) {
+    out_a[i] = (in_a[i] >> 1) | (in_a[(i + 1) % n] << 63);
+    out_b[i] = (in_b[i] >> 1) | (in_b[(i + 1) % n] << 63);
+  }
+}

--- a/iris-mpc-gpu/src/threshold_ring/protocol.rs
+++ b/iris-mpc-gpu/src/threshold_ring/protocol.rs
@@ -2364,7 +2364,7 @@ impl Circuits {
         assert_eq!(self.n_devices, bitvec_inout.len());
         assert!(self.chunk_size <= bitvec_inout[0].len());
         assert_eq!(self.n_devices, mask_in.len());
-        assert_eq!(mask_in[0][mask_idx].len(), bitvec_inout[0].len());
+        assert!(mask_in[0][mask_idx].len() >= bitvec_inout[0].len());
 
         for (idx, (inout, inp)) in bitvec_inout.iter_mut().zip(mask_in.iter()).enumerate() {
             let bitvec =
@@ -2632,6 +2632,7 @@ impl Circuits {
         assert_eq!(self.n_devices, code_dots.len());
         assert_eq!(self.n_devices, mask_dots.len());
         assert_eq!(thresholds_a.len(), buckets.len());
+        assert_eq!(bitmask.len(), self.n_devices);
         for chunk in code_dots.iter().chain(mask_dots.iter()) {
             assert!(chunk.len() % 64 == 0);
         }

--- a/iris-mpc-gpu/src/threshold_ring/protocol.rs
+++ b/iris-mpc-gpu/src/threshold_ring/protocol.rs
@@ -2637,7 +2637,7 @@ impl Circuits {
         }
 
         // prepare bitmasks for rotations
-        let max_rotations_needed = 31;
+        let max_rotations_needed = 30;
         // incoming bitmask looks like this for given query_indices:
         // [1,1,2,3,3,3,4,4,5] -> [1,0,1,1,0,0,1,0,1]
         // i.e., it is one if it is the first match for a given query index

--- a/iris-mpc-gpu/src/threshold_ring/protocol.rs
+++ b/iris-mpc-gpu/src/threshold_ring/protocol.rs
@@ -148,6 +148,7 @@ struct Kernels {
     pub(crate) collapse_u64_helper: CudaFunction,
     pub(crate) collapse_sum_assign: CudaFunction,
     pub(crate) collapse_sum: CudaFunction,
+    pub(crate) rotate_bitvec: CudaFunction,
 }
 
 impl Kernels {
@@ -182,6 +183,7 @@ impl Kernels {
                 "collapse_u64_helper",
                 "collapse_sum_assign",
                 "collapse_sum",
+                "rotate_bitvec",
             ],
         )
         .unwrap();
@@ -221,6 +223,7 @@ impl Kernels {
         let collapse_u64_helper = dev.get_func(Self::MOD_NAME, "collapse_u64_helper").unwrap();
         let collapse_sum_assign = dev.get_func(Self::MOD_NAME, "collapse_sum_assign").unwrap();
         let collapse_sum = dev.get_func(Self::MOD_NAME, "collapse_sum").unwrap();
+        let rotate_bitvec = dev.get_func(Self::MOD_NAME, "rotate_bitvec").unwrap();
 
         Kernels {
             and,
@@ -247,6 +250,7 @@ impl Kernels {
             collapse_u64_helper,
             collapse_sum_assign,
             collapse_sum,
+            rotate_bitvec,
         }
     }
 }
@@ -2313,6 +2317,38 @@ impl Circuits {
         }
     }
 
+    fn rotate_bitvec(
+        &mut self,
+        bitvec_out: &mut [ChunkShareView<u64>],
+        bitvec_in: &[ChunkShareView<u64>],
+        streams: &[CudaStream],
+    ) {
+        assert_eq!(self.n_devices, bitvec_out.len());
+        assert!(self.chunk_size <= bitvec_out[0].len());
+        assert_eq!(self.n_devices, bitvec_in.len());
+        assert_eq!(bitvec_in[0].len(), bitvec_out[0].len());
+
+        for (idx, (out, inp)) in bitvec_out.iter_mut().zip(bitvec_in.iter()).enumerate() {
+            let cfg = launch_config_from_elements_and_threads(
+                self.chunk_size as u32,
+                DEFAULT_LAUNCH_CONFIG_THREADS,
+                &self.devs[idx],
+            );
+
+            unsafe {
+                self.kernels[idx]
+                    .rotate_bitvec
+                    .clone()
+                    .launch_on_stream(
+                        &streams[idx],
+                        cfg,
+                        (&out.a, &out.b, &inp.a, &inp.b, self.chunk_size),
+                    )
+                    .unwrap();
+            }
+        }
+    }
+
     // Result is in the first bit of the first GPU
     pub fn or_reduce_result(&mut self, result: &mut [ChunkShare<u64>], streams: &[CudaStream]) {
         let mut bits = Vec::with_capacity(self.n_devices);
@@ -2543,6 +2579,106 @@ impl Circuits {
         self.buffers.check_buffers();
     }
 
+    pub fn compare_multiple_thresholds_while_aggregating_per_query(
+        &mut self,
+        code_dots: &[ChunkShareView<u16>],
+        mask_dots: &[ChunkShareView<u16>],
+        bitmask: &[Vec<u64>],
+        streams: &[CudaStream],
+        thresholds_a: &[u16], // Thresholds are given as a/b, where b=2^16
+        buckets: &mut ChunkShare<u32>, // Each element in the chunkshares is one bucket
+    ) {
+        assert_eq!(self.n_devices, code_dots.len());
+        assert_eq!(self.n_devices, mask_dots.len());
+        assert_eq!(thresholds_a.len(), buckets.len());
+        for chunk in code_dots.iter().chain(mask_dots.iter()) {
+            assert!(chunk.len() % 64 == 0);
+        }
+
+        // prepare bitmasks for rotations
+        let max_rotations_needed = 31;
+        // incoming bitmask looks like this for given query_indices:
+        // [1,1,2,3,3,3,4,4,5] -> [1,0,1,1,0,0,1,0,1]
+        // i.e., it is one if it is the first match for a given query index
+        // we negate it -> [0,1,0,0,1,1,0,1,0] this gives us the indices of the duplicates
+        // STEP i: We rotate the bitmask to the right by 1, so that we can use it as a mask
+        // -> [1,0,0,1,1,0,1,0,0], this is then used to MASK the OR of the original bit vector with the rotated one
+        // after the rotation, we AND the bitmask with the negated original bitmask, to clear the current bit for accumulation
+        // and then we repeat from STEP i
+        let mut bitmasks = vec![vec![]; self.n_devices];
+        for i in 0..self.n_devices {
+            bitmasks[i].push(bitmask[i].clone());
+            let mut bitmask_negated = bitmask[i].clone();
+            detail::negate_bitvec(&mut bitmask_negated);
+            let mut bitmask = bitmask_negated.clone();
+            for _ in 0..max_rotations_needed {
+                detail::rotate_bitvec_right(&mut bitmask);
+                bitmasks[i].push(bitmask.clone());
+                detail::bitvec_and(&mut bitmask, &bitmask_negated);
+            }
+        }
+
+        let x_ = Buffers::take_buffer(&mut self.buffers.lifted_shares);
+        let x1_ = Buffers::take_buffer(&mut self.buffers.lifted_shares_buckets1);
+        let x2_ = Buffers::take_buffer(&mut self.buffers.lifted_shares_buckets2);
+        let corrections_ = Buffers::take_buffer(&mut self.buffers.lifting_corrections);
+        let mut masks = Buffers::get_buffer_chunk(&x1_, 64 * self.chunk_size);
+        let mut codes = Buffers::get_buffer_chunk(&x2_, 64 * self.chunk_size);
+        let mut x = Buffers::get_buffer_chunk(&x_, 64 * self.chunk_size);
+        let mut corrections = Buffers::get_buffer_chunk(&corrections_, 128 * self.chunk_size);
+
+        // Start with lifting
+        self.lift_mpc(mask_dots, &mut masks, &mut corrections, streams);
+        self.finalize_lifts(&mut masks, &mut codes, &corrections, code_dots, streams);
+
+        for (bucket_idx, a) in thresholds_a.iter().enumerate() {
+            // Continue with threshold comparison
+            self.lifted_sub(&mut x, &masks, &codes, *a as u32, streams);
+            self.extract_msb(&mut x, streams);
+
+            // Result is in the first bit of the result buffer
+            let result = self.take_result_buffer();
+            {
+                let mut bits = Vec::with_capacity(self.n_devices);
+                for r in result.iter() {
+                    // Result is in the first bit of the input
+                    bits.push(r.get_offset_mut(0, self.chunk_size));
+                }
+
+                // we now use the prepared bitmasks to aggregate the results with OR
+                for rotation in 0..max_rotations_needed {
+                    // we need to rotate the bitvecs to the right by one
+                    self.rotate_bitvec(&mut bits, &bits, streams);
+                    self.masked_or(&mut accumulated, &bits, &bitmasks, streams);
+                }
+            }
+            // we drop the mutable view, and get a non mutable one
+
+            let mut bits = Vec::with_capacity(self.n_devices);
+            for r in result.iter() {
+                // Result is in the first bit of the input
+                bits.push(r.get_offset(0, self.chunk_size));
+            }
+            // Expand the result buffer to the x buffer and perform arithmetic xor
+            self.bit_inject_arithmetic_xor(&bits, &mut x, streams);
+            // Sum all elements in x to get the result in the first 32 bit word on each GPU
+            self.collapse_sum(&mut x, streams);
+            // Get data onto the first GPU
+            if self.n_devices > 1 {
+                self.collect_graphic_result_u32(&mut x, streams);
+            }
+            // Accumulate first result onto bucket
+            self.collapse_sum_on_gpu(buckets, &x, self.n_devices, bucket_idx, 0, streams);
+            self.return_result_buffer(result);
+        }
+
+        Buffers::return_buffer(&mut self.buffers.lifted_shares, x_);
+        Buffers::return_buffer(&mut self.buffers.lifted_shares_buckets1, x1_);
+        Buffers::return_buffer(&mut self.buffers.lifted_shares_buckets2, x2_);
+        Buffers::return_buffer(&mut self.buffers.lifting_corrections, corrections_);
+        self.buffers.check_buffers();
+    }
+
     pub fn open_buckets(&mut self, buckets: &ChunkShare<u32>, streams: &[CudaStream]) -> Vec<u32> {
         let a = dtoh_on_stream_sync(&buckets.a, &self.devs[0], &streams[0]).unwrap();
         let b = dtoh_on_stream_sync(&buckets.b, &self.devs[0], &streams[0]).unwrap();
@@ -2570,5 +2706,29 @@ impl Circuits {
             .zip(c.iter())
             .map(|((&a, &b), &c)| a.wrapping_add(b).wrapping_add(c))
             .collect()
+    }
+}
+
+mod detail {
+    // rotate a bit vector to the right by one (bit 1 -> bit 0)
+    pub fn rotate_bitvec_right(vec: &mut [u64]) {
+        let mut last = vec[0] & 1;
+        for i in (0..vec.len()).rev() {
+            let tmp = vec[i] & 1;
+            vec[i] = (last << 63) | vec[i] >> 1;
+            last = tmp;
+        }
+    }
+
+    pub fn negate_bitvec(vec: &mut [u64]) {
+        for i in 0..vec.len() {
+            vec[i] = !vec[i];
+        }
+    }
+    pub fn bitvec_and(vec: &mut [u64], vec2: &[u64]) {
+        assert!(vec.len() == vec2.len());
+        for i in 0..vec.len() {
+            vec[i] = vec[i] & vec2[i];
+        }
     }
 }

--- a/iris-mpc-gpu/src/threshold_ring/protocol.rs
+++ b/iris-mpc-gpu/src/threshold_ring/protocol.rs
@@ -2364,7 +2364,7 @@ impl Circuits {
         assert_eq!(self.n_devices, bitvec_inout.len());
         assert!(self.chunk_size <= bitvec_inout[0].len());
         assert_eq!(self.n_devices, mask_in.len());
-        assert!(mask_in[0][mask_idx].len() >= bitvec_inout[0].len());
+        assert_eq!(mask_in[0][mask_idx].len(), bitvec_inout[0].len());
 
         for (idx, (inout, inp)) in bitvec_inout.iter_mut().zip(mask_in.iter()).enumerate() {
             let bitvec =

--- a/iris-mpc-gpu/src/threshold_ring/protocol.rs
+++ b/iris-mpc-gpu/src/threshold_ring/protocol.rs
@@ -2672,6 +2672,8 @@ impl Circuits {
         self.lift_mpc(mask_dots, &mut masks, &mut corrections, streams);
         self.finalize_lifts(&mut masks, &mut codes, &corrections, code_dots, streams);
 
+        let tmp_rotated = Buffers::take_buffer(&mut self.buffers.lifted_shares_split2);
+        let mut rotated = Buffers::get_buffer_chunk(&tmp_rotated, self.chunk_size);
         for (bucket_idx, a) in thresholds_a.iter().enumerate() {
             // Continue with threshold comparison
             self.lifted_sub(&mut x, &masks, &codes, *a as u32, streams);
@@ -2679,8 +2681,6 @@ impl Circuits {
 
             // Result is in the first bit of the result buffer
             let result = self.take_result_buffer();
-            let tmp_rotated = Buffers::take_buffer(&mut self.buffers.lifted_shares_split2);
-            let mut rotated = Buffers::get_buffer_chunk(&tmp_rotated, self.chunk_size);
 
             let mut bits = Vec::with_capacity(self.n_devices);
             for r in result.iter() {
@@ -2712,7 +2712,7 @@ impl Circuits {
             self.collapse_sum_on_gpu(buckets, &x, self.n_devices, bucket_idx, 0, streams);
             self.return_result_buffer(result);
         }
-
+        Buffers::return_buffer(&mut self.buffers.lifted_shares_split2, tmp_rotated);
         Buffers::return_buffer(&mut self.buffers.lifted_shares, x_);
         Buffers::return_buffer(&mut self.buffers.lifted_shares_buckets1, x1_);
         Buffers::return_buffer(&mut self.buffers.lifted_shares_buckets2, x2_);

--- a/iris-mpc-gpu/tests/buckets_with_aggregation.rs
+++ b/iris-mpc-gpu/tests/buckets_with_aggregation.rs
@@ -52,11 +52,12 @@ mod buckets_test {
         let mut current_id = 0;
         for _ in 0..size {
             ids.push(current_id);
-            /// This ensures we have a few duplicates, with expected length of segments being around 3
+            // This ensures we have a few duplicates, with expected length of segments being around 3
             if rng.gen_bool(0.3) {
                 current_id += 1;
             }
         }
+        ids
     }
 
     fn ids_to_bitvec(ids: &[u64]) -> Vec<u64> {
@@ -203,8 +204,8 @@ mod buckets_test {
             party.compare_multiple_thresholds_while_aggregating_per_query(
                 &code_gpu,
                 &mask_gpu,
-                &streams,
                 &bitvecs,
+                &streams,
                 &threshold,
                 &mut bucket,
             );

--- a/iris-mpc-gpu/tests/buckets_with_aggregation.rs
+++ b/iris-mpc-gpu/tests/buckets_with_aggregation.rs
@@ -1,0 +1,376 @@
+// #[cfg(feature = "gpu_dependent")]
+mod buckets_test {
+    use cudarc::{
+        driver::{CudaDevice, CudaStream},
+        nccl::Id,
+    };
+    use eyre::Result;
+    use iris_mpc_common::iris_db::iris::IrisCodeArray;
+    use iris_mpc_gpu::{
+        helpers::{device_manager::DeviceManager, htod_on_stream_sync},
+        threshold_ring::protocol::{ChunkShare, Circuits},
+    };
+    use itertools::{izip, Itertools};
+    use rand::{rngs::StdRng, Rng, SeedableRng};
+    use static_assertions::const_assert;
+    use std::{env, sync::Arc};
+    use tokio::time::Instant;
+    use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+    const DB_RNG_SEED: u64 = 0xdeadbeef;
+    // ceil(930 * 125_000 / 2048) * 2048
+    // const INPUTS_PER_GPU_SIZE: usize = 116_250_624;
+    const INPUTS_PER_GPU_SIZE: usize = 12_507_136;
+
+    const B_BITS: u64 = 16;
+    pub(crate) const B: u64 = 1 << B_BITS;
+    // pub(crate) const A: u64 = ((1. - 2. * MATCH_THRESHOLD_RATIO) * B as f64) as
+    // u64;
+    const THRESHOLDS: [f64; 4] = [0.1, 0.2, 0.3, 0.375];
+
+    fn sample_code_dots<R: Rng>(size: usize, rng: &mut R) -> Vec<u16> {
+        (0..size)
+            .map(|_| {
+                let mut x = rng.gen_range::<u16, _>(0..=IrisCodeArray::IRIS_CODE_SIZE as u16);
+                let neg = rng.gen::<bool>();
+                if neg {
+                    x = (u16::MAX - x).wrapping_add(1);
+                }
+                x
+            })
+            .collect::<Vec<_>>()
+    }
+
+    fn sample_mask_dots<R: Rng>(size: usize, rng: &mut R) -> Vec<u16> {
+        (0..size)
+            .map(|_| rng.gen_range::<u16, _>(0..=IrisCodeArray::IRIS_CODE_SIZE as u16))
+            .collect::<Vec<_>>()
+    }
+
+    fn sample_ids<R: Rng>(size: usize, rng: &mut R) -> Vec<u64> {
+        let mut ids = Vec::with_capacity(size);
+        let mut current_id = 0;
+        for _ in 0..size {
+            ids.push(current_id);
+            /// This ensures we have a few duplicates, with expected length of segments being around 3
+            if rng.gen_bool(0.3) {
+                current_id += 1;
+            }
+        }
+    }
+
+    fn ids_to_bitvec(ids: &[u64]) -> Vec<u64> {
+        let mut result = vec![0; ids.len().div_ceil(64)];
+        // set first, bit, since it is always 1
+        result[0] = 1;
+        for (idx, (last, new)) in ids.iter().tuple_windows().enumerate() {
+            if last == new {
+                continue;
+            }
+            result[idx / 64] |= 1 << (idx % 64);
+        }
+        result
+    }
+
+    fn rep_share<R: Rng>(value: u16, rng: &mut R) -> (u16, u16, u16) {
+        let a = rng.gen();
+        let b = rng.gen();
+        let c = value.wrapping_sub(a).wrapping_sub(b);
+
+        (a, b, c)
+    }
+
+    fn rep_share_vec<R: Rng>(value: &[u16], rng: &mut R) -> (Vec<u16>, Vec<u16>, Vec<u16>) {
+        let mut a = Vec::with_capacity(value.len());
+        let mut b = Vec::with_capacity(value.len());
+        let mut c = Vec::with_capacity(value.len());
+        for v in value.iter() {
+            let (a_, b_, c_) = rep_share(*v, rng);
+            a.push(a_);
+            b.push(b_);
+            c.push(c_);
+        }
+        (a, b, c)
+    }
+
+    fn to_gpu(
+        a: &[u16],
+        b: &[u16],
+        devices: &[Arc<CudaDevice>],
+        streams: &[CudaStream],
+    ) -> Vec<ChunkShare<u16>> {
+        debug_assert_eq!(a.len(), b.len());
+
+        let mut result = Vec::with_capacity(devices.len());
+
+        for (dev, stream, a, b) in izip!(
+            devices,
+            streams,
+            a.chunks(INPUTS_PER_GPU_SIZE),
+            b.chunks(INPUTS_PER_GPU_SIZE)
+        ) {
+            let a_ = htod_on_stream_sync(a, dev, stream).unwrap();
+            let b_ = htod_on_stream_sync(b, dev, stream).unwrap();
+            result.push(ChunkShare::new(a_, b_));
+        }
+
+        result
+    }
+
+    #[allow(clippy::precedence)]
+    fn real_result_msb(code_input: Vec<u16>, mask_input: Vec<u16>, ids: &[u64]) -> Vec<u32> {
+        assert_eq!(code_input.len(), mask_input.len());
+        let mod_ = 1u64 << (16 + B_BITS);
+        let mut result = Vec::with_capacity(THRESHOLDS.len());
+
+        for t in THRESHOLDS {
+            let a = Circuits::translate_threshold_a(t);
+
+            let mut count = 0;
+            let mut current_id = u64::MAX;
+            let mut current_count = 0;
+            for (idx, &id) in ids.iter().enumerate() {
+                if id != current_id {
+                    count += current_count;
+                    current_id = id;
+                    current_count = 0;
+                }
+                let code = code_input[idx];
+                let mask = mask_input[idx];
+                let r = (((mask as u64) * a)
+                    .wrapping_sub((code as u64) << B_BITS)
+                    .wrapping_sub(1))
+                    % mod_;
+                let msb = r >> (B_BITS + 16 - 1) & 1 == 1;
+                current_count += msb as u32;
+            }
+            // also add final count
+            count += current_count;
+            result.push(count);
+        }
+        result
+    }
+
+    fn install_tracing() {
+        tracing_subscriber::registry()
+            .with(
+                tracing_subscriber::EnvFilter::try_from_default_env()
+                    .unwrap_or_else(|_| "info".into()),
+            )
+            .with(tracing_subscriber::fmt::layer())
+            .init();
+    }
+
+    fn testcase(
+        mut party: Circuits,
+        code_share_a: Vec<u16>,
+        code_share_b: Vec<u16>,
+        mask_share_a: Vec<u16>,
+        mask_share_b: Vec<u16>,
+        bitvecs: Vec<Vec<u64>>,
+        real_result: Vec<u32>,
+    ) {
+        let id = party.peer_id();
+
+        let devices = party.get_devices();
+        let streams = devices
+            .iter()
+            .map(|dev| dev.fork_default_stream().unwrap())
+            .collect::<Vec<_>>();
+
+        let mut threshold = Vec::with_capacity(THRESHOLDS.len());
+        for t in THRESHOLDS {
+            let a = ((1. - 2. * t) * (B as f64)) as u64;
+            threshold.push(a as u16);
+        }
+
+        // Import to GPU
+        let code_gpu = to_gpu(&code_share_a, &code_share_b, &devices, &streams);
+        let mask_gpu = to_gpu(&mask_share_a, &mask_share_b, &devices, &streams);
+        tracing::info!("id: {}, Data is on GPUs!", id);
+        tracing::info!("id: {}, Starting tests...", id);
+
+        let mut error = false;
+        for _ in 0..10 {
+            let a = devices[0].alloc_zeros::<u32>(THRESHOLDS.len()).unwrap();
+            let b = devices[0].alloc_zeros::<u32>(THRESHOLDS.len()).unwrap();
+            let mut bucket = ChunkShare::new(a, b);
+            let code_gpu = code_gpu.iter().map(|x| x.as_view()).collect_vec();
+            let mask_gpu = mask_gpu.iter().map(|x| x.as_view()).collect_vec();
+            party.synchronize_streams(&streams);
+
+            let now = Instant::now();
+            party.compare_multiple_thresholds_while_aggregating_per_query(
+                &code_gpu,
+                &mask_gpu,
+                &streams,
+                &bitvecs,
+                &threshold,
+                &mut bucket,
+            );
+
+            party.synchronize_streams(&streams);
+            tracing::info!("id: {}, Starting tests...", id);
+            tracing::info!("id: {}, compute time: {:?}", id, now.elapsed());
+
+            let now = Instant::now();
+            let result = party.open_buckets(&bucket, &streams);
+            party.synchronize_streams(&streams);
+            tracing::info!("id: {}, Starting tests...", id);
+            tracing::info!(
+                "id: {}, Open and transfer to CPU time: {:?}",
+                id,
+                now.elapsed()
+            );
+
+            if result == real_result {
+                tracing::info!("id: {}, Test passed!", id);
+            } else {
+                tracing::error!("id: {}, Test failed: {:?} != {:?}", id, real_result, result);
+                error = true;
+            }
+        }
+        assert!(!error);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+    async fn test_buckets() -> Result<()> {
+        install_tracing();
+        env::set_var("NCCL_P2P_LEVEL", "LOC");
+        env::set_var("NCCL_NET", "Socket");
+        env::set_var("NCCL_P2P_DIRECT_DISABLE", "1");
+        env::set_var("NCCL_SHM_DISABLE", "1");
+
+        let chacha_seeds0 = ([0u32; 8], [2u32; 8]);
+        let chacha_seeds1 = ([1u32; 8], [0u32; 8]);
+        let chacha_seeds2 = ([2u32; 8], [1u32; 8]);
+
+        const_assert!(
+            INPUTS_PER_GPU_SIZE % (2048) == 0,
+            // Mod 16 for randomness, mod 64 for chunk size
+        );
+
+        let mut rng = StdRng::seed_from_u64(DB_RNG_SEED);
+
+        let device_manager = DeviceManager::init();
+        let mut device_managers = device_manager
+            .split_into_n_chunks(3)
+            .expect("have at least 3 devices");
+        let device_manager2 = Arc::new(device_managers.pop().unwrap());
+        let device_manager1 = Arc::new(device_managers.pop().unwrap());
+        let device_manager0 = Arc::new(device_managers.pop().unwrap());
+        let n_devices = device_manager0.devices().len();
+        let ids0 = (0..n_devices)
+            .map(|_| Id::new().unwrap())
+            .collect::<Vec<_>>();
+        let ids1 = ids0.clone();
+        let ids2 = ids0.clone();
+
+        // Get inputs
+        let code_dots = sample_code_dots(INPUTS_PER_GPU_SIZE * n_devices, &mut rng);
+        let mask_dots = sample_mask_dots(INPUTS_PER_GPU_SIZE * n_devices, &mut rng);
+        let ids = sample_ids(INPUTS_PER_GPU_SIZE, &mut rng);
+        let bitvec = ids_to_bitvec(&ids);
+        let bitvecs_a = vec![bitvec.clone(); n_devices];
+        let bitvecs_b = bitvecs_a.clone();
+        let bitvecs_c = bitvecs_a.clone();
+
+        let (code_share_a, code_share_b, code_share_c) = rep_share_vec(&code_dots, &mut rng);
+        let (mask_share_a, mask_share_b, mask_share_c) = rep_share_vec(&mask_dots, &mut rng);
+        let real_result = real_result_msb(code_dots, mask_dots, &ids);
+        tracing::info!("Random shared inputs generated!");
+
+        let code_share_a_ = code_share_a.to_owned();
+        let code_share_b_ = code_share_b.to_owned();
+        let code_share_c_ = code_share_c.to_owned();
+        let mask_share_a_ = mask_share_a.to_owned();
+        let mask_share_b_ = mask_share_b.to_owned();
+        let mask_share_c_ = mask_share_c.to_owned();
+        let real_result_ = real_result.to_owned();
+        let real_result__ = real_result.to_owned();
+
+        let task0 = tokio::task::spawn_blocking(move || {
+            let comms0 = device_manager0
+                .instantiate_network_from_ids(0, &ids0)
+                .unwrap();
+
+            let party = Circuits::new(
+                0,
+                INPUTS_PER_GPU_SIZE,
+                INPUTS_PER_GPU_SIZE / 64,
+                Some(THRESHOLDS.len()),
+                chacha_seeds0,
+                device_manager0,
+                comms0,
+            );
+
+            testcase(
+                party,
+                code_share_a,
+                code_share_c,
+                mask_share_a,
+                mask_share_c,
+                bitvecs_a,
+                real_result,
+            );
+        });
+
+        let task1 = tokio::task::spawn_blocking(move || {
+            let comms1 = device_manager1
+                .instantiate_network_from_ids(1, &ids1)
+                .unwrap();
+
+            let party = Circuits::new(
+                1,
+                INPUTS_PER_GPU_SIZE,
+                INPUTS_PER_GPU_SIZE / 64,
+                Some(THRESHOLDS.len()),
+                chacha_seeds1,
+                device_manager1,
+                comms1,
+            );
+
+            testcase(
+                party,
+                code_share_b,
+                code_share_a_,
+                mask_share_b,
+                mask_share_a_,
+                bitvecs_b,
+                real_result_,
+            );
+        });
+
+        let task2 = tokio::task::spawn_blocking(move || {
+            let comms2 = device_manager2
+                .instantiate_network_from_ids(2, &ids2)
+                .unwrap();
+
+            let party = Circuits::new(
+                2,
+                INPUTS_PER_GPU_SIZE,
+                INPUTS_PER_GPU_SIZE / 64,
+                Some(THRESHOLDS.len()),
+                chacha_seeds2,
+                device_manager2,
+                comms2,
+            );
+
+            testcase(
+                party,
+                code_share_c_,
+                code_share_b_,
+                mask_share_c_,
+                mask_share_b_,
+                bitvecs_c,
+                real_result__,
+            );
+        });
+
+        task0.await.unwrap();
+        task1.await.unwrap();
+        task2.await.unwrap();
+
+        Ok(())
+    }
+}

--- a/iris-mpc-gpu/tests/buckets_with_aggregation.rs
+++ b/iris-mpc-gpu/tests/buckets_with_aggregation.rs
@@ -143,7 +143,7 @@ mod buckets_with_aggregation_test {
                     .wrapping_sub(1))
                     % mod_;
                 let msb = r >> (B_BITS + 16 - 1) & 1 == 1;
-                current_count += msb as u32;
+                current_count |= msb as u32;
             }
             // also add final count
             count += current_count;

--- a/iris-mpc-gpu/tests/buckets_with_aggregation.rs
+++ b/iris-mpc-gpu/tests/buckets_with_aggregation.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "gpu_dependent")]
+// #[cfg(feature = "gpu_dependent")]
 mod buckets_with_aggregation_test {
     use cudarc::{
         driver::{CudaDevice, CudaStream},
@@ -130,14 +130,14 @@ mod buckets_with_aggregation_test {
             let mut count = 0;
             let mut current_id = u64::MAX;
             let mut current_count = 0;
-            for (idx, &id) in ids.iter().enumerate() {
+            for (idx, (&code, &mask)) in code_input.iter().zip(mask_input.iter()).enumerate() {
+                // ids are repeated, so we need to use the index
+                let id = ids[idx % ids.len()];
                 if id != current_id {
                     count += current_count;
                     current_id = id;
                     current_count = 0;
                 }
-                let code = code_input[idx];
-                let mask = mask_input[idx];
                 let r = (((mask as u64) * a)
                     .wrapping_sub((code as u64) << B_BITS)
                     .wrapping_sub(1))

--- a/iris-mpc-gpu/tests/buckets_with_aggregation.rs
+++ b/iris-mpc-gpu/tests/buckets_with_aggregation.rs
@@ -1,4 +1,4 @@
-// #[cfg(feature = "gpu_dependent")]
+#[cfg(feature = "gpu_dependent")]
 mod buckets_with_aggregation_test {
     use cudarc::{
         driver::{CudaDevice, CudaStream},

--- a/iris-mpc-gpu/tests/buckets_with_aggregation.rs
+++ b/iris-mpc-gpu/tests/buckets_with_aggregation.rs
@@ -68,7 +68,7 @@ mod buckets_with_aggregation_test {
             if last == new {
                 continue;
             }
-            result[idx / 64] |= 1 << (idx % 64);
+            result[(idx + 1) / 64] |= 1 << ((idx + 1) % 64);
         }
         result
     }

--- a/iris-mpc-gpu/tests/buckets_with_aggregation.rs
+++ b/iris-mpc-gpu/tests/buckets_with_aggregation.rs
@@ -1,5 +1,5 @@
 // #[cfg(feature = "gpu_dependent")]
-mod buckets_test {
+mod buckets_with_aggregation_test {
     use cudarc::{
         driver::{CudaDevice, CudaStream},
         nccl::Id,


### PR DESCRIPTION
The goal of this PR is to reduce the number of collected matches to only include the minimum match per query, not all matches (we can have multiple due to rotations).
Overall strategy is to keep track of the query id over the collection of results, and later on, based on that query id reduce the calculated buckets to the minimal one by OR-ing together all of the query results.

Working now, with an additional unit-test and integrated into the main actor flow.
ATM, this does work for a maximum of 30 matches, which could be reduced dynamically. However, I do not feel like this will show up in a significant way, since the only work that is done for this 30 factor is a small OR.

Still would be nice to have some performance numbers on staging maybe?
