### PR TITLE
[POP-2586] Select HNSW layers based on identifiers

### DIFF
--- a/iris-mpc-common/src/config/mod.rs
+++ b/iris-mpc-common/src/config/mod.rs
@@ -217,7 +217,7 @@ pub struct Config {
     pub hnsw_param_ef_search: usize,
 
     #[serde(default)]
-    pub hawk_prng_seed: Option<u64>,
+    pub hawk_prf_key: Option<u64>,
 
     #[serde(default = "default_max_deletions_per_batch")]
     pub max_deletions_per_batch: usize,
@@ -565,7 +565,7 @@ pub struct CommonConfig {
     hnsw_param_ef_constr: usize,
     hnsw_param_M: usize,
     hnsw_param_ef_search: usize,
-    hawk_prng_seed: Option<u64>,
+    hawk_prf_key: Option<u64>,
     max_deletions_per_batch: usize,
     mode_of_compute: ModeOfCompute,
     mode_of_deployment: ModeOfDeployment,
@@ -645,7 +645,7 @@ impl From<Config> for CommonConfig {
             hnsw_param_ef_constr,
             hnsw_param_M,
             hnsw_param_ef_search,
-            hawk_prng_seed,
+            hawk_prf_key,
             max_deletions_per_batch,
             mode_of_compute,
             mode_of_deployment,
@@ -700,7 +700,7 @@ impl From<Config> for CommonConfig {
             hnsw_param_ef_constr,
             hnsw_param_M,
             hnsw_param_ef_search,
-            hawk_prng_seed,
+            hawk_prf_key,
             max_deletions_per_batch,
             mode_of_compute,
             mode_of_deployment,

--- a/iris-mpc-cpu/benches/hnsw.rs
+++ b/iris-mpc-cpu/benches/hnsw.rs
@@ -52,8 +52,9 @@ fn bench_plaintext_hnsw(c: &mut Criterion) {
             for _ in 0..database_size {
                 let raw_query = IrisCode::random_rng(&mut rng);
                 let query = Arc::new(raw_query.clone());
+                let insertion_layer = searcher.select_layer(&mut rng).unwrap();
                 searcher
-                    .insert(&mut vector, &mut graph, &query, &mut rng)
+                    .insert(&mut vector, &mut graph, &query, insertion_layer)
                     .await
                     .unwrap();
             }
@@ -68,8 +69,9 @@ fn bench_plaintext_hnsw(c: &mut Criterion) {
                     let mut rng = AesRng::seed_from_u64(0_u64);
                     let on_the_fly_query = IrisDB::new_random_rng(1, &mut rng).db[0].clone();
                     let query = Arc::new(on_the_fly_query);
+                    let insertion_layer = searcher.select_layer(&mut rng).unwrap();
                     searcher
-                        .insert(&mut db_vectors, &mut graph, &query, &mut rng)
+                        .insert(&mut db_vectors, &mut graph, &query, insertion_layer)
                         .await
                         .unwrap();
                 },
@@ -252,8 +254,14 @@ fn bench_gr_ready_made_hnsw(c: &mut Criterion) {
                             let mut graph_store = graph_store;
                             jobs.spawn(async move {
                                 let mut vector_store = vector_store.lock().await;
+                                let insertion_layer = searcher.select_layer(&mut rng).unwrap();
                                 searcher
-                                    .insert(&mut *vector_store, &mut graph_store, &query, &mut rng)
+                                    .insert(
+                                        &mut *vector_store,
+                                        &mut graph_store,
+                                        &query,
+                                        insertion_layer,
+                                    )
                                     .await
                                     .unwrap();
                             });

--- a/iris-mpc-cpu/benches/hnsw.rs
+++ b/iris-mpc-cpu/benches/hnsw.rs
@@ -52,7 +52,7 @@ fn bench_plaintext_hnsw(c: &mut Criterion) {
             for _ in 0..database_size {
                 let raw_query = IrisCode::random_rng(&mut rng);
                 let query = Arc::new(raw_query.clone());
-                let insertion_layer = searcher.select_layer(&mut rng).unwrap();
+                let insertion_layer = searcher.select_layer_rng(&mut rng).unwrap();
                 searcher
                     .insert(&mut vector, &mut graph, &query, insertion_layer)
                     .await
@@ -69,7 +69,7 @@ fn bench_plaintext_hnsw(c: &mut Criterion) {
                     let mut rng = AesRng::seed_from_u64(0_u64);
                     let on_the_fly_query = IrisDB::new_random_rng(1, &mut rng).db[0].clone();
                     let query = Arc::new(on_the_fly_query);
-                    let insertion_layer = searcher.select_layer(&mut rng).unwrap();
+                    let insertion_layer = searcher.select_layer_rng(&mut rng).unwrap();
                     searcher
                         .insert(&mut db_vectors, &mut graph, &query, insertion_layer)
                         .await
@@ -254,7 +254,7 @@ fn bench_gr_ready_made_hnsw(c: &mut Criterion) {
                             let mut graph_store = graph_store;
                             jobs.spawn(async move {
                                 let mut vector_store = vector_store.lock().await;
-                                let insertion_layer = searcher.select_layer(&mut rng).unwrap();
+                                let insertion_layer = searcher.select_layer_rng(&mut rng).unwrap();
                                 searcher
                                     .insert(
                                         &mut *vector_store,

--- a/iris-mpc-cpu/bin/hnsw_algorithm_metrics.rs
+++ b/iris-mpc-cpu/bin/hnsw_algorithm_metrics.rs
@@ -97,7 +97,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     for idx in 0..database_size {
         let raw_query = IrisCode::random_rng(&mut rng);
         let query = Arc::new(raw_query.clone());
-        let insertion_layer = searcher.select_layer(&mut rng)?;
+        let insertion_layer = searcher.select_layer_rng(&mut rng)?;
         searcher
             .insert(&mut vector, &mut graph, &query, insertion_layer)
             .await?;

--- a/iris-mpc-cpu/bin/hnsw_algorithm_metrics.rs
+++ b/iris-mpc-cpu/bin/hnsw_algorithm_metrics.rs
@@ -97,8 +97,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
     for idx in 0..database_size {
         let raw_query = IrisCode::random_rng(&mut rng);
         let query = Arc::new(raw_query.clone());
+        let insertion_layer = searcher.select_layer(&mut rng)?;
         searcher
-            .insert(&mut vector, &mut graph, &query, &mut rng)
+            .insert(&mut vector, &mut graph, &query, insertion_layer)
             .await?;
 
         if idx % 1000 == 999 {

--- a/iris-mpc-cpu/bin/hnsw_network_stats_example.rs
+++ b/iris-mpc-cpu/bin/hnsw_network_stats_example.rs
@@ -72,7 +72,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         let mut graph_store = graph_store;
         jobs.spawn(async move {
             let mut vector_store = vector_store.lock().await;
-            let insertion_layer = searcher.select_layer(&mut rng).unwrap();
+            let insertion_layer = searcher.select_layer_rng(&mut rng).unwrap();
             searcher
                 .insert(
                     &mut *vector_store,

--- a/iris-mpc-cpu/bin/hnsw_network_stats_example.rs
+++ b/iris-mpc-cpu/bin/hnsw_network_stats_example.rs
@@ -72,8 +72,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
         let mut graph_store = graph_store;
         jobs.spawn(async move {
             let mut vector_store = vector_store.lock().await;
+            let insertion_layer = searcher.select_layer(&mut rng).unwrap();
             searcher
-                .insert(&mut *vector_store, &mut graph_store, &query, &mut rng)
+                .insert(
+                    &mut *vector_store,
+                    &mut graph_store,
+                    &query,
+                    insertion_layer,
+                )
                 .instrument(party_span)
                 .await
                 .unwrap();

--- a/iris-mpc-cpu/bin/init_test_dbs.rs
+++ b/iris-mpc-cpu/bin/init_test_dbs.rs
@@ -354,7 +354,7 @@ async fn main() -> Result<()> {
                 let query = Arc::new(raw_query);
 
                 let inserted_id = vector_store.insert(&query).await;
-                let insertion_layer = searcher.select_layer_prf(&prf_seed, (inserted_id, side))?;
+                let insertion_layer = searcher.select_layer_prf(&prf_seed, &(inserted_id, side))?;
                 let (neighbors, set_ep) = searcher
                     .search_to_insert(&mut vector_store, &graph, &query, insertion_layer)
                     .await?;

--- a/iris-mpc-cpu/bin/init_test_dbs.rs
+++ b/iris-mpc-cpu/bin/init_test_dbs.rs
@@ -4,25 +4,18 @@ use aes_prng::AesRng;
 use clap::Parser;
 use iris_mpc_common::iris_db::iris::IrisCode;
 use iris_mpc_cpu::{
-    execution::{
-        hawk_main::{session_seeded_rng, StoreId, STORE_IDS},
-        session::SessionId,
-    },
+    execution::hawk_main::{StoreId, STORE_IDS},
     hawkers::plaintext_store::PlaintextStore,
     hnsw::{
         graph::test_utils::DbContext, vector_store::VectorStoreMut, GraphMem, HnswParams,
         HnswSearcher,
     },
     protocol::shared_iris::GaloisRingSharedIris,
-    py_bindings::{
-        io::{read_json, write_json},
-        limited_iterator,
-        plaintext_store::Base64IrisCode,
-    },
+    py_bindings::{limited_iterator, plaintext_store::Base64IrisCode},
 };
 use itertools::{izip, Itertools};
-use rand_chacha::ChaCha8Rng;
 
+use rand::SeedableRng;
 use serde_json::Deserializer;
 use tokio::{sync::mpsc, task::JoinSet};
 use tracing::{info, warn};
@@ -132,10 +125,10 @@ struct Args {
     #[clap(long("hnsw-p"), short('p'))]
     layer_probability: Option<f64>,
 
-    /// PRNG seed for HNSW insertion, used to select the layer at which new
+    /// PRF key for HNSW insertion, used to select the layer at which new
     /// elements are inserted into the hierarchical graph structure.
     #[clap(long, default_value = "0")]
-    hnsw_prng_seed: u64,
+    hnsw_prf_key: u64,
 
     /// PRNG seed for ABY3 MPC protocols, used for locally generating secret
     /// shares of iris codes.
@@ -168,9 +161,6 @@ impl Args {
     }
 }
 
-// Type: Random number generators used to transform plaintext into secret shares.
-type Rngs = (ChaCha8Rng, ChaCha8Rng, AesRng);
-
 // Convertor: Args -> HnswParams.
 impl From<&Args> for HnswParams {
     fn from(args: &Args) -> Self {
@@ -180,18 +170,6 @@ impl From<&Args> for HnswParams {
         }
 
         params
-    }
-}
-
-// Convertor: Args -> Rngs.
-impl From<&Args> for Rngs {
-    fn from(value: &Args) -> Self {
-        (
-            // Emulates session construction from `HawkActor::new_sessions` function call
-            session_seeded_rng(value.hnsw_prng_seed, StoreId::Left, SessionId(0)),
-            session_seeded_rng(value.hnsw_prng_seed, StoreId::Right, SessionId(1)),
-            <AesRng as rand::SeedableRng>::seed_from_u64(value.aby3_prng_seed),
-        )
     }
 }
 
@@ -219,26 +197,7 @@ async fn main() -> Result<()> {
         .map(|target| target.saturating_sub(n_existing_irises));
 
     info!("Setting hnsw pseudo-random number generators");
-    let (mut hnsw_rng_l, mut hnsw_rng_r, mut aby3_rng) = Rngs::from(&args);
-    let prng_state_filename = args.prng_state_file.into_os_string().into_string().unwrap();
-    if n_existing_irises > 0 {
-        if let Ok((rng_l, rng_r)) = read_json(&prng_state_filename) {
-            info!(
-                "Loaded intermediate HNSW PRNG state from file: {}",
-                prng_state_filename
-            );
-            hnsw_rng_l = rng_l;
-            hnsw_rng_r = rng_r;
-        } else {
-            warn!(
-                "Couldn't load intermediate HNSW PRNG state from file: {}",
-                prng_state_filename
-            );
-            warn!("Initialized PRNGs from explicit seeds");
-        }
-    } else {
-        info!("Initialized PRNGs from explicit seeds");
-    }
+    let mut aby3_rng = AesRng::seed_from_u64(args.aby3_prng_seed);
 
     info!("⚓ ANCHOR: Converting plaintext iris codes locally into secret shares");
 
@@ -378,15 +337,14 @@ async fn main() -> Result<()> {
     });
 
     info!("Initializing jobs to process plaintext iris codes");
-    let hnsw_rngs = [hnsw_rng_l, hnsw_rng_r];
-    for (side, mut rx, mut vector_store, mut graph, mut hnsw_rng) in izip!(
+    for (side, mut rx, mut vector_store, mut graph) in izip!(
         STORE_IDS,
         receivers.into_iter(),
         vectors.into_iter(),
         graphs.into_iter(),
-        hnsw_rngs.into_iter()
     ) {
         let params = params.clone();
+        let prf_seed = (args.hnsw_prf_key as u128).to_le_bytes();
 
         jobs.spawn(async move {
             let searcher = HnswSearcher { params };
@@ -394,9 +352,20 @@ async fn main() -> Result<()> {
 
             while let Some(raw_query) = rx.recv().await {
                 let query = Arc::new(raw_query);
-                let insertion_layer = searcher.select_layer_rng(&mut hnsw_rng)?;
+
+                let inserted_id = vector_store.insert(&query).await;
+                let insertion_layer = searcher.select_layer_prf(&prf_seed, (inserted_id, side))?;
+                let (neighbors, set_ep) = searcher
+                    .search_to_insert(&mut vector_store, &graph, &query, insertion_layer)
+                    .await?;
                 searcher
-                    .insert(&mut vector_store, &mut graph, &query, insertion_layer)
+                    .insert_from_search_results(
+                        &mut vector_store,
+                        &mut graph,
+                        inserted_id,
+                        neighbors,
+                        set_ep,
+                    )
                     .await?;
 
                 counter += 1;
@@ -405,7 +374,7 @@ async fn main() -> Result<()> {
                 }
             }
 
-            Ok((side, vector_store, graph, hnsw_rng))
+            Ok((side, vector_store, graph))
         });
     }
 
@@ -425,8 +394,7 @@ async fn main() -> Result<()> {
         results[0].1.points.len()
     );
 
-    let (_, _, graph_r, hnsw_rng_r) = results.remove(1);
-    let (_, _, graph_l, hnsw_rng_l) = results.remove(0);
+    let [(.., graph_l), (.., graph_r)] = results.try_into().unwrap();
 
     for (party, db) in dbs.iter().enumerate() {
         for (graph, side) in [(&graph_l, StoreId::Left), (&graph_r, StoreId::Right)] {
@@ -434,12 +402,6 @@ async fn main() -> Result<()> {
             db.persist_graph_db(graph.clone(), side).await?;
         }
     }
-
-    info!(
-        "Writing HNSW PRNG intermediate state to file: {}",
-        prng_state_filename
-    );
-    write_json(&(hnsw_rng_l, hnsw_rng_r), &prng_state_filename)?;
 
     info!("Exited successfully! 🎉");
 

--- a/iris-mpc-cpu/bin/init_test_dbs.rs
+++ b/iris-mpc-cpu/bin/init_test_dbs.rs
@@ -394,8 +394,9 @@ async fn main() -> Result<()> {
 
             while let Some(raw_query) = rx.recv().await {
                 let query = Arc::new(raw_query);
+                let insertion_layer = searcher.select_layer(&mut hnsw_rng)?;
                 searcher
-                    .insert(&mut vector_store, &mut graph, &query, &mut hnsw_rng)
+                    .insert(&mut vector_store, &mut graph, &query, insertion_layer)
                     .await?;
 
                 counter += 1;

--- a/iris-mpc-cpu/bin/init_test_dbs.rs
+++ b/iris-mpc-cpu/bin/init_test_dbs.rs
@@ -394,7 +394,7 @@ async fn main() -> Result<()> {
 
             while let Some(raw_query) = rx.recv().await {
                 let query = Arc::new(raw_query);
-                let insertion_layer = searcher.select_layer(&mut hnsw_rng)?;
+                let insertion_layer = searcher.select_layer_rng(&mut hnsw_rng)?;
                 searcher
                     .insert(&mut vector_store, &mut graph, &query, insertion_layer)
                     .await?;

--- a/iris-mpc-cpu/examples/hnsw-ex.rs
+++ b/iris-mpc-cpu/examples/hnsw-ex.rs
@@ -26,8 +26,9 @@ fn main() -> Result<()> {
         for idx in 0..DATABASE_SIZE {
             let raw_query = IrisCode::random_rng(&mut rng);
             let query = Arc::new(raw_query);
+            let insertion_layer = searcher.select_layer(&mut rng)?;
             searcher
-                .insert(&mut vector, &mut graph, &query, &mut rng)
+                .insert(&mut vector, &mut graph, &query, insertion_layer)
                 .await?;
             if idx % 100 == 99 {
                 println!("{}", idx + 1);

--- a/iris-mpc-cpu/examples/hnsw-ex.rs
+++ b/iris-mpc-cpu/examples/hnsw-ex.rs
@@ -26,7 +26,7 @@ fn main() -> Result<()> {
         for idx in 0..DATABASE_SIZE {
             let raw_query = IrisCode::random_rng(&mut rng);
             let query = Arc::new(raw_query);
-            let insertion_layer = searcher.select_layer(&mut rng)?;
+            let insertion_layer = searcher.select_layer_rng(&mut rng)?;
             searcher
                 .insert(&mut vector, &mut graph, &query, insertion_layer)
                 .await?;

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -2,6 +2,7 @@ use super::player::Identity;
 pub use crate::hawkers::aby3::aby3_store::VectorId;
 use crate::{
     execution::{
+        hawk_main::search::SearchIds,
         local::generate_local_identities,
         player::{Role, RoleAssignment},
         session::{NetworkSession, Session, SessionId},
@@ -17,12 +18,12 @@ use crate::{
     network::grpc::{GrpcConfig, GrpcHandle, GrpcNetworking},
     proto_generated::party_node::party_node_server::PartyNodeServer,
     protocol::{
-        ops::{setup_replicated_prf, setup_shared_rng},
+        ops::{setup_replicated_prf, setup_shared_seed},
         shared_iris::GaloisRingSharedIris,
     },
 };
 use clap::Parser;
-use eyre::Result;
+use eyre::{eyre, OptionExt, Report, Result};
 use futures::try_join;
 use intra_batch::intra_batch_is_match;
 use iris_mpc_common::helpers::sync::ModificationKey;
@@ -42,7 +43,7 @@ use matching::{
     OnlyOrBoth::{Both, Only},
     RequestType, UniquenessRequest,
 };
-use rand::{thread_rng, Rng, RngCore, SeedableRng};
+use rand::{thread_rng, Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use reset::{apply_deletions, search_to_reset, ResetPlan, ResetRequests};
 use scheduler::parallelize;
@@ -55,7 +56,7 @@ use std::{
     hash::{Hash, Hasher},
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     ops::Not,
-    sync::Arc,
+    sync::{Arc, OnceLock},
     time::{Duration, Instant},
     vec,
 };
@@ -113,7 +114,7 @@ pub struct HawkArgs {
     pub hnsw_param_ef_search: usize,
 
     #[clap(long)]
-    pub hnsw_prng_seed: Option<u64>,
+    pub hnsw_prf_key: Option<u64>,
 
     #[clap(long, default_value_t = false)]
     pub disable_persistence: bool,
@@ -132,6 +133,7 @@ pub struct HawkActor {
 
     // ---- Shared setup ----
     searcher: Arc<HnswSearcher>,
+    prf_key: OnceLock<Arc<[u8; 16]>>,
     role_assignments: Arc<HashMap<Role, Identity>>,
     consensus: Consensus,
 
@@ -157,6 +159,20 @@ pub enum StoreId {
 pub const LEFT: usize = 0;
 pub const RIGHT: usize = 1;
 pub const STORE_IDS: BothEyes<StoreId> = [StoreId::Left, StoreId::Right];
+
+impl TryFrom<usize> for StoreId {
+    type Error = Report;
+
+    fn try_from(value: usize) -> std::result::Result<Self, Self::Error> {
+        match value {
+            0 => Ok(StoreId::Left),
+            1 => Ok(StoreId::Right),
+            _ => Err(eyre!(
+                "Invalid usize representation of StoreId, valid inputs are 0 (left) and 1 (right)"
+            )),
+        }
+    }
+}
 
 // TODO: Merge with the same in iris-mpc-gpu.
 // Orientation enum to indicate the orientation of the iris code during the batch processing.
@@ -204,7 +220,7 @@ pub type GraphMut<'a> = RwLockWriteGuard<'a, GraphMem<Aby3Store>>;
 pub struct HawkSession {
     aby3_store: Aby3Store,
     graph_store: GraphRef,
-    shared_rng: Box<dyn RngCore + Send + Sync>,
+    hnsw_prf_key: Arc<[u8; 16]>,
 }
 
 // Thread safe reference to a HakwSession instance.
@@ -353,6 +369,7 @@ impl HawkActor {
         Ok(HawkActor {
             args: args.clone(),
             searcher,
+            prf_key: OnceLock::new(),
             db_size: 0,
             iris_store,
             graph_store,
@@ -377,13 +394,64 @@ impl HawkActor {
         self.graph_store[store_id as usize].clone()
     }
 
+    /// Initialize the shared PRF key for HNSW graph insertion layer selection.
+    ///
+    /// The PRF key is either statically injected via configuration in TEST environments or
+    /// mutually derived with other MPC parties in PROD environments.
+    ///
+    /// This PRF key is used to determine insertion heights for new elements added to the
+    /// HNSW graphs, so is configured to be equal across all sessions, and initialized once
+    /// upon startup of the `HawkActor` instance.
+    pub async fn try_init_prf_key(&mut self) -> Result<()> {
+        if self.prf_key.get().is_none() {
+            let prf_key_ = if let Some(prf_key) = self.args.hnsw_prf_key {
+                tracing::info!("Initializing HNSW shared PRF key to static value {prf_key:?}");
+                (prf_key as u128).to_le_bytes()
+            } else {
+                let init_session_id = self.consensus.next_session_id();
+                let grpc_session = self.networking.create_session(init_session_id).await?;
+
+                let mut network_session = NetworkSession {
+                    session_id: init_session_id,
+                    role_assignments: self.role_assignments.clone(),
+                    networking: Box::new(grpc_session),
+                    own_role: Role::new(self.party_id),
+                };
+
+                tracing::info!("Initializing HNSW shared PRF key to mutually derived random value");
+                let my_prf_key = thread_rng().gen();
+                setup_shared_seed(&mut network_session, my_prf_key)
+                    .await
+                    .unwrap_or_else(|err| {
+                        tracing::warn!("Unable to initialize shared HNSW PRF key: {err}");
+                        tracing::warn!("Using default PRF key value [0u8; 16]");
+                        [0u8; 16]
+                    })
+            };
+            let prf_key = Arc::new(prf_key_);
+
+            self.prf_key
+                .set(prf_key)
+                .map_err(|err| eyre!("Unable to set HawkActor prf_key field: {err:?}"))?;
+        }
+
+        Ok(())
+    }
+
     pub async fn new_sessions(&mut self) -> Result<BothEyes<Vec<HawkSessionRef>>> {
+        self.try_init_prf_key().await?;
+        let hnsw_prf_key = self
+            .prf_key
+            .get()
+            .ok_or_eyre("HNSW PRF key not initialized on session creation")?
+            .clone();
+
         // Futures to create sessions, ids interleaved by side: (Left, 0), (Right, 1), (Left, 2), (Right, 3), ...
         let (sessions_left, sessions_right): (Vec<_>, Vec<_>) = (0..self.args.request_parallelism)
             .map(|_| {
                 let mut new_for_side_future = |store_id: StoreId| {
                     let session_id = self.consensus.next_session_id();
-                    self.create_session(store_id, session_id)
+                    self.create_session(store_id, session_id, &hnsw_prf_key)
                 };
 
                 (
@@ -405,13 +473,14 @@ impl HawkActor {
         &self,
         store_id: StoreId,
         session_id: SessionId,
+        hnsw_prf_key: &Arc<[u8; 16]>,
     ) -> impl Future<Output = Result<HawkSessionRef>> {
         let networking = self.networking.clone();
         let role_assignments = self.role_assignments.clone();
         let storage = self.iris_store(store_id);
         let graph_store = self.graph_store(store_id);
         let party_id = self.party_id;
-        let hnsw_prng_seed = self.args.hnsw_prng_seed;
+        let hnsw_prf_key = hnsw_prf_key.clone();
 
         async move {
             let grpc_session = networking.create_session(session_id).await?;
@@ -426,18 +495,6 @@ impl HawkActor {
             let my_session_seed = thread_rng().gen();
             let prf = setup_replicated_prf(&mut network_session, my_session_seed).await?;
 
-            // PRNG seed is either statically injected via configuration in TEST environments or
-            // mutually derived with other MPC parties in PROD environments.
-            let shared_rng: Box<dyn RngCore + Send + Sync> = if let Some(base_seed) = hnsw_prng_seed
-            {
-                let rng = session_seeded_rng(base_seed, store_id, session_id);
-                Box::new(rng)
-            } else {
-                let my_rng_seed = thread_rng().gen();
-                let rng = setup_shared_rng(&mut network_session, my_rng_seed).await?;
-                Box::new(rng)
-            };
-
             let hawk_session = HawkSession {
                 aby3_store: Aby3Store {
                     session: Session {
@@ -447,7 +504,7 @@ impl HawkActor {
                     storage,
                 },
                 graph_store,
-                shared_rng,
+                hnsw_prf_key,
             };
 
             Ok(Arc::new(RwLock::new(hawk_session)))
@@ -682,6 +739,7 @@ pub struct HawkRequest {
     batch: BatchQuery,
     queries: SearchQueries,
     queries_mirror: SearchQueries,
+    ids: SearchIds,
 }
 
 // TODO: Unify `BatchQuery` and `HawkRequest`.
@@ -759,12 +817,15 @@ impl From<BatchQuery> for HawkRequest {
             Arc::new(queries)
         };
 
+        let ids = Arc::new(batch.request_ids.clone());
+
         assert_eq!(n_queries, batch.request_types.len());
         assert_eq!(n_queries, batch.or_rule_indices.len());
         Self {
             queries: extract_queries(Orientation::Normal),
             queries_mirror: extract_queries(Orientation::Mirror),
             batch,
+            ids,
         }
     }
 }
@@ -859,6 +920,7 @@ impl HawkRequest {
         });
         ResetRequests {
             vector_ids: iris_store.from_0_indices(&self.batch.reset_update_indices),
+            request_ids: Arc::new(self.batch.reset_update_request_ids.clone()),
             queries: Arc::new(queries),
         }
     }
@@ -1234,11 +1296,13 @@ impl HawkHandle {
 
             // Search for nearest neighbors.
             // For both eyes, all requests, and rotations.
+            let search_ids = &request.ids;
             let search_params = SearchParams {
                 hnsw: hawk_actor.searcher(),
                 do_match: true,
             };
-            let search_results = search::search(sessions, search_queries, search_params).await?;
+            let search_results =
+                search::search(sessions, search_queries, search_ids, search_params).await?;
 
             let match_result = {
                 let step1 = matching::BatchStep1::new(&search_results, &luc_ids, request_types);
@@ -1778,7 +1842,7 @@ mod tests_db {
             hnsw_param_ef_constr: 320,
             hnsw_param_M: 256,
             hnsw_param_ef_search: 256,
-            hnsw_prng_seed: None,
+            hnsw_prf_key: None,
             match_distances_buffer_size: 64,
             n_buckets: 10,
             disable_persistence: false,

--- a/iris-mpc-cpu/src/execution/hawk_main/reset.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/reset.rs
@@ -6,11 +6,12 @@ use super::{
     BothEyes, HawkActor, HawkRequest, HawkSessionRef, LEFT, RIGHT,
 };
 pub use crate::hawkers::aby3::aby3_store::VectorId;
-use crate::protocol::shared_iris::GaloisRingSharedIris;
+use crate::{execution::hawk_main::search::SearchIds, protocol::shared_iris::GaloisRingSharedIris};
 use eyre::Result;
 
 pub struct ResetRequests {
     pub vector_ids: Vec<VectorId>,
+    pub request_ids: SearchIds,
     pub queries: SearchQueries<WithoutRot>,
 }
 
@@ -38,7 +39,13 @@ pub async fn search_to_reset(
 
     Ok(ResetPlan {
         vector_ids: updates.vector_ids,
-        search_results: search::search(sessions, &updates.queries, search_params).await?,
+        search_results: search::search(
+            sessions,
+            &updates.queries,
+            &updates.request_ids,
+            search_params,
+        )
+        .await?,
     })
 }
 

--- a/iris-mpc-cpu/src/execution/hawk_main/scheduler.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/scheduler.rs
@@ -29,9 +29,10 @@ pub struct Batch {
 /// A task within a batch is something to do with one rotation of one request.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Task {
-    i_eye: usize,
+    pub i_eye: usize,
     pub i_request: usize,
     pub i_rotation: usize,
+    pub is_central: bool,
 }
 
 impl Task {
@@ -65,6 +66,7 @@ impl Schedule {
                         i_eye,
                         i_request,
                         i_rotation,
+                        is_central: (i_rotation == self.n_rotations / 2),
                     })
                 });
 
@@ -97,6 +99,7 @@ impl Schedule {
                                 i_eye,
                                 i_request,
                                 i_rotation,
+                                is_central: (i_rotation == self.n_rotations / 2),
                             };
                             results
                                 .remove(&task.id())

--- a/iris-mpc-cpu/src/execution/hawk_main/search.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/search.rs
@@ -80,7 +80,9 @@ async fn per_query(
     search_params: &SearchParams,
     graph_store: &GraphMem<Aby3Store>,
 ) -> Result<InsertPlan> {
-    let insertion_layer = search_params.hnsw.select_layer(&mut session.shared_rng)?;
+    let insertion_layer = search_params
+        .hnsw
+        .select_layer_rng(&mut session.shared_rng)?;
 
     let (links, set_ep) = search_params
         .hnsw
@@ -121,7 +123,7 @@ pub async fn search_single_query_no_match_count(
     let mut session = session.write().await;
 
     let graph = session.graph_store.clone().read_owned().await;
-    let insertion_layer = searcher.select_layer(&mut session.shared_rng)?;
+    let insertion_layer = searcher.select_layer_rng(&mut session.shared_rng)?;
 
     let (links, set_ep) = searcher
         .search_to_insert(&mut session.aby3_store, &graph, &query, insertion_layer)

--- a/iris-mpc-cpu/src/genesis/hawk_handle.rs
+++ b/iris-mpc-cpu/src/genesis/hawk_handle.rs
@@ -5,7 +5,7 @@ use super::{
 };
 use crate::execution::hawk_main::{
     insert::insert, scheduler::parallelize, search::search_single_query_no_match_count, BothEyes,
-    HawkActor, HawkMutation, HawkSession, HawkSessionRef, SingleHawkMutation, LEFT, RIGHT,
+    HawkActor, HawkMutation, HawkSession, HawkSessionRef, SingleHawkMutation, LEFT, RIGHT, STORE_IDS,
 };
 use eyre::{OptionExt, Result};
 use itertools::{izip, Itertools};
@@ -112,11 +112,9 @@ impl Handle {
         // Use all sessions per iris side to search for insertion indices per
         // batch, number configured by `args.request_parallelism`.
 
-        // TODO implement automatic parallelism scaling
-
         // Iterate per side
-        let jobs_per_side = izip!(request.queries.iter(), sessions.iter())
-            .map(|(queries_side, sessions_side)| {
+        let jobs_per_side = izip!(STORE_IDS, request.queries.iter(), sessions.iter())
+            .map(|(side, queries_side, sessions_side)| {
                 let searcher = actor.searcher();
                 let queries_with_ids =
                     izip!(queries_side.clone(), request.vector_ids.clone()).collect_vec();
@@ -132,13 +130,16 @@ impl Handle {
                     // Process queries in a logical insertion batch for this side
                     for queries_batch in queries_with_ids.chunks(n_sessions) {
                         let search_jobs = izip!(queries_batch.iter(), sessions.iter()).map(
-                            |((query, _id), session)| {
+                            |((query, id), session)| {
                                 let query = query.clone();
                                 let searcher = searcher.clone();
                                 let session = session.clone();
+                                let identifier = (*id, side);
                                 async move {
-                                    search_single_query_no_match_count(session, query, &searcher)
-                                        .await
+                                    search_single_query_no_match_count(
+                                        session, query, &searcher, &identifier,
+                                    )
+                                    .await
                                 }
                             },
                         );

--- a/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
@@ -498,7 +498,7 @@ mod tests {
                 let mut inserted = vec![];
                 // insert queries
                 for query in queries.iter() {
-                    let insertion_layer = db.select_layer(&mut rng).unwrap();
+                    let insertion_layer = db.select_layer_rng(&mut rng).unwrap();
                     let inserted_vector = db
                         .insert(&mut *store, &mut aby3_graph, query, insertion_layer)
                         .await

--- a/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
@@ -498,8 +498,9 @@ mod tests {
                 let mut inserted = vec![];
                 // insert queries
                 for query in queries.iter() {
+                    let insertion_layer = db.select_layer(&mut rng).unwrap();
                     let inserted_vector = db
-                        .insert(&mut *store, &mut aby3_graph, query, &mut rng)
+                        .insert(&mut *store, &mut aby3_graph, query, insertion_layer)
                         .await
                         .unwrap();
                     inserted.push(inserted_vector)

--- a/iris-mpc-cpu/src/hawkers/aby3/test_utils.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3/test_utils.rs
@@ -328,8 +328,9 @@ pub async fn shared_random_setup<R: RngCore + Clone + CryptoRng>(
                 let searcher = HnswSearcher::new_with_test_parameters();
                 // insert queries
                 for query in queries.iter() {
+                    let insertion_layer = searcher.select_layer(&mut rng_searcher)?;
                     searcher
-                        .insert(&mut *store_lock, &mut graph_store, query, &mut rng_searcher)
+                        .insert(&mut *store_lock, &mut graph_store, query, insertion_layer)
                         .await?;
                 }
                 Ok((store.clone(), graph_store))

--- a/iris-mpc-cpu/src/hawkers/aby3/test_utils.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3/test_utils.rs
@@ -328,7 +328,7 @@ pub async fn shared_random_setup<R: RngCore + Clone + CryptoRng>(
                 let searcher = HnswSearcher::new_with_test_parameters();
                 // insert queries
                 for query in queries.iter() {
-                    let insertion_layer = searcher.select_layer(&mut rng_searcher)?;
+                    let insertion_layer = searcher.select_layer_rng(&mut rng_searcher)?;
                     searcher
                         .insert(&mut *store_lock, &mut graph_store, query, insertion_layer)
                         .await?;

--- a/iris-mpc-cpu/src/hawkers/plaintext_store.rs
+++ b/iris-mpc-cpu/src/hawkers/plaintext_store.rs
@@ -56,7 +56,7 @@ impl PlaintextStore {
         for idx in 0..graph_size {
             let query = self.points[idx].clone();
             let query_id = VectorId::from_0_index(idx as u32);
-            let insertion_layer = searcher.select_layer(&mut rng)?;
+            let insertion_layer = searcher.select_layer_rng(&mut rng)?;
             let (neighbors, set_ep) = searcher
                 .search_to_insert(self, &graph, &query, insertion_layer)
                 .await?;

--- a/iris-mpc-cpu/src/hnsw/graph/graph_store.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/graph_store.rs
@@ -633,7 +633,7 @@ mod tests {
         // Insert the codes.
         let mut tx = graph_pg.tx().await?;
         for query in queries1.iter() {
-            let insertion_layer = db.select_layer(rng)?;
+            let insertion_layer = db.select_layer_rng(rng)?;
             let (neighbors, set_ep) = db
                 .search_to_insert(vector_store, graph_mem, query, insertion_layer)
                 .await?;

--- a/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
@@ -333,7 +333,7 @@ mod tests {
 
         for raw_query in raw_queries.db {
             let query = Arc::new(raw_query);
-            let insertion_layer = searcher.select_layer(&mut rng)?;
+            let insertion_layer = searcher.select_layer_rng(&mut rng)?;
             let (neighbors, set_ep) = searcher
                 .search_to_insert(&mut vector_store, &graph_store, &query, insertion_layer)
                 .await?;
@@ -372,7 +372,7 @@ mod tests {
 
         for raw_query in IrisDB::new_random_rng(20, &mut rng).db {
             let query = Arc::new(raw_query);
-            let insertion_layer = searcher.select_layer(&mut rng)?;
+            let insertion_layer = searcher.select_layer_rng(&mut rng)?;
             let (neighbors, set_ep) = searcher
                 .search_to_insert(&mut vector_store, &graph_store, &query, insertion_layer)
                 .await?;

--- a/iris-mpc-cpu/src/hnsw/searcher.rs
+++ b/iris-mpc-cpu/src/hnsw/searcher.rs
@@ -13,12 +13,17 @@ use crate::hnsw::{
     graph::neighborhood::SortedEdgeIds, metrics::ops_counter::Operation, GraphMem,
     SortedNeighborhood, VectorStore,
 };
+use aes_prng::AesRng;
 use eyre::{bail, eyre, Result};
 use itertools::{izip, Itertools};
-use rand::RngCore;
+use rand::{RngCore, SeedableRng};
 use rand_distr::{Distribution, Geometric};
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use siphasher::sip::SipHasher13;
+use std::{
+    collections::HashSet,
+    hash::{Hash, Hasher},
+};
 use tracing::{debug, instrument, trace_span, Instrument};
 
 /// The number of explicitly provided parameters for different layers of HNSW
@@ -237,6 +242,28 @@ impl HnswSearcher {
         let geom_distr = Geometric::new(p_geom)?;
 
         Ok(geom_distr.sample(rng) as usize)
+    }
+
+    /// Choose a random insertion layer from a geometric distribution, producing
+    /// graph layers which decrease in density by a constant factor per layer.
+    ///
+    /// Generates the layer value based on the evaluation of a keyed PRF on a
+    /// hashable input identifier `value`, for instance a vector id or a request id.
+    pub fn select_layer_prf<H: Hash>(&self, prf_key: &[u8; 16], value: H) -> Result<usize> {
+        // produce `value_hash` from `value` using `SipHasher13`, keyed with `prf_key`
+        let mut hasher = SipHasher13::new_with_key(prf_key);
+        value.hash(&mut hasher);
+        let value_hash: u64 = hasher.finish();
+
+        // initialize `AesRng` with seed `prf_key ^ (value_hash || value_hash)`
+        let mut rng_seed = *prf_key;
+        for (idx, byte) in value_hash.to_le_bytes().into_iter().enumerate() {
+            rng_seed[idx] ^= byte;
+            rng_seed[idx + 8] ^= byte;
+        }
+        let mut rng = AesRng::from_seed(rng_seed);
+
+        self.select_layer(&mut rng)
     }
 
     /// Return a tuple containing a distance-sorted list initialized with the

--- a/iris-mpc-cpu/src/hnsw/searcher.rs
+++ b/iris-mpc-cpu/src/hnsw/searcher.rs
@@ -249,7 +249,7 @@ impl HnswSearcher {
     ///
     /// Generates the layer value based on the evaluation of a keyed PRF on a
     /// hashable input identifier `value`, for instance a vector id or a request id.
-    pub fn select_layer_prf<H: Hash>(&self, prf_key: &[u8; 16], value: H) -> Result<usize> {
+    pub fn select_layer_prf<H: Hash>(&self, prf_key: &[u8; 16], value: &H) -> Result<usize> {
         // produce `value_hash` from `value` using `SipHasher13`, keyed with `prf_key`
         let mut hasher = SipHasher13::new_with_key(prf_key);
         value.hash(&mut hasher);

--- a/iris-mpc-cpu/src/hnsw/searcher.rs
+++ b/iris-mpc-cpu/src/hnsw/searcher.rs
@@ -828,9 +828,8 @@ impl HnswSearcher {
         store: &mut V,
         graph: &mut GraphMem<V>,
         query: &V::QueryRef,
-        rng: &mut impl RngCore,
+        insertion_layer: usize,
     ) -> Result<V::VectorRef> {
-        let insertion_layer = self.select_layer(rng)?;
         let (neighbors, set_ep) = self
             .search_to_insert(store, graph, query, insertion_layer)
             .await?;
@@ -1124,7 +1123,9 @@ mod tests {
 
         // Insert the codes with helper function
         for query in queries2.iter() {
-            db.insert(vector_store, graph_store, query, rng).await?;
+            let insertion_layer = db.select_layer(rng)?;
+            db.insert(vector_store, graph_store, query, insertion_layer)
+                .await?;
         }
 
         // Search for the same codes and find matches.

--- a/iris-mpc-cpu/src/hnsw/searcher.rs
+++ b/iris-mpc-cpu/src/hnsw/searcher.rs
@@ -237,7 +237,7 @@ impl HnswSearcher {
 
     /// Choose a random insertion layer from a geometric distribution, producing
     /// graph layers which decrease in density by a constant factor per layer.
-    pub fn select_layer(&self, rng: &mut impl RngCore) -> Result<usize> {
+    pub fn select_layer_rng(&self, rng: &mut impl RngCore) -> Result<usize> {
         let p_geom = 1f64 - self.params.get_layer_probability();
         let geom_distr = Geometric::new(p_geom)?;
 
@@ -263,7 +263,7 @@ impl HnswSearcher {
         }
         let mut rng = AesRng::from_seed(rng_seed);
 
-        self.select_layer(&mut rng)
+        self.select_layer_rng(&mut rng)
     }
 
     /// Return a tuple containing a distance-sorted list initialized with the
@@ -1104,7 +1104,7 @@ mod tests {
 
         // Insert the codes.
         for query in queries1.iter() {
-            let insertion_layer = db.select_layer(rng)?;
+            let insertion_layer = db.select_layer_rng(rng)?;
             let (neighbors, set_ep) = db
                 .search_to_insert(vector_store, graph_store, query, insertion_layer)
                 .await?;
@@ -1123,7 +1123,7 @@ mod tests {
 
         // Insert the codes with helper function
         for query in queries2.iter() {
-            let insertion_layer = db.select_layer(rng)?;
+            let insertion_layer = db.select_layer_rng(rng)?;
             db.insert(vector_store, graph_store, query, insertion_layer)
                 .await?;
         }

--- a/iris-mpc-cpu/src/py_bindings/hnsw.rs
+++ b/iris-mpc-cpu/src/py_bindings/hnsw.rs
@@ -43,7 +43,7 @@ pub fn insert(
         let mut rng = ThreadRng::default();
 
         let query = Arc::new(iris);
-        let insertion_layer = searcher.select_layer(&mut rng).unwrap();
+        let insertion_layer = searcher.select_layer_rng(&mut rng).unwrap();
         searcher
             .insert(vector, graph, &query, insertion_layer)
             .await
@@ -78,7 +78,7 @@ pub fn fill_uniform_random(
 
         for idx in 0..num {
             let query = Arc::new(IrisCode::random_rng(&mut rng));
-            let insertion_layer = searcher.select_layer(&mut rng).unwrap();
+            let insertion_layer = searcher.select_layer_rng(&mut rng).unwrap();
             searcher
                 .insert(vector, graph, &query, insertion_layer)
                 .await
@@ -116,7 +116,7 @@ pub fn fill_from_ndjson_file(
         for json_pt in stream {
             let raw_query = (&json_pt.unwrap()).into();
             let query = Arc::new(raw_query);
-            let insertion_layer = searcher.select_layer(&mut rng).unwrap();
+            let insertion_layer = searcher.select_layer_rng(&mut rng).unwrap();
             searcher
                 .insert(vector, graph, &query, insertion_layer)
                 .await

--- a/iris-mpc-cpu/src/py_bindings/hnsw.rs
+++ b/iris-mpc-cpu/src/py_bindings/hnsw.rs
@@ -43,8 +43,9 @@ pub fn insert(
         let mut rng = ThreadRng::default();
 
         let query = Arc::new(iris);
+        let insertion_layer = searcher.select_layer(&mut rng).unwrap();
         searcher
-            .insert(vector, graph, &query, &mut rng)
+            .insert(vector, graph, &query, insertion_layer)
             .await
             .unwrap()
     })
@@ -77,8 +78,9 @@ pub fn fill_uniform_random(
 
         for idx in 0..num {
             let query = Arc::new(IrisCode::random_rng(&mut rng));
+            let insertion_layer = searcher.select_layer(&mut rng).unwrap();
             searcher
-                .insert(vector, graph, &query, &mut rng)
+                .insert(vector, graph, &query, insertion_layer)
                 .await
                 .unwrap();
             if idx % 100 == 99 {
@@ -114,8 +116,9 @@ pub fn fill_from_ndjson_file(
         for json_pt in stream {
             let raw_query = (&json_pt.unwrap()).into();
             let query = Arc::new(raw_query);
+            let insertion_layer = searcher.select_layer(&mut rng).unwrap();
             searcher
-                .insert(vector, graph, &query, &mut rng)
+                .insert(vector, graph, &query, insertion_layer)
                 .await
                 .unwrap();
         }

--- a/iris-mpc-cpu/tests/e2e.rs
+++ b/iris-mpc-cpu/tests/e2e.rs
@@ -133,7 +133,7 @@ async fn e2e_test() -> Result<()> {
         hnsw_param_ef_constr: HNSW_EF_CONSTR,
         hnsw_param_M: HNSW_M,
         hnsw_param_ef_search: HNSW_EF_SEARCH,
-        hnsw_prng_seed: None,
+        hnsw_prf_key: None,
         disable_persistence: false,
         match_distances_buffer_size: 64,
         n_buckets: 10,

--- a/iris-mpc-upgrade-hawk/src/genesis/mod.rs
+++ b/iris-mpc-upgrade-hawk/src/genesis/mod.rs
@@ -628,7 +628,7 @@ async fn get_hawk_actor(config: &Config) -> Result<HawkActor> {
         hnsw_param_ef_constr: config.hnsw_param_ef_constr,
         hnsw_param_M: config.hnsw_param_M,
         hnsw_param_ef_search: config.hnsw_param_ef_search,
-        hnsw_prng_seed: config.hawk_prng_seed,
+        hnsw_prf_key: config.hawk_prf_key,
         disable_persistence: config.cpu_disable_persistence,
         match_distances_buffer_size: config.match_distances_buffer_size,
         n_buckets: config.n_buckets,

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -480,7 +480,7 @@ async fn init_hawk_actor(config: &Config) -> Result<HawkActor> {
         hnsw_param_ef_constr: config.hnsw_param_ef_constr,
         hnsw_param_M: config.hnsw_param_M,
         hnsw_param_ef_search: config.hnsw_param_ef_search,
-        hnsw_prng_seed: config.hawk_prng_seed,
+        hnsw_prf_key: config.hawk_prf_key,
         disable_persistence: config.cpu_disable_persistence,
         match_distances_buffer_size: config.match_distances_buffer_size,
         n_buckets: config.n_buckets,


### PR DESCRIPTION
This PR revises the method used by the main server executables for choosing random layers for insertion of new HNSW graph entries.  Instead of using an ongoing, stateful PRNG, the new approach uses a globally keyed PRF which takes as input a vector identifier -- either an enrollment request UUID + iris side for new insertions, or a vector id + iris side for insertions of irises with existing vector ids.  This makes the graph construction process less path-dependent, as the insertion layer for nodes no longer depends on ordering of PRNG calls and persistence of PRNG state across execution environments.  The functionality for selecting layers via a PRNG is still available, and is used in some tests, but the main server functionality now uses the PRF-based approach.