### PR TITLE
do not bubble up errors from main

### DIFF
--- a/iris-mpc-cpu/bin/hawk_main.rs
+++ b/iris-mpc-cpu/bin/hawk_main.rs
@@ -1,9 +1,16 @@
+use std::process::exit;
 use clap::Parser;
 use eyre::Result;
 use iris_mpc_cpu::execution::hawk_main::{hawk_main, HawkArgs};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let _ = hawk_main(HawkArgs::parse()).await?;
+    match hawk_main(HawkArgs::parse()).await {
+        Ok(_) => tracing::info!("Hawk main execution completed successfully!"),
+        Err(e) => {
+            tracing::error!("Encountered an error during hawk_main processing: {}", e);
+            exit(1);
+        },
+    };
     Ok(())
 }

--- a/iris-mpc-cpu/bin/hawk_main.rs
+++ b/iris-mpc-cpu/bin/hawk_main.rs
@@ -1,7 +1,7 @@
-use std::process::exit;
 use clap::Parser;
 use eyre::Result;
 use iris_mpc_cpu::execution::hawk_main::{hawk_main, HawkArgs};
+use std::process::exit;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -10,7 +10,7 @@ async fn main() -> Result<()> {
         Err(e) => {
             tracing::error!("Encountered an error during hawk_main processing: {}", e);
             exit(1);
-        },
+        }
     };
     Ok(())
 }

--- a/iris-mpc/bin/server.rs
+++ b/iris-mpc/bin/server.rs
@@ -63,6 +63,7 @@ use itertools::izip;
 use metrics_exporter_statsd::StatsdBuilder;
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
+use std::process::exit;
 use std::{
     collections::{HashMap, HashSet},
     fmt::Debug,
@@ -73,7 +74,6 @@ use std::{
     },
     time::{Duration, Instant},
 };
-use std::process::exit;
 use tokio::sync::mpsc::Receiver;
 use tokio::{
     sync::{mpsc, oneshot, Semaphore},

--- a/iris-mpc/bin/server.rs
+++ b/iris-mpc/bin/server.rs
@@ -73,6 +73,7 @@ use std::{
     },
     time::{Duration, Instant},
 };
+use std::process::exit;
 use tokio::sync::mpsc::Receiver;
 use tokio::{
     sync::{mpsc, oneshot, Semaphore},
@@ -828,7 +829,7 @@ async fn main() -> Result<()> {
         }
         Err(e) => {
             tracing::error!("Server exited with error: {:?}", e);
-            return Err(e);
+            exit(1);
         }
     }
     Ok(())

--- a/iris-mpc/bin/server/iris_mpc_hawk.rs
+++ b/iris-mpc/bin/server/iris_mpc_hawk.rs
@@ -1,11 +1,11 @@
 #![allow(clippy::needless_range_loop)]
 
-use std::process::exit;
 use clap::Parser;
 use eyre::Result;
 use iris_mpc::server::server_main;
 use iris_mpc_common::config::{Config, Opt};
 use iris_mpc_common::tracing::initialize_tracing;
+use std::process::exit;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/iris-mpc/bin/server/iris_mpc_hawk.rs
+++ b/iris-mpc/bin/server/iris_mpc_hawk.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::needless_range_loop)]
 
+use std::process::exit;
 use clap::Parser;
 use eyre::Result;
 use iris_mpc::server::server_main;
@@ -29,7 +30,7 @@ async fn main() -> Result<()> {
         }
         Err(e) => {
             tracing::error!("Server exited with error: {:?}", e);
-            return Err(e);
+            exit(1);
         }
     }
     Ok(())


### PR DESCRIPTION
## Change
- Since we bubble up the errors from main, they're not logged with tracing crate and therefore not in JSON format. Once Datadog agent forwards these errors, they show up as new because Datadog can not parse any timestamp for them. It adds current timestamp. Therefore, this causes alerts on our system.
- This PR stops populating the Err from main. Instead, it logs the error and exits with status code 1. This way, our errors from main are now in JSON format with timestamp tag and this avoids Datadog agent showing them as if there is a new error upon agent DaemonSet restarts/reschedules etc.