### PR TITLE
Revise Postgres schemas to represent ids consistently

### DIFF
--- a/migrations/20250530201832_unify_id_repr.down.sql
+++ b/migrations/20250530201832_unify_id_repr.down.sql
@@ -1,0 +1,22 @@
+DROP TABLE IF EXISTS hawk_graph_links;
+DROP TABLE IF EXISTS hawk_graph_entry;
+
+-- Links table --
+
+CREATE TABLE hawk_graph_links
+(
+    graph_id integer NOT NULL,
+    source_ref text NOT NULL,
+    layer integer NOT NULL,
+    links bytea NOT NULL,
+    CONSTRAINT hawk_graph_links_pkey PRIMARY KEY (graph_id, source_ref, layer)
+);
+
+-- Entry point table --
+
+CREATE TABLE hawk_graph_entry
+(
+    graph_id integer NOT NULL,
+    entry_point bytea,
+    CONSTRAINT hawk_graph_entry_pkey PRIMARY KEY (graph_id)
+);

--- a/migrations/20250530201832_unify_id_repr.up.sql
+++ b/migrations/20250530201832_unify_id_repr.up.sql
@@ -1,0 +1,25 @@
+DROP TABLE IF EXISTS hawk_graph_links;
+DROP TABLE IF EXISTS hawk_graph_entry;
+
+-- Links table --
+
+CREATE TABLE hawk_graph_links
+(
+    graph_id smallint NOT NULL CHECK (graph_id = 0 OR graph_id = 1),
+    serial_id bigint NOT NULL CHECK (serial_id BETWEEN 1 AND 4294967296),
+    version_id smallint NOT NULL CHECK (version_id >= 0),
+    layer smallint NOT NULL CHECK (layer >= 0),
+    links bytea NOT NULL,
+    CONSTRAINT hawk_graph_links_pkey PRIMARY KEY (graph_id, serial_id, version_id, layer)
+);
+
+-- Entry point table --
+
+CREATE TABLE hawk_graph_entry
+(
+    graph_id smallint NOT NULL CHECK (graph_id = 0 OR graph_id = 1),
+    serial_id bigint NOT NULL CHECK (serial_id BETWEEN 1 AND 4294967296),
+    version_id smallint NOT NULL CHECK (version_id >= 0),
+    layer smallint NOT NULL CHECK (layer >= 0),
+    CONSTRAINT hawk_graph_entry_pkey PRIMARY KEY (graph_id)
+);

--- a/migrations/20250530201832_unify_id_repr.up.sql
+++ b/migrations/20250530201832_unify_id_repr.up.sql
@@ -6,7 +6,7 @@ DROP TABLE IF EXISTS hawk_graph_entry;
 CREATE TABLE hawk_graph_links
 (
     graph_id smallint NOT NULL CHECK (graph_id = 0 OR graph_id = 1),
-    serial_id bigint NOT NULL CHECK (serial_id BETWEEN 1 AND 4294967296),
+    serial_id bigint NOT NULL CHECK (serial_id BETWEEN 1 AND 4294967295),
     version_id smallint NOT NULL CHECK (version_id >= 0),
     layer smallint NOT NULL CHECK (layer >= 0),
     links bytea NOT NULL,
@@ -18,7 +18,7 @@ CREATE TABLE hawk_graph_links
 CREATE TABLE hawk_graph_entry
 (
     graph_id smallint NOT NULL CHECK (graph_id = 0 OR graph_id = 1),
-    serial_id bigint NOT NULL CHECK (serial_id BETWEEN 1 AND 4294967296),
+    serial_id bigint NOT NULL CHECK (serial_id BETWEEN 1 AND 4294967295),
     version_id smallint NOT NULL CHECK (version_id >= 0),
     layer smallint NOT NULL CHECK (layer >= 0),
     CONSTRAINT hawk_graph_entry_pkey PRIMARY KEY (graph_id)


### PR DESCRIPTION
This PR modifies the Postgres schemas for the `hawk_graph_links` and `hawk_graph_entry` tables to represent ids consistently with the representation used in the `irises` table, as `serial_id: bigint` and `version_id: smallint` values.  It additionally modifies the `GraphOps` implementations to specialize to `VectorStore` structs with `VectorRef = VectorId`, and to interact properly with the new schema.

The updated schema also adds explicit range constraints on column values in the graph tables, and changes the `layer` and `graph_id` column types from `integer` to `smallint`.