### PR TITLE
Migrate persisted state to the graph store

### DIFF
--- a/.github/workflows/temp-branch-build-and-push-upgrade-hawk.yaml
+++ b/.github/workflows/temp-branch-build-and-push-upgrade-hawk.yaml
@@ -3,7 +3,7 @@ name: Branch - Hawk Upgrade Build and push docker image
 on:
   push:
     branches:
-      - "add-snapshot-aurora"
+      - "fix-persisted-state"
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'

--- a/iris-mpc-cpu/src/genesis/state_accessor.rs
+++ b/iris-mpc-cpu/src/genesis/state_accessor.rs
@@ -1,4 +1,5 @@
 use super::utils::{errors::IndexationError, logger};
+use crate::{hawkers::aby3::aby3_store::Aby3Store, hnsw::graph::graph_store::GraphPg};
 use aws_sdk_s3::Client as S3_Client;
 use eyre::Result;
 use iris_mpc_common::{config::Config, helpers::sync::Modification, IrisSerialId};
@@ -162,15 +163,15 @@ pub async fn fetch_iris_modifications(
 ///
 /// # Arguments
 ///
-/// * `iris_store` - Iris PostgreSQL store provider.
+/// * `graph_store` - Graph PostgreSQL store provider.
 ///
 /// # Returns
 ///
 /// Serial id of the last indexed iris, or 0 if no serial id is recorded.
 ///
-pub async fn get_last_indexed_id(iris_store: &Store) -> Result<IrisSerialId> {
-    let id = iris_store
-        .get_persistent_state(STATE_DOMAIN_GENESIS, STATE_KEY_LAST_INDEXED)
+pub async fn get_last_indexed_id(graph_store: &GraphPg<Aby3Store>) -> Result<IrisSerialId> {
+    let id = graph_store
+        .get_persistent_state(STATE_KEY_LAST_INDEXED, STATE_KEY_LAST_INDEXED)
         .await?
         .unwrap_or(0);
 
@@ -181,14 +182,14 @@ pub async fn get_last_indexed_id(iris_store: &Store) -> Result<IrisSerialId> {
 ///
 /// # Arguments
 ///
-/// * `iris_store` - Iris PostgreSQL store provider.
+/// * `graph_store` - Graph PostgreSQL store provider.
 ///
 /// # Returns
 ///
 /// The modification id of the last indexed modification, or 0 if no modification id is recorded.
 ///
-pub async fn get_last_indexed_modification_id(iris_store: &Store) -> Result<i64> {
-    let id = iris_store
+pub async fn get_last_indexed_modification_id(graph_store: &GraphPg<Aby3Store>) -> Result<i64> {
+    let id = graph_store
         .get_persistent_state(STATE_DOMAIN_GENESIS, STATE_KEY_LAST_INDEXED_MODIFICATION_ID)
         .await?
         .unwrap_or(0);
@@ -221,7 +222,13 @@ pub async fn set_last_indexed_id(
     tx: &mut Transaction<'_, Postgres>,
     value: IrisSerialId,
 ) -> Result<()> {
-    Store::set_persistent_state(tx, STATE_DOMAIN_GENESIS, STATE_KEY_LAST_INDEXED, &value).await
+    GraphPg::<Aby3Store>::set_persistent_state(
+        tx,
+        STATE_DOMAIN_GENESIS,
+        STATE_KEY_LAST_INDEXED,
+        &value,
+    )
+    .await
 }
 
 /// Sets the last indexed modification id.
@@ -239,7 +246,7 @@ pub async fn set_last_indexed_modification_id(
     tx: &mut Transaction<'_, Postgres>,
     value: i64,
 ) -> Result<()> {
-    Store::set_persistent_state(
+    GraphPg::<Aby3Store>::set_persistent_state(
         tx,
         STATE_DOMAIN_GENESIS,
         STATE_KEY_LAST_INDEXED_MODIFICATION_ID,
@@ -259,7 +266,8 @@ pub async fn set_last_indexed_modification_id(
 /// Result<()> on success
 ///
 pub async fn unset_last_indexed_id(tx: &mut Transaction<'_, Postgres>) -> Result<()> {
-    Store::delete_persistent_state(tx, STATE_DOMAIN_GENESIS, STATE_KEY_LAST_INDEXED).await
+    GraphPg::<Aby3Store>::delete_persistent_state(tx, STATE_DOMAIN_GENESIS, STATE_KEY_LAST_INDEXED)
+        .await
 }
 
 /// Unsets serial id of last Iris to have been indexed.
@@ -273,7 +281,7 @@ pub async fn unset_last_indexed_id(tx: &mut Transaction<'_, Postgres>) -> Result
 /// Result<()> on success
 ///
 pub async fn unset_last_indexed_modification_id(tx: &mut Transaction<'_, Postgres>) -> Result<()> {
-    Store::delete_persistent_state(
+    GraphPg::<Aby3Store>::delete_persistent_state(
         tx,
         STATE_DOMAIN_GENESIS,
         STATE_KEY_LAST_INDEXED_MODIFICATION_ID,
@@ -290,6 +298,7 @@ mod tests {
         fetch_iris_batch, get_last_indexed_id, get_last_indexed_modification_id,
         set_last_indexed_id, set_last_indexed_modification_id, unset_last_indexed_id,
     };
+    use crate::{hawkers::aby3::aby3_store::Aby3Store, hnsw::graph::graph_store::GraphPg};
     use eyre::Result;
     use iris_mpc_common::{
         postgres::{AccessMode, PostgresClient, PostgresSchemaName},
@@ -307,11 +316,17 @@ mod tests {
     const DEFAULT_SIZE_OF_IRIS_DB: usize = 100;
 
     // Returns a set of test resources.
-    async fn get_resources() -> Result<(IrisStore, PostgresClient, PostgresSchemaName)> {
+    async fn get_resources() -> Result<(
+        IrisStore,
+        GraphPg<Aby3Store>,
+        PostgresClient,
+        PostgresSchemaName,
+    )> {
         // Set PostgreSQL client + store.
         let pg_schema = temporary_name();
         let pg_client =
             PostgresClient::new(&test_db_url()?, &pg_schema, AccessMode::ReadWrite).await?;
+        let graph_store = GraphPg::new(&pg_client).await?;
 
         // Set store.
         let iris_store = IrisStore::new(&pg_client).await?;
@@ -326,16 +341,16 @@ mod tests {
             )
             .await?;
 
-        Ok((iris_store, pg_client, pg_schema))
+        Ok((iris_store, graph_store, pg_client, pg_schema))
     }
 
     #[tokio::test]
     async fn test_id_of_last_indexed() -> Result<()> {
         // Set resources.
-        let (iris_store, pg_client, pg_schema) = get_resources().await.unwrap();
+        let (iris_store, graph_store, pg_client, pg_schema) = get_resources().await.unwrap();
 
         // Get -> should be zero.
-        let id_of_last_indexed = get_last_indexed_id(&iris_store).await?;
+        let id_of_last_indexed = get_last_indexed_id(&graph_store).await?;
         assert_eq!(id_of_last_indexed, 0);
 
         // Set -> 10.
@@ -345,7 +360,7 @@ mod tests {
         tx.commit().await?;
 
         // Get -> should be 10.
-        let id_of_last_indexed = get_last_indexed_id(&iris_store).await?;
+        let id_of_last_indexed = get_last_indexed_id(&graph_store).await?;
         assert_eq!(id_of_last_indexed, 10);
 
         // Unset.
@@ -354,7 +369,7 @@ mod tests {
         tx.commit().await?;
 
         // Get -> should be 0.
-        let id_of_last_indexed = get_last_indexed_id(&iris_store).await?;
+        let id_of_last_indexed = get_last_indexed_id(&graph_store).await?;
         assert_eq!(id_of_last_indexed, 0);
 
         // Unset resources.
@@ -366,7 +381,7 @@ mod tests {
     #[tokio::test]
     async fn test_fetch_iris_batch() -> Result<()> {
         // Set resources.
-        let (iris_store, pg_client, pg_schema) = get_resources().await.unwrap();
+        let (iris_store, _graph_store, pg_client, pg_schema) = get_resources().await.unwrap();
 
         let identifiers: Vec<IrisSerialId> = (1..11).collect_vec();
         let data = fetch_iris_batch(&iris_store, identifiers).await.unwrap();
@@ -381,10 +396,11 @@ mod tests {
     #[tokio::test]
     async fn test_modification_id_of_last_indexed() -> Result<()> {
         // Set resources.
-        let (iris_store, pg_client, pg_schema) = get_resources().await.unwrap();
+        let (iris_store, graph_store, pg_client, pg_schema) = get_resources().await.unwrap();
 
         // Get -> should be zero.
-        let modification_id_of_last_indexed = get_last_indexed_modification_id(&iris_store).await?;
+        let modification_id_of_last_indexed =
+            get_last_indexed_modification_id(&graph_store).await?;
         assert_eq!(modification_id_of_last_indexed, 0);
 
         // Set -> 42.
@@ -394,7 +410,8 @@ mod tests {
         tx.commit().await?;
 
         // Get -> should be 42.
-        let modification_id_of_last_indexed = get_last_indexed_modification_id(&iris_store).await?;
+        let modification_id_of_last_indexed =
+            get_last_indexed_modification_id(&graph_store).await?;
         assert_eq!(modification_id_of_last_indexed, 42);
 
         // Set -> 999.
@@ -404,7 +421,8 @@ mod tests {
         tx.commit().await?;
 
         // Get -> should be 999.
-        let modification_id_of_last_indexed = get_last_indexed_modification_id(&iris_store).await?;
+        let modification_id_of_last_indexed =
+            get_last_indexed_modification_id(&graph_store).await?;
         assert_eq!(modification_id_of_last_indexed, 999);
 
         // Unset.
@@ -413,7 +431,8 @@ mod tests {
         tx.commit().await?;
 
         // Get -> should be 0.
-        let modification_id_of_last_indexed = get_last_indexed_modification_id(&iris_store).await?;
+        let modification_id_of_last_indexed =
+            get_last_indexed_modification_id(&graph_store).await?;
         assert_eq!(modification_id_of_last_indexed, 0);
 
         // Unset resources.

--- a/iris-mpc-cpu/src/hnsw/graph/graph_store.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/graph_store.rs
@@ -10,7 +10,10 @@ use eyre::{eyre, Result};
 use futures::{Stream, StreamExt, TryStreamExt};
 use iris_mpc_common::{postgres::PostgresClient, vector_id::VectorId};
 use itertools::izip;
-use sqlx::{error::BoxDynError, PgConnection, Postgres, Row, Transaction};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use sqlx::{
+    error::BoxDynError, types::Json, types::Text, PgConnection, Postgres, Row, Transaction,
+};
 use std::{marker::PhantomData, ops::DerefMut, str::FromStr};
 
 #[derive(sqlx::FromRow, Debug, PartialEq, Eq)]
@@ -54,6 +57,86 @@ impl<V: VectorStore> GraphPg<V> {
             schema_name: self.schema_name.clone(),
             phantom: PhantomData,
         }
+    }
+
+    /// Retrieve entry from `persistent_state` table with associated `domain` and `key` identifiers.
+    ///
+    /// Returns `Some(value)` if an entry exists for these identifiers and deserialization to generic
+    /// type `T` succeeds.  If no entry exists, then returns `None`.
+    pub async fn get_persistent_state<T: DeserializeOwned>(
+        &self,
+        domain: &str,
+        key: &str,
+    ) -> Result<Option<T>> {
+        let row = sqlx::query(
+            r#"
+            SELECT "value"
+            FROM persistent_state
+            WHERE domain = $1 AND "key" = $2
+            "#,
+        )
+        .bind(domain)
+        .bind(key)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        if let Some(row) = row {
+            let value = row.try_get("value")?;
+            let deserialized: T = serde_json::from_value(value)?;
+            Ok(Some(deserialized))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Set the entry in the `persistent_state` table for primary key `(domain, key)`.
+    ///
+    /// If an entry already exists for this primary key, this overwrites the existing
+    /// value with the value specified here.
+    pub async fn set_persistent_state<T: Serialize>(
+        tx: &mut Transaction<'_, Postgres>,
+        domain: &str,
+        key: &str,
+        value: &T,
+    ) -> Result<()> {
+        sqlx::query(
+            r#"
+            INSERT INTO persistent_state (domain, "key", "value")
+            VALUES ($1, $2, $3)
+            ON CONFLICT (domain, "key")
+            DO UPDATE SET "value" = EXCLUDED."value"
+            "#,
+        )
+        .bind(domain)
+        .bind(key)
+        .bind(Json(value))
+        .execute(tx.deref_mut())
+        .await?;
+
+        Ok(())
+    }
+
+    /// Delete an entry in the `persistent_state` table with primary key `(domain, key)`,
+    /// if it exists.
+    pub async fn delete_persistent_state(
+        tx: &mut Transaction<'_, Postgres>,
+        domain: &str,
+        key: &str,
+    ) -> Result<()> {
+        // let value_json = Json(value);
+
+        sqlx::query(
+            r#"
+            DELETE FROM persistent_state
+            WHERE domain = $1 AND "key" = $2;
+            "#,
+        )
+        .bind(domain)
+        .bind(key)
+        .execute(tx.deref_mut())
+        .await?;
+
+        Ok(())
     }
 }
 
@@ -466,6 +549,64 @@ mod tests {
 
         tx.tx.commit().await.unwrap();
         graph_pg.cleanup().await.unwrap();
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_persistent_state() -> Result<()> {
+        // Set up a temporary schema and a new store.
+        let store = TestGraphPg::<PlaintextStore>::new().await?;
+
+        let domain = "test_domain".to_string();
+        let key = "foo".to_string();
+
+        // Check no value at index
+        let value: Option<String> = store.get_persistent_state(&domain, &key).await?;
+        assert_eq!(value, None);
+
+        // Insert value at index
+        let set_value = "bar".to_string();
+        let graph_tx = store.tx().await?;
+        let mut tx = graph_tx.tx;
+        GraphPg::<PlaintextStore>::set_persistent_state(&mut tx, &domain, &key, &set_value).await?;
+        tx.commit().await?;
+
+        // Check value is set at index
+        let value: Option<String> = store.get_persistent_state(&domain, &key).await?;
+        assert_eq!(value, Some(set_value));
+
+        // Insert new value at index
+        let new_set_value = "bear".to_string();
+        let graph_tx = store.tx().await?;
+        let mut tx = graph_tx.tx;
+        GraphPg::<PlaintextStore>::set_persistent_state(&mut tx, &domain, &key, &new_set_value)
+            .await?;
+        tx.commit().await?;
+
+        // Check value is updated at index
+        let value: Option<String> = store.get_persistent_state(&domain, &key).await?;
+        assert_eq!(value, Some(new_set_value));
+
+        // Delete value at index
+        let graph_tx = store.tx().await?;
+        let mut tx = graph_tx.tx;
+        GraphPg::<PlaintextStore>::delete_persistent_state(&mut tx, &domain, &key).await?;
+        tx.commit().await?;
+
+        // Check no value at index
+        let value: Option<String> = store.get_persistent_state(&domain, &key).await?;
+        assert_eq!(value, None);
+
+        // Delete value at index again
+        let graph_tx = store.tx().await?;
+        let mut tx = graph_tx.tx;
+        GraphPg::<PlaintextStore>::delete_persistent_state(&mut tx, &domain, &key).await?;
+        tx.commit().await?;
+
+        // Check still no value at index
+        let value: Option<String> = store.get_persistent_state(&domain, &key).await?;
+        assert_eq!(value, None);
 
         Ok(())
     }

--- a/iris-mpc-cpu/src/hnsw/graph/graph_store.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/graph_store.rs
@@ -10,10 +10,8 @@ use eyre::{eyre, Result};
 use futures::{Stream, StreamExt, TryStreamExt};
 use iris_mpc_common::{postgres::PostgresClient, vector_id::VectorId};
 use itertools::izip;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use sqlx::{
-    error::BoxDynError, types::Json, types::Text, PgConnection, Postgres, Row, Transaction,
-};
+use serde::{de::DeserializeOwned, Serialize};
+use sqlx::{error::BoxDynError, types::Json, PgConnection, Postgres, Row, Transaction};
 use std::{marker::PhantomData, ops::DerefMut, str::FromStr};
 
 #[derive(sqlx::FromRow, Debug, PartialEq, Eq)]

--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -24,8 +24,7 @@ use rand::{rngs::StdRng, Rng, SeedableRng};
 pub use s3_importer::{
     fetch_and_parse_chunks, last_snapshot_timestamp, ObjectStore, S3Store, S3StoredIris,
 };
-use serde::{de::DeserializeOwned, Serialize};
-use sqlx::{types::Json, PgPool, Postgres, Row, Transaction};
+use sqlx::{PgPool, Postgres, Row, Transaction};
 use std::ops::DerefMut;
 
 /// The unified type that can hold either DB or S3 variants.
@@ -592,86 +591,6 @@ WHERE id = $1;
             "#,
         )
         .bind(&ids)
-        .execute(tx.deref_mut())
-        .await?;
-
-        Ok(())
-    }
-
-    /// Retrieve entry from `persistent_state` table with associated `domain` and `key` identifiers.
-    ///
-    /// Returns `Some(value)` if an entry exists for these identifiers and deserialization to generic
-    /// type `T` succeeds.  If no entry exists, then returns `None`.
-    pub async fn get_persistent_state<T: DeserializeOwned>(
-        &self,
-        domain: &str,
-        key: &str,
-    ) -> Result<Option<T>> {
-        let row = sqlx::query(
-            r#"
-            SELECT "value"
-            FROM persistent_state
-            WHERE domain = $1 AND "key" = $2
-            "#,
-        )
-        .bind(domain)
-        .bind(key)
-        .fetch_optional(&self.pool)
-        .await?;
-
-        if let Some(row) = row {
-            let value = row.try_get("value")?;
-            let deserialized: T = serde_json::from_value(value)?;
-            Ok(Some(deserialized))
-        } else {
-            Ok(None)
-        }
-    }
-
-    /// Set the entry in the `persistent_state` table for primary key `(domain, key)`.
-    ///
-    /// If an entry already exists for this primary key, this overwrites the existing
-    /// value with the value specified here.
-    pub async fn set_persistent_state<T: Serialize>(
-        tx: &mut Transaction<'_, Postgres>,
-        domain: &str,
-        key: &str,
-        value: &T,
-    ) -> Result<()> {
-        sqlx::query(
-            r#"
-            INSERT INTO persistent_state (domain, "key", "value")
-            VALUES ($1, $2, $3)
-            ON CONFLICT (domain, "key")
-            DO UPDATE SET "value" = EXCLUDED."value"
-            "#,
-        )
-        .bind(domain)
-        .bind(key)
-        .bind(Json(value))
-        .execute(tx.deref_mut())
-        .await?;
-
-        Ok(())
-    }
-
-    /// Delete an entry in the `persistent_state` table with primary key `(domain, key)`,
-    /// if it exists.
-    pub async fn delete_persistent_state(
-        tx: &mut Transaction<'_, Postgres>,
-        domain: &str,
-        key: &str,
-    ) -> Result<()> {
-        // let value_json = Json(value);
-
-        sqlx::query(
-            r#"
-            DELETE FROM persistent_state
-            WHERE domain = $1 AND "key" = $2;
-            "#,
-        )
-        .bind(domain)
-        .bind(key)
         .execute(tx.deref_mut())
         .await?;
 
@@ -1362,63 +1281,6 @@ pub mod tests {
                 .all(|(i, row)| row.id == (i + 1) as i64),
             "IDs must be contiguous and in order"
         );
-    }
-
-    #[tokio::test]
-    async fn test_persistent_state() -> Result<()> {
-        // Set up a temporary schema and a new store.
-        let schema_name = temporary_name();
-        let postgres_client =
-            PostgresClient::new(test_db_url()?.as_str(), &schema_name, AccessMode::ReadWrite)
-                .await?;
-        let store = Store::new(&postgres_client).await?;
-
-        let domain = "test_domain".to_string();
-        let key = "foo".to_string();
-
-        // Check no value at index
-        let value: Option<String> = store.get_persistent_state(&domain, &key).await?;
-        assert_eq!(value, None);
-
-        // Insert value at index
-        let set_value = "bar".to_string();
-        let mut tx = store.tx().await?;
-        Store::set_persistent_state(&mut tx, &domain, &key, &set_value).await?;
-        tx.commit().await?;
-
-        // Check value is set at index
-        let value: Option<String> = store.get_persistent_state(&domain, &key).await?;
-        assert_eq!(value, Some(set_value));
-
-        // Insert new value at index
-        let new_set_value = "bear".to_string();
-        let mut tx = store.tx().await?;
-        Store::set_persistent_state(&mut tx, &domain, &key, &new_set_value).await?;
-        tx.commit().await?;
-
-        // Check value is updated at index
-        let value: Option<String> = store.get_persistent_state(&domain, &key).await?;
-        assert_eq!(value, Some(new_set_value));
-
-        // Delete value at index
-        let mut tx = store.tx().await?;
-        Store::delete_persistent_state(&mut tx, &domain, &key).await?;
-        tx.commit().await?;
-
-        // Check no value at index
-        let value: Option<String> = store.get_persistent_state(&domain, &key).await?;
-        assert_eq!(value, None);
-
-        // Delete value at index again
-        let mut tx = store.tx().await?;
-        Store::delete_persistent_state(&mut tx, &domain, &key).await?;
-        tx.commit().await?;
-
-        // Check still no value at index
-        let value: Option<String> = store.get_persistent_state(&domain, &key).await?;
-        assert_eq!(value, None);
-
-        Ok(())
     }
 
     #[tokio::test]

--- a/iris-mpc-upgrade-hawk/src/genesis/mod.rs
+++ b/iris-mpc-upgrade-hawk/src/genesis/mod.rs
@@ -82,7 +82,7 @@ pub async fn exec_main(
     log_info(String::from("Service clients instantiated"));
 
     // Process: set serial identifier of last indexed Iris.
-    let last_indexed_id = get_last_indexed_id(&iris_store).await?;
+    let last_indexed_id = get_last_indexed_id(&graph_store).await?;
     log_info(format!(
         "Identifier of last Iris to have been indexed = {}",
         last_indexed_id,

--- a/iris-mpc-upgrade-hawk/src/genesis/mod.rs
+++ b/iris-mpc-upgrade-hawk/src/genesis/mod.rs
@@ -97,7 +97,7 @@ pub async fn exec_main(
     ));
 
     // Process: get modifications that need to be applied to the graph.
-    let last_indexed_modification_id = get_last_indexed_modification_id(&iris_store).await?;
+    let last_indexed_modification_id = get_last_indexed_modification_id(&graph_store).await?;
     log_info(format!(
         "Identifier of last modification to have been indexed = {}",
         last_indexed_modification_id,


### PR DESCRIPTION
### Notes
* migrate the persisted state to the graph store as its mainly used for Genesis and graph updates.
* currently, the state is read from the iris pg store but written to the graph store (https://github.com/worldcoin/iris-mpc/blob/5450212b00cb8cdba2fbf4b1eb0061f9ae97dd39/iris-mpc-upgrade-hawk/src/genesis/mod.rs#L645-L647)
* therefore the state has not been kept

This PR migrates all to use the graph store - this also makes sense since its only being used by HNSW related mechanisms