### PR TITLE
Improve hnsw graph loading

### DIFF
--- a/.github/workflows/temp-branch-build-and-push-hawk.yaml
+++ b/.github/workflows/temp-branch-build-and-push-hawk.yaml
@@ -3,7 +3,7 @@ name: Branch - Hawk Build and push docker image
 on:
   push:
     branches:
-      - "POP-2413/update-s3-importer-to-include-version-id-2"
+      - "POP-2515/improve-hnsw-loading"
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'

--- a/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw.yaml
@@ -29,7 +29,7 @@ env:
   - name: SMPC__CPU_DATABASE__URL
     valueFrom:
       secretKeyRef:
-        key: TEMP_DATABASE_AURORA_HNSW_URL
+        key: DATABASE_AURORA_HNSW_URL
         name: application
 
   - name: SMPC__MAX_DB_SIZE
@@ -81,7 +81,7 @@ env:
     value: "wf-smpcv2-stage-sns-requests"
 
   - name: SMPC__ENABLE_S3_IMPORTER
-    value: "false"
+    value: "true"
 
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "iris-mpc-db-exporter-store-node-0-stage--eun1-az3--x-s3"

--- a/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw.yaml
@@ -29,7 +29,7 @@ env:
   - name: SMPC__CPU_DATABASE__URL
     valueFrom:
       secretKeyRef:
-        key: DATABASE_AURORA_HNSW_URL
+        key: TEMP_DATABASE_AURORA_HNSW_URL
         name: application
 
   - name: SMPC__MAX_DB_SIZE
@@ -81,7 +81,7 @@ env:
     value: "wf-smpcv2-stage-sns-requests"
 
   - name: SMPC__ENABLE_S3_IMPORTER
-    value: "true"
+    value: "false"
 
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "iris-mpc-db-exporter-store-node-0-stage--eun1-az3--x-s3"

--- a/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw.yaml
@@ -113,9 +113,6 @@ env:
         key: KMS_KEYS
         name: application
 
-  - name: SMPC__PROCESSING_TIMEOUT_SECS
-    value: "240"
-
   - name: SMPC__HEARTBEAT_INITIAL_RETRIES
     value: "65"
 

--- a/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw.yaml
@@ -29,7 +29,7 @@ env:
   - name: SMPC__CPU_DATABASE__URL
     valueFrom:
       secretKeyRef:
-        key: DATABASE_AURORA_HNSW_URL
+        key: TEMP_DATABASE_AURORA_HNSW_URL
         name: application
 
   - name: SMPC__MAX_DB_SIZE
@@ -81,7 +81,7 @@ env:
     value: "wf-smpcv2-stage-sns-requests"
 
   - name: SMPC__ENABLE_S3_IMPORTER
-    value: "true"
+    value: "false"
 
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "iris-mpc-db-exporter-store-node-1-stage--eun1-az3--x-s3"

--- a/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw.yaml
@@ -113,9 +113,6 @@ env:
         key: KMS_KEYS
         name: application
 
-  - name: SMPC__PROCESSING_TIMEOUT_SECS
-    value: "240"
-
   - name: SMPC__HEARTBEAT_INITIAL_RETRIES
     value: "65"
 

--- a/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw.yaml
@@ -29,7 +29,7 @@ env:
   - name: SMPC__CPU_DATABASE__URL
     valueFrom:
       secretKeyRef:
-        key: TEMP_DATABASE_AURORA_HNSW_URL
+        key: DATABASE_AURORA_HNSW_URL
         name: application
 
   - name: SMPC__MAX_DB_SIZE
@@ -81,7 +81,7 @@ env:
     value: "wf-smpcv2-stage-sns-requests"
 
   - name: SMPC__ENABLE_S3_IMPORTER
-    value: "false"
+    value: "true"
 
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "iris-mpc-db-exporter-store-node-1-stage--eun1-az3--x-s3"

--- a/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw.yaml
@@ -113,9 +113,6 @@ env:
         key: KMS_KEYS
         name: application
 
-  - name: SMPC__PROCESSING_TIMEOUT_SECS
-    value: "240"
-
   - name: SMPC__HEARTBEAT_INITIAL_RETRIES
     value: "65"
 

--- a/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw.yaml
@@ -29,7 +29,7 @@ env:
   - name: SMPC__CPU_DATABASE__URL
     valueFrom:
       secretKeyRef:
-        key: TEMP_DATABASE_AURORA_HNSW_URL
+        key: DATABASE_AURORA_HNSW_URL
         name: application
 
   - name: SMPC__MAX_DB_SIZE
@@ -81,7 +81,7 @@ env:
     value: "wf-smpcv2-stage-sns-requests"
 
   - name: SMPC__ENABLE_S3_IMPORTER
-    value: "false"
+    value: "true"
 
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "iris-mpc-db-exporter-store-node-2-stage--eun1-az3--x-s3"

--- a/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw.yaml
@@ -29,7 +29,7 @@ env:
   - name: SMPC__CPU_DATABASE__URL
     valueFrom:
       secretKeyRef:
-        key: DATABASE_AURORA_HNSW_URL
+        key: TEMP_DATABASE_AURORA_HNSW_URL
         name: application
 
   - name: SMPC__MAX_DB_SIZE
@@ -81,7 +81,7 @@ env:
     value: "wf-smpcv2-stage-sns-requests"
 
   - name: SMPC__ENABLE_S3_IMPORTER
-    value: "true"
+    value: "false"
 
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "iris-mpc-db-exporter-store-node-2-stage--eun1-az3--x-s3"

--- a/deploy/stage/common-values-ampc-hnsw.yaml
+++ b/deploy/stage/common-values-ampc-hnsw.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc-cpu:4a415304b972c84af40c2e95406ca014c1f99c0c"
+image: "ghcr.io/worldcoin/iris-mpc-cpu:aef4ae6b91c95631f24c3dd1492e2b62be61a22f"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/common-values-ampc-hnsw.yaml
+++ b/deploy/stage/common-values-ampc-hnsw.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc-cpu:92083051af3586320f3764082db9b61491abcde2"
+image: "ghcr.io/worldcoin/iris-mpc-cpu:4a415304b972c84af40c2e95406ca014c1f99c0c"
 
 environment: stage
 replicaCount: 1

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -610,6 +610,8 @@ pub struct GraphLoader<'a>(BothEyes<GraphMut<'a>>);
 #[allow(clippy::needless_lifetimes)]
 impl<'a> GraphLoader<'a> {
     pub async fn load_graph_store(self, graph_store: &GraphStore) -> Result<()> {
+        let now = Instant::now();
+
         // Spawn two independent transactions and load each graph in parallel.
         let (graph_left, graph_right) = join!(
             async {
@@ -627,7 +629,10 @@ impl<'a> GraphLoader<'a> {
         let GraphLoader(mut graphs) = self;
         *graphs[LEFT] = graph_left;
         *graphs[RIGHT] = graph_right;
-
+        tracing::info!(
+            "GraphLoader: Loaded left and right graphs in {:?}",
+            now.elapsed()
+        );
         Ok(())
     }
 }

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -54,6 +54,7 @@ use std::{
     vec,
 };
 use tokio::{
+    join,
     sync::{mpsc, oneshot, RwLock, RwLockWriteGuard},
     task::JoinSet,
 };
@@ -609,10 +610,24 @@ pub struct GraphLoader<'a>(BothEyes<GraphMut<'a>>);
 #[allow(clippy::needless_lifetimes)]
 impl<'a> GraphLoader<'a> {
     pub async fn load_graph_store(self, graph_store: &GraphStore) -> Result<()> {
-        let mut graph_tx = graph_store.tx().await?;
-        for (side, mut graph) in izip!(STORE_IDS, self.0) {
-            *graph = graph_tx.with_graph(side).load_to_mem().await?;
-        }
+        // Spawn two independent transactions and load each graph in parallel.
+        let (graph_left, graph_right) = join!(
+            async {
+                let mut graph_tx = graph_store.tx().await?;
+                graph_tx.with_graph(StoreId::Left).load_to_mem().await
+            },
+            async {
+                let mut graph_tx = graph_store.tx().await?;
+                graph_tx.with_graph(StoreId::Right).load_to_mem().await
+            }
+        );
+        let graph_left = graph_left.expect("Could not load left graph");
+        let graph_right = graph_right.expect("Could not load right graph");
+
+        let GraphLoader(mut graphs) = self;
+        *graphs[LEFT] = graph_left;
+        *graphs[RIGHT] = graph_right;
+
         Ok(())
     }
 }

--- a/iris-mpc-cpu/src/hnsw/graph/graph_store.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/graph_store.rs
@@ -253,12 +253,18 @@ where
             graph_mem.set_entry_point(point, layer).await;
         }
 
+        let mut count = 0;
+
         let mut irises = self.stream_links();
         while let Some(row) = irises.next().await {
             let row = row?;
             graph_mem
                 .set_links(row.source_ref.0, row.links.0, row.layer as usize)
                 .await;
+            count += 1;
+            if count % 100000 == 0 {
+                tracing::info!("GraphLoader: Loaded {} graph links", count);
+            }
         }
 
         Ok(graph_mem)


### PR DESCRIPTION
## Change
- This PR brings down the HNSW loading (iris shares + graph) from 14-15 minutes to 8-9 minutes in stage
- It loads graph and iris dbs in parallel. It also parallelizes left and right graph loading.
- Further improvements will be handled in follow-ups