### PR TITLE
Track SNS ID of all requests

### DIFF
--- a/iris-mpc-common/src/job.rs
+++ b/iris-mpc-common/src/job.rs
@@ -112,14 +112,17 @@ impl BatchQuery {
     /// Add a Uniqueness, Reauth, or Reset Check request to the batch.
     pub fn push_matching_request(
         &mut self,
+        sns_message_id: String,
         request_id: String,
         request_type: &str,
         metadata: BatchMetadata,
         or_rule_indices: Vec<u32>,
         skip_persistence: bool,
     ) {
+        self.sns_message_ids.push(sns_message_id);
         self.requests_order
             .push(RequestIndex::UniqueReauthResetCheck(self.request_ids.len()));
+
         self.request_ids.push(request_id);
         self.request_types.push(request_type.to_string());
         self.metadata.push(metadata);
@@ -128,9 +131,16 @@ impl BatchQuery {
     }
 
     /// Add a Deletion request to the batch.
-    pub fn push_deletion_request(&mut self, deletion_0_index: u32, metadata: BatchMetadata) {
+    pub fn push_deletion_request(
+        &mut self,
+        sns_message_id: String,
+        deletion_0_index: u32,
+        metadata: BatchMetadata,
+    ) {
+        self.sns_message_ids.push(sns_message_id);
         self.requests_order
             .push(RequestIndex::Deletion(self.deletion_requests_indices.len()));
+
         self.deletion_requests_indices.push(deletion_0_index);
         self.deletion_requests_metadata.push(metadata);
     }
@@ -138,13 +148,16 @@ impl BatchQuery {
     /// Add a Reset Update request to the batch.
     pub fn push_reset_update_request(
         &mut self,
+        sns_message_id: String,
         request_id: String,
         reset_update_0_index: u32,
         shares: GaloisSharesBothSides,
     ) {
+        self.sns_message_ids.push(sns_message_id);
         self.requests_order.push(RequestIndex::ResetUpdate(
             self.reset_update_request_ids.len(),
         ));
+
         self.reset_update_request_ids.push(request_id);
         self.reset_update_indices.push(reset_update_0_index);
         self.reset_update_shares.push(shares);

--- a/iris-mpc-common/src/test.rs
+++ b/iris-mpc-common/src/test.rs
@@ -513,7 +513,11 @@ impl TestCaseGenerator {
                 tracing::info!("Deleting index {}", idx);
 
                 for b in [&mut batch0, &mut batch1, &mut batch2] {
-                    b.push_deletion_request(idx as u32, BatchMetadata::default());
+                    b.push_deletion_request(
+                        "sns_id".to_string(),
+                        idx as u32,
+                        BatchMetadata::default(),
+                    );
                 }
             }
         }
@@ -564,10 +568,11 @@ impl TestCaseGenerator {
                     idx,
                     req_id
                 );
+                let sns_id = || "sns_id".to_string();
 
-                batch0.push_reset_update_request(req_id.clone(), idx as u32, shares0);
-                batch1.push_reset_update_request(req_id.clone(), idx as u32, shares1);
-                batch2.push_reset_update_request(req_id, idx as u32, shares2);
+                batch0.push_reset_update_request(sns_id(), req_id.clone(), idx as u32, shares0);
+                batch1.push_reset_update_request(sns_id(), req_id.clone(), idx as u32, shares1);
+                batch2.push_reset_update_request(sns_id(), req_id, idx as u32, shares2);
             }
         }
 
@@ -1380,6 +1385,7 @@ fn prepare_batch(
     }
 
     batch.push_matching_request(
+        "sns_id".to_string(),
         request_id.clone(),
         &message_type,
         BatchMetadata::default(),

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -1635,6 +1635,7 @@ mod tests {
         };
         for i in 0..batch_size {
             batch_0.push_matching_request(
+                format!("sns_{i}"),
                 format!("request_{i}"),
                 UNIQUENESS_MESSAGE_TYPE,
                 BatchMetadata::default(),

--- a/iris-mpc-gpu/benches/preprocessing.rs
+++ b/iris-mpc-gpu/benches/preprocessing.rs
@@ -5,7 +5,7 @@ use iris_mpc_common::{
     },
     helpers::smpc_request::UNIQUENESS_MESSAGE_TYPE,
     iris_db::iris::IrisCode,
-    job::{BatchMetadata, BatchQuery, RequestIndex},
+    job::{BatchMetadata, BatchQuery},
 };
 use iris_mpc_gpu::server::PreprocessedBatchQuery;
 use rand::thread_rng;
@@ -33,6 +33,7 @@ pub fn criterion_benchmark_preprocessing(c: &mut Criterion) {
             let mask_shares_db = mask_shares_request.all_rotations();
 
             batch_query.push_matching_request(
+                "sns_id".to_string(),
                 Uuid::new_v4().to_string(),
                 UNIQUENESS_MESSAGE_TYPE,
                 BatchMetadata::default(),

--- a/iris-mpc/bin/server.rs
+++ b/iris-mpc/bin/server.rs
@@ -259,11 +259,10 @@ async fn receive_batch(
                         );
 
                         batch_query.push_deletion_request(
+                            sns_message_id,
                             identity_deletion_request.serial_id - 1,
                             batch_metadata,
                         );
-
-                        batch_query.sns_message_ids.push(sns_message_id);
                     }
 
                     UNIQUENESS_MESSAGE_TYPE => {
@@ -356,14 +355,13 @@ async fn receive_batch(
                         };
 
                         batch_query.push_matching_request(
+                            sns_message_id,
                             uniqueness_request.signup_id.clone(),
                             UNIQUENESS_MESSAGE_TYPE,
                             batch_metadata,
                             or_rule_indices,
                             uniqueness_request.skip_persistence.unwrap_or(false),
                         );
-
-                        batch_query.sns_message_ids.push(sns_message_id);
 
                         let semaphore = Arc::clone(&semaphore);
                         let s3_client_arc = s3_client.clone();
@@ -457,7 +455,6 @@ async fn receive_batch(
                                 reauth_request.reauth_id.clone(),
                                 reauth_request.use_or_rule,
                             );
-                            batch_query.sns_message_ids.push(sns_message_id);
 
                             let or_rule_indices = if reauth_request.use_or_rule {
                                 vec![reauth_request.serial_id - 1]
@@ -466,6 +463,7 @@ async fn receive_batch(
                             };
 
                             batch_query.push_matching_request(
+                                sns_message_id,
                                 reauth_request.reauth_id.clone(),
                                 REAUTH_MESSAGE_TYPE,
                                 batch_metadata,
@@ -534,14 +532,13 @@ async fn receive_batch(
                             }
 
                             batch_query.push_matching_request(
+                                sns_message_id,
                                 reset_check_request.reset_id.clone(),
                                 RESET_CHECK_MESSAGE_TYPE,
                                 batch_metadata,
                                 vec![], // use AND rule for reset check requests
                                 false,  // skip_persistence is only used for uniqueness requests
                             );
-
-                            batch_query.sns_message_ids.push(sns_message_id);
 
                             let semaphore = Arc::clone(&semaphore);
                             let s3_client_arc = s3_client.clone();
@@ -638,6 +635,7 @@ async fn receive_batch(
                             );
 
                             batch_query.push_reset_update_request(
+                                sns_message_id,
                                 reset_update_request.reset_id,
                                 reset_update_request.serial_id - 1,
                                 GaloisSharesBothSides {
@@ -647,8 +645,6 @@ async fn receive_batch(
                                     mask_right: right_shares.mask,
                                 },
                             );
-
-                            batch_query.sns_message_ids.push(sns_message_id.clone());
                         }
                     }
 


### PR DESCRIPTION
Follow-up to #1467.

- [x] Refactor sns_message_id into the BatchQuery methods.
- [x] Include the SNS message ID of all requests (CPU code, GPU already did).