### PR TITLE
enable LUC in hnsw stage

### DIFF
--- a/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw.yaml
@@ -69,7 +69,7 @@ env:
     value: "true"
 
   - name: SMPC__LUC_LOOKBACK_RECORDS
-    value: "5"
+    value: "25"
 
   - name: SMPC__LUC_SERIAL_IDS_FROM_SMPC_REQUEST
     value: "false"

--- a/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw.yaml
@@ -65,6 +65,15 @@ env:
   - name: SMPC__ENABLE_SENDING_ANONYMIZED_STATS_MESSAGE
     value: "false"
 
+  - name: SMPC__LUC_ENABLED
+    value: "true"
+
+  - name: SMPC__LUC_LOOKBACK_RECORDS
+    value: "5"
+
+  - name: SMPC__LUC_SERIAL_IDS_FROM_SMPC_REQUEST
+    value: "false"
+
   - name: SMPC__AWS__REGION
     value: "eu-north-1"
 

--- a/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw.yaml
@@ -69,7 +69,7 @@ env:
     value: "true"
 
   - name: SMPC__LUC_LOOKBACK_RECORDS
-    value: "25"
+    value: "5"
 
   - name: SMPC__LUC_SERIAL_IDS_FROM_SMPC_REQUEST
     value: "false"

--- a/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw.yaml
@@ -69,7 +69,7 @@ env:
     value: "true"
 
   - name: SMPC__LUC_LOOKBACK_RECORDS
-    value: "5"
+    value: "25"
 
   - name: SMPC__LUC_SERIAL_IDS_FROM_SMPC_REQUEST
     value: "false"

--- a/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw.yaml
@@ -65,6 +65,15 @@ env:
   - name: SMPC__ENABLE_SENDING_ANONYMIZED_STATS_MESSAGE
     value: "false"
 
+  - name: SMPC__LUC_ENABLED
+    value: "true"
+
+  - name: SMPC__LUC_LOOKBACK_RECORDS
+    value: "5"
+
+  - name: SMPC__LUC_SERIAL_IDS_FROM_SMPC_REQUEST
+    value: "false"
+
   - name: SMPC__AWS__REGION
     value: "eu-north-1"
 

--- a/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw.yaml
@@ -69,7 +69,7 @@ env:
     value: "true"
 
   - name: SMPC__LUC_LOOKBACK_RECORDS
-    value: "25"
+    value: "5"
 
   - name: SMPC__LUC_SERIAL_IDS_FROM_SMPC_REQUEST
     value: "false"

--- a/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw.yaml
@@ -69,7 +69,7 @@ env:
     value: "true"
 
   - name: SMPC__LUC_LOOKBACK_RECORDS
-    value: "5"
+    value: "25"
 
   - name: SMPC__LUC_SERIAL_IDS_FROM_SMPC_REQUEST
     value: "false"

--- a/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw.yaml
@@ -65,6 +65,15 @@ env:
   - name: SMPC__ENABLE_SENDING_ANONYMIZED_STATS_MESSAGE
     value: "false"
 
+  - name: SMPC__LUC_ENABLED
+    value: "true"
+
+  - name: SMPC__LUC_LOOKBACK_RECORDS
+    value: "5"
+
+  - name: SMPC__LUC_SERIAL_IDS_FROM_SMPC_REQUEST
+    value: "false"
+
   - name: SMPC__AWS__REGION
     value: "eu-north-1"
 

--- a/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw.yaml
@@ -69,7 +69,7 @@ env:
     value: "true"
 
   - name: SMPC__LUC_LOOKBACK_RECORDS
-    value: "25"
+    value: "5"
 
   - name: SMPC__LUC_SERIAL_IDS_FROM_SMPC_REQUEST
     value: "false"

--- a/iris-mpc/src/services/processors/job.rs
+++ b/iris-mpc/src/services/processors/job.rs
@@ -61,7 +61,6 @@ pub async fn process_job_result(
     let now = Instant::now();
 
     let _modifications = modifications;
-    let _full_face_mirror_attack_detected = full_face_mirror_attack_detected;
 
     // returned serial_ids are 0 indexed, but we want them to be 1 indexed
     let uniqueness_results = merged_results
@@ -108,12 +107,15 @@ pub async fn process_job_result(
                     false => Some(partial_match_counters_right[i]),
                     true => None,
                 },
-                None,  // not applicable for hnsw
-                None,  // not applicable for hnsw
-                None,  // not applicable for hnsw
-                None,  // not applicable for hnsw
-                None,  // not applicable for hnsw
-                false, // not applicable for hnsw
+                None, // not applicable for hnsw
+                None, // not applicable for hnsw
+                None, // not applicable for hnsw
+                None, // not applicable for hnsw
+                None, // not applicable for hnsw
+                match full_face_mirror_attack_detected.is_empty() {
+                    false => full_face_mirror_attack_detected[i],
+                    true => false,
+                },
             );
 
             serde_json::to_string(&result_event).wrap_err("failed to serialize result")


### PR DESCRIPTION
1. Enable LUC
2. We actually do care about full face mirror attacks, because they have been implemented. This PR enables sending them to the signup service. 