### PR TITLE
INFRA-482 Add SSL certificate to application container and NGINX Sidecar

### DIFF
--- a/deploy/stage/common-values-ampc-hnsw.yaml
+++ b/deploy/stage/common-values-ampc-hnsw.yaml
@@ -55,3 +55,74 @@ nodeSelector:
 podSecurityContext:
   runAsUser: 65534
   runAsGroup: 65534
+
+mountSSLCerts:
+  enabled: true
+  mountPath: /etc/ssl/private
+
+nginxSidecar:
+  enabled: true
+  port: 6443
+  ports:
+    - containerPort: 4100
+      name: tcp-4000
+      protocol: TCP
+    - containerPort: 4101
+      name: tcp-4001
+      protocol: TCP
+    - containerPort: 4102
+      name: tcp-4002
+      protocol: TCP
+  secrets:
+    enabled: true
+    volumeMount:
+      - name: nginx-certs
+        mountPath: /etc/nginx/cert
+    volume:
+      - name: nginx-certs
+        secret:
+          secretName: application
+          items:
+            - key: certificate.crt
+              path: certificate.crt
+            - key: key.pem
+              path: key.pem
+          optional: false
+  config:
+    nginx.conf: |
+      worker_processes  auto;
+  
+      # Send error logs to stderr
+      error_log /dev/stderr info;
+
+      events {
+          worker_connections 1024;
+      }
+
+      stream {
+          # Send access logs to stdout
+          access_log /dev/stdout;
+
+          ssl_certificate /etc/nginx/cert/certificate.crt;
+          ssl_certificate_key /etc/nginx/cert/key.pem;
+          ssl_protocols       TLSv1.3;
+          ssl_ciphers         HIGH:!aNULL:!MD5;
+
+          # TCP listener for port 4000
+          server {
+              listen 4100 ssl;
+              proxy_pass 127.0.0.1:4000;
+          }
+
+          # TCP listener for port 4001
+          server {
+              listen 4101 ssl;
+              proxy_pass 127.0.0.1:4001;
+          }
+
+          # TCP listener for port 4002
+          server {
+              listen 4102 ssl;
+              proxy_pass 127.0.0.1:4002;
+          }
+      }


### PR DESCRIPTION
This PR enhances the deployment configuration by introducing SSL support and secure proxying for the application container:

**SSL Certificate Mounting:**
Self-signed SSL certificate and key are now mounted into the application container at /etc/ssl/private.
Ensures the application can access SSL credentials for secure communication.

**NGINX Sidecar Container:**
Adds an NGINX sidecar container to handle SSL termination.
NGINX is configured to use the mounted certificate and key for TLS (TLSv1.3).
Proxies TCP traffic from external ports (4100, 4101, 4102) to the application’s internal ports (4000, 4001, 4002).
Access and error logs are directed to stdout/stderr for easier monitoring.

**Secret Management:**
SSL certificate and key are provided via Kubernetes secrets. Provided by Terraform.
Secrets are securely mounted into the NGINX container at /etc/nginx/cert.

**Configuration Details:**
NGINX configuration is embedded directly in the deployment values for clarity and maintainability.
All relevant ports and volume mounts are explicitly defined.

**Motivation**
Improves security by enabling encrypted communication between clients and the application.
Simplifies SSL management by offloading termination to a dedicated NGINX sidecar.
Supports multiple TCP ports for flexible service exposure.
