### PR TITLE
Add mechanism to change HSNW schema for different testing

### DIFF
--- a/.github/workflows/temp-branch-build-and-push-upgrade-hawk.yaml
+++ b/.github/workflows/temp-branch-build-and-push-upgrade-hawk.yaml
@@ -1,0 +1,50 @@
+name: Branch - Hawk Upgrade Build and push docker image 
+
+on:
+  push:
+    branches:
+      - "POP-2509/create-a-config-for-a-new-schema-for-sync-protocol"
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: "iris-mpc-genesis"
+
+jobs:
+  docker:
+    timeout-minutes: 40
+    runs-on:
+      labels: ubuntu-22.04-32core
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
+      - name: Log in to the Container registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and Push
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/worldcoin/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          file: Dockerfile.genesis.hawk
+

--- a/iris-mpc-common/src/config/mod.rs
+++ b/iris-mpc-common/src/config/mod.rs
@@ -21,8 +21,8 @@ pub struct Opt {
 #[allow(non_snake_case)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
-    #[serde(default = "default_app_name")]
-    pub app_name: String,
+    #[serde(default = "default_schema_name")]
+    pub schema_name: String,
 
     #[serde(default)]
     pub environment: String,
@@ -189,6 +189,9 @@ pub struct Config {
     #[serde(default)]
     pub enable_reset: bool,
 
+    #[serde(default)]
+    pub hnsw_schema_name_suffix: String,
+
     #[serde(default = "default_hawk_request_parallelism")]
     pub hawk_request_parallelism: usize,
 
@@ -248,28 +251,6 @@ pub struct Config {
     // used to fix max batch size to 1 for correctness testing purposes
     #[serde(default = "default_override_max_batch_size")]
     pub override_max_batch_size: bool,
-}
-
-impl Config {
-    // Returns computed name of application's postgres database schema.
-    pub fn get_database_schema_name(&self) -> String {
-        format!(
-            "{}_{}_{}",
-            self.app_name.clone(),
-            self.environment.clone(),
-            self.party_id.clone()
-        )
-    }
-
-    // Returns computed name of an S3 bucket for fetching iris deletions.
-    pub fn get_s3_bucket_for_iris_deletions(&self) -> String {
-        format!("wf-smpcv2-{}-sync-protocol", self.environment)
-    }
-
-    // Returns computed name of an S3 key for fetching iris deletions.
-    pub fn get_s3_key_for_iris_deletions(&self) -> String {
-        format!("{}_deleted_serial_ids.json", self.environment)
-    }
 }
 
 fn default_full_scan_side() -> Eye {
@@ -335,7 +316,7 @@ fn default_shares_bucket_name() -> String {
     "wf-mpc-prod-smpcv2-sns-requests".to_string()
 }
 
-fn default_app_name() -> String {
+fn default_schema_name() -> String {
     "SMPC".to_string()
 }
 
@@ -572,7 +553,8 @@ pub struct CommonConfig {
     sqs_sync_long_poll_seconds: i32,
     hawk_server_deletions_enabled: bool,
     hawk_server_reauths_enabled: bool,
-    app_name: String,
+    schema_name: String,
+    hnsw_schema_name_suffix: String,
     cpu_disable_persistence: bool,
     hawk_server_resets_enabled: bool,
     full_scan_side: Eye,
@@ -647,7 +629,8 @@ impl From<Config> for CommonConfig {
             sqs_sync_long_poll_seconds,
             hawk_server_deletions_enabled,
             hawk_server_reauths_enabled,
-            app_name,
+            schema_name,
+            hnsw_schema_name_suffix,
             cpu_disable_persistence,
             hawk_server_resets_enabled,
             full_scan_side,
@@ -698,7 +681,8 @@ impl From<Config> for CommonConfig {
             sqs_sync_long_poll_seconds,
             hawk_server_deletions_enabled,
             hawk_server_reauths_enabled,
-            app_name,
+            schema_name,
+            hnsw_schema_name_suffix,
             cpu_disable_persistence,
             hawk_server_resets_enabled,
             full_scan_side,

--- a/iris-mpc-cpu/src/genesis/state_accessor.rs
+++ b/iris-mpc-cpu/src/genesis/state_accessor.rs
@@ -82,6 +82,16 @@ pub async fn fetch_iris_batch(
     Ok(data)
 }
 
+// Returns computed name of an S3 bucket for fetching iris deletions.
+pub fn get_s3_bucket_for_iris_deletions(environment: String) -> String {
+    format!("wf-smpcv2-{}-sync-protocol", environment)
+}
+
+// Returns computed name of an S3 key for fetching iris deletions.
+pub fn get_s3_key_for_iris_deletions(environment: String) -> String {
+    format!("{}_deleted_serial_ids.json", environment)
+}
+
 /// Fetches serial identifiers marked as deleted.
 ///
 /// # Arguments
@@ -93,7 +103,6 @@ pub async fn fetch_iris_batch(
 ///
 /// A set of Iris serial identifiers marked as deleted.
 ///
-#[allow(dead_code)]
 pub async fn fetch_iris_deletions(
     config: &Config,
     s3_client: &S3_Client,
@@ -105,8 +114,8 @@ pub async fn fetch_iris_deletions(
     }
 
     // Compose bucket and key based on environment
-    let s3_bucket = config.get_s3_bucket_for_iris_deletions();
-    let s3_key = config.get_s3_key_for_iris_deletions();
+    let s3_bucket = get_s3_bucket_for_iris_deletions(config.environment.clone());
+    let s3_key = get_s3_key_for_iris_deletions(config.environment.clone());
     logger::log_info(
         COMPONENT,
         format!(

--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -1367,12 +1367,12 @@ pub mod tests {
 
 pub mod test_utils {
     use super::*;
-    const APP_NAME: &str = "SMPC";
+    const SCHEMA_NAME: &str = "SMPC";
     const DOTENV_TEST: &str = ".env.test";
 
     pub fn test_db_url() -> Result<String> {
         dotenvy::from_filename(DOTENV_TEST)?;
-        Ok(Config::load_config(APP_NAME)?
+        Ok(Config::load_config(SCHEMA_NAME)?
             .database
             .ok_or(eyre!("Missing database config"))?
             .url)

--- a/iris-mpc-upgrade-hawk/src/genesis/mod.rs
+++ b/iris-mpc-upgrade-hawk/src/genesis/mod.rs
@@ -342,6 +342,15 @@ async fn get_service_clients(
 
     /// Returns initialized PostgreSQL clients for Iris share & HNSW graph stores.
     async fn get_pgres_clients(config: &Config) -> Result<(IrisStore, GraphPg<Aby3Store>), Report> {
+        let iris_schema_name = format!(
+            "{}_{}_{}",
+            config.schema_name, config.environment, config.party_id
+        );
+
+        let hawk_schema_name = format!(
+            "{}{}_{}_{}",
+            config.schema_name, config.hnsw_schema_name_suffix, config.environment, config.party_id
+        );
         // Set config.
         let db_config_iris = config
             .database
@@ -355,13 +364,13 @@ async fn get_service_clients(
         // Set postgres clients.
         let pg_client_iris = PostgresClient::new(
             &db_config_iris.url,
-            &config.get_database_schema_name(),
+            iris_schema_name.as_str(),
             AccessMode::ReadOnly,
         )
         .await?;
         let pg_client_graph = PostgresClient::new(
             &db_config_graph.url,
-            &config.get_database_schema_name(),
+            hawk_schema_name.as_str(),
             AccessMode::ReadWrite,
         )
         .await?;

--- a/iris-mpc/bin/server.rs
+++ b/iris-mpc/bin/server.rs
@@ -1117,7 +1117,7 @@ async fn server_main(config: Config) -> Result<()> {
 
     let schema_name = format!(
         "{}_{}_{}",
-        config.app_name, config.environment, config.party_id
+        config.schema_name, config.environment, config.party_id
     );
     let db_config = config
         .database


### PR DESCRIPTION
### Notes
* remove all Genesis config from the main server config (no need to keep genesis data there)
* add mechanism to alter the HNSW schema for running different tests ie: we can run genesis on a different schema then the  normal HNSW one.
* change app name to its actual name `schema_name`