### PR TITLE
(chore): Make Networking use a NetworkValue instead of Vec<u8>

### DIFF
--- a/iris-mpc-cpu/src/execution/hawk_main/state_check.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/state_check.rs
@@ -55,12 +55,12 @@ impl HawkSession {
         let net = &mut session.aby3_store.session.network_session;
 
         // Send my state to others.
-        let my_msg = || NetworkValue::StateChecksum(my_state.clone()).to_network();
+        let my_msg = || NetworkValue::StateChecksum(my_state.clone());
         net.send_prev(my_msg()).await?;
         net.send_next(my_msg()).await?;
 
         // Receive their state.
-        let decode = |msg| match NetworkValue::from_network(msg) {
+        let decode = |msg| match msg {
             Ok(NetworkValue::StateChecksum(c)) => Ok(c),
             other => {
                 tracing::error!("Unexpected message format: {:?}", other);

--- a/iris-mpc-cpu/src/execution/session.rs
+++ b/iris-mpc-cpu/src/execution/session.rs
@@ -1,6 +1,6 @@
 use crate::{
     execution::player::{Identity, Role},
-    network::Networking,
+    network::{value::NetworkValue, Networking},
     protocol::prf::Prf,
 };
 use eyre::{eyre, Result};
@@ -40,30 +40,30 @@ pub struct NetworkSession {
 }
 
 impl NetworkSession {
-    async fn send(&self, value: Vec<u8>, receiver: &Identity) -> Result<()> {
+    async fn send(&self, value: NetworkValue, receiver: &Identity) -> Result<()> {
         self.networking.send(value, receiver).await
     }
 
-    async fn receive(&mut self, sender: &Identity) -> Result<Vec<u8>> {
+    async fn receive(&mut self, sender: &Identity) -> Result<NetworkValue> {
         self.networking.receive(sender).await
     }
 
-    pub async fn send_next(&self, value: Vec<u8>) -> Result<()> {
+    pub async fn send_next(&self, value: NetworkValue) -> Result<()> {
         let next_identity = self.next_identity()?;
         self.send(value, &next_identity).await
     }
 
-    pub async fn send_prev(&self, value: Vec<u8>) -> Result<()> {
+    pub async fn send_prev(&self, value: NetworkValue) -> Result<()> {
         let prev_identity = self.prev_identity()?;
         self.send(value, &prev_identity).await
     }
 
-    pub async fn receive_next(&mut self) -> Result<Vec<u8>> {
+    pub async fn receive_next(&mut self) -> Result<NetworkValue> {
         let next_identity = self.next_identity()?;
         self.receive(&next_identity).await
     }
 
-    pub async fn receive_prev(&mut self) -> Result<Vec<u8>> {
+    pub async fn receive_prev(&mut self) -> Result<NetworkValue> {
         let prev_identity = self.prev_identity()?;
         self.receive(&prev_identity).await
     }

--- a/iris-mpc-cpu/src/network/grpc/mod.rs
+++ b/iris-mpc-cpu/src/network/grpc/mod.rs
@@ -39,14 +39,23 @@ mod tests {
         execution::{local::generate_local_identities, player::Role, session::SessionId},
         hawkers::aby3::{aby3_store::prepare_query, test_utils::shared_random_setup},
         hnsw::HnswSearcher,
-        network::{NetworkType, Networking},
+        network::{value::NetworkValue, NetworkType, Networking},
     };
     use aes_prng::AesRng;
     use futures::future::join_all;
     use iris_mpc_common::vector_id::VectorId;
+    use rand::Rng;
     use rand::SeedableRng;
     use tokio::{task::JoinSet, time::sleep};
     use tracing_test::traced_test;
+
+    // can only send NetworkValue over the network. PrfKey is easy to make so this is used here.
+    fn get_prf() -> NetworkValue {
+        let mut rng = rand::thread_rng();
+        let mut key = [0u8; 16];
+        rng.fill(&mut key);
+        NetworkValue::PrfKey(key)
+    }
 
     async fn create_session_helper(
         session_id: SessionId,
@@ -101,7 +110,7 @@ mod tests {
                 let alice = players.pop().unwrap();
 
                 // Send a message from the first party to the second party
-                let message = b"Hey, Bob. I'm Alice. Do you copy?".to_vec();
+                let message = get_prf();
                 let message_copy = message.clone();
 
                 let task1 = tokio::spawn(async move {
@@ -118,6 +127,8 @@ mod tests {
         // Multiple parties sending messages to each other
         let all_parties_talk = |identities: Vec<Identity>, sessions: Vec<GrpcSession>| async move {
             let mut tasks = JoinSet::new();
+            let message_to_next = get_prf();
+            let message_to_prev = get_prf();
             for (player_id, session) in sessions.into_iter().enumerate() {
                 let role = Role::new(player_id);
                 let next = role.next(3).index();
@@ -126,34 +137,19 @@ mod tests {
                 let next_id = identities[next].clone();
                 let prev_id = identities[prev].clone();
 
-                let message_to_next =
-                    format!("From player {} to player {} with love", player_id, next).into_bytes();
-                let message_to_prev =
-                    format!("From player {} to player {} with love", player_id, prev).into_bytes();
-
                 let mut session = session;
+                let msg_next = message_to_next.clone();
+                let msg_prev = message_to_prev.clone();
                 tasks.spawn(async move {
                     // Sending
-                    session
-                        .send(message_to_next.clone(), &next_id)
-                        .await
-                        .unwrap();
-                    session
-                        .send(message_to_prev.clone(), &prev_id)
-                        .await
-                        .unwrap();
+                    session.send(msg_next.clone(), &next_id).await.unwrap();
+                    session.send(msg_prev.clone(), &prev_id).await.unwrap();
 
                     // Receiving
                     let received_message_from_prev = session.receive(&prev_id).await.unwrap();
-                    let expected_message_from_prev =
-                        format!("From player {} to player {} with love", prev, player_id)
-                            .into_bytes();
-                    assert_eq!(received_message_from_prev, expected_message_from_prev);
+                    assert_eq!(received_message_from_prev, msg_next);
                     let received_message_from_next = session.receive(&next_id).await.unwrap();
-                    let expected_message_from_next =
-                        format!("From player {} to player {} with love", next, player_id)
-                            .into_bytes();
-                    assert_eq!(received_message_from_next, expected_message_from_next);
+                    assert_eq!(received_message_from_next, msg_prev);
                 });
             }
             tasks.join_all().await;
@@ -230,7 +226,7 @@ mod tests {
                 let session_id = SessionId::from(0);
                 let sessions = create_session_helper(session_id, &players).await.unwrap();
 
-                let message = b"Hey, Eve. I'm Alice. Do you copy?".to_vec();
+                let message = get_prf();
                 let res = sessions[0]
                     .send(message.clone(), &Identity::from("eve"))
                     .await;
@@ -263,7 +259,7 @@ mod tests {
                 let session_id = SessionId::from(2);
                 let sessions = create_session_helper(session_id, &players).await.unwrap();
 
-                let message = b"Hey, Alice. I'm Alice. Do you copy?".to_vec();
+                let message = get_prf();
                 let res = sessions[0]
                     .send(message.clone(), &Identity::from("alice"))
                     .await;

--- a/iris-mpc-cpu/src/network/grpc/session.rs
+++ b/iris-mpc-cpu/src/network/grpc/session.rs
@@ -60,7 +60,7 @@ impl Networking for GrpcSession {
         match timeout(self.config.timeout_duration, incoming_stream.recv()).await {
             Ok(res) => res
                 .ok_or(eyre!("No message received"))
-                .and_then(|msg| NetworkValue::from_network(Ok(msg.data))),
+                .and_then(|msg| NetworkValue::from_network(&msg.data)),
             Err(_) => Err(eyre!(
                 "{:?}: Timeout while waiting for message from {sender:?} in \
                  {:?}",

--- a/iris-mpc-cpu/src/network/grpc/session.rs
+++ b/iris-mpc-cpu/src/network/grpc/session.rs
@@ -60,7 +60,7 @@ impl Networking for GrpcSession {
         match timeout(self.config.timeout_duration, incoming_stream.recv()).await {
             Ok(res) => res
                 .ok_or(eyre!("No message received"))
-                .and_then(|msg| NetworkValue::from_network(&msg.data)),
+                .and_then(|msg| NetworkValue::deserialize(&msg.data)),
             Err(_) => Err(eyre!(
                 "{:?}: Timeout while waiting for message from {sender:?} in \
                  {:?}",

--- a/iris-mpc-cpu/src/network/local.rs
+++ b/iris-mpc-cpu/src/network/local.rs
@@ -1,4 +1,7 @@
-use crate::{execution::player::Identity, network::Networking};
+use crate::{
+    execution::player::Identity,
+    network::{value::NetworkValue, Networking},
+};
 use async_trait::async_trait;
 use dashmap::DashMap;
 use eyre::{eyre, Result};
@@ -56,7 +59,8 @@ pub struct LocalNetworking {
 
 #[async_trait]
 impl Networking for LocalNetworking {
-    async fn send(&self, val: Vec<u8>, receiver: &Identity) -> Result<()> {
+    async fn send(&self, val: NetworkValue, receiver: &Identity) -> Result<()> {
+        let val = val.to_network();
         let (tx, _) = self
             .p2p_channels
             .get(&(self.owner.clone(), receiver.clone()))
@@ -73,7 +77,7 @@ impl Networking for LocalNetworking {
         tx.send(ready_to_send_value).await.map_err(|e| e.into())
     }
 
-    async fn receive(&mut self, sender: &Identity) -> Result<Vec<u8>> {
+    async fn receive(&mut self, sender: &Identity) -> Result<NetworkValue> {
         let (_, rx) = self
             .p2p_channels
             .get(&(sender.clone(), self.owner.clone()))
@@ -87,7 +91,7 @@ impl Networking for LocalNetworking {
             .clone();
 
         let received_value = rx.recv().await?;
-        Ok(received_value.value)
+        NetworkValue::from_network(Ok(received_value.value))
     }
 }
 
@@ -106,14 +110,11 @@ mod tests {
 
         let task1 = tokio::spawn(async move {
             let recv = bob.receive(&"alice".into()).await;
-            assert_eq!(
-                NetworkValue::from_network(recv).unwrap(),
-                NetworkValue::RingElement16(RingElement(777))
-            );
+            assert_eq!(recv.unwrap(), NetworkValue::RingElement16(RingElement(777)));
         });
         let task2 = tokio::spawn(async move {
             let value = NetworkValue::RingElement16(RingElement(777));
-            alice.send(value.to_network(), &"bob".into()).await
+            alice.send(value, &"bob".into()).await
         });
 
         let _ = tokio::try_join!(task1, task2).unwrap();

--- a/iris-mpc-cpu/src/network/local.rs
+++ b/iris-mpc-cpu/src/network/local.rs
@@ -91,7 +91,7 @@ impl Networking for LocalNetworking {
             .clone();
 
         let received_value = rx.recv().await?;
-        NetworkValue::from_network(&received_value.value)
+        NetworkValue::deserialize(&received_value.value)
     }
 }
 

--- a/iris-mpc-cpu/src/network/local.rs
+++ b/iris-mpc-cpu/src/network/local.rs
@@ -91,7 +91,7 @@ impl Networking for LocalNetworking {
             .clone();
 
         let received_value = rx.recv().await?;
-        NetworkValue::from_network(Ok(received_value.value))
+        NetworkValue::from_network(&received_value.value)
     }
 }
 

--- a/iris-mpc-cpu/src/network/mod.rs
+++ b/iris-mpc-cpu/src/network/mod.rs
@@ -1,6 +1,9 @@
-use crate::execution::{
-    player::Identity,
-    session::{SessionId, StreamId},
+use crate::{
+    execution::{
+        player::Identity,
+        session::{SessionId, StreamId},
+    },
+    network::value::NetworkValue,
 };
 use async_trait::async_trait;
 use eyre::Result;
@@ -8,9 +11,9 @@ use eyre::Result;
 /// Requirements for networking.
 #[async_trait]
 pub trait Networking {
-    async fn send(&self, value: Vec<u8>, receiver: &Identity) -> Result<()>;
+    async fn send(&self, value: NetworkValue, receiver: &Identity) -> Result<()>;
 
-    async fn receive(&mut self, sender: &Identity) -> Result<Vec<u8>>;
+    async fn receive(&mut self, sender: &Identity) -> Result<NetworkValue>;
 }
 
 #[derive(Clone)]

--- a/iris-mpc-cpu/src/network/tcp/handle.rs
+++ b/iris-mpc-cpu/src/network/tcp/handle.rs
@@ -509,7 +509,13 @@ async fn handle_inbound_traffic(
         }
         // forward the message to the correct session.
         if let Some(ch) = inbound_tx.get(&SessionId::from(session_id)) {
-            let nv = NetworkValue::from_network(&buf[..total_len]).unwrap();
+            let nv = match NetworkValue::from_network(&buf[..total_len]) {
+                Ok(m) => m,
+                Err(e) => {
+                    tracing::error!("failed to deserialize message: {e}");
+                    continue;
+                }
+            };
             if ch.send(nv).is_err() {
                 return Err(io::Error::new(
                     io::ErrorKind::Other,

--- a/iris-mpc-cpu/src/network/tcp/handle.rs
+++ b/iris-mpc-cpu/src/network/tcp/handle.rs
@@ -398,7 +398,7 @@ async fn handle_outbound_traffic(
         let _wakeup_time = Instant::now();
         buffered_msgs += 1;
         buf.extend_from_slice(&session_id.0.to_le_bytes());
-        msg.write_to_buf(&mut buf);
+        msg.serialize(&mut buf);
 
         let loop_start_time = Instant::now();
         while buffered_msgs < num_sessions {
@@ -406,7 +406,7 @@ async fn handle_outbound_traffic(
                 Ok((session_id, msg)) => {
                     buffered_msgs += 1;
                     buf.extend_from_slice(&session_id.0.to_le_bytes());
-                    msg.write_to_buf(&mut buf);
+                    msg.serialize(&mut buf);
                     if buf.len() >= BUFFER_CAPACITY {
                         break;
                     }
@@ -509,7 +509,7 @@ async fn handle_inbound_traffic(
         }
         // forward the message to the correct session.
         if let Some(ch) = inbound_tx.get(&SessionId::from(session_id)) {
-            let nv = match NetworkValue::from_network(&buf[..total_len]) {
+            let nv = match NetworkValue::deserialize(&buf[..total_len]) {
                 Ok(m) => m,
                 Err(e) => {
                     tracing::error!("failed to deserialize message: {e}");

--- a/iris-mpc-cpu/src/network/tcp/handle.rs
+++ b/iris-mpc-cpu/src/network/tcp/handle.rs
@@ -1,12 +1,11 @@
 use super::{
-    session::TcpSession, NetworkMsg, OutStream, OutboundMsg, PeerConnections, StreamId,
-    TcpConnection,
+    session::TcpSession, OutStream, OutboundMsg, PeerConnections, StreamId, TcpConnection,
 };
 use crate::{
     execution::{player::Identity, session::SessionId},
     network::{
         tcp::{networking::connection_builder::Reconnector, TcpConfig},
-        value::DescriptorByte,
+        value::{DescriptorByte, NetworkValue},
     },
 };
 use bytes::BytesMut;
@@ -32,8 +31,8 @@ const READ_BUF_SIZE: usize = BUFFER_CAPACITY;
 struct SessionChannels {
     outbound_tx: HashMap<Identity, HashMap<StreamId, UnboundedSender<OutboundMsg>>>,
     outbound_rx: HashMap<Identity, HashMap<StreamId, UnboundedReceiver<OutboundMsg>>>,
-    inbound_tx: HashMap<Identity, HashMap<SessionId, UnboundedSender<NetworkMsg>>>,
-    inbound_rx: HashMap<Identity, HashMap<SessionId, UnboundedReceiver<NetworkMsg>>>,
+    inbound_tx: HashMap<Identity, HashMap<SessionId, UnboundedSender<NetworkValue>>>,
+    inbound_rx: HashMap<Identity, HashMap<SessionId, UnboundedReceiver<NetworkValue>>>,
 }
 
 /// spawns a task for each TCP connection (there are x connections per peer and each of the x
@@ -208,7 +207,7 @@ fn make_channels(
 
             // insert one pair of inbound channels per stream_parallelism
             for session_id in sessions {
-                let (tx, rx) = mpsc::unbounded_channel::<NetworkMsg>();
+                let (tx, rx) = mpsc::unbounded_channel::<NetworkValue>();
                 inbound_tx.insert(session_id, tx);
                 inbound_rx.insert(session_id, rx);
             }
@@ -337,8 +336,8 @@ async fn manage_connection(
 fn spawn_forwarders(
     reader: Arc<Mutex<Option<BufReader<OwnedReadHalf>>>>,
     writer: Arc<Mutex<Option<OwnedWriteHalf>>>,
-    inbound_forwarder: Arc<Mutex<HashMap<SessionId, UnboundedSender<Vec<u8>>>>>,
-    outbound_rx: Arc<Mutex<UnboundedReceiver<(SessionId, Vec<u8>)>>>,
+    inbound_forwarder: Arc<Mutex<HashMap<SessionId, UnboundedSender<NetworkValue>>>>,
+    outbound_rx: Arc<Mutex<UnboundedReceiver<(SessionId, NetworkValue)>>>,
     num_sessions: usize,
 ) -> JoinSet<()> {
     let mut join_set = JoinSet::new();
@@ -399,7 +398,7 @@ async fn handle_outbound_traffic(
         let _wakeup_time = Instant::now();
         buffered_msgs += 1;
         buf.extend_from_slice(&session_id.0.to_le_bytes());
-        buf.extend_from_slice(&msg);
+        msg.write_to_buf(&mut buf);
 
         let loop_start_time = Instant::now();
         while buffered_msgs < num_sessions {
@@ -407,7 +406,7 @@ async fn handle_outbound_traffic(
                 Ok((session_id, msg)) => {
                     buffered_msgs += 1;
                     buf.extend_from_slice(&session_id.0.to_le_bytes());
-                    buf.extend_from_slice(&msg);
+                    msg.write_to_buf(&mut buf);
                     if buf.len() >= BUFFER_CAPACITY {
                         break;
                     }
@@ -459,7 +458,7 @@ async fn handle_outbound_traffic(
 /// Inbound: read from the socket and send to tx.
 async fn handle_inbound_traffic(
     reader: &mut BufReader<OwnedReadHalf>,
-    inbound_tx: &HashMap<SessionId, UnboundedSender<NetworkMsg>>,
+    inbound_tx: &HashMap<SessionId, UnboundedSender<NetworkValue>>,
 ) -> io::Result<()> {
     let mut buf = vec![0u8; READ_BUF_SIZE];
 
@@ -510,7 +509,8 @@ async fn handle_inbound_traffic(
         }
         // forward the message to the correct session.
         if let Some(ch) = inbound_tx.get(&SessionId::from(session_id)) {
-            if ch.send(buf[..total_len].to_vec()).is_err() {
+            let nv = NetworkValue::from_network(&buf[..total_len]).unwrap();
+            if ch.send(nv).is_err() {
                 return Err(io::Error::new(
                     io::ErrorKind::Other,
                     "failed to forward message",

--- a/iris-mpc-cpu/src/network/tcp/mod.rs
+++ b/iris-mpc-cpu/src/network/tcp/mod.rs
@@ -207,8 +207,8 @@ mod tests {
 
     async fn all_parties_talk(identities: Vec<Identity>, sessions: Vec<TcpSession>) {
         let mut tasks = JoinSet::new();
-        let message_to_next = get_prf().to_network();
-        let message_to_prev = get_prf().to_network();
+        let message_to_next = get_prf();
+        let message_to_prev = get_prf();
 
         for (player_id, session) in sessions.into_iter().enumerate() {
             let role = Role::new(player_id);
@@ -282,14 +282,13 @@ mod tests {
 
                 // Send a message from the first party to the second party
                 let alice_prf = get_prf();
-                let alice_msg = alice_prf.to_network();
+                let alice_msg = alice_prf.clone();
 
                 let task1 = tokio::spawn(async move {
                     alice.send(alice_msg, &"bob".into()).await.unwrap();
                 });
                 let task2 = tokio::spawn(async move {
-                    let received_message = bob.receive(&"alice".into()).await;
-                    let rx_msg = NetworkValue::from_network(received_message).unwrap();
+                    let rx_msg = bob.receive(&"alice".into()).await.unwrap();
                     assert_eq!(alice_prf, rx_msg);
                 });
                 let _ = tokio::try_join!(task1, task2).unwrap();

--- a/iris-mpc-cpu/src/network/tcp/mod.rs
+++ b/iris-mpc-cpu/src/network/tcp/mod.rs
@@ -1,6 +1,6 @@
 use std::{cmp, time::Duration};
 
-use crate::execution::session::SessionId;
+use crate::{execution::session::SessionId, network::value::NetworkValue};
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
 mod data;
@@ -10,11 +10,10 @@ pub mod session;
 
 use data::*;
 
-type NetworkMsg = Vec<u8>;
 // session multiplexing over a socket requires a SessionId
-type OutboundMsg = (SessionId, NetworkMsg);
-type OutStream = UnboundedSender<NetworkMsg>;
-type InStream = UnboundedReceiver<NetworkMsg>;
+type OutboundMsg = (SessionId, NetworkValue);
+type OutStream = UnboundedSender<NetworkValue>;
+type InStream = UnboundedReceiver<NetworkValue>;
 
 #[derive(Default, Clone, Debug)]
 pub struct TcpConfig {

--- a/iris-mpc-cpu/src/network/value.rs
+++ b/iris-mpc-cpu/src/network/value.rs
@@ -361,6 +361,7 @@ where
     fn new_network_element(element: RingElement<Self>) -> NetworkValue;
     fn new_network_vec(elements: Vec<RingElement<Self>>) -> NetworkValue;
     fn into_vec(value: NetworkValue) -> Result<Vec<RingElement<Self>>>;
+    fn vec_from_network(nv: NetworkValue) -> Result<Vec<RingElement<Self>>>;
 }
 
 macro_rules! impl_network_int {
@@ -372,6 +373,16 @@ macro_rules! impl_network_int {
             fn new_network_vec(v: Vec<RingElement<$t>>) -> NetworkValue {
                 NetworkValue::$vec(v)
             }
+            /*
+            // example implementation:
+             fn into_vec(value: NetworkValue) -> Result<Vec<RingElement<Self>>> {
+                match value {
+                    NetworkValue::VecRing16(x) => Ok(x),
+                    NetworkValue::RingElement16(x) => Ok(vec![x]),
+                    _ => Err(eyre!("Invalid conversion to Vec<RingElement<u16>>")),
+                }
+            }
+            */
             fn into_vec(val: NetworkValue) -> Result<Vec<RingElement<$t>>> {
                 match val {
                     NetworkValue::$vec(v) => Ok(v),
@@ -379,6 +390,15 @@ macro_rules! impl_network_int {
                     _ => Err(eyre!(
                         "Invalid conversion to Vec<RingElement<{}>>",
                         stringify!($t)
+                    )),
+                }
+            }
+            fn vec_from_network(nv: NetworkValue) -> Result<Vec<RingElement<$t>>> {
+                match nv {
+                    NetworkValue::$vec(v) => Ok(v),
+                    _ => Err(eyre!(
+                        "invalid network value in NetworkInt::vec_from_network: {}",
+                        nv.get_descriptor_byte()
                     )),
                 }
             }

--- a/iris-mpc-cpu/src/network/value.rs
+++ b/iris-mpc-cpu/src/network/value.rs
@@ -19,6 +19,7 @@ pub enum NetworkValue {
     VecRing32(Vec<RingElement<u32>>),
     VecRing64(Vec<RingElement<u64>>),
     StateChecksum(StateChecksum),
+    // outside of this module, use vec_to_network() and vec_from_network() instead of accessing this variant directly.
     NetworkVec(Vec<Self>),
 }
 
@@ -108,7 +109,31 @@ impl NetworkValue {
         }
     }
 
-    fn to_network_inner(&self, res: &mut BytesMut) {
+    // serialize_internal() doesn't allow for NetworkValue::NetworkVec. a separate code path
+    // is used to handle that variant.
+    pub fn serialize(&self, res: &mut BytesMut) {
+        match &self {
+            NetworkValue::NetworkVec(v) => Self::serialize_vec(v, res),
+            _ => {
+                self.serialize_internal(res);
+            }
+        }
+    }
+
+    fn serialize_vec(values: &Vec<Self>, res: &mut BytesMut) {
+        let res_start = res.len();
+        res.extend_from_slice(&[DescriptorByte::NetworkVec.into()]);
+        // this is a placeholder
+        let len_idx = res.len();
+        res.extend_from_slice(&[0_u8; 4]);
+        for value in values {
+            value.serialize_internal(res);
+        }
+        let msg_len = res.len() - res_start;
+        res[len_idx..len_idx + 4].copy_from_slice(&((msg_len - 5) as u32).to_le_bytes());
+    }
+
+    fn serialize_internal(&self, res: &mut BytesMut) {
         res.extend_from_slice(&[self.get_descriptor_byte()]);
 
         match self {
@@ -146,34 +171,67 @@ impl NetworkValue {
         }
     }
 
-    pub fn write_to_buf(&self, res: &mut BytesMut) {
-        match &self {
-            NetworkValue::NetworkVec(v) => Self::vec_to_network(v, res),
-            _ => {
-                self.to_network_inner(res);
-            }
-        }
-    }
-
-    pub fn to_network(&self) -> Vec<u8> {
-        let mut res = BytesMut::with_capacity(self.byte_len());
-        self.write_to_buf(&mut res);
-        res.freeze().into()
-    }
-
-    pub fn from_network(serialized: &[u8]) -> Result<Self> {
+    pub fn deserialize(serialized: &[u8]) -> Result<Self> {
         if serialized
             .first()
             .map(|byte| *byte == DescriptorByte::NetworkVec as u8)
             .unwrap_or_default()
         {
-            Self::vec_from_network(serialized).map(NetworkValue::NetworkVec)
+            Self::deserialize_vec(serialized).map(NetworkValue::NetworkVec)
         } else {
-            Self::from_network_slice(serialized)
+            Self::deserialize_internal(serialized)
         }
     }
 
-    fn from_network_slice(serialized: &[u8]) -> Result<Self> {
+    pub fn deserialize_vec(serialized: &[u8]) -> Result<Vec<Self>> {
+        if serialized.len() < 5 {
+            bail!("Can't parse vector length: buffer too short");
+        }
+        if serialized[0] != DescriptorByte::NetworkVec as u8 {
+            return Err(eyre!("called deserialize_vec() on invalid buffer"));
+        }
+        let payload_len = u32::from_le_bytes(<[u8; 4]>::try_from(&serialized[1..5])?) as usize;
+        if serialized.len() != 5 + payload_len {
+            bail!(
+                "NetworkVec length mismatch: {} vs expected {}",
+                serialized.len() - 5,
+                payload_len,
+            );
+        }
+
+        let mut res = Vec::new();
+        let mut idx = 5;
+        let end_idx = 5 + payload_len;
+
+        while idx < end_idx {
+            let descriptor_byte: DescriptorByte = serialized[idx].try_into()?;
+            let value_len = match descriptor_byte {
+                DescriptorByte::RingElementBit0 | DescriptorByte::RingElementBit1 => 1,
+                DescriptorByte::RingElement16 => 3,
+                DescriptorByte::RingElement32 => 5,
+                DescriptorByte::RingElement64 => 9,
+                DescriptorByte::VecRing16
+                | DescriptorByte::VecRing32
+                | DescriptorByte::VecRing64 => {
+                    if end_idx < idx + 5 {
+                        bail!("Invalid length for VecRing: can't parse vector length");
+                    }
+                    let len =
+                        u32::from_le_bytes(<[u8; 4]>::try_from(&serialized[idx + 1..idx + 5])?)
+                            as usize;
+                    5 + len
+                }
+                _ => bail!("Invalid type for NetworkVec"),
+            };
+            res.push(NetworkValue::deserialize_internal(
+                &serialized[idx..idx + value_len],
+            )?);
+            idx += value_len;
+        }
+        Ok(res)
+    }
+
+    fn deserialize_internal(serialized: &[u8]) -> Result<Self> {
         if serialized.is_empty() {
             bail!("Empty serialized data");
         }
@@ -224,15 +282,15 @@ impl NetworkValue {
                 )))
             }
             DescriptorByte::VecRing16 => {
-                let res = get_vec_ring_elements::<u16, 2, _>(serialized, u16::from_le_bytes)?;
+                let res = deserialize_vec_ring::<u16, 2, _>(serialized, u16::from_le_bytes)?;
                 Ok(NetworkValue::VecRing16(res))
             }
             DescriptorByte::VecRing32 => {
-                let res = get_vec_ring_elements::<u32, 4, _>(serialized, u32::from_le_bytes)?;
+                let res = deserialize_vec_ring::<u32, 4, _>(serialized, u32::from_le_bytes)?;
                 Ok(NetworkValue::VecRing32(res))
             }
             DescriptorByte::VecRing64 => {
-                let res = get_vec_ring_elements::<u64, 8, _>(serialized, u64::from_le_bytes)?;
+                let res = deserialize_vec_ring::<u64, 8, _>(serialized, u64::from_le_bytes)?;
                 Ok(NetworkValue::VecRing64(res))
             }
             DescriptorByte::StateChecksum => {
@@ -249,67 +307,30 @@ impl NetworkValue {
         }
     }
 
-    fn vec_to_network(values: &Vec<Self>, res: &mut BytesMut) {
-        let res_start = res.len();
-        res.extend_from_slice(&[DescriptorByte::NetworkVec.into()]);
-        // this is a placeholder
-        let len_idx = res.len();
-        res.extend_from_slice(&[0_u8; 4]);
-        for value in values {
-            value.to_network_inner(res);
-        }
-        let msg_len = res.len() - res_start;
-        res[len_idx..len_idx + 4].copy_from_slice(&((msg_len - 5) as u32).to_le_bytes());
+    // below are functions whose names have been preserved to not impact existing code.
+
+    pub fn to_network(&self) -> Vec<u8> {
+        let mut res = BytesMut::with_capacity(self.byte_len());
+        self.serialize(&mut res);
+        res.freeze().into()
     }
 
-    pub fn vec_from_network(serialized: &[u8]) -> Result<Vec<Self>> {
-        // note that the descriptor byte gets skipped here. (idx 0)
-        if serialized.len() < 5 {
-            bail!("Can't parse vector length: buffer too short");
-        }
-        let payload_len = u32::from_le_bytes(<[u8; 4]>::try_from(&serialized[1..5])?) as usize;
-        if serialized.len() != 5 + payload_len {
-            bail!(
-                "NetworkVec length mismatch: {} vs expected {}",
-                serialized.len() - 5,
-                payload_len,
-            );
-        }
+    pub fn vec_to_network(v: Vec<Self>) -> Self {
+        Self::NetworkVec(v)
+    }
 
-        let mut res = Vec::new();
-        let mut idx = 5;
-        let end_idx = 5 + payload_len;
-
-        while idx < end_idx {
-            let descriptor_byte: DescriptorByte = serialized[idx].try_into()?;
-            let value_len = match descriptor_byte {
-                DescriptorByte::RingElementBit0 | DescriptorByte::RingElementBit1 => 1,
-                DescriptorByte::RingElement16 => 3,
-                DescriptorByte::RingElement32 => 5,
-                DescriptorByte::RingElement64 => 9,
-                DescriptorByte::VecRing16
-                | DescriptorByte::VecRing32
-                | DescriptorByte::VecRing64 => get_vec_ring_len(idx, end_idx, serialized)?,
-                _ => bail!("Invalid type for NetworkVec"),
-            };
-            res.push(NetworkValue::from_network_slice(
-                &serialized[idx..idx + value_len],
-            )?);
-            idx += value_len;
+    pub fn vec_from_network(nv: Self) -> Result<Vec<Self>> {
+        match nv {
+            NetworkValue::NetworkVec(v) => Ok(v),
+            _ => Err(eyre!(
+                "expected NetworkVec but got {}",
+                nv.get_descriptor_byte()
+            )),
         }
-        Ok(res)
     }
 }
 
-fn get_vec_ring_len(idx: usize, end_idx: usize, serialized: &[u8]) -> Result<usize> {
-    if end_idx < idx + 5 {
-        bail!("Invalid length for VecRing: can't parse vector length");
-    }
-    let len = u32::from_le_bytes(<[u8; 4]>::try_from(&serialized[idx + 1..idx + 5])?) as usize;
-    Ok(5 + len)
-}
-
-fn get_vec_ring_elements<T, const N: usize, F>(
+fn deserialize_vec_ring<T, const N: usize, F>(
     serialized: &[u8],
     from_bytes: F,
 ) -> Result<Vec<RingElement<T>>>
@@ -361,7 +382,6 @@ where
     fn new_network_element(element: RingElement<Self>) -> NetworkValue;
     fn new_network_vec(elements: Vec<RingElement<Self>>) -> NetworkValue;
     fn into_vec(value: NetworkValue) -> Result<Vec<RingElement<Self>>>;
-    fn vec_from_network(nv: NetworkValue) -> Result<Vec<RingElement<Self>>>;
 }
 
 macro_rules! impl_network_int {
@@ -373,32 +393,13 @@ macro_rules! impl_network_int {
             fn new_network_vec(v: Vec<RingElement<$t>>) -> NetworkValue {
                 NetworkValue::$vec(v)
             }
-            /*
-            // example implementation:
-             fn into_vec(value: NetworkValue) -> Result<Vec<RingElement<Self>>> {
-                match value {
-                    NetworkValue::VecRing16(x) => Ok(x),
-                    NetworkValue::RingElement16(x) => Ok(vec![x]),
-                    _ => Err(eyre!("Invalid conversion to Vec<RingElement<u16>>")),
-                }
-            }
-            */
             fn into_vec(val: NetworkValue) -> Result<Vec<RingElement<$t>>> {
                 match val {
-                    NetworkValue::$vec(v) => Ok(v),
                     NetworkValue::$elem(e) => Ok(vec![e]),
+                    NetworkValue::$vec(v) => Ok(v),
                     _ => Err(eyre!(
                         "Invalid conversion to Vec<RingElement<{}>>",
                         stringify!($t)
-                    )),
-                }
-            }
-            fn vec_from_network(nv: NetworkValue) -> Result<Vec<RingElement<$t>>> {
-                match nv {
-                    NetworkValue::$vec(v) => Ok(v),
-                    _ => Err(eyre!(
-                        "invalid network value in NetworkInt::vec_from_network: {}",
-                        nv.get_descriptor_byte()
                     )),
                 }
             }
@@ -422,9 +423,9 @@ mod tests {
             .map(|v| NetworkValue::RingElement16(*v))
             .collect::<Vec<_>>();
         let mut bm = BytesMut::new();
-        NetworkValue::vec_to_network(&network_values, &mut bm);
+        NetworkValue::NetworkVec(network_values.clone()).serialize(&mut bm);
         let serialized = bm.freeze().to_vec();
-        let result_vec = NetworkValue::vec_from_network(&serialized)?;
+        let result_vec = NetworkValue::deserialize_vec(&serialized)?;
         assert_eq!(network_values, result_vec);
 
         Ok(())
@@ -433,7 +434,7 @@ mod tests {
     /// Test from_network with empty data
     #[test]
     fn test_from_network_empty() -> Result<()> {
-        let result = NetworkValue::from_network(&[]);
+        let result = NetworkValue::deserialize(&[]);
         assert_eq!(result.unwrap_err().to_string(), "Empty serialized data");
         Ok(())
     }

--- a/iris-mpc-cpu/src/protocol/binary.rs
+++ b/iris-mpc-cpu/src/protocol/binary.rs
@@ -863,7 +863,7 @@ pub(crate) async fn open_bin(session: &mut Session, shares: &[Share<Bit>]) -> Re
             .iter()
             .map(|x| NetworkValue::RingElementBit(x.b))
             .collect::<Vec<_>>();
-        NetworkValue::NetworkVec(bits)
+        NetworkValue::vec_to_network(bits)
     };
 
     network.send_next(message).await?;
@@ -878,8 +878,8 @@ pub(crate) async fn open_bin(session: &mut Session, shares: &[Share<Bit>]) -> Re
                 _ => Err(eyre!("Wrong value type is received in open_bin operation")),
             }
         } else {
-            match other_shares {
-                Ok(NetworkValue::NetworkVec(v)) => {
+            match NetworkValue::vec_from_network(other_shares) {
+                Ok(v) => {
                     if matches!(v[0], NetworkValue::RingElementBit(_)) {
                         Ok(v.into_iter()
                             .map(|x| match x {
@@ -892,7 +892,6 @@ pub(crate) async fn open_bin(session: &mut Session, shares: &[Share<Bit>]) -> Re
                     }
                 }
                 Err(e) => Err(eyre!("Error in receiving in open_bin operation: {}", e)),
-                _ => Err(eyre!("Wrong value type is received in open_bin operation")),
             }
         }
     }?;

--- a/iris-mpc-cpu/src/protocol/binary.rs
+++ b/iris-mpc-cpu/src/protocol/binary.rs
@@ -313,7 +313,7 @@ where
 
     // Receive m0 or m1 from Receiver
     let m0_or_m1 = match network.receive_next().await {
-        Ok(nv) => T::vec_from_network(nv)?,
+        Ok(nv) => T::into_vec(nv)?,
         Err(e) => return Err(eyre!("Could not deserialize properly in bit inject: {e}")),
     };
 
@@ -336,8 +336,8 @@ where
     let network = &mut session.network_session;
 
     let (m0, m1, wc) = {
-        let m0_and_m1 = match network.receive_next().await? {
-            NetworkValue::NetworkVec(v) => v,
+        let m0_and_m1 = match network.receive_next().await {
+            Ok(v) => NetworkValue::vec_from_network(v)?,
             _ => bail!("Cannot deserialize m0 and m1 into vec"),
         };
         if m0_and_m1.len() != 2 {
@@ -353,7 +353,7 @@ where
             .ok_or(eyre!("Cannot deserialize m0 and m1 into tuple"))?;
 
         let wc = match network.receive_prev().await {
-            Ok(nv) => T::vec_from_network(nv),
+            Ok(v) => T::into_vec(v),
             Err(e) => Err(eyre!("Could not deserialize properly in bit inject: {e}")),
         };
         (m0, m1, wc)
@@ -438,7 +438,7 @@ where
     // Send m0 and m1 to Receiver
     session
         .network_session
-        .send_prev(NetworkValue::NetworkVec(m0_and_m1))
+        .send_prev(NetworkValue::vec_to_network(m0_and_m1))
         .await?;
     Ok(shares)
 }

--- a/iris-mpc-cpu/src/protocol/binary.rs
+++ b/iris-mpc-cpu/src/protocol/binary.rs
@@ -870,11 +870,13 @@ pub(crate) async fn open_bin(session: &mut Session, shares: &[Share<Bit>]) -> Re
 
     // Receiving `b` from previous party
     let b_from_previous = {
-        let other_shares = network.receive_prev().await;
+        let other_shares = network
+            .receive_prev()
+            .await
+            .map_err(|e| eyre!("Error in receiving in open_bin operation: {}", e))?;
         if shares.len() == 1 {
             match other_shares {
-                Ok(NetworkValue::RingElementBit(message)) => Ok(vec![message]),
-                Err(e) => Err(eyre!("Error in receiving in open_bin operation: {}", e)),
+                NetworkValue::RingElementBit(message) => Ok(vec![message]),
                 _ => Err(eyre!("Wrong value type is received in open_bin operation")),
             }
         } else {

--- a/iris-mpc-cpu/src/protocol/binary.rs
+++ b/iris-mpc-cpu/src/protocol/binary.rs
@@ -312,12 +312,10 @@ where
     network.send_next(T::new_network_vec(wc)).await?;
 
     // Receive m0 or m1 from Receiver
-    let m0_or_m1 = {
-        match network.receive_next().await {
-            Ok(v) => T::into_vec(v),
-            Err(e) => Err(eyre!("Could not deserialize properly in bit inject: {e}")),
-        }
-    }?;
+    let m0_or_m1 = match network.receive_next().await {
+        Ok(nv) => T::vec_from_network(nv)?,
+        Err(e) => return Err(eyre!("Could not deserialize properly in bit inject: {e}")),
+    };
 
     // Set the first share to the value of m0 or m1
     for (s, mb) in shares.iter_mut().zip(m0_or_m1) {
@@ -355,7 +353,7 @@ where
             .ok_or(eyre!("Cannot deserialize m0 and m1 into tuple"))?;
 
         let wc = match network.receive_prev().await {
-            Ok(v) => T::into_vec(v),
+            Ok(nv) => T::vec_from_network(nv),
             Err(e) => Err(eyre!("Could not deserialize properly in bit inject: {e}")),
         };
         (m0, m1, wc)


### PR DESCRIPTION
Outbound messages get batched into a `BytesMut`. Rather than serialize a `NetworkValue` to a `Vec<u8>` and then copy that to the `BytesMut`, the `Networking` trait now operates on a `NetworkValue` so that it can be serialized directly into the `BytesMut`.  A copy is also eliminated from inbound traffic. Now, instead of copying a slice to a vec and then converting the vec to a `NetworkValue`, a `NetworkValue` can be deserialized directly from the slice.

The `grpc` module was also updated, though this change should have no effect on it. 

`binary.rs` operates on vecs of `NetworkValue`s, and the `NetworkValue::NetworkVec` variant was added to support this. `NetworkValue::vec_to_network()` and `NetworkValue::vec_from_network()` were updated to expect a `NetworkVec` variant so that the code in `binary.rs` doesn't change too much. 

