### PR TITLE
Bump the AMPC HNSW Stage instance type

### DIFF
--- a/deploy/stage/common-values-ampc-hnsw.yaml
+++ b/deploy/stage/common-values-ampc-hnsw.yaml
@@ -55,11 +55,11 @@ startupProbe:
 
 resources:
   limits:
-    cpu: 31
-    memory: 930Gi
+    cpu: 62
+    memory: 1860Gi
   requests:
-    cpu: 31
-    memory: 930Gi
+    cpu: 62
+    memory: 1860Gi
 
 imagePullSecrets:
   - name: github-secret
@@ -70,7 +70,7 @@ podAnnotations:
 nodeSelector:
   kubernetes.io/arch: amd64
   karpenter.sh/capacity-type: on-demand
-  node.kubernetes.io/instance-type: "x2iedn.8xlarge"
+  node.kubernetes.io/instance-type: "x2iedn.16xlarge"
 
 podSecurityContext:
   runAsUser: 65534


### PR DESCRIPTION
This pull request updates the resource allocation and node configuration for the `ampc-hnsw` deployment in the staging environment. The most important changes include doubling the CPU and memory limits and requests, as well as updating the instance type for the node selector.

We have finished testing the 8XL instance type and are ready to start testing the next one.