### PR TITLE
feat: add production participants' CA certs

### DIFF
--- a/Dockerfile.dev.hawk
+++ b/Dockerfile.dev.hawk
@@ -38,6 +38,11 @@ RUN apt-get update && apt-get install -y ca-certificates awscli curl
 RUN curl -o /usr/local/share/ca-certificates/ca_party_stage_0.crt https://wf-ampc-hnsw-ca-stage-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_stage_0.pem && \
     curl -o /usr/local/share/ca-certificates/ca_party_stage_1.crt https://wf-ampc-hnsw-ca-stage-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_stage_1.pem && \
     curl -o /usr/local/share/ca-certificates/ca_party_stage_2.crt https://wf-ampc-hnsw-ca-stage-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_stage_2.pem
+
+RUN curl -o /usr/local/share/ca-certificates/ca_party_prod_0.crt https://wf-ampc-hnsw-ca-prod-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_prod_0.pem && \
+    curl -o /usr/local/share/ca-certificates/ca_party_prod_1.crt https://wf-ampc-hnsw-ca-prod-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_prod_1.pem && \
+    curl -o /usr/local/share/ca-certificates/ca_party_prod_2.crt https://wf-ampc-hnsw-ca-prod-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_prod_2.pem
+
 COPY certs /usr/local/share/ca-certificates/
 RUN update-ca-certificates
 

--- a/Dockerfile.genesis.dev.hawk
+++ b/Dockerfile.genesis.dev.hawk
@@ -38,6 +38,11 @@ RUN apt-get update && apt-get install -y ca-certificates awscli curl
 RUN curl -o /usr/local/share/ca-certificates/ca_party_stage_0.crt https://wf-ampc-hnsw-ca-stage-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_stage_0.pem && \
     curl -o /usr/local/share/ca-certificates/ca_party_stage_1.crt https://wf-ampc-hnsw-ca-stage-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_stage_1.pem && \
     curl -o /usr/local/share/ca-certificates/ca_party_stage_2.crt https://wf-ampc-hnsw-ca-stage-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_stage_2.pem
+
+RUN curl -o /usr/local/share/ca-certificates/ca_party_prod_0.crt https://wf-ampc-hnsw-ca-prod-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_prod_0.pem && \
+    curl -o /usr/local/share/ca-certificates/ca_party_prod_1.crt https://wf-ampc-hnsw-ca-prod-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_prod_1.pem && \
+    curl -o /usr/local/share/ca-certificates/ca_party_prod_2.crt https://wf-ampc-hnsw-ca-prod-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_prod_2.pem
+
 COPY certs /usr/local/share/ca-certificates/
 RUN update-ca-certificates
 

--- a/Dockerfile.genesis.hawk
+++ b/Dockerfile.genesis.hawk
@@ -38,6 +38,11 @@ RUN apt-get update && apt-get install -y ca-certificates awscli curl
 RUN curl -o /usr/local/share/ca-certificates/ca_party_stage_0.crt https://wf-ampc-hnsw-ca-stage-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_stage_0.pem && \
     curl -o /usr/local/share/ca-certificates/ca_party_stage_1.crt https://wf-ampc-hnsw-ca-stage-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_stage_1.pem && \
     curl -o /usr/local/share/ca-certificates/ca_party_stage_2.crt https://wf-ampc-hnsw-ca-stage-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_stage_2.pem
+
+RUN curl -o /usr/local/share/ca-certificates/ca_party_prod_0.crt https://wf-ampc-hnsw-ca-prod-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_prod_0.pem && \
+    curl -o /usr/local/share/ca-certificates/ca_party_prod_1.crt https://wf-ampc-hnsw-ca-prod-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_prod_1.pem && \
+    curl -o /usr/local/share/ca-certificates/ca_party_prod_2.crt https://wf-ampc-hnsw-ca-prod-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_prod_2.pem
+
 COPY certs /usr/local/share/ca-certificates/
 RUN update-ca-certificates
 

--- a/Dockerfile.hawk
+++ b/Dockerfile.hawk
@@ -38,6 +38,11 @@ RUN apt-get update && apt-get install -y ca-certificates awscli curl
 RUN curl -o /usr/local/share/ca-certificates/ca_party_stage_0.crt https://wf-ampc-hnsw-ca-stage-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_stage_0.pem && \
     curl -o /usr/local/share/ca-certificates/ca_party_stage_1.crt https://wf-ampc-hnsw-ca-stage-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_stage_1.pem && \
     curl -o /usr/local/share/ca-certificates/ca_party_stage_2.crt https://wf-ampc-hnsw-ca-stage-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_stage_2.pem
+
+RUN curl -o /usr/local/share/ca-certificates/ca_party_prod_0.crt https://wf-ampc-hnsw-ca-prod-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_prod_0.pem && \
+    curl -o /usr/local/share/ca-certificates/ca_party_prod_1.crt https://wf-ampc-hnsw-ca-prod-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_prod_1.pem && \
+    curl -o /usr/local/share/ca-certificates/ca_party_prod_2.crt https://wf-ampc-hnsw-ca-prod-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_prod_2.pem
+
 COPY certs /usr/local/share/ca-certificates/
 RUN update-ca-certificates
 


### PR DESCRIPTION
Each participant generates their own CA certificate for the production environment. We need to download them and add them to docker image.