### PR TITLE
fix: build script for iris-mpc upgrade no longer always invalidates generated sources

### DIFF
--- a/iris-mpc-upgrade/build.rs
+++ b/iris-mpc-upgrade/build.rs
@@ -1,7 +1,8 @@
 fn main() {
-    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=protos/reshare.proto");
     tonic_build::configure()
         .out_dir("src/proto/")
+        .emit_rerun_if_changed(false) // https://github.com/hyperium/tonic/issues/1070#issuecomment-1729075588
         .compile_protos(
             &["reshare.proto"], // Files in the path
             &["protos"],        // The include path to search


### PR DESCRIPTION
This is a long standing minor annoyance, for some reason (that is not happening in the iris-cpu-mpc proto setup) the emit `rerun-if-changed` directives are invalid and trigger rebuild of the upgrade crate on every build.
This fixes the issue with a workaround.
