### PR TITLE
[POP-2703] Implement iris shares database init for genesis e2e testing

### DIFF
--- a/iris-mpc-upgrade-hawk/tests/utils/irises.rs
+++ b/iris-mpc-upgrade-hawk/tests/utils/irises.rs
@@ -1,0 +1,101 @@
+use std::{fs::File, io::BufReader, ops::DerefMut, path::PathBuf};
+
+use eyre::Result;
+use iris_mpc_common::iris_db::iris::IrisCode;
+use iris_mpc_cpu::{
+    hnsw::graph::test_utils::DbContext, protocol::shared_iris::GaloisRingSharedIris,
+    py_bindings::plaintext_store::Base64IrisCode,
+};
+use itertools::{izip, Itertools};
+use rand::{rngs::StdRng, SeedableRng};
+
+use crate::utils::logger::log_info;
+
+/// Component name for logging purposes.
+const COMPONENT: &str = "SystemState-PgresIrises";
+
+/// Number of MPC parties.
+const N_PARTIES: usize = 3;
+
+/// Number of iris code pairs to generate secret shares for at a time.
+const SECRET_SHARING_BATCH_SIZE: usize = 5000;
+
+pub async fn read_irises_from_ndjson(
+    ndjson_path: PathBuf,
+    num_pairs: usize,
+) -> Result<Vec<(IrisCode, IrisCode)>> {
+    log_info(
+        COMPONENT,
+        &format!(
+            "Reading {num_pairs} iris code pairs from file {}",
+            ndjson_path.display()
+        ),
+    );
+
+    let file = File::open(ndjson_path.as_path())?;
+    let reader = BufReader::new(file);
+
+    let iris_pairs = serde_json::Deserializer::from_reader(reader)
+        .into_iter::<Base64IrisCode>()
+        .map(|x| IrisCode::from(&x.unwrap()))
+        .tuples::<(_, _)>()
+        .take(num_pairs)
+        .collect_vec();
+
+    Ok(iris_pairs)
+}
+
+pub fn share_irises_locally(
+    irises: &Vec<(IrisCode, IrisCode)>,
+    shares_rng_seed: u64,
+) -> Result<Vec<Vec<(GaloisRingSharedIris, GaloisRingSharedIris)>>> {
+    let mut shared_irises: Vec<Vec<(GaloisRingSharedIris, GaloisRingSharedIris)>> = (0..N_PARTIES)
+        .map(|_| Vec::with_capacity(SECRET_SHARING_BATCH_SIZE))
+        .collect();
+
+    for (left_iris, right_iris) in irises {
+        // Reset RNG for each pair to match shares_encoding.rs behavior
+        let mut shares_seed = StdRng::seed_from_u64(shares_rng_seed);
+
+        let left_shares =
+            GaloisRingSharedIris::generate_shares_locally(&mut shares_seed, left_iris.clone());
+        let right_shares =
+            GaloisRingSharedIris::generate_shares_locally(&mut shares_seed, right_iris.clone());
+
+        for (party, (shares_l, shares_r)) in izip!(left_shares, right_shares).enumerate() {
+            shared_irises[party].push((shares_l, shares_r));
+        }
+    }
+
+    Ok(shared_irises)
+}
+
+pub async fn persist_iris_shares(
+    iris_shares: &Vec<Vec<(GaloisRingSharedIris, GaloisRingSharedIris)>>,
+    dbs: &Vec<DbContext>,
+) -> Result<()> {
+    for (db, shares) in izip!(dbs, iris_shares) {
+        #[allow(clippy::drain_collect)]
+        db.persist_vector_shares(shares.clone()).await?;
+    }
+
+    Ok(())
+}
+
+pub async fn init_dbs(db_urls: Vec<String>, db_schemas: Vec<String>) -> Vec<DbContext> {
+    let mut dbs = Vec::new();
+    for (url, schema) in izip!(db_urls.iter(), db_schemas.iter()).take(N_PARTIES) {
+        dbs.push(DbContext::new(url, schema).await);
+    }
+    dbs
+}
+
+pub async fn clear_iris_shares(db: &DbContext) -> Result<()> {
+    let mut query = sqlx::QueryBuilder::new("TRUNCATE irises");
+
+    let mut tx = db.store.tx().await?;
+    query.build().execute(tx.deref_mut()).await?;
+    tx.commit().await?;
+
+    Ok(())
+}

--- a/iris-mpc-upgrade-hawk/tests/utils/mod.rs
+++ b/iris-mpc-upgrade-hawk/tests/utils/mod.rs
@@ -1,6 +1,7 @@
 pub mod constants;
 mod errors;
 mod logger;
+pub mod irises;
 pub mod resources;
 pub mod runner;
 pub mod s3_deletions;

--- a/iris-mpc-upgrade-hawk/tests/utils/mod.rs
+++ b/iris-mpc-upgrade-hawk/tests/utils/mod.rs
@@ -1,7 +1,7 @@
 pub mod constants;
 mod errors;
-mod logger;
 pub mod irises;
+mod logger;
 pub mod resources;
 pub mod runner;
 pub mod s3_deletions;

--- a/iris-mpc-upgrade-hawk/tests/utils/resources.rs
+++ b/iris-mpc-upgrade-hawk/tests/utils/resources.rs
@@ -13,10 +13,17 @@ impl TestRunEnvironment {
 }
 
 /// Returns path to resources root directory.
-fn get_path_to_resources() -> String {
+fn get_resources_root() -> String {
     let crate_root = env!("CARGO_MANIFEST_DIR");
 
     format!("{crate_root}/tests/resources")
+}
+
+/// Returns the path in the source tree of a resource asset.
+///
+/// Format of resource location should start with a leading forward slash.
+pub fn get_resource_path(location: String) -> String {
+    format!("{}{}", get_resources_root(), location)
 }
 
 /// Returns node configuration deserialized from a toml file.
@@ -26,7 +33,7 @@ pub fn read_node_config(
 ) -> Result<NodeConfig, Error> {
     let path_to_cfg = format!(
         "{}/node-config/{}/{}.toml",
-        get_path_to_resources(),
+        get_resources_root(),
         ctx.env().subdirectory(),
         config_fname
     );

--- a/iris-mpc-upgrade-hawk/tests/workflows/genesis_100/runner.rs
+++ b/iris-mpc-upgrade-hawk/tests/workflows/genesis_100/runner.rs
@@ -1,6 +1,9 @@
 use super::{factory, types::TestInputs};
 use crate::utils::{
-    irises::{clear_iris_shares, init_dbs, persist_iris_shares, read_irises_from_ndjson, share_irises_locally},
+    irises::{
+        clear_iris_shares, init_dbs, persist_iris_shares, read_irises_from_ndjson,
+        share_irises_locally,
+    },
     resources::get_resource_path,
     s3_deletions::{get_s3_client, upload_iris_deletions},
     TestError, TestRun, TestRunContextInfo,
@@ -102,11 +105,15 @@ impl TestRun for Test {
 
         // Clear GPU database iris shares
         for db in dbs_gpu.iter() {
-            clear_iris_shares(db).await.map_err(|e| TestError::SetupError(e.to_string()))?;
+            clear_iris_shares(db)
+                .await
+                .map_err(|e| TestError::SetupError(e.to_string()))?;
         }
 
         // Write 100 Iris shares -> GPU databases
-        persist_iris_shares(&iris_shares, &dbs_gpu).await.map_err(|e| TestError::SetupError(e.to_string()))?;
+        persist_iris_shares(&iris_shares, &dbs_gpu)
+            .await
+            .map_err(|e| TestError::SetupError(e.to_string()))?;
 
         // Initialize CPU databases
         let (db_urls, db_schemas) = test_inputs
@@ -124,7 +131,9 @@ impl TestRun for Test {
 
         // Clear CPU database iris shares
         for db in dbs_cpu.iter() {
-            clear_iris_shares(db).await.map_err(|e| TestError::SetupError(e.to_string()))?;
+            clear_iris_shares(db)
+                .await
+                .map_err(|e| TestError::SetupError(e.to_string()))?;
         }
 
         // Initialize deleted iris codes in S3 bucket

--- a/iris-mpc-upgrade-hawk/tests/workflows/genesis_100/runner.rs
+++ b/iris-mpc-upgrade-hawk/tests/workflows/genesis_100/runner.rs
@@ -1,5 +1,7 @@
 use super::{factory, types::TestInputs};
 use crate::utils::{
+    irises::{clear_iris_shares, init_dbs, persist_iris_shares, read_irises_from_ndjson, share_irises_locally},
+    resources::get_resource_path,
     s3_deletions::{get_s3_client, upload_iris_deletions},
     TestError, TestRun, TestRunContextInfo,
 };
@@ -69,11 +71,63 @@ impl TestRun for Test {
 
     async fn setup(&mut self, ctx: &TestRunContextInfo) -> Result<(), TestError> {
         // Set inputs.
-        self.inputs = Some(factory::get_test_inputs(ctx));
+        let test_inputs = factory::get_test_inputs(ctx);
+        self.inputs = Some(test_inputs.clone());
 
-        // Write 100 Iris shares -> GPU dB.
-        // TODO
+        // Initialize GPU databases
+        let (db_urls, db_schemas) = test_inputs
+            .net_inputs()
+            .node_process_inputs()
+            .iter()
+            .map(|n| {
+                (
+                    n.config().database.as_ref().unwrap().url.clone(),
+                    n.config().gpu_schema_name_suffix.clone(),
+                )
+            })
+            .unzip();
+        let dbs_gpu = init_dbs(db_urls, db_schemas).await;
 
+        // Read 100 iris code pairs into memory
+        let irises_path = get_resource_path(
+            "/iris-shares-plaintext/20250710-synthetic-irises-1k.ndjson".to_string(),
+        );
+        let iris_codes = read_irises_from_ndjson(irises_path.into(), 100)
+            .await
+            .map_err(|e| TestError::SetupError(e.to_string()))?;
+
+        // Generate secret shares of iris codes
+        let iris_shares = share_irises_locally(&iris_codes, 0)
+            .map_err(|e| TestError::SetupError(e.to_string()))?;
+
+        // Clear GPU database iris shares
+        for db in dbs_gpu.iter() {
+            clear_iris_shares(db).await.map_err(|e| TestError::SetupError(e.to_string()))?;
+        }
+
+        // Write 100 Iris shares -> GPU databases
+        persist_iris_shares(&iris_shares, &dbs_gpu).await.map_err(|e| TestError::SetupError(e.to_string()))?;
+
+        // Initialize CPU databases
+        let (db_urls, db_schemas) = test_inputs
+            .net_inputs()
+            .node_process_inputs()
+            .iter()
+            .map(|n| {
+                (
+                    n.config().cpu_database.as_ref().unwrap().url.clone(),
+                    n.config().hnsw_schema_name_suffix.clone(),
+                )
+            })
+            .unzip();
+        let dbs_cpu = init_dbs(db_urls, db_schemas).await;
+
+        // Clear CPU database iris shares
+        for db in dbs_cpu.iter() {
+            clear_iris_shares(db).await.map_err(|e| TestError::SetupError(e.to_string()))?;
+        }
+
+        // Initialize deleted iris codes in S3 bucket
         let deleted_serial_ids = vec![];
         let s3_region = "us-east-1";
         let deployment_mode = "dev";
@@ -81,6 +135,8 @@ impl TestRun for Test {
             .await
             .map_err(|e| TestError::SetupError(e.to_string()))?;
         upload_iris_deletions(&deleted_serial_ids, &s3_client, deployment_mode).await?;
+
+        // TODO clear modifications table in GPU and CPU databases
 
         Ok(())
     }


### PR DESCRIPTION
PR implements functionality to initialize `irises` Postgres tables in Rust prior to execution of genesis threads.  Includes functionality to clear `irises` table, read iris codes from a static resources file, share codes locally, and export codes to database.  Initialization is implemented for the genesis 100 workflow.  Based on work by @siajasl.