### PR TITLE
aurel/refactor-batch: Group related "pushes" into methods

### DIFF
--- a/iris-mpc-common/src/job.rs
+++ b/iris-mpc-common/src/job.rs
@@ -108,6 +108,49 @@ pub struct BatchQuery {
     pub full_face_mirror_attacks_detection_enabled: bool,
 }
 
+impl BatchQuery {
+    /// Add a Uniqueness, Reauth, or Reset Check request to the batch.
+    pub fn push_matching_request(
+        &mut self,
+        request_id: String,
+        request_type: &str,
+        metadata: BatchMetadata,
+        or_rule_indices: Vec<u32>,
+        skip_persistence: bool,
+    ) {
+        self.requests_order
+            .push(RequestIndex::UniqueReauthResetCheck(self.request_ids.len()));
+        self.request_ids.push(request_id);
+        self.request_types.push(request_type.to_string());
+        self.metadata.push(metadata);
+        self.or_rule_indices.push(or_rule_indices);
+        self.skip_persistence.push(skip_persistence);
+    }
+
+    /// Add a Deletion request to the batch.
+    pub fn push_deletion_request(&mut self, deletion_0_index: u32, metadata: BatchMetadata) {
+        self.requests_order
+            .push(RequestIndex::Deletion(self.deletion_requests_indices.len()));
+        self.deletion_requests_indices.push(deletion_0_index);
+        self.deletion_requests_metadata.push(metadata);
+    }
+
+    /// Add a Reset Update request to the batch.
+    pub fn push_reset_update_request(
+        &mut self,
+        request_id: String,
+        reset_update_0_index: u32,
+        shares: GaloisSharesBothSides,
+    ) {
+        self.requests_order.push(RequestIndex::ResetUpdate(
+            self.reset_update_request_ids.len(),
+        ));
+        self.reset_update_request_ids.push(request_id);
+        self.reset_update_indices.push(reset_update_0_index);
+        self.reset_update_shares.push(shares);
+    }
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum RequestIndex {
     /// Request types: Uniqueness, Reauth, Reset Check.

--- a/iris-mpc-common/src/job.rs
+++ b/iris-mpc-common/src/job.rs
@@ -112,14 +112,17 @@ impl BatchQuery {
     /// Add a Uniqueness, Reauth, or Reset Check request to the batch.
     pub fn push_matching_request(
         &mut self,
+        sns_message_id: String,
         request_id: String,
         request_type: &str,
         metadata: BatchMetadata,
         or_rule_indices: Vec<u32>,
         skip_persistence: bool,
     ) {
+        self.sns_message_ids.push(sns_message_id);
         self.requests_order
             .push(RequestIndex::UniqueReauthResetCheck(self.request_ids.len()));
+
         self.request_ids.push(request_id);
         self.request_types.push(request_type.to_string());
         self.metadata.push(metadata);
@@ -128,9 +131,16 @@ impl BatchQuery {
     }
 
     /// Add a Deletion request to the batch.
-    pub fn push_deletion_request(&mut self, deletion_0_index: u32, metadata: BatchMetadata) {
+    pub fn push_deletion_request(
+        &mut self,
+        sns_message_id: String,
+        deletion_0_index: u32,
+        metadata: BatchMetadata,
+    ) {
+        self.sns_message_ids.push(sns_message_id);
         self.requests_order
             .push(RequestIndex::Deletion(self.deletion_requests_indices.len()));
+
         self.deletion_requests_indices.push(deletion_0_index);
         self.deletion_requests_metadata.push(metadata);
     }
@@ -138,13 +148,16 @@ impl BatchQuery {
     /// Add a Reset Update request to the batch.
     pub fn push_reset_update_request(
         &mut self,
+        sns_message_id: String,
         request_id: String,
         reset_update_0_index: u32,
         shares: GaloisSharesBothSides,
     ) {
+        self.sns_message_ids.push(sns_message_id);
         self.requests_order.push(RequestIndex::ResetUpdate(
             self.reset_update_request_ids.len(),
         ));
+
         self.reset_update_request_ids.push(request_id);
         self.reset_update_indices.push(reset_update_0_index);
         self.reset_update_shares.push(shares);

--- a/iris-mpc-common/src/test.rs
+++ b/iris-mpc-common/src/test.rs
@@ -1,5 +1,5 @@
 use crate::galois_engine::degree4::FullGaloisRingIrisCodeShare;
-use crate::job::{GaloisSharesBothSides, RequestIndex};
+use crate::job::{BatchMetadata, GaloisSharesBothSides};
 use crate::{
     galois_engine::degree4::{GaloisRingIrisCodeShare, GaloisRingTrimmedMaskCodeShare},
     helpers::{
@@ -513,9 +513,7 @@ impl TestCaseGenerator {
                 tracing::info!("Deleting index {}", idx);
 
                 for b in [&mut batch0, &mut batch1, &mut batch2] {
-                    b.requests_order
-                        .push(RequestIndex::Deletion(b.deletion_requests_indices.len()));
-                    b.deletion_requests_indices.push(idx as u32);
+                    b.push_deletion_request(idx as u32, BatchMetadata::default());
                 }
             }
         }
@@ -567,16 +565,9 @@ impl TestCaseGenerator {
                     req_id
                 );
 
-                for b in [&mut batch0, &mut batch1, &mut batch2] {
-                    b.requests_order
-                        .push(RequestIndex::ResetUpdate(b.reset_update_indices.len()));
-                    b.reset_update_indices.push(idx as u32);
-                    b.reset_update_request_ids.push(req_id.clone());
-                }
-
-                batch0.reset_update_shares.push(shares0);
-                batch1.reset_update_shares.push(shares1);
-                batch2.reset_update_shares.push(shares2);
+                batch0.push_reset_update_request(req_id.clone(), idx as u32, shares0);
+                batch1.push_reset_update_request(req_id.clone(), idx as u32, shares1);
+                batch2.push_reset_update_request(req_id, idx as u32, shares2);
             }
         }
 
@@ -1376,15 +1367,8 @@ fn prepare_batch(
     skip_persistence: bool,
     message_type: String,
 ) -> Result<()> {
-    batch.metadata.push(Default::default());
     batch.valid_entries.push(is_valid);
-    batch.skip_persistence.push(skip_persistence);
-    batch
-        .requests_order
-        .push(RequestIndex::UniqueReauthResetCheck(
-            batch.request_ids.len(),
-        ));
-    batch.request_ids.push(request_id.clone());
+
     if message_type == REAUTH_MESSAGE_TYPE {
         let target_index = maybe_reauth_target_index.unwrap();
         batch
@@ -1395,8 +1379,13 @@ fn prepare_batch(
             .insert(request_id.clone(), *target_index);
     }
 
-    batch.request_types.push(message_type);
-    batch.or_rule_indices.push(or_rule_indices);
+    batch.push_matching_request(
+        request_id.clone(),
+        &message_type,
+        BatchMetadata::default(),
+        or_rule_indices,
+        skip_persistence,
+    );
 
     batch
         .left_iris_requests

--- a/iris-mpc-common/src/test.rs
+++ b/iris-mpc-common/src/test.rs
@@ -513,7 +513,11 @@ impl TestCaseGenerator {
                 tracing::info!("Deleting index {}", idx);
 
                 for b in [&mut batch0, &mut batch1, &mut batch2] {
-                    b.push_deletion_request(idx as u32, BatchMetadata::default());
+                    b.push_deletion_request(
+                        "sns_id".to_string(),
+                        idx as u32,
+                        BatchMetadata::default(),
+                    );
                 }
             }
         }
@@ -564,10 +568,11 @@ impl TestCaseGenerator {
                     idx,
                     req_id
                 );
+                let sns_id = || "sns_id".to_string();
 
-                batch0.push_reset_update_request(req_id.clone(), idx as u32, shares0);
-                batch1.push_reset_update_request(req_id.clone(), idx as u32, shares1);
-                batch2.push_reset_update_request(req_id, idx as u32, shares2);
+                batch0.push_reset_update_request(sns_id(), req_id.clone(), idx as u32, shares0);
+                batch1.push_reset_update_request(sns_id(), req_id.clone(), idx as u32, shares1);
+                batch2.push_reset_update_request(sns_id(), req_id, idx as u32, shares2);
             }
         }
 
@@ -1380,6 +1385,7 @@ fn prepare_batch(
     }
 
     batch.push_matching_request(
+        "sns_id".to_string(),
         request_id.clone(),
         &message_type,
         BatchMetadata::default(),

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -1629,36 +1629,19 @@ mod tests {
             })
             .collect_vec();
 
-        let requests_order = (0..batch_size)
-            .map(RequestIndex::UniqueReauthResetCheck)
-            .collect_vec();
-
-        let request_ids = {
-            (0..batch_size as u32)
-                .map(|i| format!("request_{i}"))
-                .collect_vec()
-        };
-
-        let batch_0 = BatchQuery {
-            // Batch details to be just copied to the result.
-            requests_order,
-            request_ids: request_ids.clone(),
-            request_types: vec![UNIQUENESS_MESSAGE_TYPE.to_string(); batch_size],
-            metadata: vec![
-                BatchMetadata {
-                    node_id: "X".to_string(),
-                    trace_id: "X".to_string(),
-                    span_id: "X".to_string(),
-                };
-                batch_size
-            ],
-
-            or_rule_indices: vec![vec![]; batch_size],
+        let mut batch_0 = BatchQuery {
             luc_lookback_records: 2,
-            skip_persistence: vec![false; batch_size],
-
             ..BatchQuery::default()
         };
+        for i in 0..batch_size {
+            batch_0.push_matching_request(
+                format!("request_{i}"),
+                UNIQUENESS_MESSAGE_TYPE,
+                BatchMetadata::default(),
+                vec![],
+                false,
+            );
+        }
 
         let all_results =
             parallelize(izip!(&irises, handles.clone()).map(|(shares, mut handle)| {
@@ -1701,10 +1684,11 @@ mod tests {
             request_types: vec![REAUTH_MESSAGE_TYPE.to_string(); batch_size],
 
             // Map the request ID to the inserted index.
-            reauth_target_indices: izip!(&request_ids, &inserted_indices)
+            reauth_target_indices: izip!(&batch_0.request_ids, &inserted_indices)
                 .map(|(req_id, inserted_index)| (req_id.clone(), *inserted_index))
                 .collect(),
-            reauth_use_or_rule: request_ids
+            reauth_use_or_rule: batch_0
+                .request_ids
                 .iter()
                 .map(|req_id| (req_id.clone(), false))
                 .collect(),

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -1635,6 +1635,7 @@ mod tests {
         };
         for i in 0..batch_size {
             batch_0.push_matching_request(
+                format!("sns_{i}"),
                 format!("request_{i}"),
                 UNIQUENESS_MESSAGE_TYPE,
                 BatchMetadata::default(),

--- a/iris-mpc-gpu/benches/preprocessing.rs
+++ b/iris-mpc-gpu/benches/preprocessing.rs
@@ -5,7 +5,7 @@ use iris_mpc_common::{
     },
     helpers::smpc_request::UNIQUENESS_MESSAGE_TYPE,
     iris_db::iris::IrisCode,
-    job::{BatchMetadata, BatchQuery, RequestIndex},
+    job::{BatchMetadata, BatchQuery},
 };
 use iris_mpc_gpu::server::PreprocessedBatchQuery;
 use rand::thread_rng;

--- a/iris-mpc-gpu/benches/preprocessing.rs
+++ b/iris-mpc-gpu/benches/preprocessing.rs
@@ -5,7 +5,7 @@ use iris_mpc_common::{
     },
     helpers::smpc_request::UNIQUENESS_MESSAGE_TYPE,
     iris_db::iris::IrisCode,
-    job::{BatchQuery, RequestIndex},
+    job::{BatchMetadata, BatchQuery, RequestIndex},
 };
 use iris_mpc_gpu::server::PreprocessedBatchQuery;
 use rand::thread_rng;
@@ -32,15 +32,14 @@ pub fn criterion_benchmark_preprocessing(c: &mut Criterion) {
             let code_shares_db = code_shares_request.all_rotations();
             let mask_shares_db = mask_shares_request.all_rotations();
 
-            batch_query
-                .requests_order
-                .push(RequestIndex::UniqueReauthResetCheck(
-                    batch_query.request_ids.len(),
-                ));
-            batch_query.request_ids.push(Uuid::new_v4().to_string());
-            batch_query
-                .request_types
-                .push(UNIQUENESS_MESSAGE_TYPE.to_owned());
+            batch_query.push_matching_request(
+                Uuid::new_v4().to_string(),
+                UNIQUENESS_MESSAGE_TYPE,
+                BatchMetadata::default(),
+                vec![],
+                false,
+            );
+
             batch_query
                 .left_iris_interpolated_requests
                 .code

--- a/iris-mpc-gpu/benches/preprocessing.rs
+++ b/iris-mpc-gpu/benches/preprocessing.rs
@@ -33,6 +33,7 @@ pub fn criterion_benchmark_preprocessing(c: &mut Criterion) {
             let mask_shares_db = mask_shares_request.all_rotations();
 
             batch_query.push_matching_request(
+                "sns_id".to_string(),
                 Uuid::new_v4().to_string(),
                 UNIQUENESS_MESSAGE_TYPE,
                 BatchMetadata::default(),

--- a/iris-mpc/bin/server.rs
+++ b/iris-mpc/bin/server.rs
@@ -259,11 +259,10 @@ async fn receive_batch(
                         );
 
                         batch_query.push_deletion_request(
+                            sns_message_id,
                             identity_deletion_request.serial_id - 1,
                             batch_metadata,
                         );
-
-                        batch_query.sns_message_ids.push(sns_message_id);
                     }
 
                     UNIQUENESS_MESSAGE_TYPE => {
@@ -356,14 +355,13 @@ async fn receive_batch(
                         };
 
                         batch_query.push_matching_request(
+                            sns_message_id,
                             uniqueness_request.signup_id.clone(),
                             UNIQUENESS_MESSAGE_TYPE,
                             batch_metadata,
                             or_rule_indices,
                             uniqueness_request.skip_persistence.unwrap_or(false),
                         );
-
-                        batch_query.sns_message_ids.push(sns_message_id);
 
                         let semaphore = Arc::clone(&semaphore);
                         let s3_client_arc = s3_client.clone();
@@ -457,7 +455,6 @@ async fn receive_batch(
                                 reauth_request.reauth_id.clone(),
                                 reauth_request.use_or_rule,
                             );
-                            batch_query.sns_message_ids.push(sns_message_id);
 
                             let or_rule_indices = if reauth_request.use_or_rule {
                                 vec![reauth_request.serial_id - 1]
@@ -466,6 +463,7 @@ async fn receive_batch(
                             };
 
                             batch_query.push_matching_request(
+                                sns_message_id,
                                 reauth_request.reauth_id.clone(),
                                 REAUTH_MESSAGE_TYPE,
                                 batch_metadata,
@@ -534,14 +532,13 @@ async fn receive_batch(
                             }
 
                             batch_query.push_matching_request(
+                                sns_message_id,
                                 reset_check_request.reset_id.clone(),
                                 RESET_CHECK_MESSAGE_TYPE,
                                 batch_metadata,
                                 vec![], // use AND rule for reset check requests
                                 false,  // skip_persistence is only used for uniqueness requests
                             );
-
-                            batch_query.sns_message_ids.push(sns_message_id);
 
                             let semaphore = Arc::clone(&semaphore);
                             let s3_client_arc = s3_client.clone();
@@ -638,6 +635,7 @@ async fn receive_batch(
                             );
 
                             batch_query.push_reset_update_request(
+                                sns_message_id,
                                 reset_update_request.reset_id,
                                 reset_update_request.serial_id - 1,
                                 GaloisSharesBothSides {
@@ -647,8 +645,6 @@ async fn receive_batch(
                                     mask_right: right_shares.mask,
                                 },
                             );
-
-                            batch_query.sns_message_ids.push(sns_message_id.clone());
                         }
                     }
 

--- a/iris-mpc/src/services/processors/batch.rs
+++ b/iris-mpc/src/services/processors/batch.rs
@@ -30,7 +30,7 @@ use iris_mpc_common::helpers::smpc_response::{
 };
 use iris_mpc_common::helpers::sync::Modification;
 use iris_mpc_common::helpers::sync::ModificationKey::{RequestId, RequestSerialId};
-use iris_mpc_common::job::{BatchMetadata, BatchQuery, GaloisSharesBothSides, RequestIndex};
+use iris_mpc_common::job::{BatchMetadata, BatchQuery, GaloisSharesBothSides};
 use iris_mpc_store::Store;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -409,15 +409,8 @@ impl<'a> BatchProcessor<'a> {
                 modification,
             );
 
-            self.batch_query.requests_order.push(RequestIndex::Deletion(
-                self.batch_query.deletion_requests_indices.len(),
-            ));
             self.batch_query
-                .deletion_requests_indices
-                .push(identity_deletion_request.serial_id - 1);
-            self.batch_query
-                .deletion_requests_metadata
-                .push(batch_metadata);
+                .push_deletion_request(identity_deletion_request.serial_id - 1, batch_metadata);
         } else {
             tracing::warn!("Identity deletions are disabled");
         }
@@ -452,34 +445,26 @@ impl<'a> BatchProcessor<'a> {
             modification,
         );
 
-        self.update_luc_config_if_needed(&uniqueness_request);
+        let or_rule_indices = self.update_luc_config_if_needed(&uniqueness_request);
 
         self.msg_counter += 1;
 
-        self.batch_query
-            .requests_order
-            .push(RequestIndex::UniqueReauthResetCheck(
-                self.batch_query.request_ids.len(),
-            ));
-        self.batch_query
-            .request_ids
-            .push(uniqueness_request.signup_id.clone());
-        self.batch_query
-            .request_types
-            .push(UNIQUENESS_MESSAGE_TYPE.to_string());
-        self.batch_query.metadata.push(batch_metadata);
+        self.batch_query.push_matching_request(
+            uniqueness_request.signup_id.clone(),
+            UNIQUENESS_MESSAGE_TYPE,
+            batch_metadata,
+            or_rule_indices,
+            uniqueness_request.skip_persistence.unwrap_or(false),
+        );
 
         self.add_iris_shares_task(uniqueness_request.s3_key)?;
-        // skip_persistence is only used for uniqueness requests
+
         if let Some(skip_persistence) = uniqueness_request.skip_persistence {
             tracing::info!(
                 "Setting skip_persistence to {} for request id {}",
                 skip_persistence,
                 uniqueness_request.signup_id
             );
-            self.batch_query.skip_persistence.push(skip_persistence);
-        } else {
-            self.batch_query.skip_persistence.push(false);
         }
 
         Ok(())
@@ -542,19 +527,6 @@ impl<'a> BatchProcessor<'a> {
 
         self.msg_counter += 1;
 
-        self.batch_query
-            .requests_order
-            .push(RequestIndex::UniqueReauthResetCheck(
-                self.batch_query.request_ids.len(),
-            ));
-        self.batch_query
-            .request_ids
-            .push(reauth_request.reauth_id.clone());
-        self.batch_query
-            .request_types
-            .push(REAUTH_MESSAGE_TYPE.to_string());
-        self.batch_query.metadata.push(batch_metadata);
-
         self.batch_query.reauth_target_indices.insert(
             reauth_request.reauth_id.clone(),
             reauth_request.serial_id - 1,
@@ -570,10 +542,15 @@ impl<'a> BatchProcessor<'a> {
             vec![]
         };
 
-        self.batch_query.or_rule_indices.push(or_rule_indices);
+        self.batch_query.push_matching_request(
+            reauth_request.reauth_id.clone(),
+            REAUTH_MESSAGE_TYPE,
+            batch_metadata,
+            or_rule_indices,
+            false, // skip_persistence is only used for uniqueness requests
+        );
+
         self.add_iris_shares_task(reauth_request.s3_key)?;
-        // skip_persistence is only used for uniqueness requests
-        self.batch_query.skip_persistence.push(false);
 
         Ok(())
     }
@@ -615,24 +592,14 @@ impl<'a> BatchProcessor<'a> {
 
         self.msg_counter += 1;
 
-        self.batch_query
-            .requests_order
-            .push(RequestIndex::UniqueReauthResetCheck(
-                self.batch_query.request_ids.len(),
-            ));
-        self.batch_query
-            .request_ids
-            .push(reset_check_request.reset_id.clone());
-        self.batch_query
-            .request_types
-            .push(RESET_CHECK_MESSAGE_TYPE.to_string());
-        self.batch_query.metadata.push(batch_metadata);
+        self.batch_query.push_matching_request(
+            reset_check_request.reset_id.clone(),
+            RESET_CHECK_MESSAGE_TYPE,
+            batch_metadata,
+            vec![], // reset checks use the AND rule
+            false,  // skip_persistence is only used for uniqueness requests
+        );
 
-        // skip_persistence is only used for uniqueness requests
-        self.batch_query.skip_persistence.push(false);
-
-        // We need to use AND rule for reset check requests
-        self.batch_query.or_rule_indices.push(vec![]);
         self.add_iris_shares_task(reset_check_request.s3_key)?;
 
         Ok(())
@@ -641,7 +608,7 @@ impl<'a> BatchProcessor<'a> {
     async fn process_reset_update_request(
         &mut self,
         message: &SQSMessage,
-        batch_metadata: BatchMetadata,
+        _batch_metadata: BatchMetadata,
         sqs_message: &aws_sdk_sqs::types::Message,
     ) -> Result<(), ReceiveRequestError> {
         let sns_message_id = &message.message_id;
@@ -713,29 +680,20 @@ impl<'a> BatchProcessor<'a> {
 
         self.msg_counter += 1;
 
-        self.batch_query
-            .requests_order
-            .push(RequestIndex::ResetUpdate(
-                self.batch_query.reset_update_indices.len(),
-            ));
-        self.batch_query
-            .reset_update_indices
-            .push(reset_update_request.serial_id - 1);
-        self.batch_query
-            .sns_message_ids
-            .push(sns_message_id.clone());
-        self.batch_query.metadata.push(batch_metadata);
-        self.batch_query
-            .reset_update_request_ids
-            .push(reset_update_request.reset_id);
-        self.batch_query
-            .reset_update_shares
-            .push(GaloisSharesBothSides {
+        self.batch_query.push_reset_update_request(
+            reset_update_request.reset_id,
+            reset_update_request.serial_id - 1,
+            GaloisSharesBothSides {
                 code_left: left_shares.code,
                 mask_left: left_shares.mask,
                 code_right: right_shares.code,
                 mask_right: right_shares.mask,
-            });
+            },
+        );
+
+        self.batch_query
+            .sns_message_ids
+            .push(sns_message_id.clone());
         Ok(())
     }
 
@@ -860,7 +818,7 @@ impl<'a> BatchProcessor<'a> {
         Ok(())
     }
 
-    fn update_luc_config_if_needed(&mut self, uniqueness_request: &UniquenessRequest) {
+    fn update_luc_config_if_needed(&mut self, uniqueness_request: &UniquenessRequest) -> Vec<u32> {
         let config = &self.config;
 
         if config.luc_enabled && config.luc_lookback_records > 0 {
@@ -880,8 +838,7 @@ impl<'a> BatchProcessor<'a> {
         } else {
             vec![]
         };
-
-        self.batch_query.or_rule_indices.push(or_rule_indices);
+        or_rule_indices
     }
 
     fn add_iris_shares_task(&mut self, s3_key: String) -> Result<(), ReceiveRequestError> {


### PR DESCRIPTION
Follow-up to #1464.

Group all the `push` to `BatchQuery` fields into methods. This makes it clear how the fields are related and it avoids forgetting some or pushing at the wrong place.

Exhibit A: There was one too many `metadata` push in `process_reset_update_request`, fixed in this PR.