### PR TITLE
Enable replaying reset check results & add HNSW reset results persistence (POP-2591 & POP-2589)

### DIFF
--- a/.github/workflows/temp-branch-build-and-push-hawk.yaml
+++ b/.github/workflows/temp-branch-build-and-push-hawk.yaml
@@ -3,7 +3,7 @@ name: Branch - Hawk Build and push docker image
 on:
   push:
     branches:
-      - "chore/hnsw-test-latest"
+      - "POP-2591/include-reset-check-messages-in-modifications-table"
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'

--- a/.github/workflows/temp-branch-build-and-push.yaml
+++ b/.github/workflows/temp-branch-build-and-push.yaml
@@ -3,7 +3,7 @@ name: Branch - Build and push docker image
 on:
   push:
     branches:
-      - "POP-2548/sync-graph-modifications-on-startup"
+      - "POP-2591/include-reset-check-messages-in-modifications-table"
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'

--- a/deploy/stage/common-values-ampc-hnsw.yaml
+++ b/deploy/stage/common-values-ampc-hnsw.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc-cpu:a440f07e9e4dc8bbda3e58595fa425c6dbbe5d84"
+image: "ghcr.io/worldcoin/iris-mpc-cpu:130450d3b6609cc3de8bd2daf6d15cf4cdca8434"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc@sha256:130450d3b6609cc3de8bd2daf6d15cf4cdca8434"
+image: "ghcr.io/worldcoin/iris-mpc:130450d3b6609cc3de8bd2daf6d15cf4cdca8434"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc@sha256:23ab8cd9be91b8305012ef57e2247c2f0e1b7e522011a8381363d228a5aef9ca" # v0.20.0
+image: "ghcr.io/worldcoin/iris-mpc@sha256:130450d3b6609cc3de8bd2daf6d15cf4cdca8434"
 
 environment: stage
 replicaCount: 1

--- a/iris-mpc-common/src/helpers/sync.rs
+++ b/iris-mpc-common/src/helpers/sync.rs
@@ -70,6 +70,10 @@ impl fmt::Debug for Modification {
             Some(bytes) => format!("Some([{} bytes])", bytes.len()),
             None => "None".to_string(),
         };
+        let result_message_summary = match &self.result_message_body {
+            Some(msg) => format!("Some([{} chars])", msg.chars().count()),
+            None => "None".to_string(),
+        };
 
         f.debug_struct("Modification")
             .field("id", &self.id)
@@ -78,7 +82,7 @@ impl fmt::Debug for Modification {
             .field("s3_url", &self.s3_url)
             .field("status", &self.status)
             .field("persisted", &self.persisted)
-            .field("result_message_body", &self.result_message_body)
+            .field("result_message_body", &result_message_summary)
             .field("graph_mutation", &graph_mutation_summary)
             .finish()
     }

--- a/iris-mpc/bin/server.rs
+++ b/iris-mpc/bin/server.rs
@@ -512,6 +512,21 @@ async fn receive_batch(
                         if config.enable_reset {
                             msg_counter += 1;
 
+                            // Persist in progress reset_check message.
+                            // Note that reset_check is only a query and does not persist anything into the database.
+                            // We store modification so that the SNS result can be replayed.
+                            let modification = store
+                                .insert_modification(
+                                    None,
+                                    RESET_CHECK_MESSAGE_TYPE,
+                                    Some(reset_check_request.s3_key.as_str()),
+                                )
+                                .await?;
+                            batch_modifications.insert(
+                                RequestId(reset_check_request.reset_id.clone()),
+                                modification,
+                            );
+
                             if let Some(batch_size) = reset_check_request.batch_size {
                                 *CURRENT_BATCH_SIZE.lock().unwrap() =
                                     batch_size.clamp(1, max_batch_size);
@@ -1607,9 +1622,17 @@ async fn server_main(config: Config) -> Result<()> {
                         Some(partial_match_counters_right[i]),
                         Some(partial_match_counters_left[i]),
                     );
+                    let result_string = serde_json::to_string(&result_event)
+                        .expect("failed to serialize reset check result");
 
-                    serde_json::to_string(&result_event)
-                        .expect("failed to serialize reset check result")
+                    // Mark the reset check modification as completed. 
+                    // Note that reset_check is only a query and does not persist anything into the database. 
+                    // We store modification so that the SNS result can be replayed.
+                    modifications
+                        .get_mut(&RequestId(reset_id))
+                        .unwrap()
+                        .mark_completed(false, &result_string, None, None);
+                    result_string
                 })
                 .collect::<Vec<String>>();
 

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -265,6 +265,7 @@ fn init_sns_attributes_maps() -> Result<SnsAttributesMaps> {
         create_message_type_attribute_map(ANONYMIZED_STATISTICS_MESSAGE_TYPE);
     let identity_deletion_result_attributes =
         create_message_type_attribute_map(IDENTITY_DELETION_MESSAGE_TYPE);
+
     Ok(SnsAttributesMaps {
         uniqueness_result_attributes,
         reauth_result_attributes,

--- a/iris-mpc/src/services/processors/batch.rs
+++ b/iris-mpc/src/services/processors/batch.rs
@@ -584,7 +584,9 @@ impl<'a> BatchProcessor<'a> {
             return Ok(());
         }
 
-        // Persist in progress modification
+        // Persist in progress reset_check message.
+        // Note that reset_check is only a query and does not persist anything into the database.
+        // We store modification so that the SNS result can be replayed.
         let modification = persist_modification(
             self.config.disable_persistence,
             self.iris_store,

--- a/iris-mpc/src/services/processors/job.rs
+++ b/iris-mpc/src/services/processors/job.rs
@@ -271,14 +271,14 @@ pub async fn process_job_result(
             let serial_id = reset_update_indices[i] + 1;
             let result_event = ResetUpdateAckResult::new(reset_id.clone(), party_id, serial_id);
             let result_string = serde_json::to_string(&result_event)
-                .expect("failed to serialize reset update result");
+                .wrap_err("failed to serialize reset update result")?;
             modifications
                 .get_mut(&RequestSerialId(serial_id))
                 .unwrap()
                 .mark_completed(true, &result_string, None, None);
-            result_string
+            Ok(result_string)
         })
-        .collect::<Vec<String>>();
+        .collect::<Result<Vec<_>>>()?;
 
     let mut iris_tx = store.tx().await?;
 


### PR DESCRIPTION
## Change
- All messages except `reset_check` was part of modifications table. This PR adds persisting `reset_check` modifications as well. Although they will always have `persisted=false`, we need to replay the SNS results upon restarts
- Persist reset update results into the database
- Send `reset_check` and `reset_update` results into SNS (as part main loop, in addition to initial results replay)
- Move deletion db persistence from pre-batch execution to post-batch execution so that we persist results in a single place with a single transaction. This was already implemented this way in GPU but it seems HNSW impl didn't match it
- Avoid persisting HNSW results if it's disabled
- Do not print SNS result body on modifications as they can get big sometimes and makes the log truncated by DD