### PR TITLE
[POP-2778] fix prf check

### DIFF
--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -1523,7 +1523,7 @@ impl HawkHandle {
         HawkSession::state_check([&sessions[0][LEFT][0], &sessions[0][RIGHT][0]]).await?;
 
         // validate that the RNGs have not diverged
-        HawkSession::prf_check(sessions).await?;
+        HawkSession::prf_check([&sessions[0][LEFT][0], &sessions[0][RIGHT][0]]).await?;
 
         Ok(())
     }

--- a/iris-mpc-cpu/src/execution/hawk_main/state_check.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/state_check.rs
@@ -5,7 +5,7 @@ use siphasher::sip::SipHasher13;
 use std::hash::{Hash, Hasher};
 
 use crate::{
-    execution::hawk_main::{BothOrient, LEFT, RIGHT},
+    execution::hawk_main::{LEFT, RIGHT},
     network::value::{NetworkValue, StateChecksum},
 };
 
@@ -37,7 +37,7 @@ impl SetHash {
 }
 
 impl HawkSession {
-    pub async fn prf_check(sessions: &BothOrient<BothEyes<Vec<HawkSession>>>) -> Result<()> {
+    pub async fn prf_check(sessions: BothEyes<&HawkSession>) -> Result<()> {
         // make a function because the borrow checker can't track the lifetimes properly if this was a closure
         async fn squeeze_rng(session: &HawkSession) -> Result<()> {
             let mut store = session.aby3_store.write().await;
@@ -52,10 +52,10 @@ impl HawkSession {
 
             let decode = |msg| match msg {
                 Ok(NetworkValue::PrfCheck(c)) => Ok(c),
-                other => {
-                    tracing::error!("Unexpected message format: {:?}", other);
-                    Err(eyre!("Could not deserialize PrfCheck"))
-                }
+                other => Err(eyre!(
+                    "Could not deserialize PrfCheck due to error: {:?}",
+                    other
+                )),
             };
             let prev_share = decode(net.receive_prev().await)?;
             let next_share = decode(net.receive_next().await)?;
@@ -66,13 +66,10 @@ impl HawkSession {
             Ok(())
         }
 
-        let _ = futures::future::try_join_all(
-            sessions
-                .iter()
-                .flat_map(|orient| orient.iter().flat_map(|eyes| eyes.iter()))
-                .map(squeeze_rng),
-        )
-        .await?;
+        let (res_left, res_right) =
+            join!(squeeze_rng(sessions[LEFT]), squeeze_rng(sessions[RIGHT]));
+        let _ = res_left?;
+        let _ = res_right?;
         Ok(())
     }
 


### PR DESCRIPTION
prf check fails to receive a message due to a timeout. this is blocking staging. somehow state_check() succeeds even though it is doing basically the same thing. 

attempt to fix the issue by checking only 2 sessions instead of all of them

also update logging to make `squeeze_challenge()` only return an error and not emit logs. emitting 128 logs per MPC node per `prf_check()` is too noisy. 