### PR TITLE
aurel/fix-skip-persistence: Make skip_persistence optional

### DIFF
--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -758,7 +758,8 @@ impl HawkRequest {
             .enumerate()
             .map(|(i, request_type)| match request_type.as_str() {
                 UNIQUENESS_MESSAGE_TYPE => Uniqueness(UniquenessRequest {
-                    skip_persistence: self.batch.skip_persistence[i],
+                    // Support for optional skip_persistence.
+                    skip_persistence: *self.batch.skip_persistence.get(i).unwrap_or(&false),
                 }),
                 REAUTH_MESSAGE_TYPE => Reauth(if orient == Orientation::Normal {
                     let request_id = &self.batch.request_ids[i];
@@ -1450,7 +1451,7 @@ mod tests {
 
                     or_rule_indices: vec![vec![]; batch_size],
                     luc_lookback_records: 2,
-                    skip_persistence: vec![false; batch_size],
+                    skip_persistence: vec![], // Unused.
 
                     ..BatchQuery::default()
                 };


### PR DESCRIPTION
Fix integration test error:
```
Panic occurred with message: index out of bounds: the len is 0 but the index is 0 [...]
location":"iris-mpc-cpu/src/execution/hawk_main.rs:758:66
```