### PR TITLE
Add TLS capability to the networking stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,29 +277,25 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.10.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd82dba44d209fddb11c190e0a94b78651f95299598e472215667417a03ff1d"
+checksum = "93fcc8f365936c834db5514fc45aee5b1202d677e6b40e48468aaaa8183ca8c7"
 dependencies = [
  "aws-lc-sys",
- "mirai-annotations",
- "paste",
  "zeroize",
 ]
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.22.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7a4168111d7eb622a31b214057b8509c0a7e1794f44c546d742330dc793972"
+checksum = "61b1d86e7705efe1be1b569bab41d4fa1e14e220b60a160f78de2db687add079"
 dependencies = [
  "bindgen",
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
- "libc",
- "paste",
 ]
 
 [[package]]
@@ -2132,11 +2128,11 @@ dependencies = [
  "hyper 1.5.2",
  "hyper-util",
  "log",
- "rustls 0.23.18",
+ "rustls 0.23.28",
  "rustls-native-certs 0.8.0",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.0",
+ "tokio-rustls 0.26.2",
  "tower-service",
 ]
 
@@ -2401,6 +2397,7 @@ dependencies = [
  "static_assertions",
  "thiserror",
  "tokio",
+ "tokio-rustls 0.26.2",
  "tokio-stream",
  "tokio-util",
  "tonic",
@@ -2493,7 +2490,7 @@ dependencies = [
  "prost",
  "rand",
  "rand_chacha",
- "rustls 0.23.18",
+ "rustls 0.23.28",
  "serde",
  "serde-big-array",
  "sha2",
@@ -2902,12 +2899,6 @@ dependencies = [
  "wasi",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "mirai-annotations"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 
 [[package]]
 name = "multimap"
@@ -4000,16 +3991,16 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.18"
+version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9cc1d47e243d655ace55ed38201c19ae02c148ae56412ab8750e8f0166ab7f"
+checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki 0.103.3",
  "subtle",
  "zeroize",
 ]
@@ -4059,9 +4050,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -4075,9 +4069,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4861,12 +4855,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.18",
- "rustls-pki-types",
+ "rustls 0.23.28",
  "tokio",
 ]
 
@@ -4953,7 +4946,7 @@ dependencies = [
  "rustls-pemfile 2.2.0",
  "socket2",
  "tokio",
- "tokio-rustls 0.26.0",
+ "tokio-rustls 0.26.2",
  "tokio-stream",
  "tower 0.4.13",
  "tower-layer",

--- a/iris-mpc-cpu/Cargo.toml
+++ b/iris-mpc-cpu/Cargo.toml
@@ -60,6 +60,7 @@ backon = { version = "1.4.0", default-features = false, features = [
 ] }
 rand_chacha = { version = "0.3", features = ["serde1"] }
 num_enum = "0.7.3"
+tokio-rustls = { version = "0.26.2" }
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["async_tokio"] }

--- a/iris-mpc-cpu/benches/networking.rs
+++ b/iris-mpc-cpu/benches/networking.rs
@@ -83,7 +83,7 @@ fn bench_is_match_batch_tcp(c: &mut Criterion) {
             let t2 = create_random_sharing(&mut rng, 10_u16);
 
             let sessions = rt
-                .block_on(async move { LocalRuntime::mock_sessions_with_tcp(cp, rp / 2).await })
+                .block_on(async move { LocalRuntime::mock_sessions_with_tcp(cp, rp).await })
                 .unwrap();
 
             let num_parties = 3;

--- a/iris-mpc-cpu/src/network/tcp/README.md
+++ b/iris-mpc-cpu/src/network/tcp/README.md
@@ -3,6 +3,12 @@
 
 # Overview
 
+The TCP networking stack supports either TCP or TLS. The following traits make that possible:
+- `NetworkConnection`: both `TcpStream` and `TlsStream` support `AsyncRead` and `AsyncWrite`. Both can be passed to `tokio::io::split()` to get a read/write half. 
+- `Client`: used to initiate a connection.
+- `Server`: used to listen for connections.
+- `NetworkHandle`: simplifies `HawkActor`. `TcpNetworkHandle` is generic over `NetworkConnection` but `HawkActor` doesn't need to be. 
+
 ## `connection_builder.rs`
 
 This module manages peer-to-peer TCP connections by coordinating connection setup, acceptance, and reconnection.

--- a/iris-mpc-cpu/src/network/tcp/config.rs
+++ b/iris-mpc-cpu/src/network/tcp/config.rs
@@ -1,0 +1,56 @@
+use crate::network::tcp::data::StreamId;
+use std::{cmp, time::Duration};
+
+#[derive(Default, Clone, Debug)]
+pub struct TcpConfig {
+    pub timeout_duration: Duration,
+    // the number of requests processed at once
+    pub request_parallelism: usize,
+    // number of TCP connections
+    pub num_connections: usize,
+    // number of sessions per connection
+    pub max_sessions_per_connection: usize,
+}
+
+impl TcpConfig {
+    pub fn new(
+        timeout_duration: Duration,
+        num_connections: usize,
+        request_parallelism: usize,
+    ) -> Self {
+        // don't allow fewer requests than connections...
+        let connection_parallelism = cmp::min(num_connections, request_parallelism);
+
+        // if connection_parallelism doesn't divide request_parallelism, need to ensure
+        // enough multiplexing or else session creation will panic.
+        let max_sessions_per_connection = request_parallelism.div_ceil(connection_parallelism);
+
+        assert!(max_sessions_per_connection * connection_parallelism >= request_parallelism);
+
+        Self {
+            timeout_duration,
+            request_parallelism,
+            num_connections: connection_parallelism,
+            max_sessions_per_connection,
+        }
+    }
+
+    // max_sessions_per_connection doesn't have to divide request_parallelism. in that case, one TcpStream may have
+    // fewer sessions than the others. This function determines how many sessions are handled by a TcpStream based on the stream id
+    pub fn get_sessions_for_stream(&self, stream_id: &StreamId) -> usize {
+        match self.num_connections {
+            0 => unreachable!(),
+            1 => self.request_parallelism,
+            num_connections => {
+                let stream_id = stream_id.0 as usize;
+                if stream_id <= num_connections - 2
+                    || self.request_parallelism % self.max_sessions_per_connection == 0
+                {
+                    self.max_sessions_per_connection
+                } else {
+                    self.request_parallelism % self.max_sessions_per_connection
+                }
+            }
+        }
+    }
+}

--- a/iris-mpc-cpu/src/network/tcp/handle.rs
+++ b/iris-mpc-cpu/src/network/tcp/handle.rs
@@ -1,31 +1,54 @@
-use super::{
-    session::TcpSession, OutStream, OutboundMsg, PeerConnections, StreamId, TcpConnection,
-};
+use super::{session::TcpSession, Connection, OutStream, OutboundMsg, PeerConnections, StreamId};
 use crate::{
     execution::{player::Identity, session::SessionId},
     network::{
-        tcp::{networking::connection_builder::Reconnector, TcpConfig},
+        tcp::{
+            config::TcpConfig, networking::connection_builder::Reconnector, NetworkConnection,
+            NetworkHandle,
+        },
         value::{DescriptorByte, NetworkValue},
     },
 };
-use bytes::BytesMut;
+use async_trait::async_trait;
+use bytes::{Buf, BytesMut};
 use eyre::Result;
 use itertools::Itertools;
-use std::{collections::HashMap, time::Instant};
-use std::{io, sync::Arc, time::Duration};
+use std::io;
+use std::{
+    collections::HashMap,
+    time::{Duration, Instant},
+};
 use tokio::{
-    io::{AsyncReadExt, AsyncWriteExt, BufReader},
-    net::tcp::{OwnedReadHalf, OwnedWriteHalf},
+    io::{AsyncReadExt, AsyncWriteExt, BufReader, ReadHalf, WriteHalf},
     sync::{
         mpsc::{self, error::TryRecvError, UnboundedReceiver, UnboundedSender},
-        oneshot, Mutex,
+        oneshot,
     },
-    task::JoinSet,
 };
 
 const FLUSH_INTERVAL_US: u64 = 500;
 const BUFFER_CAPACITY: usize = 2 * 1024 * 1024;
 const READ_BUF_SIZE: usize = BUFFER_CAPACITY;
+
+/// spawns a task for each TCP connection (there are x connections per peer and each of the x
+/// connections has y sessions, of the same session id)
+pub struct TcpNetworkHandle<T: NetworkConnection> {
+    peers: Vec<Identity>,
+    ch_map: HashMap<Identity, HashMap<StreamId, UnboundedSender<Cmd>>>,
+    reconnector: Reconnector<T>,
+    config: TcpConfig,
+    next_session_id: usize,
+}
+
+#[async_trait]
+impl<T: NetworkConnection + 'static> NetworkHandle for TcpNetworkHandle<T> {
+    async fn make_sessions(&mut self) -> Result<Vec<TcpSession>> {
+        tracing::debug!("make_sessions");
+        self.reconnector.wait_for_reconnections().await?;
+        let sc = make_channels(&self.peers, &self.config, self.next_session_id);
+        Ok(self.make_sessions_inner(sc).await)
+    }
+}
 
 #[derive(Default)]
 struct SessionChannels {
@@ -33,16 +56,6 @@ struct SessionChannels {
     outbound_rx: HashMap<Identity, HashMap<StreamId, UnboundedReceiver<OutboundMsg>>>,
     inbound_tx: HashMap<Identity, HashMap<SessionId, UnboundedSender<NetworkValue>>>,
     inbound_rx: HashMap<Identity, HashMap<SessionId, UnboundedReceiver<NetworkValue>>>,
-}
-
-/// spawns a task for each TCP connection (there are x connections per peer and each of the x
-/// connections has y sessions, of the same session id)
-pub struct TcpNetworkHandle {
-    peers: Vec<Identity>,
-    ch_map: HashMap<Identity, HashMap<StreamId, UnboundedSender<Cmd>>>,
-    reconnector: Reconnector,
-    config: TcpConfig,
-    next_session_id: usize,
 }
 
 enum Cmd {
@@ -55,9 +68,12 @@ enum Cmd {
     TestReconnect { rsp: oneshot::Sender<Result<()>> },
 }
 
-impl TcpNetworkHandle {
-    pub fn new(reconnector: Reconnector, connections: PeerConnections, config: TcpConfig) -> Self {
-        tracing::info!("TcpNetworkHandle with config: {:?}", config);
+impl<T: NetworkConnection + 'static> TcpNetworkHandle<T> {
+    pub fn new(
+        reconnector: Reconnector<T>,
+        connections: PeerConnections<T>,
+        config: TcpConfig,
+    ) -> Self {
         let peers = connections.keys().cloned().collect();
         let mut ch_map = HashMap::new();
         for (peer_id, connections) in connections {
@@ -83,13 +99,6 @@ impl TcpNetworkHandle {
             config,
             next_session_id: 0,
         }
-    }
-
-    pub async fn make_sessions(&mut self) -> Result<Vec<TcpSession>> {
-        tracing::debug!("make_sessions");
-        self.reconnector.wait_for_reconnections().await?;
-        let sc = make_channels(&self.peers, &self.config, self.next_session_id);
-        Ok(self.make_sessions_inner(sc).await)
     }
 
     #[cfg(test)]
@@ -221,25 +230,20 @@ fn make_channels(
     sc
 }
 
-async fn manage_connection(
-    connection: TcpConnection,
-    reconnector: Reconnector,
+async fn manage_connection<T: NetworkConnection>(
+    connection: Connection<T>,
+    reconnector: Reconnector<T>,
     num_sessions: usize,
     mut cmd_ch: UnboundedReceiver<Cmd>,
 ) {
-    let TcpConnection {
+    let Connection {
         peer,
         stream,
         stream_id,
     } = connection;
 
-    let (reader, writer) = stream.into_split();
-    // these are made so that the stream can be dropped for testing purposes.
-    let reader = Arc::new(Mutex::new(Some(BufReader::new(reader))));
-    let writer = Arc::new(Mutex::new(Some(writer)));
-
     // We enter the loop only after receiving the first NewSessions
-    let (inbound_forwarder, outbound_rx) = match cmd_ch.recv().await {
+    let (mut inbound_forwarder, mut outbound_rx) = match cmd_ch.recv().await {
         Some(Cmd::NewSessions {
             inbound_forwarder,
             outbound_rx,
@@ -258,19 +262,28 @@ async fn manage_connection(
             return;
         }
     };
-    let inbound_forwarder = Arc::new(Mutex::new(inbound_forwarder));
-    let outbound_rx = Arc::new(Mutex::new(outbound_rx));
+
+    // need to wrap these in an Option to drop them before reconnecting.
+    let (reader, writer) = tokio::io::split(stream);
+    let mut reader = Some(BufReader::new(reader));
+    let mut writer = Some(writer);
 
     // on disconnect, reconnect automatically. tear down and stand up the forwarders.
     // when new sessions are requested, also tear down and stand up the forwarders.
     loop {
-        let mut set = spawn_forwarders(
-            reader.clone(),
-            writer.clone(),
-            inbound_forwarder.clone(),
-            outbound_rx.clone(),
-            num_sessions,
-        );
+        let r_writer = writer.as_mut().expect("writer should be Some");
+        let r_outbound = &mut outbound_rx;
+        let outbound_task = async move {
+            let r = handle_outbound_traffic(r_writer, r_outbound, num_sessions).await;
+            tracing::debug!("handle_outbound_traffic exited: {r:?}");
+        };
+
+        let r_reader = reader.as_mut().expect("reader should be Some");
+        let r_inbound = &inbound_forwarder;
+        let inbound_task = async move {
+            let r = handle_inbound_traffic(r_reader, r_inbound).await;
+            tracing::debug!("handle_inbound_traffic exited: {r:?}");
+        };
 
         enum Evt {
             Cmd(Cmd),
@@ -286,12 +299,9 @@ async fn manage_connection(
                     }
                 }
             }
-            _ = set.join_next() => Evt::Disconnected,
+            _ = inbound_task => Evt::Disconnected,
+            _ = outbound_task => Evt::Disconnected,
         };
-
-        // shut down the forwarders
-        tracing::info!("shutting down tasks for {:?}: {:?}", peer, stream_id);
-        set.shutdown().await;
 
         // update the Arcs depending on the event. wait for reconnect if needed.
         match event {
@@ -302,93 +312,65 @@ async fn manage_connection(
                     rsp,
                 } => {
                     tracing::debug!("updating sessions for {:?}: {:?}", peer, stream_id);
-                    *inbound_forwarder.lock().await = tx;
-                    *outbound_rx.lock().await = rx;
+                    inbound_forwarder = tx;
+                    outbound_rx = rx;
                     let _ = rsp.send(());
                     continue;
                 }
                 #[cfg(test)]
                 Cmd::TestReconnect { rsp } => {
-                    if let Err(e) =
-                        reconnect_and_replace(&reconnector, &peer, stream_id, &reader, &writer)
-                            .await
+                    if let Err(e) = reconnect_and_replace(
+                        &reconnector,
+                        &peer,
+                        stream_id,
+                        &mut reader,
+                        &mut writer,
+                    )
+                    .await
                     {
                         tracing::error!("reconnect failed: {e:?}");
                         return;
-                    }
+                    };
                     rsp.send(Ok(())).unwrap();
                 }
             },
             Evt::Disconnected => {
                 tracing::info!("reconnecting to {:?}: {:?}", peer, stream_id);
                 if let Err(e) =
-                    reconnect_and_replace(&reconnector, &peer, stream_id, &reader, &writer).await
+                    reconnect_and_replace(&reconnector, &peer, stream_id, &mut reader, &mut writer)
+                        .await
                 {
                     tracing::error!("reconnect failed: {e:?}");
                     return;
-                }
+                };
             }
         }
     }
 }
 
-#[allow(clippy::type_complexity)]
-fn spawn_forwarders(
-    reader: Arc<Mutex<Option<BufReader<OwnedReadHalf>>>>,
-    writer: Arc<Mutex<Option<OwnedWriteHalf>>>,
-    inbound_forwarder: Arc<Mutex<HashMap<SessionId, UnboundedSender<NetworkValue>>>>,
-    outbound_rx: Arc<Mutex<UnboundedReceiver<(SessionId, NetworkValue)>>>,
-    num_sessions: usize,
-) -> JoinSet<()> {
-    let mut join_set = JoinSet::new();
-
-    let writer = writer.clone();
-    let outbound_rx = outbound_rx.clone();
-    join_set.spawn(async move {
-        let mut writer = writer.lock().await;
-        let mut outbound_rx = outbound_rx.lock().await;
-        let r =
-            handle_outbound_traffic(writer.as_mut().unwrap(), &mut outbound_rx, num_sessions).await;
-        tracing::debug!("handle_outbound_traffic exited: {r:?}");
-    });
-
-    let reader = reader.clone();
-    let inbound_forwarder = inbound_forwarder.clone();
-    join_set.spawn(async move {
-        let mut reader = reader.lock().await;
-        let inbound = inbound_forwarder.lock().await;
-        let r = handle_inbound_traffic(reader.as_mut().unwrap(), &inbound).await;
-        tracing::debug!("handle_inbound_traffic exited: {r:?}");
-    });
-
-    join_set
-}
-
-async fn reconnect_and_replace(
-    reconnector: &Reconnector,
+async fn reconnect_and_replace<T: NetworkConnection>(
+    reconnector: &Reconnector<T>,
     peer: &Identity,
     stream_id: StreamId,
-    reader: &Arc<Mutex<Option<BufReader<OwnedReadHalf>>>>,
-    writer: &Arc<Mutex<Option<OwnedWriteHalf>>>,
+    reader: &mut Option<BufReader<ReadHalf<T>>>,
+    writer: &mut Option<WriteHalf<T>>,
 ) -> Result<(), eyre::Report> {
-    let old_writer = writer.lock().await.take();
-    let old_reader = reader.lock().await.take().map(|br| br.into_inner());
-    drop(old_writer);
-    drop(old_reader);
+    reader.take();
+    writer.take();
 
     let stream = reconnector.reconnect(peer.clone(), stream_id).await?;
-    let (r, w) = stream.into_split();
+    let (r, w) = tokio::io::split(stream);
 
-    reader.lock().await.replace(BufReader::new(r));
-    writer.lock().await.replace(w);
+    reader.replace(BufReader::new(r));
+    writer.replace(w);
 
     Ok(())
 }
 
 /// Outbound: send messages from rx to the socket.
 /// the sender needs to prepend the session id to the message.
-async fn handle_outbound_traffic(
-    stream: &mut OwnedWriteHalf,
+async fn handle_outbound_traffic<T: NetworkConnection>(
+    stream: &mut WriteHalf<T>,
     outbound_rx: &mut UnboundedReceiver<OutboundMsg>,
     num_sessions: usize,
 ) -> io::Result<()> {
@@ -456,8 +438,8 @@ async fn handle_outbound_traffic(
 }
 
 /// Inbound: read from the socket and send to tx.
-async fn handle_inbound_traffic(
-    reader: &mut BufReader<OwnedReadHalf>,
+async fn handle_inbound_traffic<T: NetworkConnection>(
+    reader: &mut BufReader<ReadHalf<T>>,
     inbound_tx: &HashMap<SessionId, UnboundedSender<NetworkValue>>,
 ) -> io::Result<()> {
     let mut buf = vec![0u8; READ_BUF_SIZE];
@@ -509,19 +491,19 @@ async fn handle_inbound_traffic(
         }
         // forward the message to the correct session.
         if let Some(ch) = inbound_tx.get(&SessionId::from(session_id)) {
-            let nv = match NetworkValue::deserialize(&buf[..total_len]) {
-                Ok(m) => m,
+            match NetworkValue::deserialize(&buf[..total_len]) {
+                Ok(nv) => {
+                    if ch.send(nv).is_err() {
+                        return Err(io::Error::new(
+                            io::ErrorKind::Other,
+                            "failed to forward message",
+                        ));
+                    }
+                }
                 Err(e) => {
                     tracing::error!("failed to deserialize message: {e}");
-                    continue;
                 }
             };
-            if ch.send(nv).is_err() {
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    "failed to forward message",
-                ));
-            }
         } else {
             tracing::warn!(
                 "failed to forward message for {:?} - channel not found",
@@ -532,8 +514,8 @@ async fn handle_inbound_traffic(
 }
 
 /// Helper to write & flush, then clear the buffer
-async fn write_buf(
-    writer: &mut OwnedWriteHalf,
+async fn write_buf<T: NetworkConnection>(
+    stream: &mut WriteHalf<T>,
     buf: &mut BytesMut,
     buffered_msgs: &mut usize,
 ) -> io::Result<()> {
@@ -543,7 +525,13 @@ async fn write_buf(
         metrics::histogram!("network::bytes_flushed").record(buf.len() as f64);
     }
     *buffered_msgs = 0;
-    writer.write_all(buf).await?;
+
+    // maybe faster than write_all()?
+    while !buf.is_empty() {
+        let n = stream.write(buf).await?;
+        buf.advance(n);
+    }
+    stream.flush().await?;
     buf.clear();
     Ok(())
 }

--- a/iris-mpc-cpu/src/network/tcp/networking/client.rs
+++ b/iris-mpc-cpu/src/network/tcp/networking/client.rs
@@ -1,0 +1,67 @@
+use async_trait::async_trait;
+use eyre::Result;
+use std::{net::SocketAddr, sync::Arc};
+use tokio::net::TcpStream;
+use tokio_rustls::rustls::{
+    pki_types::{pem::PemObject, CertificateDer, PrivateKeyDer, ServerName},
+    ClientConfig, RootCertStore,
+};
+use tokio_rustls::{TlsConnector, TlsStream};
+
+use crate::network::tcp::Client;
+
+#[derive(Clone)]
+pub struct TlsClient {
+    tls_connector: TlsConnector,
+}
+
+#[derive(Clone)]
+pub struct TcpClient {}
+
+impl TlsClient {
+    pub async fn new(key_file: &str, cert_file: &str, root_cert: &str) -> Result<Self> {
+        let mut root_cert_store = RootCertStore::empty();
+        for cert in CertificateDer::pem_file_iter(root_cert)? {
+            root_cert_store.add(cert?)?;
+        }
+
+        let certs = CertificateDer::pem_file_iter(cert_file)?
+            .map(|res| res.map_err(eyre::Report::from))
+            .collect::<Result<Vec<_>>>()?;
+        let key = PrivateKeyDer::from_pem_file(key_file)?;
+        let client_config = ClientConfig::builder()
+            .with_root_certificates(root_cert_store)
+            .with_client_auth_cert(certs, key)?;
+
+        let tls_connector = TlsConnector::from(Arc::new(client_config));
+        Ok(Self { tls_connector })
+    }
+}
+
+impl TcpClient {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[async_trait]
+impl Client for TlsClient {
+    type Output = TlsStream<TcpStream>;
+    async fn connect(&self, addr: SocketAddr) -> Result<Self::Output> {
+        let stream = TcpStream::connect(addr).await?;
+        stream.set_nodelay(true)?;
+        let domain = ServerName::IpAddress(addr.ip().into());
+        let tls_stream = self.tls_connector.connect(domain, stream).await?;
+        Ok(TlsStream::Client(tls_stream))
+    }
+}
+
+#[async_trait]
+impl Client for TcpClient {
+    type Output = TcpStream;
+    async fn connect(&self, addr: SocketAddr) -> Result<Self::Output> {
+        let stream = TcpStream::connect(addr).await?;
+        stream.set_nodelay(true)?;
+        Ok(stream)
+    }
+}

--- a/iris-mpc-cpu/src/network/tcp/networking/handshake.rs
+++ b/iris-mpc-cpu/src/network/tcp/networking/handshake.rs
@@ -1,12 +1,12 @@
-use crate::{execution::player::Identity, network::tcp::data::StreamId};
-use eyre::{eyre, Result};
-use tokio::{
-    io::{AsyncReadExt, AsyncWriteExt},
-    net::TcpStream,
+use crate::{
+    execution::player::Identity,
+    network::tcp::{data::StreamId, NetworkConnection},
 };
+use eyre::{eyre, Result};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-pub async fn outbound(
-    stream: &mut TcpStream,
+pub async fn outbound<T: NetworkConnection>(
+    stream: &mut T,
     own_id: &Identity,
     stream_id: &StreamId,
 ) -> Result<()> {
@@ -44,7 +44,7 @@ pub async fn outbound(
     Ok(())
 }
 
-pub async fn inbound(stream: &mut TcpStream) -> Result<(Identity, StreamId)> {
+pub async fn inbound<T: NetworkConnection>(stream: &mut T) -> Result<(Identity, StreamId)> {
     let stream_id = match stream.read_u32().await {
         Ok(id) => id,
         Err(e) => {

--- a/iris-mpc-cpu/src/network/tcp/networking/mod.rs
+++ b/iris-mpc-cpu/src/network/tcp/networking/mod.rs
@@ -1,2 +1,4 @@
+pub mod client;
 pub mod connection_builder;
 mod handshake;
+pub mod server;

--- a/iris-mpc-cpu/src/network/tcp/networking/server.rs
+++ b/iris-mpc-cpu/src/network/tcp/networking/server.rs
@@ -1,0 +1,78 @@
+use std::{net::SocketAddr, sync::Arc};
+
+use async_trait::async_trait;
+use eyre::Result;
+use tokio::net::{TcpListener, TcpStream};
+use tokio_rustls::rustls::{
+    pki_types::{pem::PemObject, CertificateDer, PrivateKeyDer},
+    server::WebPkiClientVerifier,
+    RootCertStore, ServerConfig,
+};
+use tokio_rustls::{TlsAcceptor, TlsStream};
+
+use crate::network::tcp::Server;
+
+pub struct TlsServer {
+    listener: TcpListener,
+    tls_acceptor: TlsAcceptor,
+}
+
+pub struct TcpServer {
+    listener: TcpListener,
+}
+
+impl TlsServer {
+    pub async fn new(
+        own_addr: SocketAddr,
+        key_file: &str,
+        cert_file: &str,
+        root_cert: &str,
+    ) -> Result<Self> {
+        let mut root_cert_store = RootCertStore::empty();
+        for cert in CertificateDer::pem_file_iter(root_cert)? {
+            root_cert_store.add(cert?)?;
+        }
+        let client_verifier = WebPkiClientVerifier::builder(Arc::new(root_cert_store)).build()?;
+
+        let certs = CertificateDer::pem_file_iter(cert_file)?.collect::<Result<Vec<_>, _>>()?;
+        let key = PrivateKeyDer::from_pem_file(key_file)?;
+        let server_config = ServerConfig::builder()
+            .with_client_cert_verifier(client_verifier)
+            .with_single_cert(certs, key)?;
+
+        let tls_acceptor = TlsAcceptor::from(Arc::new(server_config));
+        let listener = TcpListener::bind(own_addr).await?;
+        Ok(Self {
+            listener,
+            tls_acceptor,
+        })
+    }
+}
+
+impl TcpServer {
+    pub async fn new(own_addr: SocketAddr) -> Result<Self> {
+        let listener = TcpListener::bind(own_addr).await?;
+        Ok(Self { listener })
+    }
+}
+
+#[async_trait]
+impl Server for TlsServer {
+    type Output = TlsStream<TcpStream>;
+    async fn accept(&self) -> Result<(SocketAddr, Self::Output)> {
+        let (tcp_stream, peer_addr) = self.listener.accept().await?;
+        tcp_stream.set_nodelay(true)?;
+        let tls_stream = self.tls_acceptor.accept(tcp_stream).await?;
+        Ok((peer_addr, TlsStream::Server(tls_stream)))
+    }
+}
+
+#[async_trait]
+impl Server for TcpServer {
+    type Output = TcpStream;
+    async fn accept(&self) -> Result<(SocketAddr, Self::Output)> {
+        let (tcp_stream, peer_addr) = self.listener.accept().await?;
+        tcp_stream.set_nodelay(true)?;
+        Ok((peer_addr, tcp_stream))
+    }
+}

--- a/iris-mpc-cpu/src/network/tcp/session.rs
+++ b/iris-mpc-cpu/src/network/tcp/session.rs
@@ -3,11 +3,11 @@ use std::collections::HashMap;
 use super::{InStream, OutboundMsg};
 use crate::{
     execution::{player::Identity, session::SessionId},
-    network::{tcp::TcpConfig, value::NetworkValue, Networking},
+    network::{tcp::config::TcpConfig, value::NetworkValue, Networking},
 };
+use async_trait::async_trait;
 use eyre::{eyre, Result};
 use tokio::{sync::mpsc::UnboundedSender, time::timeout};
-use tonic::async_trait;
 use tracing::trace;
 
 #[derive(Debug)]

--- a/iris-mpc-cpu/tests/e2e.rs
+++ b/iris-mpc-cpu/tests/e2e.rs
@@ -135,6 +135,7 @@ async fn e2e_test() -> Result<()> {
         disable_persistence: false,
         match_distances_buffer_size: 64,
         n_buckets: 10,
+        tls: None,
     };
     let args1 = HawkArgs {
         party_index: 1,

--- a/iris-mpc-upgrade-hawk/src/genesis/mod.rs
+++ b/iris-mpc-upgrade-hawk/src/genesis/mod.rs
@@ -733,6 +733,7 @@ async fn get_hawk_actor(config: &Config) -> Result<HawkActor> {
         disable_persistence: config.disable_persistence,
         match_distances_buffer_size: config.match_distances_buffer_size,
         n_buckets: config.n_buckets,
+        tls: config.tls.clone(),
     };
 
     log_info(format!(

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -401,6 +401,7 @@ async fn init_hawk_actor(config: &Config) -> Result<HawkActor> {
         disable_persistence: config.disable_persistence,
         match_distances_buffer_size: config.match_distances_buffer_size,
         n_buckets: config.n_buckets,
+        tls: config.tls.clone(),
     };
 
     tracing::info!(


### PR DESCRIPTION
Added the following traits to `networking/tcp/mod.rs`:
- `NetworkConnection`: TCP or TLS
- `Client`: initiates the connection
- `Server`: listens for connections
- `NetworkHandle`: provides `TcpSession`s via `make_sessions()`

`Client` and `Server` have an associated type `Output` which implements `NetworkConnection`, which in practice is either TLS or TCP.

the `TcpNetworkHandle`  is generic over `NetworkConnection` and the `PeerConnectionBuilder` is generic over `NetworkConnection`, `Client` and `Server`.

`TlsStream` can't be split the same way that `TcpStream` can. `handle_connections()` no longer spawns separate threads for inbound and outbound traffic. now, `tokio::io::split()` is called on the `NetworkConnection` and the read and write halves are passed to tasks that get polled by a `tokio::select!` statement.


initial testing showed bursty behavior as TCP window size fluctuated between zero and its normal value. it also showed that the TcpStream never blocked, even when the underlying connection became overloaded.

buffering was removed from `handle_outbound_traffic()` until there is a clearer indication of the need for it. messages are still batched when possible, there is just no longer a 500us delay when sending a message. 