### PR TITLE
(feature): add test tool for importing and exporting the HNSW graph

### DIFF
--- a/iris-mpc-cpu/Cargo.toml
+++ b/iris-mpc-cpu/Cargo.toml
@@ -104,5 +104,9 @@ name = "init-test-dbs"
 path = "bin/init_test_dbs.rs"
 
 [[bin]]
+name = "graph-mem-cli"
+path = "bin/graph_mem_cli.rs"
+
+[[bin]]
 name = "local_hnsw"
 path = "bin/local_hnsw.rs"

--- a/iris-mpc-cpu/bin/graph_mem_cli.rs
+++ b/iris-mpc-cpu/bin/graph_mem_cli.rs
@@ -47,7 +47,7 @@ async fn main() -> Result<()> {
         command,
     } = cli;
 
-    let mut db_context = DbContext::new(&db_url, &schema).await;
+    let db_context = DbContext::new(&db_url, &schema).await;
 
     match command {
         Command::DumpDb => {

--- a/iris-mpc-cpu/bin/graph_mem_cli.rs
+++ b/iris-mpc-cpu/bin/graph_mem_cli.rs
@@ -1,0 +1,59 @@
+use clap::{Parser, Subcommand};
+use iris_mpc_cpu::hnsw::graph::test_utils::DbContext;
+use std::path::PathBuf;
+use eyre::Result;
+
+#[derive(Parser)]
+#[command(name = "graph_mem_cli")]
+#[command(about = "Convert from db -> memory -> file or file -> memory -> db", long_about = None)]
+struct Cli {
+    /// Database URL
+    #[arg(long)]
+    db_url: String,
+    /// Database schema
+    #[arg(long)]
+    schema: String,
+    /// File path (input or output depending on mode)
+    #[arg(long)]
+    file: PathBuf,
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Load a graph from a database to memory, then write it to a file.
+    DumpDb,
+    /// Load a graph from a file to memory, then write it to a database
+    LoadDb,
+    /// verify that Dump/Load works as expected
+    Test,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    let Cli {
+        db_url,
+        schema,
+        file,
+        command,
+    } = cli;
+
+    let db_context = DbContext::new(&db_url, &schema).await;
+
+    match command {
+        Command::DumpDb => {
+            db_context.write_graph_to_file(&file).await?;
+        }
+        Command::LoadDb => {
+            db_context.load_graph_from_file(&file).await?;
+        }
+        Command::Test => {
+            db_context.test_load_store(&file).await?;
+        }
+    }
+    println!("Command succeeded");
+    Ok(())
+}

--- a/iris-mpc-cpu/src/hnsw/graph/mod.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/mod.rs
@@ -1,3 +1,4 @@
 pub mod graph_store;
 pub mod layered_graph;
 pub mod neighborhood;
+pub mod test_utils;

--- a/iris-mpc-cpu/src/hnsw/graph/test_utils.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/test_utils.rs
@@ -243,7 +243,9 @@ impl DbContext {
         };
         graph_ops.set_entry_point(ep2.point, ep2.layer).await?;
 
-        // create edges between the first 4 vectors and each of the last 4 vectors
+        // create edges between vectors 1-3 and 4-6
+        // imagine vectors 1-3 as layer 1 and vectors 4-6 as layer 2
+        // then layers 1 and 2 are fully connected.
         for i in 1..4 {
             let mut links = SortedNeighborhood::new();
 

--- a/iris-mpc-cpu/src/hnsw/graph/test_utils.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/test_utils.rs
@@ -1,0 +1,158 @@
+//! this file is used by test utilities
+
+use super::{graph_store::GraphPg, layered_graph::EntryPoint};
+use crate::{
+    execution::hawk_main::StoreId, hawkers::plaintext_store::PlaintextStore, hnsw::GraphMem,
+    protocol::shared_iris::GaloisRingSharedIris,
+};
+use bincode;
+use eyre::Result;
+use iris_mpc_common::postgres::{AccessMode, PostgresClient};
+use iris_mpc_store::{Store, StoredIrisRef};
+use itertools::Itertools;
+use serde::{Deserialize, Serialize};
+use tokio::fs::File;
+use tokio::io::AsyncWriteExt;
+
+/// Number of secret-shared iris code pairs to persist to Postgres per transaction.
+const SECRET_SHARING_PG_TX_SIZE: usize = 100;
+
+pub struct DbContext {
+    /// Postgres store to persist data against
+    pub store: Store,
+    graph_pg: GraphPg<PlaintextStore>,
+}
+
+#[derive(Serialize, Deserialize, PartialEq)]
+struct BothSides {
+    left: GraphMem<PlaintextStore>,
+    right: GraphMem<PlaintextStore>,
+}
+
+impl DbContext {
+    pub async fn new(url: &str, schema: &str) -> Self {
+        let client = PostgresClient::new(url, schema, AccessMode::ReadWrite)
+            .await
+            .unwrap();
+        let store = Store::new(&client).await.unwrap();
+        let graph_pg = GraphPg::new(&client).await.unwrap();
+        Self { store, graph_pg }
+    }
+
+    pub async fn persist_graph_db(
+        &self,
+        graph: GraphMem<PlaintextStore>,
+        side: StoreId,
+    ) -> Result<()> {
+        let mut graph_tx = self.graph_pg.tx().await.unwrap();
+
+        let GraphMem {
+            entry_point,
+            layers,
+        } = graph;
+
+        if let Some(EntryPoint { point, layer }) = entry_point {
+            let mut graph_ops = graph_tx.with_graph(side);
+            graph_ops.set_entry_point(point, layer).await?;
+        }
+
+        for (lc, layer) in layers.into_iter().enumerate() {
+            for (idx, (pt, links)) in layer.links.into_iter().enumerate() {
+                {
+                    let mut graph_ops = graph_tx.with_graph(side);
+                    graph_ops.set_links(pt, links, lc).await?;
+                }
+
+                if (idx % 1000) == 999 {
+                    graph_tx.tx.commit().await?;
+                    graph_tx = self.graph_pg.tx().await.unwrap();
+                }
+            }
+        }
+
+        graph_tx.tx.commit().await?;
+
+        Ok(())
+    }
+
+    /// Extends iris shares table by inserting irises following the current
+    /// maximum serial id.
+    ///
+    /// Returns tuple `(start, end)` giving the first and last serial ids
+    /// assigned to the inserted shares.
+    pub async fn persist_vector_shares(
+        &self,
+        shares: Vec<(GaloisRingSharedIris, GaloisRingSharedIris)>,
+    ) -> Result<(usize, usize)> {
+        let mut tx = self.store.tx().await?;
+
+        let start_serial_id = self.store.get_max_serial_id().await.unwrap_or(0) + 1;
+        let end_serial_id = start_serial_id + shares.len() - 1;
+
+        for batch in &shares.iter().enumerate().chunks(SECRET_SHARING_PG_TX_SIZE) {
+            let iris_refs: Vec<_> = batch
+                .map(|(idx, (iris_l, iris_r))| StoredIrisRef {
+                    id: (start_serial_id + idx) as i64,
+                    left_code: &iris_l.code.coefs,
+                    left_mask: &iris_l.mask.coefs,
+                    right_code: &iris_r.code.coefs,
+                    right_mask: &iris_r.mask.coefs,
+                })
+                .collect();
+
+            self.store.insert_irises(&mut tx, &iris_refs).await?;
+            tx.commit().await?;
+            tx = self.store.tx().await?;
+        }
+
+        Ok((start_serial_id, end_serial_id))
+    }
+
+    pub async fn load_graph_to_mem(
+        &self,
+        side: StoreId,
+    ) -> Result<GraphMem<PlaintextStore>, eyre::Report> {
+        let mut graph_tx = self.graph_pg.tx().await.unwrap();
+        let mut graph_ops = graph_tx.with_graph(side);
+
+        graph_ops.load_to_mem().await
+    }
+
+    // loads the graph from the database to memory and then writes it to a file
+    pub async fn write_graph_to_file(&self, path: &std::path::Path) -> Result<()> {
+        let left = self.load_graph_to_mem(StoreId::Left).await?;
+        let right = self.load_graph_to_mem(StoreId::Right).await?;
+        let graph = BothSides { left, right };
+        let serialized = bincode::serialize(&graph)?;
+        let mut file = File::create(path).await?;
+        file.write_all(&serialized).await?;
+        file.flush().await?;
+        Ok(())
+    }
+
+    // loads a graph to memory from a file and then persists it to the database
+    pub async fn load_graph_from_file(&self, path: &std::path::Path) -> Result<()> {
+        let data = tokio::fs::read(path).await?;
+        let graph: BothSides = bincode::deserialize(&data)?;
+        self.persist_graph_db(graph.left, StoreId::Left).await?;
+        self.persist_graph_db(graph.right, StoreId::Right).await?;
+        Ok(())
+    }
+
+    pub async fn test_load_store(&self, path: &std::path::Path) -> Result<()> {
+        let left = self.load_graph_to_mem(StoreId::Left).await?;
+        let right = self.load_graph_to_mem(StoreId::Right).await?;
+        let stored_graph = BothSides { left, right };
+        let serialized = bincode::serialize(&stored_graph)?;
+        let mut file = File::create(path).await?;
+        file.write_all(&serialized).await?;
+        file.flush().await?;
+
+        let data = tokio::fs::read(path).await?;
+        let loaded_graph: BothSides = bincode::deserialize(&data)?;
+        if stored_graph != loaded_graph {
+            return Err(eyre::eyre!("Loaded graph does not match stored graph"));
+        }
+        Ok(())
+    }
+}

--- a/iris-mpc-cpu/src/hnsw/graph/test_utils.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/test_utils.rs
@@ -53,7 +53,7 @@ impl DbContext {
         graph: GraphMem<PlaintextStore>,
         side: StoreId,
     ) -> Result<()> {
-        let mut graph_tx = self.graph_pg.tx().await.unwrap();
+        let mut graph_tx = self.graph_pg.tx().await?;
 
         let GraphMem {
             entry_point,
@@ -74,7 +74,7 @@ impl DbContext {
 
                 if (idx % 1000) == 999 {
                     graph_tx.tx.commit().await?;
-                    graph_tx = self.graph_pg.tx().await.unwrap();
+                    graph_tx = self.graph_pg.tx().await?;
                 }
             }
         }
@@ -121,7 +121,7 @@ impl DbContext {
         &self,
         side: StoreId,
     ) -> Result<GraphMem<PlaintextStore>, eyre::Report> {
-        let mut graph_tx = self.graph_pg.tx().await.unwrap();
+        let mut graph_tx = self.graph_pg.tx().await?;
         let mut graph_ops = graph_tx.with_graph(side);
 
         graph_ops.load_to_mem().await
@@ -182,7 +182,7 @@ impl DbContext {
     }
 
     // this function was stolen from other test code.
-    pub async fn gen_random(&mut self) -> Result<()> {
+    pub async fn gen_random(&self) -> Result<()> {
         let rng = &mut AesRng::seed_from_u64(0_u64);
         let mut vector_store = PlaintextStore::new();
 
@@ -204,7 +204,7 @@ impl DbContext {
             d
         };
 
-        let mut tx = self.graph_pg.tx().await.unwrap();
+        let mut tx = self.graph_pg.tx().await?;
         let mut graph_ops = tx.with_graph(StoreId::Left);
 
         let ep = graph_ops.get_entry_point().await?;
@@ -241,7 +241,7 @@ impl DbContext {
             assert_eq!(*links, *links2);
         }
 
-        tx.tx.commit().await.unwrap();
+        tx.tx.commit().await?;
         Ok(())
     }
 }


### PR DESCRIPTION
This tool was created in anticipation of the HNSW schema change, which will change the format of the graph edges from Json to binary.

There is currently not a good way to perform a migration that involves running custom code. A more powerful tool such as `sqlx_migrator` or `sea-orm` would allow that, but that is out of scope for the schema change PR. 

This PR allows for bypassing the migration step by going directly from `GraphMem` to/from a file, serialized/deserialized using `bincode`. 

## Intended Usage
- first, connect to the desired database and run the `backup-db` command
- next, check out a future version of `iris-mpc-cpu`, which will include a migration that drops the HNSW database tables and re-creates them with columns of the desired format. 
- finally, run the `restore-db` command. this will load the database from the file and persist it in postgres. 

## additional feature
the `compare-to-db` command was added to compare a file (generated with `backup-db`) to the database. 

## testing
Testing was performed using the  `docker-compose.test.yaml` file.

command used to populate the local database
`target/debug/graph-mem-cli --db-url postgresql://postgres:postgres@localhost:5432/SMPC_dev_2 --schema SMPC_dev_2 --file /tmp/db_loader store-random`

command used to test the dump/load functionality
`target/debug/graph-mem-cli --db-url postgresql://postgres:postgres@localhost:5432/SMPC_dev_2 --schema SMPC_dev_2 --file /tmp/db_loader verify-backup`