### PR TITLE
Add modifications table usage for the Delta part of Genesis

### DIFF
--- a/iris-mpc-cpu/src/genesis/mod.rs
+++ b/iris-mpc-cpu/src/genesis/mod.rs
@@ -8,7 +8,10 @@ pub mod utils;
 pub use batch_generator::{Batch, BatchGenerator, BatchIterator};
 pub use hawk_handle::Handle;
 pub use hawk_job::{Job, JobRequest, JobResult};
-pub use state_accessor::{fetch_iris_deletions, get_last_indexed_id, set_last_indexed_id};
+pub use state_accessor::{
+    fetch_iris_deletions, get_last_indexed_id, get_last_indexed_modification_id,
+    set_last_indexed_id, set_last_indexed_modification_id,
+};
 pub use utils::logger;
 pub use utils::{
     errors::IndexationError,

--- a/iris-mpc-cpu/src/genesis/state_accessor.rs
+++ b/iris-mpc-cpu/src/genesis/state_accessor.rs
@@ -1,7 +1,7 @@
 use super::utils::{errors::IndexationError, logger};
 use aws_sdk_s3::Client as S3_Client;
 use eyre::Result;
-use iris_mpc_common::{config::Config, IrisSerialId};
+use iris_mpc_common::{config::Config, helpers::sync::Modification, IrisSerialId};
 use iris_mpc_store::{DbStoredIris, Store};
 use serde::{Deserialize, Serialize};
 use sqlx::{Postgres, Transaction};
@@ -10,12 +10,13 @@ use sqlx::{Postgres, Transaction};
 const COMPONENT: &str = "State-Accessor";
 
 /// Domain for persistent state store entry for last indexed id
-const STATE_DOMAIN_LAST_INDEXED: &str = "genesis";
+const STATE_DOMAIN_GENESIS: &str = "genesis";
 
 /// Key for persistent state store entry for last indexed id
 const STATE_KEY_LAST_INDEXED: &str = "id_of_last_indexed";
+
 /// Key for persistent state store entry for last indexed modification id
-const STATE_KEY_MODIFICATION_ID_LAST_INDEXED: &str = "id_of_last_indexed_modification";
+const STATE_KEY_LAST_INDEXED_MODIFICATION_ID: &str = "id_of_last_indexed_modification";
 
 /// Fetch a batch of iris data for indexation.
 ///
@@ -114,26 +115,38 @@ pub async fn fetch_iris_deletions(
     Ok(s3_object.deleted_serial_ids)
 }
 
-/// Gets the modification id of the last indexed modification.
+/// Fetch Iris modifications that need to be applied post indexation phase one.
 ///
 /// # Arguments
 ///
 /// * `iris_store` - Iris PostgreSQL store provider.
+/// * `after_modification_id` - Set of Iris serial identifiers within batch.
+/// * `serial_id_less_than` - Set of Iris serial identifiers within batch.
 ///
 /// # Returns
 ///
-/// The modification id of the last indexed modification, or 0 if no modification id is recorded.
+/// 2 member tuple: (Modification data, Last modification ID).
 ///
-pub async fn get_last_indexed_modification_id(iris_store: &Store) -> Result<i64> {
-    let id = iris_store
-        .get_persistent_state(
-            STATE_DOMAIN_LAST_INDEXED,
-            STATE_KEY_MODIFICATION_ID_LAST_INDEXED,
-        )
-        .await?
-        .unwrap_or(0);
+pub async fn fetch_iris_modifications(
+    iris_store: &Store,
+    from_modification_id: i64,
+    to_serial_id: u32,
+) -> Result<(Vec<Modification>, i64), IndexationError> {
+    logger::log_info(
+        COMPONENT,
+        format!(
+            "Fetching Iris modifications for indexation: from-modification-id={} :: to-serial-id={}",
+            from_modification_id, to_serial_id
+        ),
+    );
 
-    Ok(id)
+    let data = iris_store
+        .get_persisted_modifications_after_id(from_modification_id, to_serial_id)
+        .await
+        .map_err(|err| IndexationError::PostgresFetchModificationBatch(err.to_string()))?;
+    let last_id = data.last().map(|m| m.id).unwrap_or(0);
+
+    Ok((data, last_id))
 }
 
 /// Get serial id of last iris to have been indexed.
@@ -148,7 +161,26 @@ pub async fn get_last_indexed_modification_id(iris_store: &Store) -> Result<i64>
 ///
 pub async fn get_last_indexed_id(iris_store: &Store) -> Result<IrisSerialId> {
     let id = iris_store
-        .get_persistent_state(STATE_DOMAIN_LAST_INDEXED, STATE_KEY_LAST_INDEXED)
+        .get_persistent_state(STATE_DOMAIN_GENESIS, STATE_KEY_LAST_INDEXED)
+        .await?
+        .unwrap_or(0);
+
+    Ok(id)
+}
+
+/// Gets the modification id of the last indexed modification.
+///
+/// # Arguments
+///
+/// * `iris_store` - Iris PostgreSQL store provider.
+///
+/// # Returns
+///
+/// The modification id of the last indexed modification, or 0 if no modification id is recorded.
+///
+pub async fn get_last_indexed_modification_id(iris_store: &Store) -> Result<i64> {
+    let id = iris_store
+        .get_persistent_state(STATE_DOMAIN_GENESIS, STATE_KEY_LAST_INDEXED_MODIFICATION_ID)
         .await?
         .unwrap_or(0);
 
@@ -180,13 +212,7 @@ pub async fn set_last_indexed_id(
     tx: &mut Transaction<'_, Postgres>,
     value: IrisSerialId,
 ) -> Result<()> {
-    Store::set_persistent_state(
-        tx,
-        STATE_DOMAIN_LAST_INDEXED,
-        STATE_KEY_LAST_INDEXED,
-        &value,
-    )
-    .await
+    Store::set_persistent_state(tx, STATE_DOMAIN_GENESIS, STATE_KEY_LAST_INDEXED, &value).await
 }
 
 /// Sets the last indexed modification id.
@@ -206,8 +232,8 @@ pub async fn set_last_indexed_modification_id(
 ) -> Result<()> {
     Store::set_persistent_state(
         tx,
-        STATE_DOMAIN_LAST_INDEXED,
-        STATE_KEY_MODIFICATION_ID_LAST_INDEXED,
+        STATE_DOMAIN_GENESIS,
+        STATE_KEY_LAST_INDEXED_MODIFICATION_ID,
         &value,
     )
     .await
@@ -224,12 +250,33 @@ pub async fn set_last_indexed_modification_id(
 /// Result<()> on success
 ///
 pub async fn unset_last_indexed_id(tx: &mut Transaction<'_, Postgres>) -> Result<()> {
-    Store::delete_persistent_state(tx, STATE_DOMAIN_LAST_INDEXED, STATE_KEY_LAST_INDEXED).await
+    Store::delete_persistent_state(tx, STATE_DOMAIN_GENESIS, STATE_KEY_LAST_INDEXED).await
+}
+
+/// Unsets serial id of last Iris to have been indexed.
+///
+/// # Arguments
+///
+/// * `tx` - PostgreSQL transaction to use for operation scope.
+///
+/// # Returns
+///
+/// Result<()> on success
+///
+pub async fn unset_last_indexed_modification_id(tx: &mut Transaction<'_, Postgres>) -> Result<()> {
+    Store::delete_persistent_state(
+        tx,
+        STATE_DOMAIN_GENESIS,
+        STATE_KEY_LAST_INDEXED_MODIFICATION_ID,
+    )
+    .await
 }
 
 #[cfg(test)]
-#[cfg(feature = "db_dependent")]
+// #[cfg(feature = "db_dependent")]
 mod tests {
+    use crate::genesis::state_accessor::unset_last_indexed_modification_id;
+
     use super::{
         fetch_iris_batch, get_last_indexed_id, get_last_indexed_modification_id,
         set_last_indexed_id, set_last_indexed_modification_id, unset_last_indexed_id,
@@ -350,6 +397,15 @@ mod tests {
         // Get -> should be 999.
         let modification_id_of_last_indexed = get_last_indexed_modification_id(&iris_store).await?;
         assert_eq!(modification_id_of_last_indexed, 999);
+
+        // Unset.
+        let mut tx = iris_store.tx().await?;
+        unset_last_indexed_modification_id(&mut tx).await?;
+        tx.commit().await?;
+
+        // Get -> should be 0.
+        let modification_id_of_last_indexed = get_last_indexed_modification_id(&iris_store).await?;
+        assert_eq!(modification_id_of_last_indexed, 0);
 
         // Unset resources.
         cleanup(&pg_client, &pg_schema).await?;

--- a/iris-mpc-cpu/src/genesis/state_accessor.rs
+++ b/iris-mpc-cpu/src/genesis/state_accessor.rs
@@ -14,6 +14,8 @@ const STATE_DOMAIN_LAST_INDEXED: &str = "genesis";
 
 /// Key for persistent state store entry for last indexed id
 const STATE_KEY_LAST_INDEXED: &str = "id_of_last_indexed";
+/// Key for persistent state store entry for last indexed modification id
+const STATE_KEY_MODIFICATION_ID_LAST_INDEXED: &str = "id_of_last_indexed_modification";
 
 /// Fetch a batch of iris data for indexation.
 ///
@@ -112,6 +114,28 @@ pub async fn fetch_iris_deletions(
     Ok(s3_object.deleted_serial_ids)
 }
 
+/// Gets the modification id of the last indexed modification.
+///
+/// # Arguments
+///
+/// * `iris_store` - Iris PostgreSQL store provider.
+///
+/// # Returns
+///
+/// The modification id of the last indexed modification, or 0 if no modification id is recorded.
+///
+pub async fn get_last_indexed_modification_id(iris_store: &Store) -> Result<i64> {
+    let id = iris_store
+        .get_persistent_state(
+            STATE_DOMAIN_LAST_INDEXED,
+            STATE_KEY_MODIFICATION_ID_LAST_INDEXED,
+        )
+        .await?
+        .unwrap_or(0);
+
+    Ok(id)
+}
+
 /// Get serial id of last iris to have been indexed.
 ///
 /// # Arguments
@@ -165,6 +189,30 @@ pub async fn set_last_indexed_id(
     .await
 }
 
+/// Sets the last indexed modification id.
+///
+/// # Arguments
+///
+/// * `tx` - PostgreSQL transaction to use for operation scope.
+/// * `value` - Modification id to be persisted.
+///
+/// # Returns
+///
+/// Result<()> on success
+///
+pub async fn set_last_indexed_modification_id(
+    tx: &mut Transaction<'_, Postgres>,
+    value: i64,
+) -> Result<()> {
+    Store::set_persistent_state(
+        tx,
+        STATE_DOMAIN_LAST_INDEXED,
+        STATE_KEY_MODIFICATION_ID_LAST_INDEXED,
+        &value,
+    )
+    .await
+}
+
 /// Unsets serial id of last Iris to have been indexed.
 ///
 /// # Arguments
@@ -183,7 +231,8 @@ pub async fn unset_last_indexed_id(tx: &mut Transaction<'_, Postgres>) -> Result
 #[cfg(feature = "db_dependent")]
 mod tests {
     use super::{
-        fetch_iris_batch, get_last_indexed_id, set_last_indexed_id, unset_last_indexed_id,
+        fetch_iris_batch, get_last_indexed_id, get_last_indexed_modification_id,
+        set_last_indexed_id, set_last_indexed_modification_id, unset_last_indexed_id,
     };
     use eyre::Result;
     use iris_mpc_common::{
@@ -266,6 +315,41 @@ mod tests {
         let identifiers: Vec<IrisSerialId> = (1..11).collect_vec();
         let data = fetch_iris_batch(&iris_store, identifiers).await.unwrap();
         assert_eq!(data.len(), 10);
+
+        // Unset resources.
+        cleanup(&pg_client, &pg_schema).await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_modification_id_of_last_indexed() -> Result<()> {
+        // Set resources.
+        let (iris_store, pg_client, pg_schema) = get_resources().await.unwrap();
+
+        // Get -> should be zero.
+        let modification_id_of_last_indexed = get_last_indexed_modification_id(&iris_store).await?;
+        assert_eq!(modification_id_of_last_indexed, 0);
+
+        // Set -> 42.
+        let modification_id_of_last_indexed = 42_i64;
+        let mut tx = iris_store.tx().await?;
+        set_last_indexed_modification_id(&mut tx, modification_id_of_last_indexed).await?;
+        tx.commit().await?;
+
+        // Get -> should be 42.
+        let modification_id_of_last_indexed = get_last_indexed_modification_id(&iris_store).await?;
+        assert_eq!(modification_id_of_last_indexed, 42);
+
+        // Set -> 999.
+        let modification_id_of_last_indexed = 999_i64;
+        let mut tx = iris_store.tx().await?;
+        set_last_indexed_modification_id(&mut tx, modification_id_of_last_indexed).await?;
+        tx.commit().await?;
+
+        // Get -> should be 999.
+        let modification_id_of_last_indexed = get_last_indexed_modification_id(&iris_store).await?;
+        assert_eq!(modification_id_of_last_indexed, 999);
 
         // Unset resources.
         cleanup(&pg_client, &pg_schema).await?;

--- a/iris-mpc-cpu/src/genesis/state_accessor.rs
+++ b/iris-mpc-cpu/src/genesis/state_accessor.rs
@@ -42,7 +42,7 @@ pub async fn fetch_iris_batch(
     );
 
     let data = iris_store
-        .fetch_iris_batch(identifiers)
+        .get_iris_batch(identifiers)
         .await
         .map_err(|err| IndexationError::PostgresFetchIrisBatch(err.to_string()))?;
 

--- a/iris-mpc-cpu/src/genesis/state_sync.rs
+++ b/iris-mpc-cpu/src/genesis/state_sync.rs
@@ -9,6 +9,7 @@ pub struct Config {
     pub last_indexed_id: IrisSerialId,
     pub excluded_serial_ids: Vec<IrisSerialId>,
     pub batch_size: usize,
+    pub max_modification_id: i64,
 }
 
 /// Constructor.
@@ -18,12 +19,14 @@ impl Config {
         last_indexed_id: IrisSerialId,
         excluded_serial_ids: Vec<IrisSerialId>,
         batch_size: usize,
+        max_modification_id: i64,
     ) -> Self {
         Self {
             batch_size,
             max_indexation_id,
             last_indexed_id,
             excluded_serial_ids,
+            max_modification_id,
         }
     }
 }
@@ -90,11 +93,11 @@ mod tests {
 
     impl Config {
         fn new_1() -> Self {
-            Self::new(100, 50, vec![3, 5], 64)
+            Self::new(100, 50, vec![3, 5], 64, 100)
         }
 
         fn new_2() -> Self {
-            Self::new(200, 150, vec![3, 5, 6], 64)
+            Self::new(200, 150, vec![3, 5, 6], 64, 200)
         }
     }
 

--- a/iris-mpc-cpu/src/genesis/state_sync.rs
+++ b/iris-mpc-cpu/src/genesis/state_sync.rs
@@ -5,27 +5,36 @@ use serde::{Deserialize, Serialize};
 /// Encpasulates common Genesis specific configuration information.  This is a network level type.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Config {
-    pub max_indexation_id: IrisSerialId,
-    pub last_indexed_id: IrisSerialId,
-    pub excluded_serial_ids: Vec<IrisSerialId>,
+    // Size of indexation batch.
     pub batch_size: usize,
+
+    // Set of identifiers of Iris's to be excluded from indexation.
+    pub excluded_serial_ids: Vec<IrisSerialId>,
+
+    // Identifier of last Iris serial ID to have been indexed.
+    pub last_indexed_id: IrisSerialId,
+
+    // Identifier of the last Iris serial ID to be indexed.
+    pub max_indexation_id: IrisSerialId,
+
+    // Identifier of the last modification ID to be indexed.
     pub max_modification_id: i64,
 }
 
 /// Constructor.
 impl Config {
     pub fn new(
-        max_indexation_id: IrisSerialId,
-        last_indexed_id: IrisSerialId,
-        excluded_serial_ids: Vec<IrisSerialId>,
         batch_size: usize,
+        excluded_serial_ids: Vec<IrisSerialId>,
+        last_indexed_id: IrisSerialId,
+        max_indexation_id: IrisSerialId,
         max_modification_id: i64,
     ) -> Self {
         Self {
             batch_size,
-            max_indexation_id,
-            last_indexed_id,
             excluded_serial_ids,
+            last_indexed_id,
+            max_indexation_id,
             max_modification_id,
         }
     }
@@ -93,11 +102,11 @@ mod tests {
 
     impl Config {
         fn new_1() -> Self {
-            Self::new(100, 50, vec![3, 5], 64, 100)
+            Self::new(64, vec![3, 5], 50, 100, 100)
         }
 
         fn new_2() -> Self {
-            Self::new(200, 150, vec![3, 5, 6], 64, 200)
+            Self::new(64, vec![3, 5, 6], 150, 200, 200)
         }
     }
 

--- a/iris-mpc-cpu/src/genesis/utils/errors.rs
+++ b/iris-mpc-cpu/src/genesis/utils/errors.rs
@@ -18,6 +18,9 @@ pub enum IndexationError {
     #[error("Failed to fetch Iris data from PostgreSQL dB")]
     PostgresFetchIrisById,
 
+    #[error("Failed to fetch Modification batch from PostgreSQL dB: {0}")]
+    PostgresFetchModificationBatch(String),
+
     #[error("Failed to persist genesis Graph indexation state to PostgreSQL dB: {0}")]
     PostgresPersistIndexationState(String),
 }

--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -173,7 +173,7 @@ impl Store {
     ///
     /// An ordered vector of `DbStoredIris` instances.
     ///
-    pub async fn fetch_iris_batch(
+    pub async fn get_iris_batch(
         &self,
         identifiers: Vec<u32>,
     ) -> sqlx::Result<Vec<DbStoredIris>, sqlx::Error> {
@@ -763,7 +763,7 @@ fn cast_u8_to_u16(s: &[u8]) -> &[u16] {
 }
 
 #[cfg(test)]
-#[cfg(feature = "db_dependent")]
+// #[cfg(feature = "db_dependent")]
 pub mod tests {
     use super::{test_utils::*, *};
     use futures::TryStreamExt;

--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -469,8 +469,19 @@ WHERE id = $1;
         let modifications = rows.into_iter().map(Into::into).collect();
         Ok(modifications)
     }
-    // Fetch modifications updated after a certain ID that are less than a serial id.
-    // This is for the genesis protocol to fetch modifications that need to be indexed.
+
+    /// Fetch modifications updated after a certain ID that are less than a serial id.
+    /// This is for the genesis protocol to fetch modifications that need to be indexed.
+    ///
+    /// # Arguments
+    ///
+    /// * `after_modification_id` - Modification identifier from which to filter result.
+    /// * `serial_id_less_than` - Iris serial identifier to which to filter result.
+    ///
+    /// # Returns
+    ///
+    /// An ordered vector of `Modification` instances.
+    ///
     pub async fn get_persisted_modifications_after_id(
         &self,
         after_modification_id: i64,


### PR DESCRIPTION
### Notes
* https://www.notion.so/worldcoin/Sync-Protocol-Requirements-and-Design-1ae8614bdf8c807ab836fa0356e42714?pvs=4#1ae8614bdf8c8099a634e93fb89f57e1 - adds the usage of the modifications table for updates to delta.

### Process
* we only apply modifications that have occurred since the last time Genesis was run and only include modifications that affect what Genesis has already indexed.