### PR TITLE
chore: Set hostNetwork: false

### DIFF
--- a/deploy/stage/common-values-ampc-hnsw.yaml
+++ b/deploy/stage/common-values-ampc-hnsw.yaml
@@ -9,6 +9,8 @@ strategy:
 datadog:
   enabled: true
 
+hostNetwork: false
+
 ports:
   - containerPort: 3000
     name: health


### PR DESCRIPTION
With the introduction of pod security groups it was required not to use hostNetwork.