### PR TITLE
chore(POP-2549): Include full scan side in the batch hash as a safeguard

### DIFF
--- a/deploy/stage/common-values-ampc-hnsw.yaml
+++ b/deploy/stage/common-values-ampc-hnsw.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc-cpu:436472935e9e70b12c9fe9f83ed66f1f5ab90d95"
+image: "ghcr.io/worldcoin/iris-mpc-cpu:67314f00a7637c7f561d107ac79cfc87d177eb7c"
 
 environment: stage
 replicaCount: 1

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -793,7 +793,11 @@ impl ServerActor {
         tracing::info!("Syncing batch entries");
 
         // Compute hash of the SNS message ids concatenated + currently used scan side
-        let batch_hash = sha256_bytes(format!("{}{}", batch.sns_message_ids.join(""), self.full_scan_side));
+        let batch_hash = sha256_bytes(format!(
+            "{}{}",
+            batch.sns_message_ids.join(""),
+            self.full_scan_side
+        ));
         tracing::info!("Current batch hash: {}", hex::encode(&batch_hash[0..4]));
 
         let valid_entries =

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -49,7 +49,6 @@ use std::{
     sync::Arc,
     time::Instant,
 };
-use rand::Rng;
 use tokio::sync::{mpsc, oneshot};
 
 macro_rules! record_stream_time {
@@ -793,10 +792,8 @@ impl ServerActor {
         let tmp_now = Instant::now();
         tracing::info!("Syncing batch entries");
 
-        let mut rng = rand::thread_rng();
         // Compute hash of the SNS message ids concatenated + currently used scan side
-        let random_number_to_break_batch = rng.gen::<u32>();
-        let batch_hash = sha256_bytes(format!("{}{}{}", batch.sns_message_ids.join(""), self.full_scan_side, random_number_to_break_batch));
+        let batch_hash = sha256_bytes(format!("{}{}", batch.sns_message_ids.join(""), self.full_scan_side));
         tracing::info!("Current batch hash: {}", hex::encode(&batch_hash[0..4]));
 
         let valid_entries =

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -49,6 +49,7 @@ use std::{
     sync::Arc,
     time::Instant,
 };
+use rand::Rng;
 use tokio::sync::{mpsc, oneshot};
 
 macro_rules! record_stream_time {
@@ -792,8 +793,10 @@ impl ServerActor {
         let tmp_now = Instant::now();
         tracing::info!("Syncing batch entries");
 
+        let mut rng = rand::thread_rng();
         // Compute hash of the SNS message ids concatenated + currently used scan side
-        let batch_hash = sha256_bytes(format!("{}{}", batch.sns_message_ids.join(""), self.full_scan_side));
+        let random_number_to_break_batch = rng.gen::<u32>();
+        let batch_hash = sha256_bytes(format!("{}{}{}", batch.sns_message_ids.join(""), self.full_scan_side, random_number_to_break_batch));
         tracing::info!("Current batch hash: {}", hex::encode(&batch_hash[0..4]));
 
         let valid_entries =

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -792,8 +792,8 @@ impl ServerActor {
         let tmp_now = Instant::now();
         tracing::info!("Syncing batch entries");
 
-        // Compute hash of the SNS message ids concatenated
-        let batch_hash = sha256_bytes(batch.sns_message_ids.join(""));
+        // Compute hash of the SNS message ids concatenated + currently used scan side
+        let batch_hash = sha256_bytes(format!("{}{}", batch.sns_message_ids.join(""), self.full_scan_side));
         tracing::info!("Current batch hash: {}", hex::encode(&batch_hash[0..4]));
 
         let valid_entries =
@@ -2622,12 +2622,12 @@ impl ServerActor {
             if &results[i][max_batch_size..] != batch_hash {
                 tracing::error!(
                     party_id = self.party_id,
-                    "Batch mismatch with node {}. Queues seem to be out of sync.",
+                    "Batch mismatch with node {}. Queues seem to be out of sync (check requests and full scan side).",
                     i
                 );
                 metrics::counter!("batch.mismatch").increment(1);
                 bail!(
-                    "Batch mismatch with node {}. Queues seem to be out of sync.",
+                    "Batch mismatch with node {}. Queues seem to be out of sync (check requests and full scan side).",
                     i
                 );
             }


### PR DESCRIPTION
Minimal implementation to check if all the nodes are processing the same side in each batch.