### PR TITLE
Fix saving prev modification

### DIFF
--- a/iris-mpc-cpu/src/genesis/state_accessor.rs
+++ b/iris-mpc-cpu/src/genesis/state_accessor.rs
@@ -105,7 +105,7 @@ pub async fn get_iris_deletions(
 ///
 /// # Returns
 ///
-/// 2 member tuple: (Modification data, Last modification ID).
+/// 2 member tuple: (Modification data, Max completed modification from the table).
 ///
 pub async fn get_iris_modifications(
     iris_store: &Store,
@@ -124,7 +124,7 @@ pub async fn get_iris_modifications(
         .get_persisted_modifications_after_id(from_modification_id, to_serial_id)
         .await
         .map_err(|err| IndexationError::FetchModificationBatch(err.to_string()))?;
-
+    let max_id = max_id.unwrap_or(0);
     Ok((modifications, max_id))
 }
 

--- a/iris-mpc-cpu/src/genesis/state_accessor.rs
+++ b/iris-mpc-cpu/src/genesis/state_accessor.rs
@@ -120,13 +120,12 @@ pub async fn get_iris_modifications(
         ),
     );
 
-    let data = iris_store
+    let (modifications, max_id) = iris_store
         .get_persisted_modifications_after_id(from_modification_id, to_serial_id)
         .await
         .map_err(|err| IndexationError::FetchModificationBatch(err.to_string()))?;
-    let last_id = data.last().map(|m| m.id).unwrap_or(0);
 
-    Ok((data, last_id))
+    Ok((modifications, max_id))
 }
 
 /// Get serial id of last iris to have been indexed.

--- a/iris-mpc-cpu/src/genesis/state_accessor.rs
+++ b/iris-mpc-cpu/src/genesis/state_accessor.rs
@@ -148,7 +148,7 @@ pub async fn get_last_indexed_iris_id(
 ///
 /// # Arguments
 ///
-/// * `graph_store` - Graph PostgreSQL store provider.
+/// * `graph_store` -Arc of Graph PostgreSQL store provider.
 ///
 /// # Returns
 ///

--- a/iris-mpc-cpu/src/genesis/state_accessor.rs
+++ b/iris-mpc-cpu/src/genesis/state_accessor.rs
@@ -6,7 +6,7 @@ use iris_mpc_common::{config::Config, helpers::sync::Modification, IrisSerialId}
 use iris_mpc_store::Store;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use sqlx::{Postgres, Transaction};
-use std::fmt::Debug;
+use std::{fmt::Debug, sync::Arc};
 
 // Component name for logging purposes.
 const COMPONENT: &str = "State-Accessor";
@@ -138,7 +138,9 @@ pub async fn get_iris_modifications(
 ///
 /// The serial id of last iris to have been indexed, or 0 if none has been recorded.
 ///
-pub async fn get_last_indexed_iris_id(graph_store: &GraphPg<Aby3Store>) -> Result<IrisSerialId> {
+pub async fn get_last_indexed_iris_id(
+    graph_store: Arc<GraphPg<Aby3Store>>,
+) -> Result<IrisSerialId> {
     get_state_element(graph_store, STATE_KEY_LAST_INDEXED_IRIS_ID).await
 }
 
@@ -152,13 +154,13 @@ pub async fn get_last_indexed_iris_id(graph_store: &GraphPg<Aby3Store>) -> Resul
 ///
 /// The modification id of the last indexed modification, or 0 if none has been recorded.
 ///
-pub async fn get_last_indexed_modification_id(graph_store: &GraphPg<Aby3Store>) -> Result<i64> {
+pub async fn get_last_indexed_modification_id(graph_store: Arc<GraphPg<Aby3Store>>) -> Result<i64> {
     get_state_element(graph_store, STATE_KEY_LAST_INDEXED_MODIFICATION_ID).await
 }
 
 /// Gets a state element value from remote store.
 async fn get_state_element<T: DeserializeOwned + Default>(
-    graph_store: &GraphPg<Aby3Store>,
+    graph_store: Arc<GraphPg<Aby3Store>>,
     key: &str,
 ) -> Result<T> {
     utils::log_info(
@@ -310,6 +312,7 @@ mod tests {
         test_utils::{cleanup, temporary_name, test_db_url},
         Store as IrisStore,
     };
+    use std::sync::Arc;
 
     // Defaults.
     const DEFAULT_RNG_SEED: u64 = 0;
@@ -319,7 +322,7 @@ mod tests {
     // Returns a set of test resources.
     async fn get_resources() -> Result<(
         IrisStore,
-        GraphPg<Aby3Store>,
+        Arc<GraphPg<Aby3Store>>,
         PostgresClient,
         PostgresSchemaName,
     )> {
@@ -329,6 +332,7 @@ mod tests {
             PostgresClient::new(&test_db_url()?, &pg_schema, AccessMode::ReadWrite).await?;
         // Set graph store
         let graph_store = GraphPg::new(&pg_client).await?;
+        let graph_store_arc = Arc::new(graph_store);
 
         // Set iris store.
         let iris_store = IrisStore::new(&pg_client).await?;
@@ -343,7 +347,7 @@ mod tests {
             )
             .await?;
 
-        Ok((iris_store, graph_store, pg_client, pg_schema))
+        Ok((iris_store, graph_store_arc, pg_client, pg_schema))
     }
 
     #[tokio::test]
@@ -352,7 +356,7 @@ mod tests {
         let (_iris_store, graph_store, pg_client, pg_schema) = get_resources().await.unwrap();
 
         // Get -> should be zero.
-        let id_of_last_indexed = get_last_indexed_iris_id(&graph_store).await?;
+        let id_of_last_indexed = get_last_indexed_iris_id(graph_store.clone()).await?;
         assert_eq!(id_of_last_indexed, 0);
 
         // Set -> 10.
@@ -363,7 +367,7 @@ mod tests {
         tx.commit().await?;
 
         // Get -> should be 10.
-        let id_of_last_indexed = get_last_indexed_iris_id(&graph_store).await?;
+        let id_of_last_indexed = get_last_indexed_iris_id(graph_store.clone()).await?;
         assert_eq!(id_of_last_indexed, 10);
 
         // Unset.
@@ -373,7 +377,7 @@ mod tests {
         tx.commit().await?;
 
         // Get -> should be 0.
-        let id_of_last_indexed = get_last_indexed_iris_id(&graph_store).await?;
+        let id_of_last_indexed = get_last_indexed_iris_id(graph_store.clone()).await?;
         assert_eq!(id_of_last_indexed, 0);
 
         // Unset resources.
@@ -389,7 +393,7 @@ mod tests {
 
         // Get -> should be zero.
         let modification_id_of_last_indexed =
-            get_last_indexed_modification_id(&graph_store).await?;
+            get_last_indexed_modification_id(graph_store.clone()).await?;
         assert_eq!(modification_id_of_last_indexed, 0);
 
         // Set -> 42.
@@ -401,7 +405,7 @@ mod tests {
 
         // Get -> should be 42.
         let modification_id_of_last_indexed =
-            get_last_indexed_modification_id(&graph_store).await?;
+            get_last_indexed_modification_id(graph_store.clone()).await?;
         assert_eq!(modification_id_of_last_indexed, 42);
 
         // Set -> 999.
@@ -413,7 +417,7 @@ mod tests {
 
         // Get -> should be 999.
         let modification_id_of_last_indexed =
-            get_last_indexed_modification_id(&graph_store).await?;
+            get_last_indexed_modification_id(graph_store.clone()).await?;
         assert_eq!(modification_id_of_last_indexed, 999);
 
         // Unset.
@@ -424,7 +428,7 @@ mod tests {
 
         // Get -> should be 0.
         let modification_id_of_last_indexed =
-            get_last_indexed_modification_id(&graph_store).await?;
+            get_last_indexed_modification_id(graph_store.clone()).await?;
         assert_eq!(modification_id_of_last_indexed, 0);
 
         // Unset resources.

--- a/iris-mpc-cpu/src/genesis/state_sync.rs
+++ b/iris-mpc-cpu/src/genesis/state_sync.rs
@@ -22,6 +22,9 @@ pub struct Config {
 
     // Identifier of the last modification ID to be indexed.
     pub max_modification_id: i64,
+
+    // Identifier of the max completed modification the node has seen
+    pub max_completed_modification: i64,
 }
 
 /// Constructor.
@@ -33,6 +36,7 @@ impl Config {
         last_indexed_id: IrisSerialId,
         max_indexation_id: IrisSerialId,
         max_modification_id: i64,
+        max_completed_modification: i64,
     ) -> Self {
         Self {
             batch_size,
@@ -41,6 +45,7 @@ impl Config {
             last_indexed_id,
             max_indexation_id,
             max_modification_id,
+            max_completed_modification,
         }
     }
 }
@@ -107,10 +112,10 @@ mod tests {
 
     impl Config {
         fn new_1() -> Self {
-            Self::new(64, 128, vec![3, 5], 50, 100, 100)
+            Self::new(64, 128, vec![3, 5], 50, 100, 100, 100)
         }
         fn new_2() -> Self {
-            Self::new(64, 128, vec![3, 5, 6], 150, 200, 200)
+            Self::new(64, 128, vec![3, 5, 6], 150, 200, 200, 200)
         }
     }
 

--- a/iris-mpc-cpu/src/genesis/state_sync.rs
+++ b/iris-mpc-cpu/src/genesis/state_sync.rs
@@ -24,7 +24,7 @@ pub struct Config {
     pub max_modification_id: i64,
 
     // Identifier of the max completed modification the node has seen
-    pub max_completed_modification_id: i64,
+    pub max_modification_persisted_id: i64,
 }
 
 /// Constructor.
@@ -36,7 +36,7 @@ impl Config {
         last_indexed_id: IrisSerialId,
         max_indexation_id: IrisSerialId,
         max_modification_id: i64,
-        max_completed_modification_id: i64,
+        max_modification_persisted_id: i64,
     ) -> Self {
         Self {
             batch_size,
@@ -45,7 +45,7 @@ impl Config {
             last_indexed_id,
             max_indexation_id,
             max_modification_id,
-            max_completed_modification_id,
+            max_modification_persisted_id,
         }
     }
 }

--- a/iris-mpc-cpu/src/genesis/state_sync.rs
+++ b/iris-mpc-cpu/src/genesis/state_sync.rs
@@ -24,7 +24,7 @@ pub struct Config {
     pub max_modification_id: i64,
 
     // Identifier of the max completed modification the node has seen
-    pub max_completed_modification: i64,
+    pub max_completed_modification_id: i64,
 }
 
 /// Constructor.
@@ -36,7 +36,7 @@ impl Config {
         last_indexed_id: IrisSerialId,
         max_indexation_id: IrisSerialId,
         max_modification_id: i64,
-        max_completed_modification: i64,
+        max_completed_modification_id: i64,
     ) -> Self {
         Self {
             batch_size,
@@ -45,7 +45,7 @@ impl Config {
             last_indexed_id,
             max_indexation_id,
             max_modification_id,
-            max_completed_modification,
+            max_completed_modification_id,
         }
     }
 }

--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -539,6 +539,7 @@ WHERE id = $1;
             r#"
             SELECT MAX(id) FROM modifications
             WHERE persisted = true
+                AND request_type = ANY($2)
                 AND status = 'COMPLETED'
             "#,
         )

--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -545,7 +545,6 @@ WHERE id = $1;
         )
         .bind(after_modification_id)
         .bind(message_types)
-        .bind(serial_id_less_than as i64)
         .fetch_one(&mut *tx)
         .await?;
 

--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -506,7 +506,7 @@ WHERE id = $1;
             REAUTH_MESSAGE_TYPE,
             IDENTITY_DELETION_MESSAGE_TYPE,
         ];
-            let mut tx = self.pool.begin().await?;
+        let mut tx = self.pool.begin().await?;
 
         let rows = sqlx::query_as::<_, StoredModification>(
             r#"
@@ -534,7 +534,7 @@ WHERE id = $1;
         .fetch_all(&mut *tx)
         .await?;
 
-            // Fetch the max id from modifications that are persisted and completed.
+        // Fetch the max id from modifications that are persisted and completed.
         let max_id: Option<i64> = sqlx::query_scalar(
             r#"
             SELECT MAX(id) FROM modifications

--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -500,12 +500,13 @@ WHERE id = $1;
         &self,
         after_modification_id: i64,
         serial_id_less_than: u32,
-    ) -> Result<Vec<Modification>> {
+    ) -> Result<(Vec<Modification>, Option<i64>)> {
         let message_types = &[
             RESET_UPDATE_MESSAGE_TYPE,
             REAUTH_MESSAGE_TYPE,
             IDENTITY_DELETION_MESSAGE_TYPE,
         ];
+            let mut tx = self.pool.begin().await?;
 
         let rows = sqlx::query_as::<_, StoredModification>(
             r#"
@@ -522,6 +523,7 @@ WHERE id = $1;
             WHERE id > $1
               AND request_type = ANY($2)
               AND persisted = true
+              AND status = 'COMPLETED'
               AND serial_id <= $3
             ORDER BY id ASC
             "#,
@@ -529,11 +531,25 @@ WHERE id = $1;
         .bind(after_modification_id)
         .bind(message_types)
         .bind(serial_id_less_than as i64)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *tx)
+        .await?;
+
+            // Fetch the max id from modifications that are persisted and completed.
+        let max_id: Option<i64> = sqlx::query_scalar(
+            r#"
+            SELECT MAX(id) FROM modifications
+            WHERE persisted = true
+                AND status = 'COMPLETED'
+            "#,
+        )
+        .bind(after_modification_id)
+        .bind(message_types)
+        .bind(serial_id_less_than as i64)
+        .fetch_one(&mut *tx)
         .await?;
 
         let modifications = rows.into_iter().map(Into::into).collect();
-        Ok(modifications)
+        Ok((modifications, max_id))
     }
 
     /// Update the status, persisted flag, and result_message_body of the
@@ -1388,12 +1404,13 @@ pub mod tests {
         tx.commit().await?;
 
         // Test 1: Get all modifications with ID > 0 (should return only the 3 persisted ones with valid request types)
-        let modifications = store.get_persisted_modifications_after_id(0, 106).await?;
+        let (modifications, max_id) = store.get_persisted_modifications_after_id(0, 106).await?;
         assert_eq!(
             modifications.len(),
             3,
             "Should return 3 persisted modifications"
         );
+        assert_eq!(max_id, Some(4), "Max ID should be 4");
 
         // Check the specific request types are correct
         let request_types: Vec<&str> = modifications
@@ -1414,12 +1431,13 @@ pub mod tests {
         );
 
         // Test 2: Get persisted modifications with ID > 2 (should exclude the first two)
-        let modifications = store.get_persisted_modifications_after_id(2, 106).await?;
+        let (modifications, max_id) = store.get_persisted_modifications_after_id(2, 106).await?;
         assert_eq!(
             modifications.len(),
             1,
             "Should return 1 persisted modification"
         );
+        assert_eq!(max_id, Some(4), "Max ID should be 4");
 
         // The IDs should be greater than 2
         for modification in &modifications {
@@ -1440,28 +1458,31 @@ pub mod tests {
 
         // Test 3: Get persisted modifications with ID > 3 (should include ID 4 now)
         // Should not include the last serial id
-        let modifications = store.get_persisted_modifications_after_id(3, 105).await?;
+        let (modifications, max_id) = store.get_persisted_modifications_after_id(3, 105).await?;
         assert_eq!(
             modifications.len(),
             1,
             "Should return 1 persisted modification"
         );
+        assert_eq!(max_id, Some(7), "Max ID should be 7");
         assert_eq!(
             modifications[0].id, 4,
             "Should return modification with ID 4"
         );
 
         // Test 4: Get modifications with ID > 6 (should return none)
-        let modifications = store.get_persisted_modifications_after_id(7, 106).await?;
+        let (modifications, max_id) = store.get_persisted_modifications_after_id(7, 106).await?;
         assert_eq!(modifications.len(), 0, "Should return 0 modifications");
+        assert_eq!(max_id, Some(7), "Max ID should be 7");
 
         // Test 5: Get modifications with ID > 0 and serial id is less than 102
-        let modifications = store.get_persisted_modifications_after_id(0, 102).await?;
+        let (modifications, max_id) = store.get_persisted_modifications_after_id(0, 102).await?;
         assert_eq!(
             modifications.len(),
             2,
             "Should return 2 persisted modifications"
         );
+        assert_eq!(max_id, Some(7), "Max ID should be 7");
         assert_eq!(
             modifications[0].id, 1,
             "Should return modification with ID 1"

--- a/iris-mpc-upgrade-hawk/src/genesis/mod.rs
+++ b/iris-mpc-upgrade-hawk/src/genesis/mod.rs
@@ -252,17 +252,16 @@ async fn exec_setup(
     ));
 
     // Coordinator: Await coordination server to start.
-    let my_state = get_sync_state(
-        config,
+    let genesis_config = GenesisConfig::new(
         args.batch_size,
         args.batch_size_error_rate,
-        args.max_indexation_id,
+        excluded_serial_ids.clone(),
         last_indexed_id,
-        &excluded_serial_ids,
+        args.max_indexation_id,
         max_modification_id,
         max_completed_modification_id,
-    )
-    .await?;
+    );
+    let my_state = get_sync_state(config, genesis_config).await?;
     log_info(String::from("Synchronization state initialised"));
 
     // Coordinator: await server start.
@@ -970,25 +969,9 @@ async fn get_results_thread(
 ///
 async fn get_sync_state(
     config: &Config,
-    batch_size: usize,
-    batch_size_error_rate: usize,
-    max_indexation_id: IrisSerialId,
-    last_indexed_id: IrisSerialId,
-    excluded_serial_ids: &[IrisSerialId],
-    max_modification_id: i64,
-    max_completed_modification: i64,
+    genesis_config: GenesisConfig,
 ) -> Result<GenesisSyncState> {
     let common_config = CommonConfig::from(config.clone());
-    let genesis_config = GenesisConfig::new(
-        batch_size,
-        batch_size_error_rate,
-        excluded_serial_ids.to_vec(),
-        last_indexed_id,
-        max_indexation_id,
-        max_modification_id,
-        max_completed_modification,
-    );
-
     Ok(GenesisSyncState::new(common_config, genesis_config))
 }
 

--- a/iris-mpc-upgrade-hawk/src/genesis/mod.rs
+++ b/iris-mpc-upgrade-hawk/src/genesis/mod.rs
@@ -93,7 +93,11 @@ struct ExecutionContextInfo {
     modifications: Vec<Modification>,
 
     // Maximum modification id to be performed
-    max_modification_id: i64,
+    max_modification_indexed_id: i64,
+
+    // The largest modification id that has been completed and persisted by the source version.
+    // Used to track up to which modification the next run of Genesis can start from
+    max_modification_persist_id: i64,
 }
 
 /// Constructor.
@@ -104,7 +108,8 @@ impl ExecutionContextInfo {
         last_indexed_id: IrisSerialId,
         excluded_serial_ids: Vec<IrisSerialId>,
         modifications: Vec<Modification>,
-        max_modification_id: i64,
+        max_modification_indexed_id: i64,
+        max_modification_persist_id: i64,
     ) -> Self {
         Self {
             args: args.clone(),
@@ -112,7 +117,8 @@ impl ExecutionContextInfo {
             excluded_serial_ids,
             last_indexed_id,
             modifications,
-            max_modification_id,
+            max_modification_indexed_id,
+            max_modification_persist_id,
         }
     }
 }
@@ -138,6 +144,7 @@ pub async fn exec(args: ExecutionArgs, config: Config) -> Result<()> {
         imem_iris_stores,
         mut hawk_handle,
         tx_results,
+        graph_store,
     ) = exec_setup(&args, &config).await?;
     log_info(String::from("Setup complete."));
 
@@ -148,6 +155,7 @@ pub async fn exec(args: ExecutionArgs, config: Config) -> Result<()> {
         hawk_handle = exec_delta(
             &config,
             &ctx,
+            graph_store,
             hawk_handle,
             &tx_results,
             &mut task_monitor_bg,
@@ -198,6 +206,7 @@ async fn exec_setup(
     Arc<BothEyes<SharedIrisesRef>>,
     GenesisHawkHandle,
     Sender<JobResult>,
+    Arc<GraphPg<Aby3Store>>,
 )> {
     // Bail if config is invalid.
     validate_config(config)?;
@@ -214,9 +223,10 @@ async fn exec_setup(
         (iris_store, (hnsw_iris_store, graph_store)),
     ) = get_service_clients(config).await?;
     log_info(String::from("Service clients instantiated"));
+    let graph_store_arc = Arc::new(graph_store);
 
     // Set serial identifier of last indexed Iris.
-    let last_indexed_id = get_last_indexed_iris_id(&graph_store).await?;
+    let last_indexed_id = get_last_indexed_iris_id(graph_store_arc.clone()).await?;
     log_info(format!(
         "Identifier of last Iris to have been indexed = {}",
         last_indexed_id,
@@ -236,18 +246,20 @@ async fn exec_setup(
     ));
 
     // Set modifications that have occurred since last indexation.
-    let last_indexed_modification_id = get_last_indexed_modification_id(&graph_store).await?;
+    let last_indexed_modification_id =
+        get_last_indexed_modification_id(graph_store_arc.clone()).await?;
     log_info(format!(
         "Identifier of last modification to have been indexed = {}",
         last_indexed_modification_id,
     ));
-    let (modifications, max_completed_modification_id) =
+    // This is the largest modification id that has been completed by the node.
+    let (modifications, max_modification_id_to_persist) =
         get_iris_modifications(&iris_store, last_indexed_modification_id, last_indexed_id).await?;
     let max_modification_id = modifications.last().map_or(0, |m| m.id);
     log_info(format!(
         "Modifications to be applied count = {}. Max modification id completed = {}, Max modification to be performed = {}",
         modifications.len(),
-        max_completed_modification_id,
+        max_modification_id_to_persist,
         max_modification_id,
     ));
 
@@ -259,7 +271,7 @@ async fn exec_setup(
         last_indexed_id,
         args.max_indexation_id,
         max_modification_id,
-        max_completed_modification_id,
+        max_modification_id_to_persist,
     );
     let my_state = get_sync_state(config, genesis_config).await?;
     log_info(String::from("Synchronization state initialised"));
@@ -303,7 +315,7 @@ async fn exec_setup(
     init_graph_from_stores(
         config,
         &iris_store,
-        &graph_store,
+        graph_store_arc.clone(),
         &mut hawk_actor,
         Arc::clone(&shutdown_handler),
     )
@@ -334,18 +346,11 @@ async fn exec_setup(
     let hawk_handle = GenesisHawkHandle::new(hawk_actor).await?;
     log_info(String::from("Hawk handle initialised"));
 
-    if modifications.is_empty() {
-        log_info(String::from("No modifications to apply. Therefore setting the last modification id as the largest completed modification id."));
-        let mut graph_tx = graph_store.tx().await?;
-        set_last_indexed_modification_id(&mut graph_tx.tx, max_completed_modification_id).await?;
-        graph_tx.tx.commit().await?;
-    }
-
     // Set thread for persisting indexing results to DB.
     let tx_results = get_results_thread(
         Arc::clone(&imem_iris_stores),
         hnsw_iris_store,
-        graph_store,
+        graph_store_arc.clone(),
         &mut task_monitor_bg,
         &shutdown_handler,
     )
@@ -360,6 +365,7 @@ async fn exec_setup(
             excluded_serial_ids,
             modifications,
             max_modification_id,
+            max_modification_id_to_persist,
         ),
         shutdown_handler,
         task_monitor_bg,
@@ -367,6 +373,7 @@ async fn exec_setup(
         imem_iris_stores,
         hawk_handle,
         tx_results,
+        graph_store_arc,
     ))
 }
 
@@ -384,6 +391,7 @@ async fn exec_setup(
 async fn exec_delta(
     config: &Config,
     ctx: &ExecutionContextInfo,
+    graph_store: Arc<GraphPg<Aby3Store>>,
     mut hawk_handle: GenesisHawkHandle,
     tx_results: &Sender<JobResult>,
     task_monitor_bg: &mut TaskMonitor,
@@ -391,7 +399,8 @@ async fn exec_delta(
 ) -> Result<GenesisHawkHandle> {
     let ExecutionContextInfo {
         modifications,
-        max_modification_id,
+        max_modification_indexed_id,
+        max_modification_persist_id,
         ..
     } = ctx;
 
@@ -399,11 +408,11 @@ async fn exec_delta(
         log_info(format!(
             "Applying modifications: count={} :: max-id={}",
             modifications.len(),
-            max_modification_id
+            max_modification_indexed_id
         ));
 
         metrics::gauge!("genesis_number_modifications").set(modifications.len() as f64);
-        metrics::gauge!("genesis_max_modification_id").set(*max_modification_id as f64);
+        metrics::gauge!("genesis_max_modification_id").set(*max_modification_indexed_id as f64);
 
         let processing_timeout = Duration::from_secs(config.processing_timeout_secs);
 
@@ -443,6 +452,12 @@ async fn exec_delta(
             ));
             shutdown_handler.wait_for_pending_batches_completion().await;
             log_info(String::from("All delta modifications have been processed"));
+
+            log_info(format!( "Setting last indexed modification id to the largest completed and persisted modification id = {}", max_modification_persist_id));
+            let mut graph_tx = graph_store.tx().await?;
+            set_last_indexed_modification_id(&mut graph_tx.tx, *max_modification_persist_id)
+                .await?;
+            graph_tx.tx.commit().await?;
 
             Ok(hawk_handle)
         }
@@ -820,13 +835,14 @@ async fn get_service_clients(
 async fn get_results_thread(
     imem_iris_stores: Arc<BothEyes<SharedIrisesRef>>,
     hnsw_iris_store: IrisStore,
-    graph_store: GraphPg<Aby3Store>,
+    graph_store: Arc<GraphPg<Aby3Store>>,
     task_monitor: &mut TaskMonitor,
     shutdown_handler: &Arc<ShutdownHandler>,
 ) -> Result<Sender<JobResult>> {
     let (tx, mut rx) = mpsc::channel::<JobResult>(32); // TODO: pick some buffer value
     let shutdown_handler_bg = Arc::clone(shutdown_handler);
     let imem_iris_stores_bg = Arc::clone(&imem_iris_stores);
+    let graph_store_bg = Arc::clone(&graph_store);
     let _result_sender_abort = task_monitor.spawn(async move {
         while let Some(result) = rx.recv().await {
             match result {
@@ -912,7 +928,7 @@ async fn get_results_thread(
                         .get_vector(&vector_id_to_persist)
                         .await;
 
-                    let mut graph_tx = graph_store.tx().await?;
+                    let mut graph_tx = graph_store_bg.tx().await?;
                     let iris_data =StoredIrisRef {
                                     id: vector_id_to_persist.serial_id() as i64,
                                     left_code: &left_iris.code.coefs,
@@ -1005,7 +1021,7 @@ async fn get_sync_result(
 async fn init_graph_from_stores(
     config: &Config,
     iris_store: &IrisStore,
-    graph_store: &GraphPg<Aby3Store>,
+    graph_store: Arc<GraphPg<Aby3Store>>,
     hawk_actor: &mut HawkActor,
     shutdown_handler: Arc<ShutdownHandler>,
 ) -> Result<()> {
@@ -1049,7 +1065,7 @@ async fn init_graph_from_stores(
     .expect("Failed to load DB");
 
     graph_loader
-        .load_graph_store(graph_store, graph_db_parallelism)
+        .load_graph_store(&graph_store, graph_db_parallelism)
         .await?;
 
     Ok(())


### PR DESCRIPTION
### Notes
* Fixes bug in Genesis. During the first Genesis run the last modification ID is not saved since there is no delta. This means for the second run, we perform all modifications but there is no need since the Genesis included them.
* This PR then saves the largest modification id if there is no delta