### PR TITLE
Skip actions on config changes [POP-2639]

### DIFF
--- a/.github/workflows/cpu-integration-tests.yaml
+++ b/.github/workflows/cpu-integration-tests.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Get all test, doc and src files that have changed
         id: changed-files-yaml
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c
         with:
           files_yaml: |
             src:

--- a/.github/workflows/cpu-integration-tests.yaml
+++ b/.github/workflows/cpu-integration-tests.yaml
@@ -24,12 +24,15 @@ jobs:
         with:
           files_yaml: |
             src:
-            - Dockerfile*
-            - Cargo.lock
-            - Cargo.toml
-            - deny.toml
-            - iris-*/**
-#            - .github/workflows/cpu-integration-tests.yaml -- bring this back after Canonical incident
+              - Dockerfile*
+              - Cargo.lock
+              - Cargo.toml
+              - deny.toml
+              - rust-toolchain.toml
+              - iris-*/**
+              - migrations/**
+              - scripts/**
+#              - .github/workflows/cpu-integration-tests.yaml -- bring this back after Canonical incident
 
       - name: Cache Rust build
         if: steps.changed-files-yaml.outputs.src_any_changed == 'true'

--- a/.github/workflows/cpu-integration-tests.yaml
+++ b/.github/workflows/cpu-integration-tests.yaml
@@ -18,7 +18,21 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
+      - name: Get all test, doc and src files that have changed
+        id: changed-files-yaml
+        uses: tj-actions/changed-files@v45
+        with:
+          files_yaml: |
+            src:
+            - Dockerfile*
+            - Cargo.lock
+            - Cargo.toml
+            - deny.toml
+            - iris-*/**
+#            - .github/workflows/cpu-integration-tests.yaml -- bring this back after Canonical incident
+
       - name: Cache Rust build
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
         id: cache-rust
         with:
@@ -30,12 +44,15 @@ jobs:
           restore-keys: |
             rust-build-${{ runner.os }}-
       - name: Set up QEMU
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
 
       - name: Set up Docker Buildx
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
 
       - name: Log in to the Container registry
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
         with:
           registry: ${{ env.REGISTRY }}
@@ -43,6 +60,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and export to Docker
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4
         with:
           context: .
@@ -54,10 +72,12 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Run docker compose
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         uses: hoverkraft-tech/compose-action@8be2d741e891ac9b8ac20825e6f3904149599925
         with:
           compose-file: "./docker-compose.test.yaml"
 
       - name: Execute tests in the running services
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: |
           docker compose -f docker-compose.test.yaml exec iris_mpc_client "./run-client-docker.sh"

--- a/.github/workflows/lint-clippy.yaml
+++ b/.github/workflows/lint-clippy.yaml
@@ -32,7 +32,9 @@ jobs:
               - Cargo.lock
               - Cargo.toml
               - deny.toml
+              - rust-toolchain.toml
               - iris-*/**
+#              - .github/workflows/lint-clippy.yaml -- bring this back after Canonical incident
 
       - name: Cache Rust build
         if: steps.changed-files-yaml.outputs.src_any_changed == 'true'

--- a/.github/workflows/lint-clippy.yaml
+++ b/.github/workflows/lint-clippy.yaml
@@ -22,7 +22,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
+      - name: Get all test, doc and src files that have changed
+        id: changed-files-yaml
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c
+        with:
+          files_yaml: |
+            src:
+              - Dockerfile*
+              - Cargo.lock
+              - Cargo.toml
+              - deny.toml
+              - iris-*/**
+
       - name: Cache Rust build
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
         id: cache-rust
         with:
@@ -36,16 +49,21 @@ jobs:
 
       # The following steps will only run if any of the src files have changed
       - name: Install Dependencies
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: sudo apt install protobuf-compiler
 
       - name: Install Rust
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: rustup toolchain install 1.85.0
 
       - name: Set Rust  as default
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: rustup default 1.85.0
 
       - name: Install Rust clippy for checking clippy errors
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: rustup component add clippy
 
       - name: Clippy
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: cargo clippy --all-targets --all-features -- -D warnings --no-deps

--- a/.github/workflows/lint-rustfmt.yaml
+++ b/.github/workflows/lint-rustfmt.yaml
@@ -25,7 +25,10 @@ jobs:
               - Cargo.lock
               - Cargo.toml
               - deny.toml
+              - rust-toolchain.toml
+              - rustfmt.toml
               - iris-*/**
+#              - .github/workflows/lint-rustfmt.yaml -- bring this back after Canonical incident
 
       - name: Cache Rust build
         if: steps.changed-files-yaml.outputs.src_any_changed == 'true'

--- a/.github/workflows/lint-rustfmt.yaml
+++ b/.github/workflows/lint-rustfmt.yaml
@@ -14,7 +14,21 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Get all test, doc and src files that have changed
+        id: changed-files-yaml
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c
+        with:
+          files_yaml: |
+            src:
+              - Dockerfile*
+              - Cargo.lock
+              - Cargo.toml
+              - deny.toml
+              - iris-*/**
+
       - name: Cache Rust build
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
         id: cache-rust
         with:
@@ -25,13 +39,23 @@ jobs:
           key: rust-build-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             rust-build-${{ runner.os }}-
+
       - name: Show errors inline
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         uses: r7kamura/rust-problem-matchers@9fe7ca9f6550e5d6358e179d451cc25ea6b54f98
+
       - name: Install Rust
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: rustup toolchain install 1.85.0
+
       - name: Set Rust as default
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: rustup default 1.85.0
+
       - name: Install Rustfmt for formatting
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: rustup component add rustfmt
+
       - name: Run Rustfmt
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: cargo fmt -- --check

--- a/.github/workflows/run-unit-tests.yaml
+++ b/.github/workflows/run-unit-tests.yaml
@@ -40,7 +40,10 @@ jobs:
               - Cargo.lock
               - Cargo.toml
               - deny.toml
+              - rust-toolchain.toml
               - iris-*/**
+              - migrations/**
+              - scripts/**
 #              - .github/workflows/run-unit-tests.yaml -- bring this back after Canonical incident
 
       # The following steps will only run if any of the src files have changed

--- a/.github/workflows/run-unit-tests.yaml
+++ b/.github/workflows/run-unit-tests.yaml
@@ -30,11 +30,25 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
+      - name: Get all test, doc and src files that have changed
+        id: changed-files-yaml
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c
+        with:
+          files_yaml: |
+            src:
+              - Dockerfile*
+              - Cargo.lock
+              - Cargo.toml
+              - deny.toml
+              - iris-*/**
+
       # The following steps will only run if any of the src files have changed
       - name: Install Dependencies
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: sudo apt install protobuf-compiler
 
       - name: Cache Rust build
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
         id: cache-rust
         with:
@@ -47,18 +61,23 @@ jobs:
             rust-build-${{ runner.os }}-
 
       - name: Install Rust
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: rustup toolchain install 1.85.0
 
       - name: Set Rust  as default
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: rustup default 1.85.0
 
       - name: Run Tests
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: cargo test --release -- --test-threads=1
 
       - name: Run Tests with DB
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: cargo test --release --features db_dependent -- --test-threads=1
 
       - name: Run CPU E2E tests
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: cargo test --release -p iris-mpc-cpu -- e2e --test-threads=1 --include-ignored
         env:
           RUST_LOG: info

--- a/.github/workflows/test-gpu.yaml
+++ b/.github/workflows/test-gpu.yaml
@@ -15,14 +15,30 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
+      - name: Get all test, doc and src files that have changed
+        id: changed-files-yaml
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c
+        with:
+          files_yaml: |
+            src:
+            - Dockerfile*
+            - Cargo.lock
+            - Cargo.toml
+            - deny.toml
+            - iris-*/**
+            - .github/workflows/test-gpu.yaml
+
       # The following steps will only run if any of the src files have changed
       - name: Validate presence of GPU devices
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: nvidia-smi
 
       - name: Check shared memory size
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: df -h
 
       - name: Update gcc to version 11
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: |
           sudo apt-get install --reinstall ca-certificates
           sudo apt-get update
@@ -34,10 +50,12 @@ jobs:
           gcc --version
 
       - name: Install OpenSSL && pkg-config && protobuf-compiler
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev protobuf-compiler
 
       - name: Install CUDA and NCCL dependencies
-        if: steps.cache-cuda-nccl.outputs.cache-hit != 'true'
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true' && 
+            steps.cache-cuda-nccl.outputs.cache-hit != 'true'
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
@@ -48,9 +66,11 @@ jobs:
           sudo apt install -y cuda-toolkit-12-2 cuda-command-line-tools-12-2 libnccl2 libnccl-dev
 
       - name: Find libs
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: find /usr -name "libnvrtc*" && find /usr -name libcuda.so
 
       - name: Cache Rust build
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
         id: cache-rust
         with:
@@ -63,14 +83,17 @@ jobs:
             rust-build-${{ runner.os }}-
 
       - name: Find libs
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         run: find /usr -name "libnvrtc*" && find /usr -name libcuda.so
 
       - name: Install Rust
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.85.0
 
       - name: GPU Dependent Tests
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         timeout-minutes: 15
         run: cargo test -p iris-mpc-gpu --release --features gpu_dependent -- --test-threads=1
         shell: bash

--- a/.github/workflows/test-gpu.yaml
+++ b/.github/workflows/test-gpu.yaml
@@ -26,7 +26,7 @@ jobs:
             - Cargo.toml
             - deny.toml
             - iris-*/**
-            - .github/workflows/test-gpu.yaml
+#            - .github/workflows/test-gpu.yaml -- bring this back after Canonical incident
 
       # The following steps will only run if any of the src files have changed
       - name: Validate presence of GPU devices

--- a/.github/workflows/test-gpu.yaml
+++ b/.github/workflows/test-gpu.yaml
@@ -21,12 +21,15 @@ jobs:
         with:
           files_yaml: |
             src:
-            - Dockerfile*
-            - Cargo.lock
-            - Cargo.toml
-            - deny.toml
-            - iris-*/**
-#            - .github/workflows/test-gpu.yaml -- bring this back after Canonical incident
+              - Dockerfile*
+              - Cargo.lock
+              - Cargo.toml
+              - deny.toml
+              - rust-toolchain.toml
+              - iris-*/**
+              - migrations/**
+              - scripts/**
+#              - .github/workflows/test-gpu.yaml -- bring this back after Canonical incident
 
       # The following steps will only run if any of the src files have changed
       - name: Validate presence of GPU devices


### PR DESCRIPTION
## Change
- Previously, we were using `tj-actions` to skip running specific jobs for simple config changes so that we iterate fast
- We abandoned it due to a vulnerability where all the tags were pointed to a malicious commit
- Now, we bring it back but referring to specific commit SHA instead of mutable tags

## Reference
- https://medium.com/@info_37956/unraveling-cve-2025-30066-the-hidden-risk-of-mutable-version-tags-in-github-actions-c91a88197086