### PR TITLE
[POP-2699] Add TCP keepalive and metrics for reconnect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2073,7 +2073,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -2178,7 +2178,7 @@ dependencies = [
  "http-body 1.0.1",
  "hyper 1.5.2",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -2382,7 +2382,6 @@ dependencies = [
  "iris-mpc-common",
  "iris-mpc-store",
  "itertools 0.13.0",
- "libc",
  "metrics 0.22.3",
  "num-traits",
  "num_enum",
@@ -2394,6 +2393,7 @@ dependencies = [
  "serde",
  "serde_json",
  "siphasher",
+ "socket2 0.6.0",
  "sqlx",
  "static_assertions",
  "thiserror",
@@ -4348,6 +4348,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "sodiumoxide"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4818,7 +4828,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.5.7",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -4945,7 +4955,7 @@ dependencies = [
  "prost",
  "rustls-native-certs 0.8.0",
  "rustls-pemfile 2.2.0",
- "socket2",
+ "socket2 0.5.7",
  "tokio",
  "tokio-rustls 0.26.2",
  "tokio-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2382,6 +2382,7 @@ dependencies = [
  "iris-mpc-common",
  "iris-mpc-store",
  "itertools 0.13.0",
+ "libc",
  "metrics 0.22.3",
  "num-traits",
  "num_enum",
@@ -2646,9 +2647,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libloading"

--- a/iris-mpc-cpu/Cargo.toml
+++ b/iris-mpc-cpu/Cargo.toml
@@ -27,7 +27,6 @@ futures.workspace = true
 iris-mpc-common = { path = "../iris-mpc-common" }
 iris-mpc-store = { path = "../iris-mpc-store" }
 itertools.workspace = true
-libc = "0.2.174"
 num-traits.workspace = true
 prost = "0.13"
 rand.workspace = true
@@ -36,6 +35,7 @@ rstest = "0.23.0"
 serde.workspace = true
 serde_json.workspace = true
 siphasher = "1"
+socket2 = { version = "0.6.0", features = ["all"] }
 static_assertions.workspace = true
 sqlx.workspace = true
 thiserror.workspace = true

--- a/iris-mpc-cpu/Cargo.toml
+++ b/iris-mpc-cpu/Cargo.toml
@@ -27,6 +27,7 @@ futures.workspace = true
 iris-mpc-common = { path = "../iris-mpc-common" }
 iris-mpc-store = { path = "../iris-mpc-store" }
 itertools.workspace = true
+libc = "0.2.174"
 num-traits.workspace = true
 prost = "0.13"
 rand.workspace = true

--- a/iris-mpc-cpu/src/network/tcp/networking/client.rs
+++ b/iris-mpc-cpu/src/network/tcp/networking/client.rs
@@ -8,7 +8,7 @@ use tokio_rustls::rustls::{
 };
 use tokio_rustls::{TlsConnector, TlsStream};
 
-use crate::network::tcp::Client;
+use crate::network::tcp::{networking::configure_tcp_stream, Client};
 
 #[derive(Clone)]
 pub struct TlsClient {
@@ -49,7 +49,7 @@ impl Client for TlsClient {
     type Output = TlsStream<TcpStream>;
     async fn connect(&self, addr: SocketAddr) -> Result<Self::Output> {
         let stream = TcpStream::connect(addr).await?;
-        stream.set_nodelay(true)?;
+        configure_tcp_stream(&stream)?;
         let domain = ServerName::IpAddress(addr.ip().into());
         let tls_stream = self.tls_connector.connect(domain, stream).await?;
         Ok(TlsStream::Client(tls_stream))
@@ -61,7 +61,7 @@ impl Client for TcpClient {
     type Output = TcpStream;
     async fn connect(&self, addr: SocketAddr) -> Result<Self::Output> {
         let stream = TcpStream::connect(addr).await?;
-        stream.set_nodelay(true)?;
+        configure_tcp_stream(&stream)?;
         Ok(stream)
     }
 }

--- a/iris-mpc-cpu/src/network/tcp/networking/mod.rs
+++ b/iris-mpc-cpu/src/network/tcp/networking/mod.rs
@@ -1,4 +1,62 @@
+use eyre::{bail, Result};
+use std::io;
+use std::os::unix::io::AsRawFd;
+use tokio::net::TcpStream;
+
 pub mod client;
 pub mod connection_builder;
 mod handshake;
 pub mod server;
+
+/// set no_delay and keepalive
+fn configure_tcp_stream(stream: &TcpStream) -> Result<()> {
+    // idle time before keepalives get sent. NGINX default is 60 seconds. want to be less than that.
+    const KEEPALIVE_TIME_SECS: libc::c_int = 30;
+    // how often to send keepalives
+    const KEEPALIVE_INTERVAL_SECS: libc::c_int = 30;
+    // how many unanswered probes before the connection is closed
+    const KEEPALIVE_PROBES: libc::c_int = 4;
+
+    stream.set_nodelay(true)?;
+
+    let fd = stream.as_raw_fd();
+    unsafe {
+        let ret = libc::setsockopt(
+            fd,
+            libc::SOL_TCP,
+            libc::TCP_KEEPIDLE,
+            &KEEPALIVE_TIME_SECS as *const _ as *const libc::c_void,
+            std::mem::size_of_val(&KEEPALIVE_TIME_SECS) as libc::socklen_t,
+        );
+        if ret != 0 {
+            let err = io::Error::last_os_error();
+            bail!("Failed to set TCP_KEEPIDLE: {}", err);
+        }
+
+        let ret = libc::setsockopt(
+            fd,
+            libc::SOL_TCP,
+            libc::TCP_KEEPINTVL,
+            &KEEPALIVE_INTERVAL_SECS as *const _ as *const libc::c_void,
+            std::mem::size_of_val(&KEEPALIVE_INTERVAL_SECS) as libc::socklen_t,
+        );
+        if ret != 0 {
+            let err = io::Error::last_os_error();
+            bail!("Failed to set TCP_KEEPINTVL: {}", err);
+        }
+
+        let ret = libc::setsockopt(
+            fd,
+            libc::SOL_TCP,
+            libc::TCP_KEEPCNT,
+            &KEEPALIVE_PROBES as *const _ as *const libc::c_void,
+            std::mem::size_of_val(&KEEPALIVE_PROBES) as libc::socklen_t,
+        );
+        if ret != 0 {
+            let err = io::Error::last_os_error();
+            bail!("Failed to set TCP_KEEPCNT: {}", err);
+        }
+    }
+
+    Ok(())
+}

--- a/iris-mpc-cpu/src/network/tcp/networking/server.rs
+++ b/iris-mpc-cpu/src/network/tcp/networking/server.rs
@@ -10,7 +10,7 @@ use tokio_rustls::rustls::{
 };
 use tokio_rustls::{TlsAcceptor, TlsStream};
 
-use crate::network::tcp::Server;
+use crate::network::tcp::{networking::configure_tcp_stream, Server};
 
 pub struct TlsServer {
     listener: TcpListener,
@@ -61,7 +61,7 @@ impl Server for TlsServer {
     type Output = TlsStream<TcpStream>;
     async fn accept(&self) -> Result<(SocketAddr, Self::Output)> {
         let (tcp_stream, peer_addr) = self.listener.accept().await?;
-        tcp_stream.set_nodelay(true)?;
+        configure_tcp_stream(&tcp_stream)?;
         let tls_stream = self.tls_acceptor.accept(tcp_stream).await?;
         Ok((peer_addr, TlsStream::Server(tls_stream)))
     }
@@ -72,7 +72,7 @@ impl Server for TcpServer {
     type Output = TcpStream;
     async fn accept(&self) -> Result<(SocketAddr, Self::Output)> {
         let (tcp_stream, peer_addr) = self.listener.accept().await?;
-        tcp_stream.set_nodelay(true)?;
+        configure_tcp_stream(&tcp_stream)?;
         Ok((peer_addr, tcp_stream))
     }
 }


### PR DESCRIPTION
Unexpected disconnects were observed during testing in staging with NGINX TLS sidecar. To troubleshoot this, this PR does the follwing:
- enables TCP keepalive after 30 seconds of inactivity
- adds metrics for reconnect
- adds metrics for creating new sessions
- changes the logging in `network/tcp/handle.rs` to  warn when the inbound or outbound forwarder returns early instead of when a message is received for a session that is no longer in use (this is a symptom of making new sessions)