### PR TITLE
set terminationGracePeriodSecods in stage

### DIFF
--- a/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw.yaml
@@ -27,7 +27,7 @@ env:
     value: "32"
 
   - name: SMPC__PROCESSING_TIMEOUT_SECS
-    value: "1240"
+    value: "240"  # 2 minutes per batch in stage, bump to 4 in prod
 
   - name: SMPC__HAWK_REQUEST_PARALLELISM
     value: "1024"

--- a/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw.yaml
@@ -27,7 +27,7 @@ env:
     value: "32"
 
   - name: SMPC__PROCESSING_TIMEOUT_SECS
-    value: "1240"
+    value: "240"  # 2 minutes per batch in stage, bump to 4 in prod
 
   - name: SMPC__HAWK_REQUEST_PARALLELISM
     value: "1024"

--- a/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw.yaml
@@ -27,7 +27,7 @@ env:
     value: "32"
 
   - name: SMPC__PROCESSING_TIMEOUT_SECS
-    value: "1240"
+    value: "240"  # 2 minutes per batch in stage, bump to 4 in prod
 
   - name: SMPC__HAWK_REQUEST_PARALLELISM
     value: "1024"

--- a/deploy/stage/common-values-ampc-hnsw.yaml
+++ b/deploy/stage/common-values-ampc-hnsw.yaml
@@ -55,3 +55,7 @@ nodeSelector:
 podSecurityContext:
   runAsUser: 65534
   runAsGroup: 65534
+
+# long enough to allow for graceful shutdown to safely process 2 batches
+# single batch timeout in stage is 240 seconds
+terminationGracePeriodSeconds: 500


### PR DESCRIPTION
we had initially set an exceedingly high batch processing timeout due to a bug in anonymized statistics (it would calculate anon stats on _all_ the neighbors, not just the partial matches, leading to far too large messages to be broadcasted between parties) and never tuned it down to reflect the actual runtime of batches.

It is still now set to a very conservative 6 minutes, or 7.5 seconds per item on a full 32-item batch, which should be enough for staging performance tests.

The main change here is the introduction of the `terminationGracePeriodSecods` that allows for safely processing 2 batches to allow for a graceful shutdown. 