### PR TITLE
Fix/anon stats session

### DIFF
--- a/.github/workflows/temp-branch-build-and-push-hawk.yaml
+++ b/.github/workflows/temp-branch-build-and-push-hawk.yaml
@@ -3,7 +3,7 @@ name: Branch - Hawk Build and push docker image
 on:
   push:
     branches:
-      - "POP-2269/add-pushing-branches-for-cpu"
+      - "fix/anon-stats-session"
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
@@ -42,7 +42,7 @@ jobs:
           context: .
           push: true
           tags: |
-            ${{ env.REGISTRY }}/worldcoin/${{ env.IMAGE_NAME }}:${{ github.sha }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
           platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/temp-branch-build-and-push-hawk.yaml
+++ b/.github/workflows/temp-branch-build-and-push-hawk.yaml
@@ -46,3 +46,4 @@ jobs:
           platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          file: Dockerfile.hawk

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -473,9 +473,14 @@ impl HawkActor {
         let distances = search_results
             .iter() // All requests.
             .flat_map(|rots| rots.iter()) // All rotations.
-            .flat_map(|plan| plan.links.first()) // Bottom layer.
-            .flat_map(|neighbors| neighbors.iter()) // Nearest neighbors.
-            .map(|(_, distance)| distance.clone());
+            .flat_map(|plan| {
+                plan.links.first().into_iter().flat_map(move |neighbors| {
+                    neighbors
+                        .iter()
+                        .take(plan.match_count)
+                        .map(|(_, distance)| distance.clone())
+                })
+            });
 
         self.distances_cache[side].extend(distances);
     }
@@ -1550,6 +1555,3 @@ mod tests_db {
         Ok(())
     }
 }
-
-// { environment: "dev", results_topic_arn: "arn:aws:sns:us-east-1:000000000000:iris-mpc-results.fifo", processing_timeout_secs: 60, startup_sync_timeout_secs: 300, public_key_base_url: "", shares_bucket_name: "wf-smpcv2-dev-sns-requests", clear_db_before_init: false, init_db_size: 0, max_db_size: 10000, max_batch_size: 15, heartbeat_interval_secs: 2, heartbeat_initial_retries: 10, fake_db_size: 0, return_partial_results: false, disable_persistence: false, shutdown_last_results_sync_timeout_secs: 10, image_name: "", fixed_shared_secrets: false, luc_enabled: false, luc_lookback_records: 0, luc_serial_ids_from_smpc_request: false, match_distances_buffer_size: 128, match_distances_buffer_size_extra_percent: 20, n_buckets: 10, enable_sending_anonymized_stats_message: false, enable_sending_mirror_anonymized_stats_message: false, enable_reauth: false, enable_reset: false, hawk_request_parallelism: 10, hawk_stream_parallelism: 8, hawk_connection_parallelism: 16, hnsw_param_ef_constr: 320, hnsw_param_M: 256, hnsw_param_ef_search: 256, hawk_prng_seed: None, max_deletions_per_batch: 100, mode_of_compute: Cpu, mode_of_deployment: Standard, enable_modifications_sync: false, enable_modifications_replay: false, sqs_sync_long_poll_seconds: 10, hawk_server_deletions_enabled: false, hawk_server_reauths_enabled: false, app_name: "SMPC", cpu_disable_persistence: false, hawk_server_resets_enabled: false, full_scan_side: Left }
-// { environment: "dev", results_topic_arn: "arn:aws:sns:us-east-1:000000000000:iris-mpc-results.fifo", processing_timeout_secs: 60, startup_sync_timeout_secs: 300, public_key_base_url: "", shares_bucket_name: "wf-smpcv2-dev-sns-requests", clear_db_before_init: false, init_db_size: 0, max_db_size: 10000, max_batch_size: 64, heartbeat_interval_secs: 2, heartbeat_initial_retries: 10, fake_db_size: 0, return_partial_results: false, disable_persistence: false, shutdown_last_results_sync_timeout_secs: 10, image_name: "", fixed_shared_secrets: false, luc_enabled: false, luc_lookback_records: 0, luc_serial_ids_from_smpc_request: false, match_distances_buffer_size: 64, match_distances_buffer_size_extra_percent: 20, n_buckets: 10, enable_sending_anonymized_stats_message: false, enable_sending_mirror_anonymized_stats_message: false, enable_reauth: false, enable_reset: false, hawk_request_parallelism: 10, hawk_stream_parallelism: 8, hawk_connection_parallelism: 16, hnsw_param_ef_constr: 320, hnsw_param_M: 256, hnsw_param_ef_search: 256, hawk_prng_seed: None, max_deletions_per_batch: 100, mode_of_compute: Cpu, mode_of_deployment: Standard, enable_modifications_sync: false, enable_modifications_replay: false, sqs_sync_long_poll_seconds: 10, hawk_server_deletions_enabled: false, hawk_server_reauths_enabled: false, app_name: "SMPC", cpu_disable_persistence: false, hawk_server_resets_enabled: false, full_scan_side: Left }

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -481,7 +481,11 @@ impl HawkActor {
                         .map(|(_, distance)| distance.clone())
                 })
             });
-
+        tracing::info!(
+            "Keeping {} distances for eye {side} out of {} search results.",
+            distances.clone().count(),
+            search_results.len()
+        );
         self.distances_cache[side].extend(distances);
     }
 

--- a/iris-mpc-cpu/src/protocol/ops.rs
+++ b/iris-mpc-cpu/src/protocol/ops.rs
@@ -124,11 +124,13 @@ pub async fn compare_threshold_buckets(
         })
         .collect_vec();
 
+    tracing::info!("compare_threshold_buckets diffs: {}", diffs.len());
     let msbs = extract_msb_u32_batch(session, &diffs).await?;
     let msbs = VecShare::new_vec(msbs);
 
     // bit_inject all MSBs into u32 to be able to add them up
     let sums = bit_inject_ot_2round(session, msbs).await?;
+    tracing::info!("bit_inject_ot_2round");
     // add them up, bucket-wise, with each bucket corresponding to a threshold and containing len(distances) results
     let buckets = sums
         .into_iter()

--- a/iris-mpc-cpu/src/protocol/ops.rs
+++ b/iris-mpc-cpu/src/protocol/ops.rs
@@ -124,13 +124,13 @@ pub async fn compare_threshold_buckets(
         })
         .collect_vec();
 
-    tracing::info!("compare_threshold_buckets diffs: {}", diffs.len());
+    tracing::info!("compare_threshold_buckets diffs length: {}", diffs.len());
     let msbs = extract_msb_u32_batch(session, &diffs).await?;
     let msbs = VecShare::new_vec(msbs);
-
+    tracing::info!("msbs extracted, now bit_injecting");
     // bit_inject all MSBs into u32 to be able to add them up
     let sums = bit_inject_ot_2round(session, msbs).await?;
-    tracing::info!("bit_inject_ot_2round");
+    tracing::info!("bit_inject done, now summing");
     // add them up, bucket-wise, with each bucket corresponding to a threshold and containing len(distances) results
     let buckets = sums
         .into_iter()


### PR DESCRIPTION
The main and only change that's relevant reviewing here is the filtering of the matches, so that we keep only the neighbors that actually matched for anonymized statistics reporting: https://github.com/worldcoin/iris-mpc/pull/1377/files#diff-334cb4ae1a3bea043540c0991c569ee4527398a51ee2eb6321ec987fcdebebcdR476-R488