### PR TITLE
Update s3 importer to include version id

### DIFF
--- a/.github/workflows/temp-branch-build-and-push-hawk.yaml
+++ b/.github/workflows/temp-branch-build-and-push-hawk.yaml
@@ -3,7 +3,7 @@ name: Branch - Hawk Build and push docker image
 on:
   push:
     branches:
-      - "fix/anon-stats-session"
+      - "POP-2413/update-s3-importer-to-include-version-id"
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'

--- a/.github/workflows/temp-branch-build-and-push-hawk.yaml
+++ b/.github/workflows/temp-branch-build-and-push-hawk.yaml
@@ -3,7 +3,7 @@ name: Branch - Hawk Build and push docker image
 on:
   push:
     branches:
-      - "POP-2413/update-s3-importer-to-include-version-id"
+      - "POP-2413/update-s3-importer-to-include-version-id-2"
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'

--- a/.github/workflows/temp-branch-build-and-push.yaml
+++ b/.github/workflows/temp-branch-build-and-push.yaml
@@ -3,7 +3,7 @@ name: Branch - Build and push docker image
 on:
   push:
     branches:
-      - "POP-2413/update-s3-importer-to-include-version-id"
+      - "POP-2413/update-s3-importer-to-include-version-id-2"
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'

--- a/.github/workflows/temp-branch-build-and-push.yaml
+++ b/.github/workflows/temp-branch-build-and-push.yaml
@@ -3,7 +3,7 @@ name: Branch - Build and push docker image
 on:
   push:
     branches:
-      - "chore/insert-sns-msg-id-upon-reset-update-msg"
+      - "POP-2413/update-s3-importer-to-include-version-id"
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2454,6 +2454,7 @@ name = "iris-mpc-store"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "aws-config",
  "aws-sdk-s3",
  "bytemuck",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1345,27 +1345,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "csv"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "cudarc"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2457,16 +2436,11 @@ dependencies = [
  "aws-config",
  "aws-sdk-s3",
  "bytemuck",
- "bytes",
- "csv",
  "dotenvy",
  "eyre",
  "futures",
- "hex",
  "iris-mpc-common",
- "itertools 0.13.0",
  "rand",
- "rayon",
  "serde",
  "serde_json",
  "sqlx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ aws-sdk-secretsmanager = { version = "1.47.0" }
 async-trait = "0.1.83"
 axum = "0.7"
 clap = { version = "4", features = ["derive", "env"] }
-csv = "1.3.1"
 base64 = "0.22.1"
 bytes = "1.5"
 bytemuck = { version = "1.17", features = ["derive"] }

--- a/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw.yaml
@@ -80,6 +80,21 @@ env:
   - name: SMPC__SHARES_BUCKET_NAME
     value: "wf-smpcv2-stage-sns-requests"
 
+  - name: SMPC__ENABLE_S3_IMPORTER
+    value: "true"
+
+  - name: SMPC__DB_CHUNKS_BUCKET_NAME
+    value: "iris-mpc-db-exporter-store-node-0-stage--eun1-az3--x-s3"
+
+  - name: SMPC__DB_CHUNKS_FOLDER_NAME
+    value: "hnsw_even_odd_with_version_id_output_16k"
+
+  - name: SMPC__LOAD_CHUNKS_PARALLELISM
+    value: "64"
+
+  - name: SMPC__LOAD_CHUNKS_BUFFER_SIZE
+    value: "1024"
+
   - name: SMPC__REQUESTS_QUEUE_URL
     valueFrom:
       secretKeyRef:

--- a/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw.yaml
@@ -30,7 +30,7 @@ env:
     valueFrom:
       secretKeyRef:
         key: DATABASE_AURORA_HNSW_URL
-        name: testing-db-creds-manual
+        name: application
 
   - name: SMPC__MAX_DB_SIZE
     value: "2000000"

--- a/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw.yaml
@@ -29,7 +29,7 @@ env:
   - name: SMPC__CPU_DATABASE__URL
     valueFrom:
       secretKeyRef:
-        key: DATABASE_AURORA_HNSW_URL
+        key: TEMP_DATABASE_AURORA_HNSW_URL
         name: application
 
   - name: SMPC__MAX_DB_SIZE
@@ -81,7 +81,7 @@ env:
     value: "wf-smpcv2-stage-sns-requests"
 
   - name: SMPC__ENABLE_S3_IMPORTER
-    value: "true"
+    value: "false"
 
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "iris-mpc-db-exporter-store-node-0-stage--eun1-az3--x-s3"

--- a/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw.yaml
@@ -81,7 +81,7 @@ env:
     value: "wf-smpcv2-stage-sns-requests"
 
   - name: SMPC__ENABLE_S3_IMPORTER
-    value: "false"
+    value: "true"
 
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "iris-mpc-db-exporter-store-node-0-stage--eun1-az3--x-s3"

--- a/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw.yaml
@@ -81,7 +81,7 @@ env:
     value: "wf-smpcv2-stage-sns-requests"
 
   - name: SMPC__ENABLE_S3_IMPORTER
-    value: "true"
+    value: "false"
 
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "iris-mpc-db-exporter-store-node-0-stage--eun1-az3--x-s3"

--- a/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw.yaml
@@ -81,7 +81,7 @@ env:
     value: "wf-smpcv2-stage-sns-requests"
 
   - name: SMPC__ENABLE_S3_IMPORTER
-    value: "true"
+    value: "false"
 
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "iris-mpc-db-exporter-store-node-1-stage--eun1-az3--x-s3"

--- a/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw.yaml
@@ -30,7 +30,7 @@ env:
     valueFrom:
       secretKeyRef:
         key: DATABASE_AURORA_HNSW_URL
-        name: testing-db-creds-manual
+        name: application
 
   - name: SMPC__MAX_DB_SIZE
     value: "2000000"

--- a/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw.yaml
@@ -80,6 +80,21 @@ env:
   - name: SMPC__SHARES_BUCKET_NAME
     value: "wf-smpcv2-stage-sns-requests"
 
+  - name: SMPC__ENABLE_S3_IMPORTER
+    value: "true"
+
+  - name: SMPC__DB_CHUNKS_BUCKET_NAME
+    value: "iris-mpc-db-exporter-store-node-1-stage--eun1-az3--x-s3"
+
+  - name: SMPC__DB_CHUNKS_FOLDER_NAME
+    value: "hnsw_even_odd_with_version_id_output_16k"
+
+  - name: SMPC__LOAD_CHUNKS_PARALLELISM
+    value: "64"
+
+  - name: SMPC__LOAD_CHUNKS_BUFFER_SIZE
+    value: "1024"
+
   - name: SMPC__REQUESTS_QUEUE_URL
     valueFrom:
       secretKeyRef:

--- a/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw.yaml
@@ -29,7 +29,7 @@ env:
   - name: SMPC__CPU_DATABASE__URL
     valueFrom:
       secretKeyRef:
-        key: DATABASE_AURORA_HNSW_URL
+        key: TEMP_DATABASE_AURORA_HNSW_URL
         name: application
 
   - name: SMPC__MAX_DB_SIZE
@@ -81,7 +81,7 @@ env:
     value: "wf-smpcv2-stage-sns-requests"
 
   - name: SMPC__ENABLE_S3_IMPORTER
-    value: "true"
+    value: "false"
 
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "iris-mpc-db-exporter-store-node-1-stage--eun1-az3--x-s3"

--- a/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw.yaml
@@ -81,7 +81,7 @@ env:
     value: "wf-smpcv2-stage-sns-requests"
 
   - name: SMPC__ENABLE_S3_IMPORTER
-    value: "false"
+    value: "true"
 
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "iris-mpc-db-exporter-store-node-1-stage--eun1-az3--x-s3"

--- a/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw.yaml
@@ -81,7 +81,7 @@ env:
     value: "wf-smpcv2-stage-sns-requests"
 
   - name: SMPC__ENABLE_S3_IMPORTER
-    value: "true"
+    value: "false"
 
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "iris-mpc-db-exporter-store-node-2-stage--eun1-az3--x-s3"

--- a/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw.yaml
@@ -80,6 +80,21 @@ env:
   - name: SMPC__SHARES_BUCKET_NAME
     value: "wf-smpcv2-stage-sns-requests"
 
+  - name: SMPC__ENABLE_S3_IMPORTER
+    value: "true"
+
+  - name: SMPC__DB_CHUNKS_BUCKET_NAME
+    value: "iris-mpc-db-exporter-store-node-2-stage--eun1-az3--x-s3"
+
+  - name: SMPC__DB_CHUNKS_FOLDER_NAME
+    value: "hnsw_even_odd_with_version_id_output_16k"
+
+  - name: SMPC__LOAD_CHUNKS_PARALLELISM
+    value: "64"
+
+  - name: SMPC__LOAD_CHUNKS_BUFFER_SIZE
+    value: "1024"
+
   - name: SMPC__REQUESTS_QUEUE_URL
     valueFrom:
       secretKeyRef:

--- a/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw.yaml
@@ -30,7 +30,7 @@ env:
     valueFrom:
       secretKeyRef:
         key: DATABASE_AURORA_HNSW_URL
-        name: testing-db-creds-manual
+        name: application
 
   - name: SMPC__MAX_DB_SIZE
     value: "2000000"

--- a/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw.yaml
@@ -81,7 +81,7 @@ env:
     value: "wf-smpcv2-stage-sns-requests"
 
   - name: SMPC__ENABLE_S3_IMPORTER
-    value: "false"
+    value: "true"
 
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "iris-mpc-db-exporter-store-node-2-stage--eun1-az3--x-s3"

--- a/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw.yaml
@@ -29,7 +29,7 @@ env:
   - name: SMPC__CPU_DATABASE__URL
     valueFrom:
       secretKeyRef:
-        key: DATABASE_AURORA_HNSW_URL
+        key: TEMP_DATABASE_AURORA_HNSW_URL
         name: application
 
   - name: SMPC__MAX_DB_SIZE
@@ -81,7 +81,7 @@ env:
     value: "wf-smpcv2-stage-sns-requests"
 
   - name: SMPC__ENABLE_S3_IMPORTER
-    value: "true"
+    value: "false"
 
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "iris-mpc-db-exporter-store-node-2-stage--eun1-az3--x-s3"

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -72,13 +72,13 @@ env:
     value: "wf-smpcv2-stage-sns-requests"
 
   - name: SMPC__ENABLE_S3_IMPORTER
-    value: "false"
+    value: "true"
 
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "iris-mpc-db-exporter-store-node-0-stage--eun1-az3--x-s3"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "even_odd_binary_output_16k"
+    value: "even_odd_with_version_id_output_16k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
     value: "64"

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -72,13 +72,13 @@ env:
     value: "wf-smpcv2-stage-sns-requests"
 
   - name: SMPC__ENABLE_S3_IMPORTER
-    value: "false"
+    value: "true"
 
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "iris-mpc-db-exporter-store-node-1-stage--eun1-az3--x-s3"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "even_odd_binary_output_16k"
+    value: "even_odd_with_version_id_output_16k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
     value: "64"

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -72,13 +72,13 @@ env:
     value: "wf-smpcv2-stage-sns-requests"
 
   - name: SMPC__ENABLE_S3_IMPORTER
-    value: "false"
+    value: "true"
 
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "iris-mpc-db-exporter-store-node-2-stage--eun1-az3--x-s3"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "even_odd_binary_output_16k"
+    value: "even_odd_with_version_id_output_16k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
     value: "64"

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -638,6 +638,7 @@ impl ServerActor {
 
             metrics::histogram!("full_batch_duration").record(now.elapsed().as_secs_f64());
         }
+        self.full_scan_side = self.full_scan_side.other();
         tracing::info!("Server Actor finished due to all job queues being closed");
     }
 

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -638,7 +638,6 @@ impl ServerActor {
 
             metrics::histogram!("full_batch_duration").record(now.elapsed().as_secs_f64());
         }
-        self.full_scan_side = self.full_scan_side.other();
         tracing::info!("Server Actor finished due to all job queues being closed");
     }
 

--- a/iris-mpc-store/Cargo.toml
+++ b/iris-mpc-store/Cargo.toml
@@ -10,24 +10,18 @@ repository.workspace = true
 [dependencies]
 aws-config.workspace = true
 aws-sdk-s3.workspace = true
-
-bytes.workspace = true
 async-trait.workspace = true
 iris-mpc-common = { path = "../iris-mpc-common" }
 bytemuck.workspace = true
-csv.workspace = true
 dotenvy.workspace = true
 futures.workspace = true
 sqlx.workspace = true
 eyre.workspace = true
-hex.workspace = true
-itertools.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
 tokio.workspace = true
 rand.workspace = true
-rayon.workspace = true
 
 [dev-dependencies]
 rand.workspace = true

--- a/iris-mpc-store/Cargo.toml
+++ b/iris-mpc-store/Cargo.toml
@@ -8,7 +8,9 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+aws-config.workspace = true
 aws-sdk-s3.workspace = true
+
 bytes.workspace = true
 async-trait.workspace = true
 iris-mpc-common = { path = "../iris-mpc-common" }

--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -221,6 +221,7 @@ impl Store {
         .bind(i64::try_from(id_range.end).expect("id fits into i64"))
         .fetch(&self.pool)
     }
+
     /// Stream irises in parallel, without a particular order.
     pub async fn stream_irises_par(
         &self,

--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -1,4 +1,5 @@
 mod s3_importer;
+pub mod loader;
 
 use bytemuck::cast_slice;
 use eyre::{eyre, Result};

--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -1,5 +1,5 @@
-mod s3_importer;
 pub mod loader;
+mod s3_importer;
 
 use bytemuck::cast_slice;
 use eyre::{eyre, Result};

--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -62,8 +62,7 @@ impl DbStoredIris {
     }
 
     pub fn vector_id(&self) -> VectorId {
-        // TODO: Distinguish vector_id from serial_id.
-        VectorId::from_serial_id(self.id as u32)
+        VectorId::new(self.id as u32, self.version_id)
     }
 
     pub fn left_code(&self) -> &[u16] {

--- a/iris-mpc-store/src/s3_importer.rs
+++ b/iris-mpc-store/src/s3_importer.rs
@@ -93,8 +93,7 @@ impl S3StoredIris {
     }
 
     pub fn vector_id(&self) -> VectorId {
-        // TODO: Distinguish vector_id from serial_id.
-        VectorId::from_serial_id(self.id as u32)
+        VectorId::new(self.id as u32, self.version_id)
     }
 
     pub fn left_code_odd(&self) -> &Vec<u8> {

--- a/iris-mpc-upgrade-hawk/src/genesis/mod.rs
+++ b/iris-mpc-upgrade-hawk/src/genesis/mod.rs
@@ -6,9 +6,7 @@ use aws_sdk_s3::{
 use eyre::{bail, eyre, Report, Result};
 use iris_mpc_common::{
     config::{CommonConfig, Config, ModeOfCompute, ModeOfDeployment},
-    helpers::{
-        inmemory_store::InMemoryStore, shutdown_handler::ShutdownHandler, task_monitor::TaskMonitor,
-    },
+    helpers::{shutdown_handler::ShutdownHandler, task_monitor::TaskMonitor},
     postgres::{AccessMode, PostgresClient},
     server_coordination as coordinator, IrisSerialId,
 };
@@ -111,7 +109,14 @@ pub async fn exec_main(config: Config, max_indexation_id: IrisSerialId) -> Resul
 
     // Process: initialise HNSW graph from previously indexed.
     let mut hawk_actor = get_hawk_actor(&config).await?;
-    init_graph_from_stores(&config, &iris_store, &graph_store, &mut hawk_actor).await?;
+    init_graph_from_stores(
+        &config,
+        &iris_store,
+        &graph_store,
+        &mut hawk_actor,
+        Arc::clone(&shutdown_handler),
+    )
+    .await?;
     background_tasks.check_tasks();
 
     // Start thread for persisting indexing results to DB.

--- a/iris-mpc-upgrade-hawk/src/genesis/mod.rs
+++ b/iris-mpc-upgrade-hawk/src/genesis/mod.rs
@@ -26,7 +26,7 @@ use iris_mpc_cpu::{
     hawkers::aby3::aby3_store::Aby3Store,
     hnsw::graph::graph_store::GraphPg,
 };
-use iris_mpc_store::{DbStoredIris, Store as IrisStore};
+use iris_mpc_store::{DbStoredIris, S3Store, Store as IrisStore};
 use std::{
     collections::HashSet,
     sync::Arc,
@@ -465,6 +465,7 @@ async fn init_graph_from_stores(
     iris_store: &IrisStore,
     graph_store: &GraphPg<Aby3Store>,
     hawk_actor: &mut HawkActor,
+    shutdown_handler: Arc<ShutdownHandler>,
 ) -> Result<()> {
     // ANCHOR: Load the database
     log_info(String::from("⚓️ ANCHOR: Load the database"));
@@ -485,7 +486,7 @@ async fn init_graph_from_stores(
     //       to read into memory
     // -------------------------------------------------------------------
     let store_len = iris_store.count_irises().await?;
-    load_db(&mut iris_loader, iris_store, store_len, parallelism)
+    load_db(&mut iris_loader, iris_store, store_len, parallelism, config, shutdown_handler)
         .await
         .expect("Failed to load DB");
 
@@ -553,105 +554,6 @@ async fn init_shutdown_handler(config: &Config) -> Arc<ShutdownHandler> {
     shutdown_handler.wait_for_shutdown_signal().await;
 
     shutdown_handler
-}
-
-/// Loads Aurora db records from the stream into memory
-///
-/// # Arguments
-///
-/// * `actor` - Hawk actor Iris loader.
-/// * `store` - Iris PostgreSQL store provider.
-/// * `store_len` - Count of Iris serial identifiers.
-/// * `store_load_parallelism` - Number of parallel threads to utilise when loading.
-///
-async fn load_db(
-    actor: &mut impl InMemoryStore,
-    store: &IrisStore,
-    store_len: usize,
-    store_load_parallelism: usize,
-) -> Result<()> {
-    let total_load_time = Instant::now();
-
-    let mut all_serial_ids: HashSet<i64> = HashSet::from_iter(1..=(store_len as i64));
-    actor.reserve(store_len);
-    let stream_db = store
-        .stream_irises_par(None, store_load_parallelism)
-        .await
-        .boxed();
-    load_db_records(actor, &mut all_serial_ids, stream_db).await;
-
-    if !all_serial_ids.is_empty() {
-        let msg = log_error(format!(
-            "Not all serial_ids were loaded: {:?}",
-            all_serial_ids
-        ));
-        bail!(msg);
-    }
-
-    log_info(String::from("Preprocessing db"));
-    actor.preprocess_db();
-
-    log_info(format!(
-        "Loaded set records from db into memory in {:?} [DB sizes: {:?}]",
-        total_load_time.elapsed(),
-        actor.current_db_sizes()
-    ));
-
-    eyre::Ok(())
-}
-
-/// Loads Aurora db records from the stream into memory
-///
-/// # Arguments
-///
-/// * `actor` - Hawk actor Iris loader.
-/// * `all_serial_ids` - Set of Iris serial identifiers.
-/// * `stream_db` - Db stream for pulling data.
-///
-#[allow(clippy::needless_lifetimes)]
-async fn load_db_records<'a>(
-    actor: &mut impl InMemoryStore,
-    all_serial_ids: &mut HashSet<i64>,
-    mut stream_db: BoxStream<'a, Result<DbStoredIris>>,
-) {
-    let mut load_summary_ts = Instant::now();
-    let mut time_waiting_for_stream = Duration::from_secs(0);
-    let mut time_loading_into_memory = Duration::from_secs(0);
-    let mut record_counter = 0;
-    while let Some(iris) = stream_db.next().await {
-        // Update time waiting for the stream
-        time_waiting_for_stream += load_summary_ts.elapsed();
-        load_summary_ts = Instant::now();
-
-        let iris = iris.unwrap();
-
-        actor.load_single_record_from_db(
-            iris.serial_id() - 1,
-            iris.vector_id(),
-            iris.left_code(),
-            iris.left_mask(),
-            iris.right_code(),
-            iris.right_mask(),
-        );
-
-        // Only increment db size if record has not been loaded via s3 before
-        if all_serial_ids.contains(&(iris.serial_id() as i64)) {
-            actor.increment_db_size(iris.serial_id() - 1);
-            all_serial_ids.remove(&(iris.serial_id() as i64));
-            record_counter += 1;
-        }
-
-        // Update time spent loading into memory
-        time_loading_into_memory += load_summary_ts.elapsed();
-        load_summary_ts = Instant::now();
-    }
-
-    log_info(format!(
-        "Aurora Loading summary => Loaded {:?} items. Waited for stream: {:?}, Loaded into memory: {:?}",
-        record_counter,
-        time_waiting_for_stream,
-        time_loading_into_memory,
-    ));
 }
 
 /// Helper: logs & returns an error message.

--- a/iris-mpc/bin/server.rs
+++ b/iris-mpc/bin/server.rs
@@ -48,6 +48,7 @@ use iris_mpc_common::{
     job::{BatchMetadata, BatchQuery, JobSubmissionHandle, ServerJobResult},
 };
 use iris_mpc_gpu::server::ServerActor;
+use iris_mpc_store::loader::load_iris_db;
 use iris_mpc_store::{
     fetch_and_parse_chunks, last_snapshot_timestamp, DbStoredIris, ObjectStore, S3Store,
     S3StoredIris, Store, StoredIrisRef,
@@ -72,7 +73,6 @@ use tokio::{
     task::{spawn_blocking, JoinHandle},
     time::timeout,
 };
-use iris_mpc_store::loader::{load_db};
 
 const RNG_SEED_INIT_DB: u64 = 42;
 const SQS_POLLING_INTERVAL: Duration = Duration::from_secs(1);
@@ -1677,9 +1677,9 @@ async fn server_main(config: Config) -> Result<()> {
                         parallelism
                     );
                     let download_shutdown_handler = Arc::clone(&download_shutdown_handler);
-                    
+
                     tokio::runtime::Handle::current().block_on(async {
-                        load_db(
+                        load_iris_db(
                             &mut actor,
                             &store,
                             store_len,

--- a/iris-mpc/bin/server.rs
+++ b/iris-mpc/bin/server.rs
@@ -72,6 +72,7 @@ use tokio::{
     task::{spawn_blocking, JoinHandle},
     time::timeout,
 };
+use iris_mpc_store::loader::{load_db};
 
 const RNG_SEED_INIT_DB: u64 = 42;
 const SQS_POLLING_INTERVAL: Duration = Duration::from_secs(1);
@@ -1676,11 +1677,7 @@ async fn server_main(config: Config) -> Result<()> {
                         parallelism
                     );
                     let download_shutdown_handler = Arc::clone(&download_shutdown_handler);
-                    let db_chunks_s3_store = S3Store::new(
-                        aws_clients.db_chunks_s3_client.clone(),
-                        s3_chunks_bucket_name.clone(),
-                    );
-
+                    
                     tokio::runtime::Handle::current().block_on(async {
                         load_db(
                             &mut actor,
@@ -1688,13 +1685,6 @@ async fn server_main(config: Config) -> Result<()> {
                             store_len,
                             parallelism,
                             &config,
-                            db_chunks_s3_store,
-                            aws_clients.db_chunks_s3_client,
-                            s3_chunks_folder_name,
-                            s3_chunks_bucket_name,
-                            s3_load_parallelism,
-                            s3_load_max_retries,
-                            s3_load_initial_backoff_ms,
                             download_shutdown_handler,
                         )
                         .await
@@ -2391,207 +2381,4 @@ async fn server_main(config: Config) -> Result<()> {
         }
     }
     Ok(())
-}
-
-// Helper function to load Aurora db records from the stream into memory
-#[allow(clippy::needless_lifetimes)]
-async fn load_db_records<'a>(
-    actor: &mut impl InMemoryStore,
-    mut record_counter: i32,
-    all_serial_ids: &mut HashSet<i64>,
-    mut stream_db: BoxStream<'a, Result<DbStoredIris>>,
-) {
-    let mut load_summary_ts = Instant::now();
-    let mut time_waiting_for_stream = Duration::from_secs(0);
-    let mut time_loading_into_memory = Duration::from_secs(0);
-    let n_loaded_via_s3 = record_counter;
-    while let Some(iris) = stream_db.next().await {
-        // Update time waiting for the stream
-        time_waiting_for_stream += load_summary_ts.elapsed();
-        load_summary_ts = Instant::now();
-
-        let iris = iris.unwrap();
-
-        actor.load_single_record_from_db(
-            iris.serial_id() - 1,
-            iris.vector_id(),
-            iris.left_code(),
-            iris.left_mask(),
-            iris.right_code(),
-            iris.right_mask(),
-        );
-
-        // Only increment db size if record has not been loaded via s3 before
-        if all_serial_ids.contains(&(iris.serial_id() as i64)) {
-            actor.increment_db_size(iris.serial_id() - 1);
-            all_serial_ids.remove(&(iris.serial_id() as i64));
-            record_counter += 1;
-        }
-
-        // Update time spent loading into memory
-        time_loading_into_memory += load_summary_ts.elapsed();
-        load_summary_ts = Instant::now();
-    }
-
-    tracing::info!(
-        "Aurora Loading summary => Loaded {:?} items. Waited for stream: {:?}, Loaded into \
-         memory: {:?}",
-        record_counter - n_loaded_via_s3,
-        time_waiting_for_stream,
-        time_loading_into_memory,
-    );
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn load_db(
-    actor: &mut impl InMemoryStore,
-    store: &Store,
-    store_len: usize,
-    store_load_parallelism: usize,
-    config: &Config,
-    db_chunks_s3_store: impl ObjectStore,
-    db_chunks_s3_client: S3Client,
-    s3_chunks_folder_name: String,
-    s3_chunks_bucket_name: String,
-    s3_load_parallelism: usize,
-    s3_load_max_retries: usize,
-    s3_load_initial_backoff_ms: u64,
-    download_shutdown_handler: Arc<ShutdownHandler>,
-) -> Result<()> {
-    let total_load_time = Instant::now();
-    let now = Instant::now();
-
-    let mut record_counter = 0;
-    let mut all_serial_ids: HashSet<i64> = HashSet::from_iter(1..=(store_len as i64));
-    actor.reserve(store_len);
-
-    if config.enable_s3_importer {
-        tracing::info!("S3 importer enabled. Fetching from s3 + db");
-
-        // First fetch last snapshot from S3
-        let last_snapshot_details =
-            last_snapshot_timestamp(&db_chunks_s3_store, s3_chunks_folder_name.clone()).await?;
-
-        let min_last_modified_at =
-            last_snapshot_details.timestamp - config.db_load_safety_overlap_seconds;
-        tracing::info!(
-            "Last snapshot timestamp: {}, min_last_modified_at: {}",
-            last_snapshot_details.timestamp,
-            min_last_modified_at
-        );
-
-        let s3_store = S3Store::new(db_chunks_s3_client, s3_chunks_bucket_name);
-        let s3_arc = Arc::new(s3_store);
-
-        let (tx, mut rx) = mpsc::channel::<S3StoredIris>(config.load_chunks_buffer_size);
-
-        tokio::spawn(async move {
-            fetch_and_parse_chunks(
-                s3_arc,
-                s3_load_parallelism,
-                s3_chunks_folder_name,
-                last_snapshot_details,
-                tx.clone(),
-                s3_load_max_retries,
-                s3_load_initial_backoff_ms,
-            )
-            .await
-            .expect("Couldn't fetch and parse chunks from s3");
-        });
-
-        let mut time_waiting_for_stream = Duration::from_secs(0);
-        let mut time_loading_into_memory = Duration::from_secs(0);
-        let mut load_summary_ts = Instant::now();
-        while let Some(iris) = rx.recv().await {
-            time_waiting_for_stream += load_summary_ts.elapsed();
-            load_summary_ts = Instant::now();
-            let index = iris.serial_id();
-
-            if index == 0 {
-                tracing::error!("Invalid iris index {}", index);
-                bail!("Invalid iris index {}", index);
-            } else if index > store_len {
-                tracing::warn!(
-                    "Skip loading rolled back item: index {} > store_len {}",
-                    index,
-                    store_len
-                );
-                continue;
-            } else if !all_serial_ids.contains(&(index as i64)) {
-                tracing::warn!("Skip loading s3 retried item: index {}", index);
-                continue;
-            }
-
-            actor.load_single_record_from_s3(
-                iris.serial_id() - 1,
-                iris.vector_id(),
-                iris.left_code_odd(),
-                iris.left_code_even(),
-                iris.right_code_odd(),
-                iris.right_code_even(),
-                iris.left_mask_odd(),
-                iris.left_mask_even(),
-                iris.right_mask_odd(),
-                iris.right_mask_even(),
-            );
-            actor.increment_db_size(index - 1);
-
-            if record_counter % 100_000 == 0 {
-                let elapsed = now.elapsed();
-                tracing::info!(
-                    "Loaded {} records into memory in {:?} ({:.2} entries/s)",
-                    record_counter,
-                    elapsed,
-                    record_counter as f64 / elapsed.as_secs_f64()
-                );
-                if download_shutdown_handler.is_shutting_down() {
-                    tracing::warn!("Shutdown requested by shutdown_handler.");
-                    return Err(eyre::eyre!("Shutdown requested"));
-                }
-            }
-
-            time_loading_into_memory += load_summary_ts.elapsed();
-            load_summary_ts = Instant::now();
-
-            all_serial_ids.remove(&(index as i64));
-            record_counter += 1;
-        }
-        tracing::info!(
-            "S3 Loading summary => Loaded {:?} items. Waited for stream: {:?}, Loaded into \
-             memory: {:?}.",
-            record_counter,
-            time_waiting_for_stream,
-            time_loading_into_memory,
-        );
-
-        let stream_db = store
-            .stream_irises_par(Some(min_last_modified_at), store_load_parallelism)
-            .await
-            .boxed();
-        load_db_records(actor, record_counter, &mut all_serial_ids, stream_db).await;
-    } else {
-        tracing::info!("S3 importer disabled. Fetching only from db");
-        let stream_db = store
-            .stream_irises_par(None, store_load_parallelism)
-            .await
-            .boxed();
-        load_db_records(actor, record_counter, &mut all_serial_ids, stream_db).await;
-    }
-
-    if !all_serial_ids.is_empty() {
-        tracing::error!("Not all serial_ids were loaded: {:?}", all_serial_ids);
-        bail!("Not all serial_ids were loaded: {:?}", all_serial_ids);
-    }
-
-    tracing::info!("Preprocessing db");
-    actor.preprocess_db();
-
-    tracing::info!(
-        "Loaded {} records from db into memory in {:?} [DB sizes: {:?}]",
-        record_counter,
-        total_load_time.elapsed(),
-        actor.current_db_sizes()
-    );
-
-    eyre::Ok(())
 }

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -30,14 +30,14 @@ use iris_mpc_cpu::execution::hawk_main::{
 };
 use iris_mpc_cpu::hawkers::aby3::aby3_store::Aby3Store;
 use iris_mpc_cpu::hnsw::graph::graph_store::GraphPg;
-use iris_mpc_store::{S3Store, Store};
+use iris_mpc_store::loader::load_iris_db;
+use iris_mpc_store::Store;
 use std::collections::HashMap;
 use std::sync::{Arc, LazyLock, Mutex};
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::Sender;
 use tokio::time::timeout;
-use iris_mpc_store::loader::{load_db, S3LoaderParams};
 
 const RNG_SEED_INIT_DB: u64 = 42;
 pub const SQS_POLLING_INTERVAL: Duration = Duration::from_secs(1);
@@ -91,7 +91,6 @@ pub async fn server_main(config: Config) -> Result<()> {
         &config,
         &iris_store,
         &graph_store,
-        &aws_clients,
         &shutdown_handler,
         &mut hawk_actor,
     )
@@ -554,7 +553,6 @@ async fn load_database(
     config: &Config,
     iris_store: &Store,
     graph_store: &GraphPg<Aby3Store>,
-    aws_clients: &AwsClients,
     shutdown_handler: &Arc<ShutdownHandler>,
     hawk_actor: &mut HawkActor,
 ) -> Result<()> {
@@ -582,7 +580,7 @@ async fn load_database(
 
     let store_len = iris_store.count_irises().await?;
 
-    load_db(
+    load_iris_db(
         &mut iris_loader,
         iris_store,
         store_len,

--- a/iris-mpc/src/services/aws/clients.rs
+++ b/iris-mpc/src/services/aws/clients.rs
@@ -1,4 +1,4 @@
-use crate::services::aws::s3::{create_db_chunks_s3_client, create_s3_client};
+use crate::services::aws::s3::{create_s3_client};
 use aws_sdk_s3::Client as S3Client;
 use aws_sdk_secretsmanager::Client as SecretsManagerClient;
 use aws_sdk_sns::Client as SNSClient;
@@ -12,7 +12,6 @@ pub struct AwsClients {
     pub sqs_client: SQSClient,
     pub sns_client: SNSClient,
     pub s3_client: S3Client,
-    pub db_chunks_s3_client: S3Client,
     pub secrets_manager_client: SecretsManagerClient,
 }
 
@@ -33,14 +32,12 @@ impl AwsClients {
         let force_path_style = config.environment != "prod" && config.environment != "stage";
 
         let s3_client = create_s3_client(&shared_config, force_path_style);
-        let db_chunks_s3_client = create_db_chunks_s3_client(&shared_config, force_path_style);
         let secrets_manager_client = SecretsManagerClient::new(&shared_config);
 
         Ok(Self {
             sqs_client,
             sns_client,
             s3_client,
-            db_chunks_s3_client,
             secrets_manager_client,
         })
     }

--- a/iris-mpc/src/services/aws/clients.rs
+++ b/iris-mpc/src/services/aws/clients.rs
@@ -1,4 +1,4 @@
-use crate::services::aws::s3::{create_s3_client};
+use crate::services::aws::s3::create_s3_client;
 use aws_sdk_s3::Client as S3Client;
 use aws_sdk_secretsmanager::Client as SecretsManagerClient;
 use aws_sdk_sns::Client as SNSClient;

--- a/iris-mpc/src/services/aws/s3.rs
+++ b/iris-mpc/src/services/aws/s3.rs
@@ -1,9 +1,5 @@
-use aws_config::{retry::RetryConfig, timeout::TimeoutConfig};
-use aws_sdk_s3::{
-    config::{Builder as S3ConfigBuilder, StalledStreamProtectionConfig},
-    Client as S3Client,
-};
-use std::time::Duration;
+use aws_config::retry::RetryConfig;
+use aws_sdk_s3::{config::Builder as S3ConfigBuilder, Client as S3Client};
 
 /// Creates an S3 client with retry configuration
 pub fn create_s3_client(shared_config: &aws_config::SdkConfig, force_path_style: bool) -> S3Client {

--- a/iris-mpc/src/services/aws/s3.rs
+++ b/iris-mpc/src/services/aws/s3.rs
@@ -16,27 +16,3 @@ pub fn create_s3_client(shared_config: &aws_config::SdkConfig, force_path_style:
 
     S3Client::from_conf(s3_config)
 }
-
-/// Creates an S3 client specifically for database chunks with additional
-/// configuration
-pub fn create_db_chunks_s3_client(
-    shared_config: &aws_config::SdkConfig,
-    force_path_style: bool,
-) -> S3Client {
-    let retry_config = RetryConfig::standard().with_max_attempts(5);
-
-    // Increase S3 connect timeouts to 10s
-    let timeout_config = TimeoutConfig::builder()
-        .connect_timeout(Duration::from_secs(10))
-        .build();
-
-    let db_chunks_s3_config = S3ConfigBuilder::from(shared_config)
-        // disable stalled stream protection to avoid panics during s3 import
-        .stalled_stream_protection(StalledStreamProtectionConfig::disabled())
-        .retry_config(retry_config)
-        .timeout_config(timeout_config)
-        .force_path_style(force_path_style)
-        .build();
-
-    S3Client::from_conf(db_chunks_s3_config)
-}

--- a/iris-mpc/src/services/mod.rs
+++ b/iris-mpc/src/services/mod.rs
@@ -1,4 +1,3 @@
 pub mod aws;
 pub mod init;
 pub mod processors;
-pub mod store;

--- a/scripts/tools/argo_stage_update_revision.sh
+++ b/scripts/tools/argo_stage_update_revision.sh
@@ -4,10 +4,10 @@
 # The script will loop through each cluster, port-forward ArgoCD server, authenticate to it, update the targetRevision of the application, and close port-forward.
 # The script can be configured to use either CPU or GPU clusters by passing the appropriate argument. The default is GPU
 # Usage examples:
-#   ./scripts/argo_stage_update_revision.sh $(git branch --show-current)
-#   ./scripts/argo_stage_update_revision.sh main
-#   ./scripts/argo_stage_update_revision.sh <another-branch>
-#   ./scripts/argo_stage_update_revision.sh <another-branch> cpu 
+#   ./scripts/tools/argo_stage_update_revision.sh $(git branch --show-current)
+#   ./scripts/tools/argo_stage_update_revision.sh main
+#   ./scripts/tools/argo_stage_update_revision.sh <another-branch>
+#   ./scripts/tools/argo_stage_update_revision.sh <another-branch> cpu
 #
 # Pre-requisites:
 # 1. Ensure that you have the ArgoCD CLI installed on your local machine. (brew install argocd)


### PR DESCRIPTION
## Changes
- We want to use s3 import logic in HNSW too. Therefore, we added the `version_id` to the exporter format already.
- In this PR, we update the export binary parsing logic to take `version_id` into account as well

## Refactors
- There were three different implementations for database loading: GPU, HNSW, Genesis. This PR unifies all of them and moves all the s3 related logic into the iris-mpc-store crate so that everything is isolated there - including the specific s3 client creation.

## Tests
- [x] GPU imports work as before. (In prod, we need to update the s3 directory name when we release this version)
- [x] HNSW works with s3 imports