### PR TITLE
(bugfix): fix logic that assigns sessions to network connections

### DIFF
--- a/iris-mpc-cpu/src/network/tcp/config.rs
+++ b/iris-mpc-cpu/src/network/tcp/config.rs
@@ -8,8 +8,6 @@ pub struct TcpConfig {
     pub request_parallelism: usize,
     // number of TCP connections
     pub num_connections: usize,
-    // number of sessions per connection
-    pub max_sessions_per_connection: usize,
 }
 
 impl TcpConfig {
@@ -21,36 +19,17 @@ impl TcpConfig {
         // don't allow fewer requests than connections...
         let connection_parallelism = cmp::min(num_connections, request_parallelism);
 
-        // if connection_parallelism doesn't divide request_parallelism, need to ensure
-        // enough multiplexing or else session creation will panic.
-        let max_sessions_per_connection = request_parallelism.div_ceil(connection_parallelism);
-
-        assert!(max_sessions_per_connection * connection_parallelism >= request_parallelism);
-
         Self {
             timeout_duration,
             request_parallelism,
             num_connections: connection_parallelism,
-            max_sessions_per_connection,
         }
     }
 
-    // max_sessions_per_connection doesn't have to divide request_parallelism. in that case, one TcpStream may have
-    // fewer sessions than the others. This function determines how many sessions are handled by a TcpStream based on the stream id
+    // This function determines how many sessions are handled by a TcpStream based on the stream id
     pub fn get_sessions_for_stream(&self, stream_id: &StreamId) -> usize {
-        match self.num_connections {
-            0 => unreachable!(),
-            1 => self.request_parallelism,
-            num_connections => {
-                let stream_id = stream_id.0 as usize;
-                if stream_id <= num_connections - 2
-                    || self.request_parallelism % self.max_sessions_per_connection == 0
-                {
-                    self.max_sessions_per_connection
-                } else {
-                    self.request_parallelism % self.max_sessions_per_connection
-                }
-            }
-        }
+        (0..self.request_parallelism)
+            .filter(|i| i % self.num_connections == stream_id.0 as usize)
+            .count()
     }
 }


### PR DESCRIPTION
This change makes `tcp/handle.rs` assign sessions to streams round robin rather than chunking `request_parallelism.div_ceil(max_streams_per_connection)`. the old way made it possible to panic for certain combinations of `request_parallelism` and `connection_parallelism`