### PR TITLE
[POP-2750] Refactor HawkActor insertion code to support plaintext execution

### DIFF
--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -1,7 +1,7 @@
 use super::player::Identity;
 use crate::{
     execution::{
-        hawk_main::search::SearchIds,
+        hawk_main::{insert::InsertPlanV, search::SearchIds},
         local::generate_local_identities,
         player::{Role, RoleAssignment},
         session::{NetworkSession, Session, SessionId},
@@ -11,9 +11,7 @@ use crate::{
         shared_irises::SharedIrises,
     },
     hnsw::{
-        graph::{graph_store, neighborhood::SortedNeighborhoodV},
-        searcher::ConnectPlanV,
-        GraphMem, HnswParams, HnswSearcher, VectorStore,
+        graph::graph_store, searcher::ConnectPlanV, GraphMem, HnswParams, HnswSearcher, VectorStore,
     },
     network::tcp::{build_network_handle, NetworkHandle},
     protocol::{
@@ -232,31 +230,10 @@ pub type SearchResult = (
     <Aby3Store as VectorStore>::DistanceRef,
 );
 
-/// InsertPlan specifies where a query may be inserted into the HNSW graph.
-/// That is lists of neighbors for each layer.
-#[derive(Debug)]
-pub struct InsertPlanV<V: VectorStore> {
-    query: V::QueryRef,
-    links: Vec<SortedNeighborhoodV<V>>,
-    set_ep: bool,
-}
-
-// Manual implementation of Clone for InsertPlanV, since derive(Clone) does not
-// propagate the nested Clone bounds on V::QueryRef via TransientRef.
-impl<V: VectorStore> Clone for InsertPlanV<V> {
-    fn clone(&self) -> Self {
-        Self {
-            query: self.query.clone(),
-            links: self.links.clone(),
-            set_ep: self.set_ep,
-        }
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct HawkInsertPlan {
-    plan: InsertPlanV<Aby3Store>,
-    match_count: usize,
+    pub plan: InsertPlanV<Aby3Store>,
+    pub match_count: usize,
 }
 
 /// ConnectPlan specifies how to connect a new node to the HNSW graph.

--- a/iris-mpc-cpu/src/execution/hawk_main/insert.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/insert.rs
@@ -108,7 +108,7 @@ async fn add_batch_neighbors<V: VectorStore>(
 }
 
 /// Combine insert plans from parallel searches, repairing any conflict.
-pub fn join_plans<V: VectorStore>(
+fn join_plans<V: VectorStore>(
     mut plans: Vec<Option<InsertPlanV<V>>>,
 ) -> Vec<Option<InsertPlanV<V>>> {
     let set_ep = plans.iter().flatten().any(|plan| plan.set_ep);

--- a/iris-mpc-cpu/src/execution/hawk_main/insert.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/insert.rs
@@ -29,9 +29,8 @@ impl<V: VectorStore> Clone for InsertPlanV<V> {
     }
 }
 
-/// Insert a collection `plans` of `InsertPlan` structs into the graph and vector store
-/// represented by `session`, adjusting the insertion plans as needed to repair any conflict
-/// from parallel searches.
+/// Insert a collection `plans` of `InsertPlanV` structs into the graph and vector store,
+/// adjusting the insertion plans as needed to repair any conflict from parallel searches.
 ///
 /// The `ids` argument consists of `Option<VectorId>`s which are `Some(id)` if the associated
 /// plan is to be inserted with a specific identifier (e.g. for updates or for insertions
@@ -83,8 +82,7 @@ pub async fn insert<V: VectorStoreMut>(
     Ok(connect_plans)
 }
 
-/// Extends the bottom layer of links with additional vectors in `extra_ids` if there
-/// is room.
+/// Extends the bottom layer of links with additional vectors in `extra_ids` if there is room.
 async fn add_batch_neighbors<V: VectorStore>(
     store: &mut V,
     query: &V::QueryRef,

--- a/iris-mpc-cpu/src/execution/hawk_main/search.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/search.rs
@@ -147,7 +147,7 @@ pub async fn search_single_query_no_match_count<H: std::hash::Hash>(
     query: Aby3Query,
     searcher: &HnswSearcher,
     identifier: &H,
-) -> Result<HawkInsertPlan> {
+) -> Result<InsertPlanV<Aby3Store>> {
     let mut store = session.aby3_store.write().await;
     let graph = session.graph_store.clone().read_owned().await;
 
@@ -157,14 +157,10 @@ pub async fn search_single_query_no_match_count<H: std::hash::Hash>(
         .search_to_insert(&mut *store, &graph, &query, insertion_layer)
         .await?;
 
-    // TODO replace with InsertPlanV
-    Ok(HawkInsertPlan {
-        plan: InsertPlanV {
-            query,
-            links,
-            set_ep,
-        },
-        match_count: 0,
+    Ok(InsertPlanV {
+        query,
+        links,
+        set_ep,
     })
 }
 

--- a/iris-mpc-cpu/src/genesis/mod.rs
+++ b/iris-mpc-cpu/src/genesis/mod.rs
@@ -1,6 +1,7 @@
 mod batch_generator;
 mod hawk_handle;
 mod hawk_job;
+pub mod plaintext;
 pub mod state_accessor;
 pub mod state_sync;
 pub mod utils;

--- a/iris-mpc-cpu/src/genesis/plaintext.rs
+++ b/iris-mpc-cpu/src/genesis/plaintext.rs
@@ -1,0 +1,316 @@
+use std::{collections::HashMap, sync::Arc};
+
+use eyre::{OptionExt, Result};
+use iris_mpc_common::{iris_db::iris::IrisCode, IrisSerialId, IrisVectorId, IrisVersionId};
+use itertools::izip;
+use rand::{thread_rng, Rng};
+
+use crate::{
+    execution::hawk_main::{
+        insert::{self, InsertPlanV},
+        BothEyes, STORE_IDS,
+    },
+    genesis::BatchSize,
+    hawkers::plaintext_store::PlaintextStore,
+    hnsw::{vector_store::VectorStoreMut, GraphMem, HnswParams, HnswSearcher},
+};
+
+/// Represents irises db table, mapping serial ids to version, and left and right iris codes.
+pub type IrisesTable = HashMap<IrisSerialId, (IrisVersionId, IrisCode, IrisCode)>;
+
+/// Represents a left/right pair of plaintext in-memory HNSW graphs.
+pub type PlaintextGraphs = BothEyes<GraphMem<PlaintextStore>>;
+
+/// List of serial ids to treat as deleted enrollments in the source iris database.
+pub type GenesisDeletions = Vec<IrisSerialId>;
+
+/// Plaintext representation of global state of genesis indexer.
+pub struct GenesisState {
+    pub src_db: GenesisSrcDbState,
+
+    pub dst_db: GenesisDstDbState,
+
+    pub config: GenesisConfig,
+
+    pub args: GenesisArgs,
+
+    pub s3_deletions: GenesisDeletions,
+}
+
+/// State of the source database from the GPU server.
+pub struct GenesisSrcDbState {
+    pub irises: IrisesTable,
+
+    pub modifications: (),
+}
+
+/// State of the destination database for the CPU server.
+pub struct GenesisDstDbState {
+    pub irises: IrisesTable,
+
+    pub graphs: PlaintextGraphs,
+
+    pub persistent_state: PersistentState,
+}
+
+/// Database entries for the PersistentState table.
+pub struct PersistentState {
+    pub last_indexed_iris_id: Option<IrisSerialId>,
+
+    pub last_indexed_modification_id: Option<i64>,
+}
+
+/// Logical configuration parameters of genesis `Config` struct.
+#[allow(non_snake_case)]
+pub struct GenesisConfig {
+    pub hnsw_M: usize,
+
+    pub hnsw_ef_constr: usize,
+
+    pub hnsw_ef_search: usize,
+
+    pub hawk_prf_key: Option<u64>,
+}
+
+/// Logical CLI arguments for genesis process.
+pub struct GenesisArgs {
+    pub max_indexation_id: IrisSerialId,
+
+    pub batch_size: usize,
+
+    pub batch_size_error_rate: usize,
+}
+
+/// Execute the genesis indexer over a plaintext state representation, and
+/// return the resulting state.
+pub async fn run_plaintext_genesis(mut state: GenesisState) -> Result<GenesisState> {
+    // Id currently being inspected
+    let mut id = state
+        .dst_db
+        .persistent_state
+        .last_indexed_iris_id
+        .unwrap_or(0);
+    let target_id = state.args.max_indexation_id;
+
+    let batch_size = match state.args.batch_size {
+        0 => BatchSize::get_dynamic_size(id, state.args.batch_size_error_rate, state.config.hnsw_M),
+        batch_size => batch_size,
+    };
+
+    // Initialize existing vector stores
+    let mut left_store = PlaintextStore::new();
+    let mut right_store = PlaintextStore::new();
+    for (serial_id, (version, left_iris, right_iris)) in state.dst_db.irises.iter() {
+        let vector_id = IrisVectorId::new(*serial_id, *version);
+        left_store
+            .insert_at(&vector_id, &Arc::new(left_iris.clone()))
+            .await?;
+        right_store
+            .insert_at(&vector_id, &Arc::new(right_iris.clone()))
+            .await?;
+    }
+
+    let search_params = HnswParams::new(
+        state.config.hnsw_ef_constr,
+        state.config.hnsw_ef_search,
+        state.config.hnsw_M,
+    );
+    let searcher = HnswSearcher {
+        params: search_params,
+    };
+
+    let prf_key: [u8; 16] = state
+        .config
+        .hawk_prf_key
+        .map(|key_u64| (key_u64 as u128).to_le_bytes())
+        .unwrap_or_else(|| thread_rng().gen());
+
+    // Generate and process batches until we've reached the target indexation id
+    while id < target_id {
+        // 1. Generate new batch
+        let mut batch: Vec<(IrisSerialId, bool)> = Vec::new(); // Iris serial id, whether it should be indexed
+        let mut n_to_index = 0;
+        while n_to_index < batch_size && id < target_id {
+            id += 1;
+
+            let do_index = !state.s3_deletions.contains(&id);
+            batch.push((id, do_index));
+
+            if do_index {
+                n_to_index += 1;
+            }
+        }
+
+        // 2. Insert non-deleted entries into HNSW graphs
+        let mut left_insert_plans = Vec::new();
+        let mut right_insert_plans = Vec::new();
+
+        let mut ids = Vec::new();
+
+        for (cur_id, _) in batch.iter().filter(|(_, do_index)| *do_index) {
+            let (version, left_iris, right_iris) = state
+                .src_db
+                .irises
+                .get(cur_id)
+                .ok_or_eyre("Expected iris id missing")?
+                .clone();
+            let vector_id = IrisVectorId::new(*cur_id, version);
+            ids.push(Some(vector_id));
+
+            // Initial search and construct insert plans
+            for (side, iris, store, graph, results) in izip!(
+                STORE_IDS,
+                [left_iris, right_iris],
+                [&mut left_store, &mut right_store],
+                &state.dst_db.graphs,
+                [&mut left_insert_plans, &mut right_insert_plans]
+            ) {
+                let query = Arc::new(iris);
+                let identifier = (vector_id, side);
+                let insertion_layer = searcher.select_layer_prf(&prf_key, &identifier)?;
+
+                let (links, set_ep) = searcher
+                    .search_to_insert(store, graph, &query, insertion_layer)
+                    .await?;
+
+                let insert_plan: InsertPlanV<PlaintextStore> = InsertPlanV {
+                    query,
+                    links,
+                    set_ep,
+                };
+
+                results.push(Some(insert_plan));
+            }
+        }
+
+        // Insert batch of insert plans using HawkActor insertion logic
+        for (store, graph, plans) in izip!(
+            [&mut left_store, &mut right_store],
+            &mut state.dst_db.graphs,
+            [left_insert_plans, right_insert_plans]
+        ) {
+            insert::insert(store, graph, &searcher, plans, &ids).await?;
+        }
+
+        // 3. Copy all irises to destination db
+        for (cur_id, _) in batch {
+            let irises = state.src_db.irises.get(&cur_id).unwrap().clone();
+            state.dst_db.irises.insert(cur_id, irises);
+        }
+
+        // 4. Update last_indexed_iris_id in destination db
+        state.dst_db.persistent_state.last_indexed_iris_id = Some(id);
+    }
+
+    Ok(state)
+}
+
+#[cfg(test)]
+mod tests {
+    use aes_prng::AesRng;
+    use iris_mpc_common::iris_db::db::IrisDB;
+    use rand::SeedableRng;
+
+    use super::*;
+
+    fn gen_base_state(n_src_enrollments: usize) -> GenesisState {
+        let mut rng = AesRng::seed_from_u64(0);
+        let irises_left = IrisDB::new_random_rng(n_src_enrollments, &mut rng).db;
+        let irises_right = IrisDB::new_random_rng(n_src_enrollments, &mut rng).db;
+        let src_db_irises: HashMap<_, _> = izip!(irises_left, irises_right)
+            .enumerate()
+            .map(|(id, (left, right))| (id as IrisSerialId, (0, left, right)))
+            .collect();
+
+        GenesisState {
+            src_db: GenesisSrcDbState {
+                irises: src_db_irises,
+                modifications: (),
+            },
+            dst_db: GenesisDstDbState {
+                irises: HashMap::new(),
+                graphs: [GraphMem::new(), GraphMem::new()],
+                persistent_state: PersistentState {
+                    last_indexed_iris_id: None,
+                    last_indexed_modification_id: None,
+                },
+            },
+            config: GenesisConfig {
+                hnsw_M: 256,
+                hnsw_ef_constr: 320,
+                hnsw_ef_search: 320,
+                hawk_prf_key: Some(0),
+            },
+            args: GenesisArgs {
+                max_indexation_id: 100,
+                batch_size: 0,
+                batch_size_error_rate: 128,
+            },
+            s3_deletions: Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_plaintext_genesis() -> Result<()> {
+        let init_state = gen_base_state(200);
+
+        let new_state = run_plaintext_genesis(init_state).await?;
+
+        assert_eq!(new_state.dst_db.irises.len(), 100);
+        assert_eq!(new_state.dst_db.graphs[0].layers[0].links.len(), 100);
+        assert_eq!(new_state.dst_db.graphs[1].layers[0].links.len(), 100);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_plaintext_genesis_with_deletions() -> Result<()> {
+        let mut init_state = gen_base_state(200);
+        init_state.s3_deletions = vec![25, 40, 50, 60, 90];
+
+        let new_state = run_plaintext_genesis(init_state).await?;
+
+        assert_eq!(new_state.dst_db.irises.len(), 100);
+        assert_eq!(new_state.dst_db.graphs[0].layers[0].links.len(), 95);
+        assert_eq!(new_state.dst_db.graphs[1].layers[0].links.len(), 95);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_plaintext_genesis_repeated() -> Result<()> {
+        let mut init_state = gen_base_state(200);
+        init_state.s3_deletions = vec![25, 40, 50, 60, 90];
+        init_state.args.max_indexation_id = 50;
+
+        let mut state_1 = run_plaintext_genesis(init_state).await?;
+
+        assert_eq!(state_1.dst_db.irises.len(), 50);
+        assert_eq!(state_1.dst_db.graphs[0].layers[0].links.len(), 47);
+        assert_eq!(state_1.dst_db.graphs[1].layers[0].links.len(), 47);
+
+        state_1.args.max_indexation_id = 100;
+        let state_2 = run_plaintext_genesis(state_1).await?;
+
+        assert_eq!(state_2.dst_db.irises.len(), 100);
+        assert_eq!(state_2.dst_db.graphs[0].layers[0].links.len(), 95);
+        assert_eq!(state_2.dst_db.graphs[1].layers[0].links.len(), 95);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_plaintext_genesis_batched() -> Result<()> {
+        let mut init_state = gen_base_state(200);
+        init_state.s3_deletions = vec![25, 40, 50, 60, 90];
+        init_state.args.batch_size = 10;
+
+        let new_state = run_plaintext_genesis(init_state).await?;
+
+        assert_eq!(new_state.dst_db.irises.len(), 100);
+        assert_eq!(new_state.dst_db.graphs[0].layers[0].links.len(), 95);
+        assert_eq!(new_state.dst_db.graphs[1].layers[0].links.len(), 95);
+
+        Ok(())
+    }
+}

--- a/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
@@ -240,6 +240,14 @@ impl VectorStoreMut for Aby3Store {
     async fn insert(&mut self, query: &Self::QueryRef) -> Self::VectorRef {
         self.storage.append(&query.iris).await
     }
+
+    async fn insert_at(
+        &mut self,
+        vector_ref: &Self::VectorRef,
+        query: &Self::QueryRef,
+    ) -> Result<Self::VectorRef> {
+        Ok(self.storage.insert(*vector_ref, &query.iris).await)
+    }
 }
 
 #[cfg(test)]

--- a/iris-mpc-cpu/src/hawkers/plaintext_store.rs
+++ b/iris-mpc-cpu/src/hawkers/plaintext_store.rs
@@ -164,6 +164,14 @@ impl VectorStoreMut for PlaintextStore {
     async fn insert(&mut self, query: &Self::QueryRef) -> Self::VectorRef {
         self.storage.append(query.clone())
     }
+
+    async fn insert_at(
+        &mut self,
+        vector_ref: &Self::VectorRef,
+        query: &Self::QueryRef,
+    ) -> Result<Self::VectorRef> {
+        Ok(self.storage.insert(*vector_ref, query.clone()))
+    }
 }
 
 /// PlaintextStore with synchronization primitives for multithreaded use.
@@ -238,6 +246,14 @@ impl VectorStore for SharedPlaintextStore {
 impl VectorStoreMut for SharedPlaintextStore {
     async fn insert(&mut self, query: &Self::QueryRef) -> Self::VectorRef {
         self.storage.append(query).await
+    }
+
+    async fn insert_at(
+        &mut self,
+        vector_ref: &Self::VectorRef,
+        query: &Self::QueryRef,
+    ) -> Result<Self::VectorRef> {
+        Ok(self.storage.insert(*vector_ref, query).await)
     }
 }
 

--- a/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
@@ -320,6 +320,14 @@ mod tests {
             self.points.get_mut(query).unwrap().is_persistent = true;
             *query
         }
+
+        async fn insert_at(
+            &mut self,
+            _vector_ref: &Self::VectorRef,
+            _query: &Self::QueryRef,
+        ) -> Result<Self::VectorRef> {
+            unimplemented!()
+        }
     }
 
     #[tokio::test]

--- a/iris-mpc-cpu/src/hnsw/vector_store.rs
+++ b/iris-mpc-cpu/src/hnsw/vector_store.rs
@@ -129,18 +129,15 @@ pub trait VectorStore: Debug {
 /// The operations exposed by a vector store, including mutations.
 #[allow(async_fn_in_trait)]
 pub trait VectorStoreMut: VectorStore {
-    /// Persist a query as a new vector in the store, and return a reference to
-    /// it.
+    /// Persist a query as a new vector in the store, and return a reference to it.
     async fn insert(&mut self, query: &Self::QueryRef) -> Self::VectorRef;
 
-    /// Persist a batch of queries as new vectors in the store, and return
-    /// references to them. The default implementation is a loop over
-    /// `insert`. Override for more efficient batch insertions.
-    async fn insert_batch(&mut self, queries: &[Self::QueryRef]) -> Vec<Self::VectorRef> {
-        let mut results = Vec::with_capacity(queries.len());
-        for query in queries {
-            results.push(self.insert(query).await);
-        }
-        results
-    }
+    /// Persist a query as a vector in the store with specified vector reference.
+    ///
+    /// Returns an Err output when a specified insertion is not supported.
+    async fn insert_at(
+        &mut self,
+        vector_ref: &Self::VectorRef,
+        query: &Self::QueryRef,
+    ) -> Result<Self::VectorRef>;
 }


### PR DESCRIPTION
This PR restructures the logic used by `HawkActor` to do insertion of parallel batches of iris codes so that it is generic over `VectorStore`s and can be used in particular with plaintext iris codes.  This involved separating out some of the `HawkActor`-specific usage of sessions and augmented insertion plans, and extending the `VectorStoreMut` trait to support generic insertion at a specific vector id.

This will be useful soon for a plaintext implementation of the genesis indexer which will be used for validation of genesis server behavior in e2e tests.