### PR TITLE
Simplify pairwise_distance

### DIFF
--- a/iris-mpc-cpu/benches/hnsw.rs
+++ b/iris-mpc-cpu/benches/hnsw.rs
@@ -172,8 +172,7 @@ fn bench_gr_primitives(c: &mut Criterion) {
                     y2.code.preprocess_iris_code_query_share();
                     y2.mask.preprocess_mask_code_query_share();
                     let pairs = [Some((&x1, &y1)), Some((&x2, &y2))];
-                    let ds_and_ts =
-                        galois_ring_pairwise_distance(&mut player_session, &pairs).await;
+                    let ds_and_ts = galois_ring_pairwise_distance(&pairs).await;
                     let ds_and_ts = galois_ring_to_rep3(&mut player_session, ds_and_ts)
                         .await
                         .unwrap();

--- a/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
@@ -366,7 +366,7 @@ impl Aby3Store {
         if pairs.is_empty() {
             return Ok(vec![]);
         }
-        let ds_and_ts = galois_ring_pairwise_distance(&mut self.session, pairs).await;
+        let ds_and_ts = galois_ring_pairwise_distance(pairs).await;
         galois_ring_to_rep3(&mut self.session, ds_and_ts).await
     }
 }

--- a/iris-mpc-cpu/src/protocol/ops.rs
+++ b/iris-mpc-cpu/src/protocol/ops.rs
@@ -249,7 +249,6 @@ pub async fn cross_compare(
 /// mask of the irises. We pack the dot products of the code and mask into one
 /// vector to be able to reshare it later.
 pub async fn galois_ring_pairwise_distance(
-    _session: &mut Session,
     pairs: &[Option<(&GaloisRingSharedIris, &GaloisRingSharedIris)>],
 ) -> Vec<RingElement<u16>> {
     let mut additive_shares = Vec::with_capacity(2 * pairs.len());
@@ -728,7 +727,7 @@ mod tests {
             jobs.spawn(async move {
                 let mut player_session = session.lock().await;
                 let own_shares = own_shares.iter().map(|(x, y)| Some((x, y))).collect_vec();
-                let x = galois_ring_pairwise_distance(&mut player_session, &own_shares).await;
+                let x = galois_ring_pairwise_distance(&own_shares).await;
                 let opened_x = open_additive(&mut player_session, x.clone()).await.unwrap();
                 let x_rep = galois_ring_to_rep3(&mut player_session, x).await.unwrap();
                 let opened_x_rep = open_t_many(&mut player_session, x_rep).await.unwrap();


### PR DESCRIPTION
Recognize that `galois_ring_pairwise_distance` is stateless. Might be easier to call it from async context.