### PR TITLE
bump stage versions

### DIFF
--- a/.github/workflows/build-and-push-hawk-server.yaml
+++ b/.github/workflows/build-and-push-hawk-server.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  release:
+    types:
+      - 'published'
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'

--- a/deploy/stage/common-values-ampc-hnsw.yaml
+++ b/deploy/stage/common-values-ampc-hnsw.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc-cpu:460b1ccda48cd40778fd5b6f4ef886cc6c530cf5"
+image: "ghcr.io/worldcoin/iris-mpc-cpu:a440f07e9e4dc8bbda3e58595fa425c6dbbe5d84"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:e7a58f34db956a4c07819cfef07b80aec594c6eb"
+image: "ghcr.io/worldcoin/iris-mpc@sha256:23ab8cd9be91b8305012ef57e2247c2f0e1b7e522011a8381363d228a5aef9ca" # v0.20.0
 
 environment: stage
 replicaCount: 1


### PR DESCRIPTION
## Change
- Bump both GPU and HNSW stage versions to the latest main
- Trigger HNSW build and push on release so that we can easily compare things with GPU version. But keep `main` build and push trigger so that we don't need to trigger a release every time we develop smt on HNSW. We can remove `main` trigger once it's more stable and requires less development