### PR TITLE
remove properties from batch

### DIFF
--- a/iris-mpc/src/services/processors/batch.rs
+++ b/iris-mpc/src/services/processors/batch.rs
@@ -381,8 +381,6 @@ impl<'a> BatchProcessor<'a> {
         }
 
         self.delete_message(sqs_message).await?;
-        // skip_persistence is only used for uniqueness requests
-        self.batch_query.skip_persistence.push(false);
         self.msg_counter += 1;
         Ok(())
     }
@@ -584,9 +582,6 @@ impl<'a> BatchProcessor<'a> {
             .push(sns_message_id.clone());
         self.batch_query.metadata.push(batch_metadata);
         self.batch_query
-            .request_types
-            .push(RESET_UPDATE_MESSAGE_TYPE.to_string());
-        self.batch_query
             .reset_update_request_ids
             .push(reset_update_request.reset_id);
         self.batch_query
@@ -597,9 +592,6 @@ impl<'a> BatchProcessor<'a> {
                 code_right: right_shares.code,
                 mask_right: right_shares.mask,
             });
-        // skip_persistence is only used for uniqueness requests
-        self.batch_query.skip_persistence.push(false);
-
         Ok(())
     }
 


### PR DESCRIPTION
Addressing the comments from a previously merged PR: https://github.com/worldcoin/iris-mpc/pull/1438


The structure BatchQuery has multiple independent "tables" inside:

Uniqueness, reauth, and reset check, with columns: 
 - request_ids
 - request_types 
 - metadata
 - or_rule_indices 
 - skip_persistence
 
Deletions with columns: deletion_requests_*.

Reset updates with columns: reset_update_*.
