### PR TITLE
Read irises from in-memory store in genesis

### DIFF
--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -355,11 +355,11 @@ impl HawkActor {
         self.searcher.clone()
     }
 
-    fn iris_store(&self, store_id: StoreId) -> SharedIrisesRef {
+    pub fn iris_store(&self, store_id: StoreId) -> SharedIrisesRef {
         self.iris_store[store_id as usize].clone()
     }
 
-    fn graph_store(&self, store_id: StoreId) -> GraphRef {
+    pub fn graph_store(&self, store_id: StoreId) -> GraphRef {
         self.graph_store[store_id as usize].clone()
     }
 

--- a/iris-mpc-cpu/src/genesis/batch_generator.rs
+++ b/iris-mpc-cpu/src/genesis/batch_generator.rs
@@ -1,28 +1,36 @@
-use super::{
-    state_accessor as fetcher,
-    utils::{errors::IndexationError, logger},
+use crate::{
+    execution::hawk_main::BothEyes,
+    hawkers::aby3::aby3_store::{QueryRef, SharedIrisesRef},
 };
+
+use super::utils::{errors::IndexationError, logger};
 use eyre::Result;
-use iris_mpc_common::IrisSerialId;
-use iris_mpc_store::{DbStoredIris, Store as IrisStore};
+use iris_mpc_common::{vector_id::VectorId, IrisSerialId};
+use itertools::{izip, Itertools};
 use std::{fmt, future::Future, iter::Peekable, ops::RangeInclusive};
 
 /// Component name for logging purposes.
 const COMPONENT: &str = "Batch-Generator";
 
+/// Type representing stored iris data for a batch.  Tuple represents:
+/// - Vector id of iris enrollment
+/// - Left iris code, in query format
+/// - Right iris code, in query format
+type BatchData = Vec<(VectorId, QueryRef, QueryRef)>;
+
 /// A batch for upstream indexation.
 #[derive(Debug)]
 pub struct Batch {
-    // Array of stored Iris's to be indexed.
-    pub data: Vec<DbStoredIris>,
+    /// Array of stored iris data for the batch.
+    pub data: BatchData,
 
-    // Ordinal batch identifier scoped by processing context.
+    /// Ordinal batch identifier scoped by processing context.
     pub id: usize,
 }
 
 /// Constructor.
 impl Batch {
-    pub fn new(batch_id: usize, data: Vec<DbStoredIris>) -> Self {
+    pub fn new(batch_id: usize, data: BatchData) -> Self {
         Self { data, id: batch_id }
     }
 }
@@ -45,18 +53,12 @@ impl fmt::Display for Batch {
 impl Batch {
     // Returns Iris serial id of batch's last element.
     pub fn id_end(&self) -> IrisSerialId {
-        self.data
-            .last()
-            .map(|value| value.id() as IrisSerialId)
-            .unwrap()
+        self.data.last().map(|value| value.0.serial_id()).unwrap()
     }
 
     // Returns Iris serial id of batch's first element.
     pub fn id_start(&self) -> IrisSerialId {
-        self.data
-            .first()
-            .map(|value| value.id() as IrisSerialId)
-            .unwrap()
+        self.data.first().map(|value| value.0.serial_id()).unwrap()
     }
 
     // Returns size of the batch.
@@ -173,7 +175,7 @@ pub trait BatchIterator {
     // Iterator over batches of Iris data to be indexed.
     fn next_batch(
         &mut self,
-        iris_store: &IrisStore,
+        iris_stores: &BothEyes<SharedIrisesRef>,
     ) -> impl Future<Output = Result<Option<Batch>, IndexationError>> + Send;
 }
 
@@ -187,12 +189,26 @@ impl BatchIterator for BatchGenerator {
     // Returns next batch of Iris data to be indexed or None if exhausted.
     async fn next_batch(
         &mut self,
-        iris_store: &IrisStore,
+        iris_stores: &BothEyes<SharedIrisesRef>,
     ) -> Result<Option<Batch>, IndexationError> {
         if let Some(identifiers) = self.next_identifiers() {
-            let data = fetcher::fetch_iris_batch(iris_store, identifiers).await?;
+            // Assumption: ids are the same in both left and right stores, esp. versions
+            let ids = iris_stores[0]
+                .get_vector_ids(&identifiers)
+                .await
+                .into_iter()
+                .zip(identifiers)
+                .map(|(id_opt, serial_id)| {
+                    id_opt.ok_or(IndexationError::MissingSerialId(serial_id))
+                })
+                .collect::<Result<Vec<_>, IndexationError>>()?;
+
+            let iris_data_left = iris_stores[0].get_queries(ids.iter()).await;
+            let iris_data_right = iris_stores[1].get_queries(ids.iter()).await;
+            let batch_data = izip!(ids, iris_data_left, iris_data_right).collect_vec();
+
             self.batch_count += 1;
-            let batch = Batch::new(self.batch_count, data);
+            let batch = Batch::new(self.batch_count, batch_data);
             Self::log_info(format!("Generated batch: {}", batch));
             Ok(Some(batch))
         } else {
@@ -202,12 +218,19 @@ impl BatchIterator for BatchGenerator {
 }
 
 #[cfg(test)]
-#[cfg(feature = "db_dependent")]
 mod tests {
+    use crate::{
+        execution::hawk_main::StoreId,
+        hawkers::{
+            aby3::test_utils::setup_aby3_shared_iris_stores_with_preloaded_db,
+            plaintext_store::PlaintextStore,
+        },
+    };
+
     use super::*;
+    use aes_prng::AesRng;
     use eyre::Result;
-    use iris_mpc_common::postgres::{AccessMode, PostgresClient};
-    use iris_mpc_store::test_utils::{cleanup, temporary_name, test_db_url};
+    use rand::SeedableRng;
 
     // Defaults.
     const DEFAULT_RNG_SEED: u64 = 0;
@@ -217,44 +240,27 @@ mod tests {
     const DEFAULT_COUNT_OF_BATCHES: usize = 10;
 
     // Returns a set of test resources.
-    async fn get_resources() -> Result<(IrisStore, PostgresClient, String)> {
-        // Set PostgreSQL client + store.
-        let pg_schema = temporary_name();
-        let pg_client =
-            PostgresClient::new(&test_db_url()?, &pg_schema, AccessMode::ReadWrite).await?;
+    fn get_iris_stores() -> (BothEyes<SharedIrisesRef>, usize) {
+        let mut rng = AesRng::seed_from_u64(DEFAULT_RNG_SEED);
+        let iris_stores: BothEyes<SharedIrisesRef> = [StoreId::Left, StoreId::Right].map(|_| {
+            let plaintext_store = PlaintextStore::new_random(&mut rng, DEFAULT_SIZE_OF_IRIS_DB);
+            setup_aby3_shared_iris_stores_with_preloaded_db(&mut rng, &plaintext_store)
+                .remove(DEFAULT_PARTY_ID)
+        });
 
-        // Set store.
-        let iris_store = IrisStore::new(&pg_client).await?;
-
-        // Set dB with 100 irises.
-        iris_store
-            .init_db_with_random_shares(
-                DEFAULT_RNG_SEED,
-                DEFAULT_PARTY_ID,
-                DEFAULT_SIZE_OF_IRIS_DB,
-                true,
-            )
-            .await?;
-
-        Ok((iris_store, pg_client, pg_schema))
+        (iris_stores, DEFAULT_SIZE_OF_IRIS_DB)
     }
 
-    /// Test new from range pulled from dB.
+    /// Test new.
     #[tokio::test]
     async fn test_new() -> Result<()> {
-        // Set resources.
-        let (iris_store, pg_client, pg_schema) = get_resources().await.unwrap();
-
         let instance = BatchGenerator::new(
             1,
-            iris_store.count_irises().await.unwrap() as IrisSerialId,
+            DEFAULT_SIZE_OF_IRIS_DB as IrisSerialId,
             DEFAULT_SIZE_OF_BATCH,
             Vec::new(),
         );
         assert_eq!(*instance.range.end() as usize, DEFAULT_SIZE_OF_IRIS_DB);
-
-        // Unset resources.
-        cleanup(&pg_client, &pg_schema).await?;
 
         Ok(())
     }
@@ -263,23 +269,21 @@ mod tests {
     #[tokio::test]
     async fn test_iterator() -> Result<()> {
         // Set resources.
-        let (iris_store, pg_client, pg_schema) = get_resources().await.unwrap();
+        let (iris_stores, db_size) = get_iris_stores();
+        // let (iris_store, pg_client, pg_schema) = get_iris_stores().await.unwrap();
 
         let mut instance = BatchGenerator::new(
             1,
-            iris_store.count_irises().await.unwrap() as IrisSerialId,
+            db_size as IrisSerialId,
             DEFAULT_SIZE_OF_BATCH,
             Vec::new(),
         );
 
         // Expecting M batches of N Iris's per batch.
-        while let Some(batch) = instance.next_batch(&iris_store).await? {
+        while let Some(batch) = instance.next_batch(&iris_stores).await? {
             assert_eq!(batch.size(), DEFAULT_SIZE_OF_BATCH);
         }
         assert_eq!(instance.batch_count, DEFAULT_COUNT_OF_BATCHES);
-
-        // Unset resources.
-        cleanup(&pg_client, &pg_schema).await?;
 
         Ok(())
     }

--- a/iris-mpc-cpu/src/genesis/utils/errors.rs
+++ b/iris-mpc-cpu/src/genesis/utils/errors.rs
@@ -1,3 +1,4 @@
+use iris_mpc_common::IrisSerialId;
 use thiserror::Error;
 
 // Encpasulates a non-exhaustive set of errors raised during indexation.
@@ -11,6 +12,9 @@ pub enum IndexationError {
 
     #[error("Current height of indexation exceeds maximum allowed")]
     IndexationHeightMismatch,
+
+    #[error("Failed to fetch Iris with given serial ID: {0}")]
+    MissingSerialId(IrisSerialId),
 
     #[error("Failed to fetch Iris batch from PostgreSQL dB: {0}")]
     PostgresFetchIrisBatch(String),


### PR DESCRIPTION
This PR changes the genesis indexer to read irises from the in-memory iris shares database during the indexing process, rather than reading them directly from Postgres as irises are indexed.

Because the indexer now reads from the `irises` table just once at startup, any restrictions that need to be in place on this table to ensure consistency of the state (esp. with regards to in-place iris code modifications) are only needed during the initial startup phase.