### PR TITLE
Add retries for the heartbeat task

### DIFF
--- a/.github/workflows/build-all-targets.yml
+++ b/.github/workflows/build-all-targets.yml
@@ -19,12 +19,11 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       
       # remove this once the latest ubuntu image has been rolled out
-      - name: Fix APT mirror (Temporary workaround for protobuf install on Ubuntu 24.04)
+      - name: Fix APT mirror (working patch)
         run: |
-          echo "Removing /etc/apt/apt-mirrors.txt if present..."
-          sudo rm -f /etc/apt/apt-mirrors.txt || true
-          echo "Forcing APT to use archive.ubuntu.com"
-          sudo sed -i 's|mirror+file:/etc/apt/apt-mirrors.txt|http://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list || true
+          echo "Patching sources.list..."
+          sudo sed -i 's|mirror+file:/etc/apt/apt-mirrors.txt|http://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list
+          sudo apt-get clean
           sudo apt-get update
 
       - name: Install Dependencies
@@ -61,12 +60,11 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       
       # remove this once the latest ubuntu image has been rolled out
-      - name: Fix APT mirror (Temporary workaround for protobuf install on Ubuntu 24.04)
+      - name: Fix APT mirror (working patch)
         run: |
-          echo "Removing /etc/apt/apt-mirrors.txt if present..."
-          sudo rm -f /etc/apt/apt-mirrors.txt || true
-          echo "Forcing APT to use archive.ubuntu.com"
-          sudo sed -i 's|mirror+file:/etc/apt/apt-mirrors.txt|http://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list || true
+          echo "Patching sources.list..."
+          sudo sed -i 's|mirror+file:/etc/apt/apt-mirrors.txt|http://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list
+          sudo apt-get clean
           sudo apt-get update
 
       - name: Install Dependencies

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -31,12 +31,11 @@ jobs:
             rust-build-${{ runner.os }}-
       
       # remove this once the latest ubuntu image has been rolled out
-      - name: Fix APT mirror (Temporary workaround for protobuf install on Ubuntu 24.04)
+      - name: Fix APT mirror (working patch)
         run: |
-          echo "Removing /etc/apt/apt-mirrors.txt if present..."
-          sudo rm -f /etc/apt/apt-mirrors.txt || true
-          echo "Forcing APT to use archive.ubuntu.com"
-          sudo sed -i 's|mirror+file:/etc/apt/apt-mirrors.txt|http://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list || true
+          echo "Patching sources.list..."
+          sudo sed -i 's|mirror+file:/etc/apt/apt-mirrors.txt|http://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list
+          sudo apt-get clean
           sudo apt-get update
 
       - name: Install Dependencies

--- a/.github/workflows/lint-clippy.yaml
+++ b/.github/workflows/lint-clippy.yaml
@@ -35,25 +35,6 @@ jobs:
               - rust-toolchain.toml
               - iris-*/**
 #              - .github/workflows/lint-clippy.yaml -- bring this back after Canonical incident
-      # remove this once the latest ubuntu image has been rolled out
-      - name: Fix APT mirror (Temporary workaround for protobuf install on Ubuntu 24.04)
-        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
-        run: |
-          echo "Removing /etc/apt/apt-mirrors.txt if present..."
-          sudo rm -f /etc/apt/apt-mirrors.txt || true
-          echo "Forcing APT to use archive.ubuntu.com"
-          sudo sed -i 's|mirror+file:/etc/apt/apt-mirrors.txt|http://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list || true
-          sudo apt-get update
-
-      # remove this once the latest ubuntu image has been rolled out
-      - name: Fix APT mirror (Temporary workaround for protobuf install on Ubuntu 24.04)
-        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
-        run: |
-          echo "Removing /etc/apt/apt-mirrors.txt if present..."
-          sudo rm -f /etc/apt/apt-mirrors.txt || true
-          echo "Forcing APT to use archive.ubuntu.com"
-          sudo sed -i 's|mirror+file:/etc/apt/apt-mirrors.txt|http://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list || true
-          sudo apt-get update
 
       - name: Cache Rust build
         if: steps.changed-files-yaml.outputs.src_any_changed == 'true'

--- a/.github/workflows/lint-clippy.yaml
+++ b/.github/workflows/lint-clippy.yaml
@@ -36,6 +36,15 @@ jobs:
               - iris-*/**
 #              - .github/workflows/lint-clippy.yaml -- bring this back after Canonical incident
 
+      # remove this once the latest ubuntu image has been rolled out
+      - name: Fix APT mirror (working patch)
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
+        run: |
+          echo "Patching sources.list..."
+          sudo sed -i 's|mirror+file:/etc/apt/apt-mirrors.txt|http://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list
+          sudo apt-get clean
+          sudo apt-get update
+
       - name: Cache Rust build
         if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684

--- a/.github/workflows/run-unit-tests.yaml
+++ b/.github/workflows/run-unit-tests.yaml
@@ -45,7 +45,15 @@ jobs:
               - migrations/**
               - scripts/**
 #              - .github/workflows/run-unit-tests.yaml -- bring this back after Canonical incident
-
+            
+      # remove this once the latest ubuntu image has been rolled out
+      - name: Fix APT mirror (working patch)
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
+        run: |
+          echo "Patching sources.list..."
+          sudo sed -i 's|mirror+file:/etc/apt/apt-mirrors.txt|http://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list
+          sudo apt-get clean
+          sudo apt-get update
       # The following steps will only run if any of the src files have changed
       - name: Install Dependencies
         if: steps.changed-files-yaml.outputs.src_any_changed == 'true'

--- a/.github/workflows/run-unit-tests.yaml
+++ b/.github/workflows/run-unit-tests.yaml
@@ -45,16 +45,7 @@ jobs:
               - migrations/**
               - scripts/**
 #              - .github/workflows/run-unit-tests.yaml -- bring this back after Canonical incident
-            
-      # remove this once the latest ubuntu image has been rolled out
-      - name: Fix APT mirror (Temporary workaround for protobuf install on Ubuntu 24.04)
-        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
-        run: |
-          echo "Removing /etc/apt/apt-mirrors.txt if present..."
-          sudo rm -f /etc/apt/apt-mirrors.txt || true
-          echo "Forcing APT to use archive.ubuntu.com"
-          sudo sed -i 's|mirror+file:/etc/apt/apt-mirrors.txt|http://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list || true
-          sudo apt-get update
+
       # The following steps will only run if any of the src files have changed
       - name: Install Dependencies
         if: steps.changed-files-yaml.outputs.src_any_changed == 'true'

--- a/iris-mpc-common/src/server_coordination.rs
+++ b/iris-mpc-common/src/server_coordination.rs
@@ -237,6 +237,10 @@ pub async fn init_heartbeat_task(
         let mut last_response = [String::default(), String::default()];
         let mut connected = [false, false];
         let mut retries = [0, 0];
+        // Track consecutive failures
+        let mut consecutive_failures = [0, 0];
+        // Number of consecutive failures before triggering shutdown
+        const MAX_CONSECUTIVE_FAILURES: u32 = 3;
 
         loop {
             for (i, host) in [next_node, prev_node].iter().enumerate() {
@@ -256,32 +260,47 @@ pub async fn init_heartbeat_task(
                         tracing::warn!("Node {} did not respond with success, retrying...", host);
                         continue;
                     }
-                    tracing::info!(
-                        "Node {} did not respond with success, starting graceful shutdown",
-                        host
-                    );
+
                     // if the nodes are still starting up and they get a failure - we can panic and
                     // not start graceful shutdown
+                    // we ignore consecutive failures for the initial response
                     if last_response[i] == String::default() {
                         panic!(
-                            "Node {} did not respond with success during heartbeat init phase, \
-                             killing server...",
+                            "Node {} did not respond with success during heartbeat init phase, killing server...",
                             host
                         );
                     }
 
-                    if !heartbeat_shutdown_handler.is_shutting_down() {
-                        heartbeat_shutdown_handler.trigger_manual_shutdown();
+                    consecutive_failures[i] += 1;
+                    tracing::warn!(
+                        "Node {} failed health check {} times consecutively",
+                        host,
+                        consecutive_failures[i]
+                    );
+
+                    // Only trigger shutdown after multiple consecutive failures
+                    if consecutive_failures[i] >= MAX_CONSECUTIVE_FAILURES {
                         tracing::error!(
-                            "Node {} has not completed health check, therefore graceful shutdown \
-                             has been triggered",
-                            host
+                            "Node {} has failed {} consecutive health checks, starting graceful shutdown",
+                            host,
+                            MAX_CONSECUTIVE_FAILURES
                         );
-                    } else {
-                        tracing::info!("Node {} has already started graceful shutdown.", host);
+
+                        if !heartbeat_shutdown_handler.is_shutting_down() {
+                            heartbeat_shutdown_handler.trigger_manual_shutdown();
+                            tracing::error!(
+                                "Node {} has failed consecutive health checks, therefore graceful shutdown has been triggered",
+                                host
+                            );
+                        } else {
+                            tracing::info!("Node {} has already started graceful shutdown.", host);
+                        }
                     }
                     continue;
                 }
+
+                // Reset consecutive failures counter on successful health check
+                consecutive_failures[i] = 0;
 
                 let probe_response = res
                     .unwrap()


### PR DESCRIPTION
### Notes
* add retries for heartbeat task
* Genesis is sometimes failing due to [connection issues](https://app.datadoghq.com/logs?query=service%3A%28sync-protocol-0%20OR%20sync-protocol-1%20OR%20sync-protocol-2%29%20env%3Astage%20%21%22connection%20received%20which%20was%20not%20requested%22%20%21%22reconnecting%20to%20Identity%22%20%21%22shutting%20down%20tasks%20for%20Identity%22%20%21%22dial%22%20%21healthy&additional_filters=%5B%5D&cols=service&event=AwAAAZf001rJpEKBZQAAABhBWmYwMDJIZ0FBQS16X3loUUpaMExBQUwAAAAkMDE5N2Y0ZDktYmQzNS00YTA4LTkyMjgtMzEzNWE3NmIzZDJjAAFc0g&messageDisplay=inline&refresh_mode=paused&saved-view-id=3562396&storage=hot&stream_sort=desc&viz=stream&from_ts=1752159120000&to_ts=1752159240000&live=false)
```
Node http://genesis.0.stage.hnsw.worldcoin.dev:8000/health did not respond with success, response: Err(reqwest::Error { kind: Request, url: "http://genesis.0.stage.hnsw.worldcoin.dev:8000/health", source: hyper_util::client::legacy::Error(Connect, ConnectError("tcp connect error", Os { code: 110, kind: TimedOut, message: "Connection timed out" })) })
```
* the nodes are still up and are only killed due to this according to [events](https://app.datadoghq.com/event/explorer?query=env%3Astage%20service%3A%28sync-protocol-0%20OR%20sync-protocol-1%20OR%20sync-protocol-2%29&cols=&fromUser=true&messageDisplay=expanded-lg&options=&refresh_mode=paused&sort=DESC&view=all&from_ts=1752158628647&to_ts=1752160803748&live=false). The nodes exited with code zero 14 seconds after the connection error
