### PR TITLE
Do not tolerate HNSW result sender failures

### DIFF
--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -35,6 +35,7 @@ use iris_mpc_cpu::hnsw::graph::graph_store::GraphPg;
 use iris_mpc_store::loader::load_iris_db;
 use iris_mpc_store::Store;
 use std::collections::HashMap;
+use std::process::exit;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -497,7 +498,8 @@ async fn start_results_thread(
             )
             .await
             {
-                tracing::error!("Error processing job result: {:?}", e);
+                tracing::error!("Error processing job result: {:?}. Exiting...", e);
+                exit(1);
             }
         }
 


### PR DESCRIPTION
## Change
- In GPU implementation, we crash if the result handler job fails (if we can not persist batch results or send result SNS messages) but HNSW implementation logs and continues. This PR makes HNSW crash upon server results handler failures
- Current behavior (not crashing) causes two main problems:
  - Some nodes could persist their changes and some not. If we continue the flow, those changes could not be in modifications lookback window when we restart next time and we could end up with differing dbs.
  - The requests could be stuck in `InProgress` state when we don't write SNS results