### PR TITLE
better logging / visibility / fix deadlock in e2e

### DIFF
--- a/iris-mpc/src/client/e2e.rs
+++ b/iris-mpc/src/client/e2e.rs
@@ -37,7 +37,7 @@ use tokio::{
 use uuid::Uuid;
 
 const DEFAULT_MAX_CONCURRENT_REQUESTS: usize = 4;
-const DEFAULT_BATCH_SIZE: usize = 7;
+const DEFAULT_BATCH_SIZE: usize = 10;
 const DEFAULT_N_BATCHES: usize = 3;
 
 const WAIT_AFTER_BATCH: Duration = Duration::from_secs(0);


### PR DESCRIPTION
Integration tests do seem to randomly hang at times, ~without a clear cause~. Seemingly, it was because of a deadlock accessing `responses` and `used_response_indices`. This should be fixed. Locally, seems to solve the problem, waiting for more iterations on the server to better validate the behavior.

See the logs of a successful run: https://github.com/worldcoin/iris-mpc/actions/runs/15305175684/job/43055901327?pr=1406

Here we fix the deadlock, improve slightly the logging to ensure we have good visibility, and add a timeout when polling SQS. This makes introspecting the localstack and service logs easier, and lets us better understand how many messages are left to be received by the client.



