### PR TITLE
Fix: add NGINX access log format

### DIFF
--- a/deploy/stage/common-values-ampc-hnsw.yaml
+++ b/deploy/stage/common-values-ampc-hnsw.yaml
@@ -100,8 +100,13 @@ nginxSidecar:
       }
 
       stream {
-          # Send access logs to stdout
-          access_log /dev/stdout;
+          # Define a custom log format for stream context
+          log_format basic '$remote_addr [$time_local] '
+                          '$protocol $status $bytes_sent $bytes_received '
+                          '$session_time';
+
+          # Send access logs to stdout with custom format
+          access_log /dev/stdout basic;
 
           ssl_certificate /etc/nginx/cert/certificate.crt;
           ssl_certificate_key /etc/nginx/cert/key.pem;


### PR DESCRIPTION
This pull request updates the logging configuration in the `nginxSidecar` section of `deploy/stage/common-values-ampc-hnsw.yaml` to enhance the logging format for stream context.

In the stream context (which we're using for TCP proxying), nginx doesn't have default log formats like it does in the http context.

Error log: `nginx: [emerg] log format is not specified in /etc/nginx/nginx.conf:13`