### PR TITLE
[POP-2700] allow multiple root TLS certs

### DIFF
--- a/iris-mpc-common/src/config/mod.rs
+++ b/iris-mpc-common/src/config/mod.rs
@@ -503,9 +503,10 @@ pub struct TlsConfig {
     // used by a peer to identify itself
     #[arg(required = false)]
     pub leaf_cert: String,
-    // used by the client to make them trust the server cert
+    // used by the client to make them trust the server certs
     #[arg(required = false)]
-    pub root_cert: String,
+    #[serde(default, deserialize_with = "deserialize_yaml_json_string")]
+    pub root_certs: Vec<String>,
 }
 
 fn deserialize_yaml_json_string<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>

--- a/iris-mpc-cpu/src/network/tcp/mod.rs
+++ b/iris-mpc-cpu/src/network/tcp/mod.rs
@@ -82,8 +82,8 @@ pub async fn build_network_handle(
             tcp_config
         );
         let listener =
-            TlsServer::new(my_addr, &tls.private_key, &tls.leaf_cert, &tls.root_cert).await?;
-        let connector = TlsClient::new(&tls.private_key, &tls.leaf_cert, &tls.root_cert).await?;
+            TlsServer::new(my_addr, &tls.private_key, &tls.leaf_cert, &tls.root_certs).await?;
+        let connector = TlsClient::new(&tls.private_key, &tls.leaf_cert, &tls.root_certs).await?;
         let connection_builder =
             PeerConnectionBuilder::new(my_identity, tcp_config.clone(), listener, connector)
                 .await?;

--- a/iris-mpc-cpu/src/network/tcp/networking/client.rs
+++ b/iris-mpc-cpu/src/network/tcp/networking/client.rs
@@ -19,10 +19,12 @@ pub struct TlsClient {
 pub struct TcpClient {}
 
 impl TlsClient {
-    pub async fn new(key_file: &str, cert_file: &str, root_cert: &str) -> Result<Self> {
+    pub async fn new(key_file: &str, cert_file: &str, root_certs: &[String]) -> Result<Self> {
         let mut root_cert_store = RootCertStore::empty();
-        for cert in CertificateDer::pem_file_iter(root_cert)? {
-            root_cert_store.add(cert?)?;
+        for root_cert in root_certs {
+            for cert in CertificateDer::pem_file_iter(root_cert)? {
+                root_cert_store.add(cert?)?;
+            }
         }
 
         let certs = CertificateDer::pem_file_iter(cert_file)?

--- a/iris-mpc-cpu/src/network/tcp/networking/server.rs
+++ b/iris-mpc-cpu/src/network/tcp/networking/server.rs
@@ -26,11 +26,13 @@ impl TlsServer {
         own_addr: SocketAddr,
         key_file: &str,
         cert_file: &str,
-        root_cert: &str,
+        root_certs: &[String],
     ) -> Result<Self> {
         let mut root_cert_store = RootCertStore::empty();
-        for cert in CertificateDer::pem_file_iter(root_cert)? {
-            root_cert_store.add(cert?)?;
+        for root_cert in root_certs {
+            for cert in CertificateDer::pem_file_iter(root_cert)? {
+                root_cert_store.add(cert?)?;
+            }
         }
         let client_verifier = WebPkiClientVerifier::builder(Arc::new(root_cert_store)).build()?;
 


### PR DESCRIPTION
It was requested that for application level TLS, a different root cert be used for each party. This PR makes that possible. However, this implementation seems no more secure than using 1 cert because any of the root certs provided could be used to sign any leaf cert. 

to set the environment variable:
OLD  
`export SMPC__TLS__ROOT_CERT="certs/root.crt"`
NEW  
`export SMPC__TLS__ROOT_CERTS='["certs/root1.crt","certs/root2.crt","certs/root3.crt"]'`