### PR TITLE
Cover edge case in sqs sync

### DIFF
--- a/iris-mpc-common/src/helpers/sync.rs
+++ b/iris-mpc-common/src/helpers/sync.rs
@@ -143,9 +143,26 @@ impl SyncResult {
     }
 
     pub fn max_sns_sequence_num(&self) -> Option<u128> {
-        self.all_states
+        let sequence_nums: Vec<Option<u128>> = self
+            .all_states
             .iter()
             .map(|s| s.next_sns_sequence_num)
+            .collect();
+
+        // All nodes should either have an empty queue or filled with some items.
+        // Otherwise, we can not conclude queue sync and proceed safely.
+        // More info: https://linear.app/worldcoin/issue/POP-2577/cover-edge-case-in-sqs-sync
+        let any_empty_queues = sequence_nums.iter().any(|seq| seq.is_none());
+        let any_non_empty_queues = sequence_nums.iter().any(|seq| seq.is_some());
+        if any_empty_queues && any_non_empty_queues {
+            panic!(
+                "Can not deduce max SNS sequence number safely out of {:?}. Restarting...",
+                sequence_nums
+            );
+        }
+
+        sequence_nums
+            .into_iter()
             .max()
             .expect("can get max u128 value")
     }
@@ -746,7 +763,7 @@ mod tests {
 
     #[test]
     fn test_max_sns_sequence_num() {
-        // 1. Test with mixed sequence values
+        // 1. Test with all Some sequence values
         let states = vec![
             SyncState {
                 db_len: 10,
@@ -763,7 +780,7 @@ mod tests {
             SyncState {
                 db_len: 30,
                 modifications: vec![],
-                next_sns_sequence_num: None,
+                next_sns_sequence_num: Some(150),
                 common_config: CommonConfig::default(),
             },
         ];
@@ -786,6 +803,37 @@ mod tests {
 
         let sync_result_none = SyncResult::new(state_with_none_sequence_num, all_states);
         assert_eq!(sync_result_none.max_sns_sequence_num(), None);
+    }
+
+    #[test]
+    #[should_panic(expected = "Can not deduce max SNS sequence number safely")]
+    fn test_max_sns_sequence_num_mixed_panic() {
+        // Test the edge case where some nodes have None while others have Some
+        // This should panic to prevent the batch mismatch described in the issue
+        let states = vec![
+            SyncState {
+                db_len: 10,
+                modifications: vec![],
+                next_sns_sequence_num: None, // NodeX - advanced but empty queue
+                common_config: CommonConfig::default(),
+            },
+            SyncState {
+                db_len: 20,
+                modifications: vec![],
+                next_sns_sequence_num: Some(123), // Other nodes still have messages
+                common_config: CommonConfig::default(),
+            },
+            SyncState {
+                db_len: 30,
+                modifications: vec![],
+                next_sns_sequence_num: Some(123),
+                common_config: CommonConfig::default(),
+            },
+        ];
+
+        let sync_result = SyncResult::new(states[0].clone(), states);
+        // This should panic due to inconsistent sequence numbers
+        sync_result.max_sns_sequence_num();
     }
 
     #[test]


### PR DESCRIPTION
## Problematic Scenario:

- NodeX is advanced, it deleted all items in queue while other nodes still have other items
- Nodes restart and sync
- NodeX returns None while others return some number for sns_sequence_num. Sequence numbers are: [None, Some(123), Some(123)]
- Other nodes think they're already the most advanced. They pass sync check.
- NodeX thinks it is behind although it’s the most advanced
- NodeX waits for a message from SQS so that it can delete all until 123. When it receives a message, it sees its seq num is already bigger than 123 and exits sync check.

## Change

- If some SQS is empty for some nodes and non-empty for others, panic to prevent batch mismatch. This will make nodes to restart and sync again until there is at least one message in all the queues. This way, we can safely deduce the max sns sequence number and discard the items until that