### PR TITLE
fix: only clear anon stat buckets after normal&mirror orientation run

### DIFF
--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -635,6 +635,16 @@ impl ServerActor {
                     }
                 }
             }
+
+            self.anonymized_bucket_statistics_left.buckets.clear();
+            self.anonymized_bucket_statistics_right.buckets.clear();
+            self.anonymized_bucket_statistics_left_mirror
+                .buckets
+                .clear();
+            self.anonymized_bucket_statistics_right_mirror
+                .buckets
+                .clear();
+
             tracing::info!(
                 "Full batch duration took:  {:?}",
                 now.elapsed().as_secs_f64()
@@ -1597,15 +1607,6 @@ impl ServerActor {
             actor_data: (),
             full_face_mirror_attack_detected,
         };
-
-        self.anonymized_bucket_statistics_left.buckets.clear();
-        self.anonymized_bucket_statistics_right.buckets.clear();
-        self.anonymized_bucket_statistics_left_mirror
-            .buckets
-            .clear();
-        self.anonymized_bucket_statistics_right_mirror
-            .buckets
-            .clear();
 
         // Reset the results buffers for reuse
         for dst in [


### PR DESCRIPTION
### Description
After the latest production release, we expected to see anonymized stats for the mirror case. However, after a recent investigation it has been remarked that although the mirror buckets are filled, server is never sending mirror anon stats.

Logs that justify the bucket fill for mirror case: https://app.datadoghq.com/logs?query=service%3Airis-mpc%20env%3Aprod%20%22Mirror%20bucket%20results%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1749071567166&to_ts=1749157967166&live=true

### Issue
First call (Mirror orientation): Mirror bucket statistics are calculated and filled, but then immediately cleared at the end of process_batch_query()
Second call (Normal orientation): Creates the final ServerJobResult with empty mirror buckets (because they were cleared after the first call)

The Root Cause: The bucket clearing logic was happening at the end of every process_batch_query call, which meant that mirror bucket statistics were being cleared after the Mirror orientation processing, before the Normal orientation processing that creates the final result.


### Fix
Just move the clearing of the buckets ONLY after calling `process_batch_query()` for both orientations