### PR TITLE
E2E tests for GPU anon stats

### DIFF
--- a/iris-mpc-common/src/iris_db/iris.rs
+++ b/iris-mpc-common/src/iris_db/iris.rs
@@ -22,6 +22,7 @@ impl Default for IrisCodeArray {
 
 impl IrisCodeArray {
     pub const IRIS_CODE_SIZE: usize = 12800;
+    pub const CODE_COLS: usize = 200;
     pub const IRIS_CODE_SIZE_BYTES: usize = (Self::IRIS_CODE_SIZE + 7) / 8;
     pub const IRIS_CODE_SIZE_U64: usize = (Self::IRIS_CODE_SIZE + 63) / 64;
     pub const ZERO: Self = IrisCodeArray([0; Self::IRIS_CODE_SIZE_U64]);
@@ -43,6 +44,15 @@ impl IrisCodeArray {
             index: 0,
         }
     }
+
+    pub fn from_bits(bits: &[bool]) -> Self {
+        let mut code = IrisCodeArray::ZERO;
+        for (i, bit) in bits.iter().enumerate() {
+            code.set_bit(i, *bit);
+        }
+        code
+    }
+
     #[inline]
     pub fn get_bit(&self, i: usize) -> bool {
         let word = i / 64;
@@ -104,6 +114,20 @@ impl IrisCodeArray {
                 .collect::<Vec<_>>(),
         ))
     }
+
+    pub fn rotate_left(&mut self, by: usize) {
+        let mut bits = self.bits().collect::<Vec<_>>();
+        bits.chunks_exact_mut(Self::CODE_COLS * 4)
+            .for_each(|chunk| chunk.rotate_left(by * 4));
+        *self = IrisCodeArray::from_bits(&bits);
+    }
+
+    pub fn rotate_right(&mut self, by: usize) {
+        let mut bits = self.bits().collect::<Vec<_>>();
+        bits.chunks_exact_mut(Self::CODE_COLS * 4)
+            .for_each(|chunk| chunk.rotate_right(by * 4));
+        *self = IrisCodeArray::from_bits(&bits);
+    }
 }
 
 impl std::ops::BitAndAssign for IrisCodeArray {
@@ -161,6 +185,8 @@ impl Default for IrisCode {
 
 impl IrisCode {
     pub const IRIS_CODE_SIZE: usize = IrisCodeArray::IRIS_CODE_SIZE;
+    pub const CODE_COLS: usize = 200;
+    pub const ROTATIONS_PER_DIRECTION: usize = 15;
 
     pub fn random_rng<R: Rng>(rng: &mut R) -> Self {
         let mut code = IrisCode {
@@ -180,11 +206,65 @@ impl IrisCode {
         code
     }
 
+    /// Generate a random iris code but with pattern_size number of equal bits in each column.
+    /// The purpose of this is to have iris codes that keep similarity across rotations.
+    /// The distance between one of those iris codes and its nth rotation (in each direction)
+    /// is (min(n, pattern_size) * 1/(2 * pattern_size)).
+    pub fn random_rng_with_pattern<R: Rng>(rng: &mut R, pattern_size: usize) -> Self {
+        assert!(pattern_size <= IrisCode::CODE_COLS);
+        assert!(IrisCode::CODE_COLS % pattern_size == 0);
+        const LEN: usize = IrisCode::CODE_COLS * 4;
+        let mut code = IrisCode::random_rng(rng);
+        for i in (0..Self::IRIS_CODE_SIZE).step_by(LEN) {
+            for j in (0..LEN).step_by(pattern_size * 4) {
+                for k in 0..pattern_size {
+                    for l in 0..4 {
+                        code.code
+                            .set_bit(i + j + k * 4 + l, code.code.get_bit(i + j + l));
+                    }
+                }
+            }
+        }
+        code
+    }
+
     /// Return the fractional Hamming distance between two iris codes, represented
     /// as a single floating point value.
     pub fn get_distance(&self, other: &Self) -> f64 {
         let (code_distance, combined_mask_len) = self.get_distance_fraction(other);
         code_distance as f64 / combined_mask_len as f64
+    }
+
+    /// Return the minimum distance of an iris code against all rotations of another iris code.
+    pub fn get_min_distance(&self, other: &Self) -> f64 {
+        let mut min_distance = f64::INFINITY;
+        for rotation in other.all_rotations() {
+            let distance = rotation.get_distance(self);
+            if distance < min_distance {
+                min_distance = distance;
+            }
+        }
+        min_distance
+    }
+
+    /// Return the minimum distance of an iris code against all rotations of another iris code.
+    pub fn get_min_distance_against_many(&self, others: &[Self]) -> f64 {
+        let mut min_distance = f64::INFINITY;
+        for rotation in others {
+            let distance = rotation.get_distance(self);
+            if distance < min_distance {
+                min_distance = distance;
+            }
+        }
+        min_distance
+    }
+
+    /// Return the minimum distance of an iris code against all rotations of another iris code.
+    pub fn get_distances_against_many(&self, others: &[Self]) -> Vec<f64> {
+        others
+            .iter()
+            .map(|rotation| rotation.get_distance(self))
+            .collect()
     }
 
     /// Return the fractional Hamming distance between two iris codes, represented
@@ -221,16 +301,21 @@ impl IrisCode {
         self.get_distance(other) < MATCH_THRESHOLD_RATIO
     }
 
-    pub fn get_similar_iris<R: Rng>(&self, rng: &mut R) -> IrisCode {
+    pub fn is_close_with_rotations(&self, other: &Self) -> bool {
+        self.get_min_distance(other) < MATCH_THRESHOLD_RATIO
+    }
+
+    pub fn get_similar_iris<R: Rng>(&self, rng: &mut R, approx_diff_factor: f64) -> IrisCode {
         let mut res = self.clone();
-        // flip a few bits in mask and code (like 5%)
-        let dist = Bernoulli::new(0.05).unwrap();
+        let dist = Bernoulli::new(approx_diff_factor).unwrap();
         for i in 0..IrisCode::IRIS_CODE_SIZE {
             if dist.sample(rng) {
                 res.code.flip_bit(i);
             }
             if dist.sample(rng) {
-                res.mask.flip_bit(i);
+                // flip both the imaginary and real bits
+                res.mask.flip_bit(i - (i % 2));
+                res.mask.flip_bit(i - (i % 2) + 1);
             }
         }
 
@@ -251,6 +336,27 @@ impl IrisCode {
                 .set_bit(mirrored_i, if b == 0 { code_bit } else { !code_bit });
         }
         mirrored
+    }
+
+    fn rotate_right(&mut self, by: usize) {
+        self.code.rotate_right(by);
+        self.mask.rotate_right(by);
+    }
+
+    fn rotate_left(&mut self, by: usize) {
+        self.code.rotate_left(by);
+        self.mask.rotate_left(by);
+    }
+
+    pub fn all_rotations(&self) -> Vec<IrisCode> {
+        let mut code = self.clone();
+        code.rotate_left(Self::ROTATIONS_PER_DIRECTION + 1);
+        let mut rotations = Vec::new();
+        for _ in 0..Self::ROTATIONS_PER_DIRECTION * 2 + 1 {
+            code.rotate_right(1);
+            rotations.push(code.clone());
+        }
+        rotations
     }
 }
 
@@ -293,6 +399,7 @@ mod tests {
     use eyre::Result;
     use eyre::{Context, ContextCompat};
     use float_eq::assert_float_eq;
+    use std::cmp::min;
     use std::collections::HashMap;
 
     #[test]
@@ -367,5 +474,74 @@ mod tests {
         }
 
         Ok((code, rotations))
+    }
+
+    #[test]
+    fn test_rotations() {
+        let mut rng = rand::thread_rng();
+        let iris = IrisCode::random_rng(&mut rng);
+        assert_eq!(
+            iris,
+            iris.all_rotations()[IrisCode::ROTATIONS_PER_DIRECTION]
+        );
+    }
+
+    #[test]
+    fn test_random_rng_with_pattern() {
+        let mut rng = rand::thread_rng();
+        let pattern_size = 4;
+        let iris0 = IrisCode::random_rng_with_pattern(&mut rng, pattern_size);
+        let rotations0 = iris0.all_rotations();
+
+        for (i, rotation) in rotations0.iter().enumerate() {
+            assert_float_eq!(
+                rotation.get_distance(&iris0),
+                min(
+                    (IrisCode::ROTATIONS_PER_DIRECTION as f64 - i as f64).abs() as usize,
+                    pattern_size
+                ) as f64
+                    / (2.0 * pattern_size as f64),
+                abs <= 0.05
+            );
+        }
+    }
+
+    #[test]
+    fn test_min_distance_random() {
+        let mut rng = rand::thread_rng();
+        let iris0 = IrisCode::random_rng(&mut rng);
+        let mut iris1 = iris0.get_similar_iris(&mut rng, 0.025);
+        iris1.rotate_left(1);
+        assert_float_eq!(iris0.get_distance(&iris1), 0.5, abs <= 0.05);
+        assert_float_eq!(iris0.get_min_distance(&iris1), 0.0, abs <= 0.05);
+    }
+
+    #[test]
+    fn test_min_distance_example_data() {
+        let lines = include_str!("../example-data/random_codes.txt")
+            .lines()
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .collect::<Vec<_>>();
+
+        let t1_code = IrisCodeArray::from_base64(lines[0]).unwrap();
+        let t1_mask = IrisCodeArray::from_base64(lines[1]).unwrap();
+        let t2_code = IrisCodeArray::from_base64(lines[2]).unwrap();
+        let t2_mask = IrisCodeArray::from_base64(lines[3]).unwrap();
+
+        let dist_0 = lines[4].parse::<f64>().unwrap();
+        let dist_15 = lines[5].parse::<f64>().unwrap();
+
+        let t1_iris = IrisCode {
+            code: t1_code,
+            mask: t1_mask,
+        };
+        let t2_iris = IrisCode {
+            code: t2_code,
+            mask: t2_mask,
+        };
+
+        assert_float_eq!(t1_iris.get_distance(&t2_iris), dist_0, abs <= 1e-6);
+        assert_float_eq!(t1_iris.get_min_distance(&t2_iris), dist_15, abs <= 1e-6);
     }
 }

--- a/iris-mpc-cpu/tests/e2e.rs
+++ b/iris-mpc-cpu/tests/e2e.rs
@@ -146,7 +146,7 @@ async fn start_hawk_node(
 async fn e2e_test() -> Result<()> {
     install_tracing();
 
-    let test_db = generate_full_test_db(DB_SIZE, DB_RNG_SEED);
+    let test_db = generate_full_test_db(DB_SIZE, DB_RNG_SEED, false);
     let db_left = test_db.plain_dbs(0);
     let db_right = test_db.plain_dbs(1);
 


### PR DESCRIPTION
This adds an E2E test for anon stats on GPU. The e2e tests test the left side of the db using a random generated DB with a specific structure such that queries will also have additional matching rotations.