### PR TITLE
add genesis test cases 102 and 103

### DIFF
--- a/iris-mpc-upgrade-hawk/tests/e2e_genesis.rs
+++ b/iris-mpc-upgrade-hawk/tests/e2e_genesis.rs
@@ -46,3 +46,30 @@ fn test_hnsw_genesis_101() -> Result<()> {
     run_test!(101, 1)?;
     Ok(())
 }
+
+#[test]
+#[serial]
+#[ignore = "requires external setup"]
+fn test_hnsw_genesis_102() -> Result<()> {
+    use workflows::genesis_102::Test;
+    run_test!(102, 1)?;
+    Ok(())
+}
+
+#[test]
+#[serial]
+#[ignore = "requires external setup"]
+fn test_hnsw_genesis_103() -> Result<()> {
+    use workflows::genesis_103::Test;
+    run_test!(103, 1)?;
+    Ok(())
+}
+
+#[test]
+#[serial]
+#[ignore = "requires external setup"]
+fn test_hnsw_genesis_104() -> Result<()> {
+    use workflows::genesis_104::Test;
+    run_test!(104, 1)?;
+    Ok(())
+}

--- a/iris-mpc-upgrade-hawk/tests/e2e_genesis.rs
+++ b/iris-mpc-upgrade-hawk/tests/e2e_genesis.rs
@@ -65,11 +65,11 @@ fn test_hnsw_genesis_103() -> Result<()> {
     Ok(())
 }
 
-#[test]
+/*#[test]
 #[serial]
 #[ignore = "requires external setup"]
 fn test_hnsw_genesis_104() -> Result<()> {
     use workflows::genesis_104::Test;
     run_test!(104, 1)?;
     Ok(())
-}
+}*/

--- a/iris-mpc-upgrade-hawk/tests/utils/mod.rs
+++ b/iris-mpc-upgrade-hawk/tests/utils/mod.rs
@@ -4,6 +4,7 @@ pub mod irises;
 mod logger;
 pub mod modifications;
 pub mod mpc_node;
+pub mod plaintext_genesis;
 pub mod resources;
 pub mod runner;
 pub mod s3_deletions;

--- a/iris-mpc-upgrade-hawk/tests/utils/mod.rs
+++ b/iris-mpc-upgrade-hawk/tests/utils/mod.rs
@@ -2,6 +2,7 @@ pub mod constants;
 mod errors;
 pub mod irises;
 mod logger;
+pub mod modifications;
 pub mod mpc_node;
 pub mod resources;
 pub mod runner;

--- a/iris-mpc-upgrade-hawk/tests/utils/modifications.rs
+++ b/iris-mpc-upgrade-hawk/tests/utils/modifications.rs
@@ -1,0 +1,64 @@
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+
+// from iris-mpc-common/helpers/smpc_request.rs
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ModificationType {
+    /// searches for a new iris scan and if it finds a match, overwrites the iris code
+    /// in the system with the new scan. AKA reset-check plus overwrite
+    ResetUpdate,
+    /// lets the user update their iris scan to a new version
+    Reauth,
+    /// ignored by genesis
+    Uniqueness,
+}
+
+/// used as inputs to iris-mpc-store > insert_modification()
+/// note that s3_url, result_message_body, and graph_mutation (from the Modification struct) can all be None
+/// look for JobRequest::Modification in iris-mpc-cpu/src/genesis/hawk_handle.rs to see how these are handled
+#[derive(Clone, Serialize, Deserialize)]
+pub struct ModificationInput {
+    /// needs to match an existing vector id
+    pub serial_id: i64,
+    pub request_type: ModificationType,
+}
+
+impl ModificationInput {
+    pub fn new(serial_id: i64, request_type: ModificationType) -> Self {
+        Self {
+            serial_id,
+            request_type,
+        }
+    }
+
+    pub fn from_slice(inputs: &[(i64, ModificationType)]) -> Vec<Self> {
+        inputs
+            .iter()
+            .map(|(serial_id, request_type)| Self::new(*serial_id, request_type.clone()))
+            .collect()
+    }
+}
+
+// may not be needed.
+impl FromStr for ModificationType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_uppercase().as_str() {
+            "reset_update" => Ok(ModificationType::ResetUpdate),
+            "reauth" => Ok(ModificationType::Reauth),
+            "uniqueness" => Ok(ModificationType::Uniqueness),
+            _ => Err(format!("Unknown ModificationType: {}", s)),
+        }
+    }
+}
+
+impl ModificationType {
+    pub fn to_str(&self) -> &'static str {
+        match self {
+            ModificationType::ResetUpdate => "reset_update",
+            ModificationType::Reauth => "reauth",
+            ModificationType::Uniqueness => "uniqueness",
+        }
+    }
+}

--- a/iris-mpc-upgrade-hawk/tests/utils/modifications.rs
+++ b/iris-mpc-upgrade-hawk/tests/utils/modifications.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use std::str::FromStr;
 
 // from iris-mpc-common/helpers/smpc_request.rs
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -53,20 +52,6 @@ impl ModificationInput {
         match self.completed {
             true => "COMPLETED",
             _ => "IN_PROGRESS",
-        }
-    }
-}
-
-// may not be needed.
-impl FromStr for ModificationType {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_uppercase().as_str() {
-            "reset_update" => Ok(ModificationType::ResetUpdate),
-            "reauth" => Ok(ModificationType::Reauth),
-            "uniqueness" => Ok(ModificationType::Uniqueness),
-            _ => Err(format!("Unknown ModificationType: {}", s)),
         }
     }
 }

--- a/iris-mpc-upgrade-hawk/tests/utils/modifications.rs
+++ b/iris-mpc-upgrade-hawk/tests/utils/modifications.rs
@@ -21,21 +21,39 @@ pub struct ModificationInput {
     /// needs to match an existing vector id
     pub serial_id: i64,
     pub request_type: ModificationType,
+    pub completed: bool,
+    pub persisted: bool,
 }
 
 impl ModificationInput {
-    pub fn new(serial_id: i64, request_type: ModificationType) -> Self {
+    pub fn new(
+        serial_id: i64,
+        request_type: ModificationType,
+        completed: bool,
+        persisted: bool,
+    ) -> Self {
         Self {
             serial_id,
             request_type,
+            completed,
+            persisted,
         }
     }
 
-    pub fn from_slice(inputs: &[(i64, ModificationType)]) -> Vec<Self> {
+    pub fn from_slice(inputs: &[(i64, ModificationType, bool, bool)]) -> Vec<Self> {
         inputs
             .iter()
-            .map(|(serial_id, request_type)| Self::new(*serial_id, request_type.clone()))
+            .map(|(serial_id, request_type, completed, persisted)| {
+                Self::new(*serial_id, request_type.clone(), *completed, *persisted)
+            })
             .collect()
+    }
+
+    pub fn get_status(&self) -> &'static str {
+        match self.completed {
+            true => "COMPLETED",
+            _ => "IN_PROGRESS",
+        }
     }
 }
 

--- a/iris-mpc-upgrade-hawk/tests/utils/modifications.rs
+++ b/iris-mpc-upgrade-hawk/tests/utils/modifications.rs
@@ -1,3 +1,6 @@
+use iris_mpc_common::helpers::smpc_request::{
+    REAUTH_MESSAGE_TYPE, RESET_UPDATE_MESSAGE_TYPE, UNIQUENESS_MESSAGE_TYPE,
+};
 use serde::{Deserialize, Serialize};
 
 // from iris-mpc-common/helpers/smpc_request.rs
@@ -59,9 +62,9 @@ impl ModificationInput {
 impl ModificationType {
     pub fn to_str(&self) -> &'static str {
         match self {
-            ModificationType::ResetUpdate => "reset_update",
-            ModificationType::Reauth => "reauth",
-            ModificationType::Uniqueness => "uniqueness",
+            ModificationType::ResetUpdate => RESET_UPDATE_MESSAGE_TYPE,
+            ModificationType::Reauth => REAUTH_MESSAGE_TYPE,
+            ModificationType::Uniqueness => UNIQUENESS_MESSAGE_TYPE,
         }
     }
 }

--- a/iris-mpc-upgrade-hawk/tests/utils/mpc_node.rs
+++ b/iris-mpc-upgrade-hawk/tests/utils/mpc_node.rs
@@ -151,7 +151,6 @@ impl MpcNode {
 impl MpcNode {
     pub async fn insert_modifications(&self, mods: &[ModificationInput]) -> Result<()> {
         let mut updates = vec![];
-        let tx = self.gpu_iris_store.tx().await?;
         for m in mods {
             let mut m2 = self
                 .gpu_iris_store
@@ -161,7 +160,6 @@ impl MpcNode {
             m2.persisted = m.persisted;
             updates.push(m2);
         }
-        tx.commit().await?;
 
         let mut tx = self.gpu_iris_store.tx().await?;
         self.gpu_iris_store

--- a/iris-mpc-upgrade-hawk/tests/utils/mpc_node.rs
+++ b/iris-mpc-upgrade-hawk/tests/utils/mpc_node.rs
@@ -1,29 +1,22 @@
 use super::constants::COUNT_OF_PARTIES;
-use crate::utils::{
-    modifications::ModificationInput, GaloisRingSharedIrisPair, HawkConfigs, IrisCodePair,
-};
+use crate::utils::{modifications::ModificationInput, GaloisRingSharedIrisPair, HawkConfigs};
 use eyre::Result;
 use iris_mpc_common::{
     config::Config,
-    iris_db::iris::IrisCode,
     postgres::{AccessMode, PostgresClient},
-    IrisSerialId, IrisVersionId,
+    IrisSerialId,
 };
 use iris_mpc_cpu::{
     execution::hawk_main::StoreId,
     genesis::{
-        plaintext::{
-            run_plaintext_genesis, GenesisArgs, GenesisConfig, GenesisDstDbState,
-            GenesisSrcDbState, GenesisState, PersistentState,
-        },
+        plaintext::GenesisState,
         state_accessor::{unset_last_indexed_iris_id, unset_last_indexed_modification_id},
     },
     hawkers::plaintext_store::PlaintextStore,
-    hnsw::{graph::graph_store::GraphPg as GraphStore, GraphMem},
+    hnsw::graph::graph_store::GraphPg as GraphStore,
 };
 use iris_mpc_store::{Store as IrisStore, StoredIrisRef};
 use itertools::Itertools;
-use std::collections::HashMap;
 
 // these constants were copied from genesis because genesis requires using an Aby3Store while the tests use a PlainTextStore
 mod constants {
@@ -104,32 +97,6 @@ impl MpcNode {
         self.clear_all_tables().await?;
         self.insert_into_gpu_iris_store(shares).await?;
         Ok(())
-    }
-
-    // the genesis simulation doesn't actually require a MpcNode
-
-    pub async fn simulate_genesis(
-        genesis_args: GenesisArgs,
-        config: &Config,
-        pairs: &[IrisCodePair],
-        deletions: Vec<u32>,
-    ) -> Result<GenesisState> {
-        let genesis_input = get_genesis_input(pairs);
-
-        let genesis_config = GenesisConfig {
-            hnsw_M: config.hnsw_param_M,
-            hnsw_ef_constr: config.hnsw_param_ef_constr,
-            hnsw_ef_search: config.hnsw_param_ef_search,
-            hawk_prf_key: config.hawk_prf_key,
-        };
-
-        let genesis_state =
-            construct_initial_genesis_state(genesis_config, genesis_args, genesis_input, deletions);
-
-        let expected_genesis_state = run_plaintext_genesis(genesis_state)
-            .await
-            .expect("plaintext genesis failed");
-        Ok(expected_genesis_state)
     }
 }
 
@@ -279,41 +246,4 @@ impl MpcNode {
 
         Ok(())
     }
-}
-
-fn construct_initial_genesis_state(
-    genesis_config: GenesisConfig,
-    genesis_args: GenesisArgs,
-    input: HashMap<IrisSerialId, (IrisVersionId, IrisCode, IrisCode)>,
-    s3_deletions: Vec<u32>,
-) -> GenesisState {
-    GenesisState {
-        src_db: GenesisSrcDbState {
-            irises: input,
-            modifications: (),
-        },
-        dst_db: GenesisDstDbState {
-            irises: HashMap::new(),
-            graphs: [GraphMem::new(), GraphMem::new()],
-            persistent_state: PersistentState {
-                last_indexed_iris_id: None,
-                last_indexed_modification_id: None,
-            },
-        },
-        config: genesis_config,
-        args: genesis_args,
-        s3_deletions,
-    }
-}
-
-// construct_initial_genesis_state() needs a special HashMap. Build it from the provided list of plaintext iris shares.
-fn get_genesis_input(
-    pairs: &[IrisCodePair],
-) -> HashMap<IrisSerialId, (IrisVersionId, IrisCode, IrisCode)> {
-    let mut r = HashMap::new();
-    for (idx, (left, right)) in pairs.iter().enumerate() {
-        // warning: iris id can't be zero
-        r.insert(idx as u32 + 1, (0, left.clone(), right.clone()));
-    }
-    r
 }

--- a/iris-mpc-upgrade-hawk/tests/utils/mpc_node.rs
+++ b/iris-mpc-upgrade-hawk/tests/utils/mpc_node.rs
@@ -112,15 +112,6 @@ impl MpcNode {
         genesis_args: GenesisArgs,
         config: &Config,
         pairs: &[IrisCodePair],
-    ) -> Result<GenesisState> {
-        Self::simulate_genesis_with_deletions(genesis_args, config, pairs, vec![]).await
-    }
-
-    // maybe a little sloppy but don't want to make merge conflicts with other branches at this time.
-    pub async fn simulate_genesis_with_deletions(
-        genesis_args: GenesisArgs,
-        config: &Config,
-        pairs: &[IrisCodePair],
         deletions: Vec<u32>,
     ) -> Result<GenesisState> {
         let genesis_input = get_genesis_input(pairs);

--- a/iris-mpc-upgrade-hawk/tests/utils/plaintext_genesis.rs
+++ b/iris-mpc-upgrade-hawk/tests/utils/plaintext_genesis.rs
@@ -1,0 +1,100 @@
+use crate::utils::IrisCodePair;
+use eyre::Result;
+use iris_mpc_common::{config::Config, iris_db::iris::IrisCode, IrisSerialId, IrisVersionId};
+use iris_mpc_cpu::{
+    genesis::plaintext::{
+        run_plaintext_genesis, GenesisArgs, GenesisConfig, GenesisDstDbState, GenesisSrcDbState,
+        GenesisState, PersistentState,
+    },
+    hnsw::GraphMem,
+};
+use std::collections::HashMap;
+
+/// use the builder pattern to run plaintext genesis, to make it easy to add arguments later without having to go back and change old tests
+pub struct PlaintextGenesis<'a> {
+    genesis_args: GenesisArgs,
+    config: &'a Config,
+    pairs: &'a [IrisCodePair],
+    deletions: Vec<u32>,
+}
+
+impl<'a> PlaintextGenesis<'a> {
+    pub fn new(genesis_args: GenesisArgs, config: &'a Config, pairs: &'a [IrisCodePair]) -> Self {
+        Self {
+            genesis_args,
+            config,
+            pairs,
+            deletions: vec![],
+        }
+    }
+
+    pub fn with_deletions(mut self, deletions: Vec<u32>) -> Self {
+        self.deletions = deletions;
+        self
+    }
+
+    pub async fn run(self) -> Result<GenesisState> {
+        simulate_genesis(self.genesis_args, self.config, self.pairs, self.deletions).await
+    }
+}
+
+async fn simulate_genesis(
+    genesis_args: GenesisArgs,
+    config: &Config,
+    pairs: &[IrisCodePair],
+    deletions: Vec<u32>,
+) -> Result<GenesisState> {
+    let genesis_input = get_genesis_input(pairs);
+
+    let genesis_config = GenesisConfig {
+        hnsw_M: config.hnsw_param_M,
+        hnsw_ef_constr: config.hnsw_param_ef_constr,
+        hnsw_ef_search: config.hnsw_param_ef_search,
+        hawk_prf_key: config.hawk_prf_key,
+    };
+
+    let genesis_state =
+        construct_initial_genesis_state(genesis_config, genesis_args, genesis_input, deletions);
+
+    let expected_genesis_state = run_plaintext_genesis(genesis_state)
+        .await
+        .expect("plaintext genesis failed");
+    Ok(expected_genesis_state)
+}
+
+fn construct_initial_genesis_state(
+    genesis_config: GenesisConfig,
+    genesis_args: GenesisArgs,
+    input: HashMap<IrisSerialId, (IrisVersionId, IrisCode, IrisCode)>,
+    s3_deletions: Vec<u32>,
+) -> GenesisState {
+    GenesisState {
+        src_db: GenesisSrcDbState {
+            irises: input,
+            modifications: (),
+        },
+        dst_db: GenesisDstDbState {
+            irises: HashMap::new(),
+            graphs: [GraphMem::new(), GraphMem::new()],
+            persistent_state: PersistentState {
+                last_indexed_iris_id: None,
+                last_indexed_modification_id: None,
+            },
+        },
+        config: genesis_config,
+        args: genesis_args,
+        s3_deletions,
+    }
+}
+
+// construct_initial_genesis_state() needs a special HashMap. Build it from the provided list of plaintext iris shares.
+fn get_genesis_input(
+    pairs: &[IrisCodePair],
+) -> HashMap<IrisSerialId, (IrisVersionId, IrisCode, IrisCode)> {
+    let mut r = HashMap::new();
+    for (idx, (left, right)) in pairs.iter().enumerate() {
+        // warning: iris id can't be zero
+        r.insert(idx as u32 + 1, (0, left.clone(), right.clone()));
+    }
+    r
+}

--- a/iris-mpc-upgrade-hawk/tests/workflows/README.md
+++ b/iris-mpc-upgrade-hawk/tests/workflows/README.md
@@ -1,0 +1,96 @@
+# Test cases
+
+## 100
+Preconditions:
+GPU iris database has entries from 1 to 100, inclusive
+CPU iris database and graph database is empty
+CPU modifications and persisted_state tables are empty
+GPU modifications and persisted_state tables are empty
+There are zero deletions on S3
+
+Test:
+index genesis up to 100
+
+Postconditions:
+GPU iris database has entries from 1 to 100, inclusive
+CPU iris database has entries from 1 to 100, inclusive
+CPU modifications table is empty
+CPU persisted_state table shows the max indexed modification is 0 and max indexed iris is 100
+CPU graph database matches the output of plaintext genesis
+There are zero deletions on S3
+
+## 101
+Preconditions:
+same as 100
+
+Test:
+index genesis up to 50
+index genesis up to 100
+
+Postconditions:
+same as 100
+
+## 102
+Preconditions:
+GPU iris database has entries from 1 to 100, inclusive
+CPU iris database and graph database is empty
+CPU modifications and persisted_state tables are empty
+GPU persisted_state table is empty
+S3 deletions: [1, 2, 3, 4, 5]
+
+Test:
+index genesis up to 100
+
+Postconditions:
+GPU iris database has entries from 1 to 100, inclusive
+CPU iris database has entries from 1 to 100, inclusive
+CPU modifications table is empty
+CPU persisted_state table shows the max indexed modification is 0 and max indexed iris is 100
+CPU graph database matches the output of plaintext genesis
+CPU graph database at layer zero has 95 links (100 irises - 5 deletions)
+
+## 103
+Preconditions:
+GPU iris database has entries from 1 to 100, inclusive
+CPU iris database and graph database is empty
+CPU modifications and persisted_state tables are empty
+GPU persisted_state table is empty
+GPU modifications table has 3 uniqueness modifications, for ids 1-3, which genesis ignores
+There are zero deletions on S3
+
+Test:
+index genesis up to 100
+
+Postconditions:
+GPU iris database has entries from 1 to 100, inclusive
+CPU iris database has entries from 1 to 100, inclusive
+CPU modifications table is empty
+CPU persisted_state table shows the max indexed modification is 0 and max indexed iris is 100
+CPU graph database matches the output of plaintext genesis
+CPU graph database at layer zero has 100 links
+There are zero deletions on S3
+
+
+## 104
+Preconditions:
+index genesis up to 50
+GPU iris database has entries from 1 to 100, inclusive
+CPU iris database and graph database are indexed up to 50
+CPU modifications table is empty
+CPU persisted state table shows max indexed iris as 50
+GPU modifications table has the following modifications:
+    ids 51-75 are reset modifications for irises 1-25
+    ids 76-100 are reauth modifications for irises 26-50
+There are zero deletions on S3
+
+Test:
+index genesis up to 100
+
+Postconditions:
+GPU iris database has 100 entries
+CPU iris database has 100 entries
+CPU modifications table 50 entries
+CPU persisted_state table shows the max indexed modification is 50 and max indexed iris is 100
+CPU graph database matches the output of plaintext genesis
+CPU graph database at layer zero has 50 links
+There are zero deletions on S3

--- a/iris-mpc-upgrade-hawk/tests/workflows/README.md
+++ b/iris-mpc-upgrade-hawk/tests/workflows/README.md
@@ -55,7 +55,8 @@ GPU iris database has entries from 1 to 100, inclusive
 CPU iris database and graph database is empty
 CPU modifications and persisted_state tables are empty
 GPU persisted_state table is empty
-GPU modifications table has 3 uniqueness modifications, for ids 1-3, which genesis ignores
+GPU modifications table has entries for irises which have not been indexed yet.
+CPU graph database at layer zero has 100 links
 There are zero deletions on S3
 
 Test:
@@ -65,32 +66,32 @@ Postconditions:
 GPU iris database has entries from 1 to 100, inclusive
 CPU iris database has entries from 1 to 100, inclusive
 CPU modifications table is empty
-CPU persisted_state table shows the max indexed modification is 0 and max indexed iris is 100
+CPU persisted_state table shows the max indexed modification is 3 and max indexed iris is 100
 CPU graph database matches the output of plaintext genesis
-CPU graph database at layer zero has 100 links
 There are zero deletions on S3
 
 
 ## 104
 Preconditions:
-index genesis up to 50
 GPU iris database has entries from 1 to 100, inclusive
-CPU iris database and graph database are indexed up to 50
-CPU modifications table is empty
-CPU persisted state table shows max indexed iris as 50
-GPU modifications table has the following modifications:
-    ids 51-75 are reset modifications for irises 1-25
-    ids 76-100 are reauth modifications for irises 26-50
+CPU iris database and graph database is empty
+CPU modifications and persisted_state tables are empty
+GPU persisted_state table is empty
+GPU modifications table is empty
+CPU graph database at layer zero has 100 links
 There are zero deletions on S3
 
+
 Test:
+index genesis up to 50
+overwrite the iris code for iris id 3 in the GPU database and add a reset_update modification for it
+overwrite the version for iris id 5 in the GPU database and add a reauth modification for it
 index genesis up to 100
 
 Postconditions:
 GPU iris database has 100 entries
 CPU iris database has 100 entries
-CPU modifications table 50 entries
-CPU persisted_state table shows the max indexed modification is 50 and max indexed iris is 100
+CPU persisted_state table shows the max indexed modification is 5 and max indexed iris is 100
 CPU graph database matches the output of plaintext genesis
-CPU graph database at layer zero has 50 links
+CPU graph database at layer zero has 100 links
 There are zero deletions on S3

--- a/iris-mpc-upgrade-hawk/tests/workflows/README.md
+++ b/iris-mpc-upgrade-hawk/tests/workflows/README.md
@@ -36,7 +36,7 @@ GPU iris database has entries from 1 to 100, inclusive
 CPU iris database and graph database is empty
 CPU modifications and persisted_state tables are empty
 GPU persisted_state table is empty
-S3 deletions: [1, 2, 3, 4, 5]
+S3 deletions: [1, 10, 20, 50, 100]
 
 Test:
 index genesis up to 100
@@ -91,6 +91,7 @@ index genesis up to 100
 Postconditions:
 GPU iris database has 100 entries
 CPU iris database has 100 entries
+CPU iris database reflects irises updated by new modifications after the first run
 CPU persisted_state table shows the max indexed modification is 5 and max indexed iris is 100
 CPU graph database matches the output of plaintext genesis
 CPU graph database at layer zero has 100 links

--- a/iris-mpc-upgrade-hawk/tests/workflows/genesis_100/runner.rs
+++ b/iris-mpc-upgrade-hawk/tests/workflows/genesis_100/runner.rs
@@ -4,6 +4,7 @@ use crate::utils::{
     constants::COUNT_OF_PARTIES,
     irises,
     mpc_node::{MpcNode, MpcNodes},
+    plaintext_genesis::PlaintextGenesis,
     resources::{self},
     s3_deletions::{get_aws_clients, upload_iris_deletions},
     HawkConfigs, IrisCodePair, TestError, TestRun, TestRunContextInfo,
@@ -83,7 +84,8 @@ impl TestRun for Test {
         let config = &self.configs[0];
         let plaintext_irises = get_irises();
         let expected = Arc::new(
-            MpcNode::simulate_genesis(DEFAULT_GENESIS_ARGS, config, &plaintext_irises, vec![])
+            PlaintextGenesis::new(DEFAULT_GENESIS_ARGS, config, &plaintext_irises)
+                .run()
                 .await
                 .unwrap(),
         );

--- a/iris-mpc-upgrade-hawk/tests/workflows/genesis_100/runner.rs
+++ b/iris-mpc-upgrade-hawk/tests/workflows/genesis_100/runner.rs
@@ -83,7 +83,7 @@ impl TestRun for Test {
         let config = &self.configs[0];
         let plaintext_irises = get_irises();
         let expected = Arc::new(
-            MpcNode::simulate_genesis(DEFAULT_GENESIS_ARGS, config, &plaintext_irises)
+            MpcNode::simulate_genesis(DEFAULT_GENESIS_ARGS, config, &plaintext_irises, vec![])
                 .await
                 .unwrap(),
         );

--- a/iris-mpc-upgrade-hawk/tests/workflows/genesis_101/runner.rs
+++ b/iris-mpc-upgrade-hawk/tests/workflows/genesis_101/runner.rs
@@ -4,6 +4,7 @@ use crate::utils::{
     constants::COUNT_OF_PARTIES,
     irises,
     mpc_node::{MpcNode, MpcNodes},
+    plaintext_genesis::PlaintextGenesis,
     resources::{self},
     s3_deletions::{get_aws_clients, upload_iris_deletions},
     HawkConfigs, IrisCodePair, TestError, TestRun, TestRunContextInfo,
@@ -109,7 +110,8 @@ impl TestRun for Test {
         let config = &self.configs[0];
         let plaintext_irises = get_irises();
         let expected = Arc::new(
-            MpcNode::simulate_genesis(DEFAULT_GENESIS_ARGS, config, &plaintext_irises, vec![])
+            PlaintextGenesis::new(DEFAULT_GENESIS_ARGS, config, &plaintext_irises)
+                .run()
                 .await
                 .unwrap(),
         );

--- a/iris-mpc-upgrade-hawk/tests/workflows/genesis_101/runner.rs
+++ b/iris-mpc-upgrade-hawk/tests/workflows/genesis_101/runner.rs
@@ -109,7 +109,7 @@ impl TestRun for Test {
         let config = &self.configs[0];
         let plaintext_irises = get_irises();
         let expected = Arc::new(
-            MpcNode::simulate_genesis(DEFAULT_GENESIS_ARGS, config, &plaintext_irises)
+            MpcNode::simulate_genesis(DEFAULT_GENESIS_ARGS, config, &plaintext_irises, vec![])
                 .await
                 .unwrap(),
         );

--- a/iris-mpc-upgrade-hawk/tests/workflows/genesis_102/mod.rs
+++ b/iris-mpc-upgrade-hawk/tests/workflows/genesis_102/mod.rs
@@ -1,0 +1,2 @@
+mod runner;
+pub use runner::Test;

--- a/iris-mpc-upgrade-hawk/tests/workflows/genesis_102/runner.rs
+++ b/iris-mpc-upgrade-hawk/tests/workflows/genesis_102/runner.rs
@@ -85,7 +85,7 @@ impl TestRun for Test {
         let config = &self.configs[0];
         let plaintext_irises = get_irises();
         let expected = Arc::new(
-            MpcNode::simulate_genesis_with_deletions(
+            MpcNode::simulate_genesis(
                 DEFAULT_GENESIS_ARGS,
                 config,
                 &plaintext_irises,

--- a/iris-mpc-upgrade-hawk/tests/workflows/genesis_102/runner.rs
+++ b/iris-mpc-upgrade-hawk/tests/workflows/genesis_102/runner.rs
@@ -4,6 +4,7 @@ use crate::utils::{
     constants::COUNT_OF_PARTIES,
     irises,
     mpc_node::{MpcNode, MpcNodes},
+    plaintext_genesis::PlaintextGenesis,
     resources::{self},
     s3_deletions::{get_aws_clients, upload_iris_deletions},
     HawkConfigs, IrisCodePair, TestError, TestRun, TestRunContextInfo,
@@ -85,14 +86,11 @@ impl TestRun for Test {
         let config = &self.configs[0];
         let plaintext_irises = get_irises();
         let expected = Arc::new(
-            MpcNode::simulate_genesis(
-                DEFAULT_GENESIS_ARGS,
-                config,
-                &plaintext_irises,
-                DELETED_SERIAL_IDS.clone(),
-            )
-            .await
-            .unwrap(),
+            PlaintextGenesis::new(DEFAULT_GENESIS_ARGS, config, &plaintext_irises)
+                .with_deletions(DELETED_SERIAL_IDS.clone())
+                .run()
+                .await
+                .unwrap(),
         );
 
         let mut join_set = JoinSet::new();

--- a/iris-mpc-upgrade-hawk/tests/workflows/genesis_102/runner.rs
+++ b/iris-mpc-upgrade-hawk/tests/workflows/genesis_102/runner.rs
@@ -26,7 +26,7 @@ const DEFAULT_GENESIS_ARGS: GenesisArgs = GenesisArgs {
     batch_size_error_rate: 250,
 };
 
-pub static DELETED_SERIAL_IDS: LazyLock<Vec<u32>> = LazyLock::new(|| vec![1, 2, 3, 4, 5]);
+pub static DELETED_SERIAL_IDS: LazyLock<Vec<u32>> = LazyLock::new(|| vec![1, 10, 20, 50, 100]);
 
 fn get_irises() -> Vec<IrisCodePair> {
     let irises_path =

--- a/iris-mpc-upgrade-hawk/tests/workflows/genesis_102/runner.rs
+++ b/iris-mpc-upgrade-hawk/tests/workflows/genesis_102/runner.rs
@@ -1,0 +1,218 @@
+use std::sync::Arc;
+
+use crate::utils::{
+    constants::COUNT_OF_PARTIES,
+    irises,
+    mpc_node::{MpcNode, MpcNodes},
+    resources::{self},
+    s3_deletions::{get_aws_clients, upload_iris_deletions},
+    HawkConfigs, IrisCodePair, TestError, TestRun, TestRunContextInfo,
+};
+use eyre::Result;
+use iris_mpc_cpu::genesis::{get_iris_deletions, plaintext::GenesisArgs};
+use iris_mpc_upgrade_hawk::genesis::{exec as exec_genesis, ExecutionArgs};
+use itertools::izip;
+use std::sync::LazyLock;
+use tokio::task::JoinSet;
+
+pub struct Test {
+    configs: HawkConfigs,
+}
+
+const DEFAULT_GENESIS_ARGS: GenesisArgs = GenesisArgs {
+    max_indexation_id: 100,
+    batch_size: 1,
+    batch_size_error_rate: 250,
+};
+
+pub static DELETED_SERIAL_IDS: LazyLock<Vec<u32>> = LazyLock::new(|| vec![1, 2, 3, 4, 5]);
+
+fn get_irises() -> Vec<IrisCodePair> {
+    let irises_path =
+        resources::get_resource_path("iris-shares-plaintext/20250710-synthetic-irises-1k.ndjson");
+    irises::read_irises_from_ndjson(irises_path, 100).unwrap()
+}
+
+impl Test {
+    pub fn new() -> Self {
+        let exec_env = TestRunContextInfo::new(0, 0);
+
+        let configs = (0..COUNT_OF_PARTIES)
+            .map(|idx| {
+                resources::read_node_config(&exec_env, format!("node-{idx}-genesis-0")).unwrap()
+            })
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap();
+
+        Self { configs }
+    }
+
+    async fn get_nodes(&self) -> impl Iterator<Item = MpcNode> {
+        MpcNodes::new(&self.configs).await.into_iter()
+    }
+}
+
+impl TestRun for Test {
+    // run genesis with deletions
+    async fn exec(&mut self) -> Result<(), TestError> {
+        // these need to be on separate tasks
+        let mut join_set = JoinSet::new();
+        for config in self.configs.iter().cloned() {
+            join_set.spawn(async move {
+                exec_genesis(
+                    ExecutionArgs::new(
+                        DEFAULT_GENESIS_ARGS.batch_size,
+                        DEFAULT_GENESIS_ARGS.batch_size_error_rate,
+                        DEFAULT_GENESIS_ARGS.max_indexation_id,
+                        false,
+                        false,
+                    ),
+                    config,
+                )
+                .await
+            });
+        }
+
+        while let Some(r) = join_set.join_next().await {
+            r.unwrap()?;
+        }
+
+        Ok(())
+    }
+
+    async fn exec_assert(&mut self) -> Result<(), TestError> {
+        let config = &self.configs[0];
+        let plaintext_irises = get_irises();
+        let expected = Arc::new(
+            MpcNode::simulate_genesis_with_deletions(
+                DEFAULT_GENESIS_ARGS,
+                config,
+                &plaintext_irises,
+                DELETED_SERIAL_IDS.clone(),
+            )
+            .await
+            .unwrap(),
+        );
+
+        let mut join_set = JoinSet::new();
+        for node in self.get_nodes().await {
+            let expected = expected.clone();
+            let max_indexation_id = DEFAULT_GENESIS_ARGS.max_indexation_id as usize;
+            join_set.spawn(async move {
+                // inspect the postgres tables - iris counts, modifications, and persisted_state
+                let num_irises = node.gpu_iris_store.count_irises().await.unwrap();
+                assert_eq!(num_irises, max_indexation_id);
+
+                let num_irises = node.cpu_iris_store.count_irises().await.unwrap();
+                assert_eq!(num_irises, max_indexation_id);
+
+                let num_modifications = node.gpu_iris_store.last_modifications(1).await.unwrap();
+                assert_eq!(num_modifications.len(), 0);
+
+                let num_modifications = node.cpu_iris_store.last_modifications(1).await.unwrap();
+                assert_eq!(num_modifications.len(), 0);
+
+                assert_eq!(100, node.get_last_indexed_iris_id().await);
+                assert_eq!(0, node.get_last_indexed_modification_id().await);
+
+                node.assert_graphs_match(&expected).await;
+
+                // the graph should not include deleted serial ids
+                assert_eq!(
+                    expected.dst_db.graphs[0].layers[0].links.len(),
+                    DEFAULT_GENESIS_ARGS.max_indexation_id as usize - DELETED_SERIAL_IDS.len()
+                );
+            });
+        }
+
+        while let Some(r) = join_set.join_next().await {
+            r.unwrap();
+        }
+
+        Ok(())
+    }
+
+    async fn setup(&mut self, _ctx: &TestRunContextInfo) -> Result<(), TestError> {
+        let hawk_prf0 = self.configs[0].hawk_prf_key;
+        assert!(
+            self.configs.iter().all(|c| c.hawk_prf_key == hawk_prf0),
+            "All hawk_prf_key values in configs must be equal"
+        );
+
+        let plaintext_irises = get_irises();
+        let secret_shared_irises =
+            irises::share_irises_locally(&plaintext_irises, hawk_prf0.unwrap_or_default()).unwrap();
+
+        let mut join_set = JoinSet::new();
+        for (node, shares) in izip!(self.get_nodes().await, secret_shared_irises.into_iter()) {
+            join_set.spawn(async move {
+                node.init_tables(&shares).await.unwrap();
+            });
+        }
+
+        while let Some(r) = join_set.join_next().await {
+            r.unwrap();
+        }
+
+        // any config file is sufficient to connect to S3
+        let config = &self.configs[0];
+
+        let aws_clients = get_aws_clients(config).await.unwrap();
+        upload_iris_deletions(
+            &DELETED_SERIAL_IDS,
+            &aws_clients.s3_client,
+            &config.environment,
+        )
+        .await
+        .unwrap();
+
+        Ok(())
+    }
+
+    async fn setup_assert(&mut self) -> Result<(), TestError> {
+        let mut join_set = JoinSet::new();
+        for node in self.get_nodes().await {
+            let max_indexation_id = DEFAULT_GENESIS_ARGS.max_indexation_id as usize;
+            join_set.spawn(async move {
+                let num_irises = node.gpu_iris_store.count_irises().await.unwrap();
+                assert_eq!(num_irises, max_indexation_id);
+
+                let num_irises = node.cpu_iris_store.count_irises().await.unwrap();
+                assert_eq!(num_irises, 0);
+
+                let num_modifications = node.gpu_iris_store.last_modifications(1).await.unwrap();
+                assert_eq!(num_modifications.len(), 0);
+
+                let num_modifications = node.cpu_iris_store.last_modifications(1).await.unwrap();
+                assert_eq!(num_modifications.len(), 0);
+
+                assert_eq!(0, node.get_last_indexed_iris_id().await);
+                assert_eq!(0, node.get_last_indexed_modification_id().await);
+            });
+        }
+
+        while let Some(r) = join_set.join_next().await {
+            r.unwrap();
+        }
+
+        // Assert localstack.
+
+        let config = &self.configs[0];
+        let aws_clients = get_aws_clients(config).await.unwrap();
+        let deletions = get_iris_deletions(config, &aws_clients.s3_client, 100)
+            .await
+            .unwrap();
+        assert_eq!(deletions.len(), DELETED_SERIAL_IDS.len());
+
+        Ok(())
+    }
+
+    async fn teardown(&mut self) -> Result<(), TestError> {
+        Ok(())
+    }
+
+    async fn teardown_assert(&mut self) -> Result<(), TestError> {
+        Ok(())
+    }
+}

--- a/iris-mpc-upgrade-hawk/tests/workflows/genesis_103/mod.rs
+++ b/iris-mpc-upgrade-hawk/tests/workflows/genesis_103/mod.rs
@@ -1,0 +1,2 @@
+mod runner;
+pub use runner::Test;

--- a/iris-mpc-upgrade-hawk/tests/workflows/genesis_103/runner.rs
+++ b/iris-mpc-upgrade-hawk/tests/workflows/genesis_103/runner.rs
@@ -89,7 +89,7 @@ impl TestRun for Test {
         let config = &self.configs[0];
         let plaintext_irises = get_irises();
         let expected = Arc::new(
-            MpcNode::simulate_genesis(DEFAULT_GENESIS_ARGS, config, &plaintext_irises)
+            MpcNode::simulate_genesis(DEFAULT_GENESIS_ARGS, config, &plaintext_irises, vec![])
                 .await
                 .unwrap(),
         );

--- a/iris-mpc-upgrade-hawk/tests/workflows/genesis_103/runner.rs
+++ b/iris-mpc-upgrade-hawk/tests/workflows/genesis_103/runner.rs
@@ -1,0 +1,219 @@
+use std::sync::{Arc, LazyLock};
+
+use crate::utils::{
+    constants::COUNT_OF_PARTIES,
+    irises,
+    modifications::{ModificationInput, ModificationType},
+    mpc_node::{MpcNode, MpcNodes},
+    resources::{self},
+    s3_deletions::{get_aws_clients, upload_iris_deletions},
+    HawkConfigs, IrisCodePair, TestError, TestRun, TestRunContextInfo,
+};
+use eyre::Result;
+use iris_mpc_cpu::genesis::{get_iris_deletions, plaintext::GenesisArgs};
+use iris_mpc_upgrade_hawk::genesis::{exec as exec_genesis, ExecutionArgs};
+use itertools::izip;
+use tokio::task::JoinSet;
+
+pub struct Test {
+    configs: HawkConfigs,
+}
+
+const DEFAULT_GENESIS_ARGS: GenesisArgs = GenesisArgs {
+    max_indexation_id: 100,
+    batch_size: 1,
+    batch_size_error_rate: 250,
+};
+
+static MODIFICATIONS: LazyLock<Vec<ModificationInput>> = LazyLock::new(|| {
+    ModificationInput::from_slice(&[
+        (1, ModificationType::Uniqueness),
+        (2, ModificationType::Uniqueness),
+        (3, ModificationType::Uniqueness),
+    ])
+});
+
+fn get_irises() -> Vec<IrisCodePair> {
+    let irises_path =
+        resources::get_resource_path("iris-shares-plaintext/20250710-synthetic-irises-1k.ndjson");
+    irises::read_irises_from_ndjson(irises_path, 100).unwrap()
+}
+
+impl Test {
+    pub fn new() -> Self {
+        let exec_env = TestRunContextInfo::new(0, 0);
+
+        let configs = (0..COUNT_OF_PARTIES)
+            .map(|idx| {
+                resources::read_node_config(&exec_env, format!("node-{idx}-genesis-0")).unwrap()
+            })
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap();
+
+        Self { configs }
+    }
+
+    async fn get_nodes(&self) -> impl Iterator<Item = MpcNode> {
+        MpcNodes::new(&self.configs).await.into_iter()
+    }
+}
+
+impl TestRun for Test {
+    // run genesis with deletions
+    async fn exec(&mut self) -> Result<(), TestError> {
+        // these need to be on separate tasks
+        let mut join_set = JoinSet::new();
+        for config in self.configs.iter().cloned() {
+            join_set.spawn(async move {
+                exec_genesis(
+                    ExecutionArgs::new(
+                        DEFAULT_GENESIS_ARGS.batch_size,
+                        DEFAULT_GENESIS_ARGS.batch_size_error_rate,
+                        DEFAULT_GENESIS_ARGS.max_indexation_id,
+                        false,
+                        false,
+                    ),
+                    config,
+                )
+                .await
+            });
+        }
+
+        while let Some(r) = join_set.join_next().await {
+            r.unwrap()?;
+        }
+
+        Ok(())
+    }
+
+    async fn exec_assert(&mut self) -> Result<(), TestError> {
+        let config = &self.configs[0];
+        let plaintext_irises = get_irises();
+        let expected = Arc::new(
+            MpcNode::simulate_genesis(DEFAULT_GENESIS_ARGS, config, &plaintext_irises)
+                .await
+                .unwrap(),
+        );
+
+        let mut join_set = JoinSet::new();
+        for node in self.get_nodes().await {
+            let expected = expected.clone();
+            let max_indexation_id = DEFAULT_GENESIS_ARGS.max_indexation_id as usize;
+            join_set.spawn(async move {
+                // inspect the postgres tables - iris counts, modifications, and persisted_state
+                let num_irises = node.gpu_iris_store.count_irises().await.unwrap();
+                assert_eq!(num_irises, max_indexation_id);
+
+                let num_irises = node.cpu_iris_store.count_irises().await.unwrap();
+                assert_eq!(num_irises, max_indexation_id);
+
+                let num_modifications = node.gpu_iris_store.last_modifications(100).await.unwrap();
+                assert_eq!(num_modifications.len(), MODIFICATIONS.len());
+
+                let num_modifications = node.cpu_iris_store.last_modifications(100).await.unwrap();
+                assert_eq!(num_modifications.len(), 0);
+
+                assert_eq!(100, node.get_last_indexed_iris_id().await);
+                assert_eq!(0, node.get_last_indexed_modification_id().await);
+
+                node.assert_graphs_match(&expected).await;
+
+                assert_eq!(
+                    expected.dst_db.graphs[0].layers[0].links.len(),
+                    DEFAULT_GENESIS_ARGS.max_indexation_id as usize
+                );
+            });
+        }
+
+        while let Some(r) = join_set.join_next().await {
+            r.unwrap();
+        }
+
+        Ok(())
+    }
+
+    async fn setup(&mut self, _ctx: &TestRunContextInfo) -> Result<(), TestError> {
+        let hawk_prf0 = self.configs[0].hawk_prf_key;
+        assert!(
+            self.configs.iter().all(|c| c.hawk_prf_key == hawk_prf0),
+            "All hawk_prf_key values in configs must be equal"
+        );
+
+        let plaintext_irises = get_irises();
+        let secret_shared_irises =
+            irises::share_irises_locally(&plaintext_irises, hawk_prf0.unwrap_or_default()).unwrap();
+
+        let mut join_set = JoinSet::new();
+        for (node, shares) in izip!(self.get_nodes().await, secret_shared_irises.into_iter()) {
+            join_set.spawn(async move {
+                node.init_tables(&shares).await.unwrap();
+                node.insert_modifications(&MODIFICATIONS).await.unwrap();
+            });
+        }
+
+        while let Some(r) = join_set.join_next().await {
+            r.unwrap();
+        }
+
+        // any config file is sufficient to connect to S3
+        let config = &self.configs[0];
+
+        let deleted_serial_ids = vec![];
+        let aws_clients = get_aws_clients(config).await.unwrap();
+        upload_iris_deletions(
+            &deleted_serial_ids,
+            &aws_clients.s3_client,
+            &config.environment,
+        )
+        .await
+        .unwrap();
+
+        Ok(())
+    }
+
+    async fn setup_assert(&mut self) -> Result<(), TestError> {
+        let mut join_set = JoinSet::new();
+        for node in self.get_nodes().await {
+            join_set.spawn(async move {
+                let num_irises = node.gpu_iris_store.count_irises().await.unwrap();
+                assert_eq!(num_irises, DEFAULT_GENESIS_ARGS.max_indexation_id as usize);
+
+                let num_irises = node.cpu_iris_store.count_irises().await.unwrap();
+                assert_eq!(num_irises, 0);
+
+                let num_modifications = node.gpu_iris_store.last_modifications(100).await.unwrap();
+                assert_eq!(num_modifications.len(), MODIFICATIONS.len());
+
+                let num_modifications = node.cpu_iris_store.last_modifications(1).await.unwrap();
+                assert_eq!(num_modifications.len(), 0);
+
+                assert_eq!(0, node.get_last_indexed_iris_id().await);
+                assert_eq!(0, node.get_last_indexed_modification_id().await);
+            });
+        }
+
+        while let Some(r) = join_set.join_next().await {
+            r.unwrap();
+        }
+
+        // Assert localstack.
+
+        let config = &self.configs[0];
+        let aws_clients = get_aws_clients(config).await.unwrap();
+        let deletions = get_iris_deletions(config, &aws_clients.s3_client, 100)
+            .await
+            .unwrap();
+        assert_eq!(deletions.len(), 0);
+
+        Ok(())
+    }
+
+    async fn teardown(&mut self) -> Result<(), TestError> {
+        Ok(())
+    }
+
+    async fn teardown_assert(&mut self) -> Result<(), TestError> {
+        Ok(())
+    }
+}

--- a/iris-mpc-upgrade-hawk/tests/workflows/genesis_103/runner.rs
+++ b/iris-mpc-upgrade-hawk/tests/workflows/genesis_103/runner.rs
@@ -27,9 +27,9 @@ const DEFAULT_GENESIS_ARGS: GenesisArgs = GenesisArgs {
 
 static MODIFICATIONS: LazyLock<Vec<ModificationInput>> = LazyLock::new(|| {
     ModificationInput::from_slice(&[
-        (1, ModificationType::Uniqueness),
-        (2, ModificationType::Uniqueness),
-        (3, ModificationType::Uniqueness),
+        (1, ModificationType::Uniqueness, true, true),
+        (2, ModificationType::ResetUpdate, true, true),
+        (3, ModificationType::Reauth, true, true),
     ])
 });
 
@@ -60,9 +60,7 @@ impl Test {
 }
 
 impl TestRun for Test {
-    // run genesis with deletions
     async fn exec(&mut self) -> Result<(), TestError> {
-        // these need to be on separate tasks
         let mut join_set = JoinSet::new();
         for config in self.configs.iter().cloned() {
             join_set.spawn(async move {
@@ -115,7 +113,7 @@ impl TestRun for Test {
                 assert_eq!(num_modifications.len(), 0);
 
                 assert_eq!(100, node.get_last_indexed_iris_id().await);
-                assert_eq!(0, node.get_last_indexed_modification_id().await);
+                assert_eq!(3, node.get_last_indexed_modification_id().await);
 
                 node.assert_graphs_match(&expected).await;
 

--- a/iris-mpc-upgrade-hawk/tests/workflows/genesis_103/runner.rs
+++ b/iris-mpc-upgrade-hawk/tests/workflows/genesis_103/runner.rs
@@ -5,6 +5,7 @@ use crate::utils::{
     irises,
     modifications::{ModificationInput, ModificationType},
     mpc_node::{MpcNode, MpcNodes},
+    plaintext_genesis::PlaintextGenesis,
     resources::{self},
     s3_deletions::{get_aws_clients, upload_iris_deletions},
     HawkConfigs, IrisCodePair, TestError, TestRun, TestRunContextInfo,
@@ -89,7 +90,8 @@ impl TestRun for Test {
         let config = &self.configs[0];
         let plaintext_irises = get_irises();
         let expected = Arc::new(
-            MpcNode::simulate_genesis(DEFAULT_GENESIS_ARGS, config, &plaintext_irises, vec![])
+            PlaintextGenesis::new(DEFAULT_GENESIS_ARGS, config, &plaintext_irises)
+                .run()
                 .await
                 .unwrap(),
         );

--- a/iris-mpc-upgrade-hawk/tests/workflows/genesis_104/mod.rs
+++ b/iris-mpc-upgrade-hawk/tests/workflows/genesis_104/mod.rs
@@ -1,0 +1,2 @@
+mod runner;
+pub use runner::Test;

--- a/iris-mpc-upgrade-hawk/tests/workflows/genesis_104/runner.rs
+++ b/iris-mpc-upgrade-hawk/tests/workflows/genesis_104/runner.rs
@@ -147,6 +147,8 @@ impl TestRun for Test {
                 let num_irises = node.cpu_iris_store.count_irises().await.unwrap();
                 assert_eq!(num_irises, max_indexation_id);
 
+                // TODO assert CPU iris database reflects irises updated by new modifications after the first run
+
                 let num_modifications = node.gpu_iris_store.last_modifications(100).await.unwrap();
                 assert_eq!(num_modifications.len(), MODIFICATIONS.len());
 

--- a/iris-mpc-upgrade-hawk/tests/workflows/genesis_104/runner.rs
+++ b/iris-mpc-upgrade-hawk/tests/workflows/genesis_104/runner.rs
@@ -129,7 +129,8 @@ impl TestRun for Test {
         let plaintext_irises = get_irises();
         todo!("add modifications to the genesis simulation");
         let expected = Arc::new(
-            MpcNode::simulate_genesis(DEFAULT_GENESIS_ARGS, config, &plaintext_irises, vec![])
+            PlaintextGenesis::new(DEFAULT_GENESIS_ARGS, config, &plaintext_irises)
+                .run()
                 .await
                 .unwrap(),
         );

--- a/iris-mpc-upgrade-hawk/tests/workflows/genesis_104/runner.rs
+++ b/iris-mpc-upgrade-hawk/tests/workflows/genesis_104/runner.rs
@@ -1,0 +1,257 @@
+use std::sync::{Arc, LazyLock};
+
+use crate::utils::{
+    constants::COUNT_OF_PARTIES,
+    irises,
+    modifications::{ModificationInput, ModificationType},
+    mpc_node::{MpcNode, MpcNodes},
+    resources::{self},
+    s3_deletions::{get_aws_clients, upload_iris_deletions},
+    HawkConfigs, IrisCodePair, TestError, TestRun, TestRunContextInfo,
+};
+use eyre::Result;
+use iris_mpc_cpu::genesis::{get_iris_deletions, plaintext::GenesisArgs};
+use iris_mpc_upgrade_hawk::genesis::{exec as exec_genesis, ExecutionArgs};
+use itertools::izip;
+use tokio::task::JoinSet;
+
+pub struct Test {
+    configs: HawkConfigs,
+}
+
+const DEFAULT_GENESIS_ARGS: GenesisArgs = GenesisArgs {
+    max_indexation_id: 100,
+    batch_size: 1,
+    batch_size_error_rate: 250,
+};
+
+static MODIFICATIONS: LazyLock<Vec<ModificationInput>> = LazyLock::new(|| {
+    ModificationInput::from_slice(
+        &(51..=75)
+            .map(|id| (id, ModificationType::ResetUpdate))
+            .chain((76..=100).map(|id| (id, ModificationType::Reauth)))
+            .collect::<Vec<_>>(),
+    )
+});
+
+fn get_irises() -> Vec<IrisCodePair> {
+    let irises_path =
+        resources::get_resource_path("iris-shares-plaintext/20250710-synthetic-irises-1k.ndjson");
+    irises::read_irises_from_ndjson(irises_path, 100).unwrap()
+}
+
+impl Test {
+    pub fn new() -> Self {
+        let exec_env = TestRunContextInfo::new(0, 0);
+
+        let configs = (0..COUNT_OF_PARTIES)
+            .map(|idx| {
+                resources::read_node_config(&exec_env, format!("node-{idx}-genesis-0")).unwrap()
+            })
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap();
+
+        Self { configs }
+    }
+
+    async fn get_nodes(&self) -> impl Iterator<Item = MpcNode> {
+        MpcNodes::new(&self.configs).await.into_iter()
+    }
+}
+
+impl TestRun for Test {
+    // run genesis with deletions
+    async fn exec(&mut self) -> Result<(), TestError> {
+        // these need to be on separate tasks
+        let mut join_set = JoinSet::new();
+        for mut config in self.configs.iter().cloned() {
+            // hack to get around an "address already in use" error, emitted by HawkHandle
+            config.service_ports = vec!["4003".into(), "4004".into(), "4005".into()];
+            join_set.spawn(async move {
+                exec_genesis(
+                    ExecutionArgs::new(
+                        DEFAULT_GENESIS_ARGS.batch_size,
+                        DEFAULT_GENESIS_ARGS.batch_size_error_rate,
+                        DEFAULT_GENESIS_ARGS.max_indexation_id,
+                        false,
+                        false,
+                    ),
+                    config,
+                )
+                .await
+            });
+        }
+
+        while let Some(r) = join_set.join_next().await {
+            r.unwrap()?;
+        }
+
+        Ok(())
+    }
+
+    async fn exec_assert(&mut self) -> Result<(), TestError> {
+        let config = &self.configs[0];
+        let plaintext_irises = get_irises();
+        let expected = Arc::new(
+            MpcNode::simulate_genesis(DEFAULT_GENESIS_ARGS, config, &plaintext_irises)
+                .await
+                .unwrap(),
+        );
+
+        let mut join_set = JoinSet::new();
+        for node in self.get_nodes().await {
+            let expected = expected.clone();
+            join_set.spawn(async move {
+                // inspect the postgres tables - iris counts, modifications, and persisted_state
+                let num_irises = node.gpu_iris_store.count_irises().await.unwrap();
+                assert_eq!(num_irises, DEFAULT_GENESIS_ARGS.max_indexation_id as usize);
+
+                let num_irises = node.cpu_iris_store.count_irises().await.unwrap();
+                assert_eq!(num_irises, DEFAULT_GENESIS_ARGS.max_indexation_id as usize);
+
+                let num_modifications = node.gpu_iris_store.last_modifications(100).await.unwrap();
+                assert_eq!(num_modifications.len(), MODIFICATIONS.len());
+
+                let num_modifications = node.cpu_iris_store.last_modifications(100).await.unwrap();
+                assert_eq!(num_modifications.len(), MODIFICATIONS.len());
+
+                assert_eq!(100, node.get_last_indexed_iris_id().await);
+                // this is the ID of the entry in the table, not the id of the iris that was modified.
+                assert_eq!(50, node.get_last_indexed_modification_id().await);
+
+                node.assert_graphs_match(&expected).await;
+
+                assert_eq!(expected.dst_db.graphs[0].layers[0].links.len(), 50);
+            });
+        }
+
+        while let Some(r) = join_set.join_next().await {
+            r.unwrap();
+        }
+
+        Ok(())
+    }
+
+    async fn setup(&mut self, _ctx: &TestRunContextInfo) -> Result<(), TestError> {
+        let hawk_prf0 = self.configs[0].hawk_prf_key;
+        assert!(
+            self.configs.iter().all(|c| c.hawk_prf_key == hawk_prf0),
+            "All hawk_prf_key values in configs must be equal"
+        );
+
+        // load 100 irises
+        let plaintext_irises = get_irises();
+        let secret_shared_irises =
+            irises::share_irises_locally(&plaintext_irises, hawk_prf0.unwrap_or_default()).unwrap();
+
+        let mut join_set = JoinSet::new();
+        for (node, shares) in izip!(self.get_nodes().await, secret_shared_irises.into_iter()) {
+            join_set.spawn(async move {
+                node.init_tables(&shares).await.unwrap();
+            });
+        }
+
+        while let Some(r) = join_set.join_next().await {
+            r.unwrap();
+        }
+
+        // any config file is sufficient to connect to S3
+        let config = &self.configs[0];
+
+        let deleted_serial_ids = vec![];
+        let aws_clients = get_aws_clients(config).await.unwrap();
+        upload_iris_deletions(
+            &deleted_serial_ids,
+            &aws_clients.s3_client,
+            &config.environment,
+        )
+        .await
+        .unwrap();
+
+        // next run genesis to index the first 50
+        let mut join_set = JoinSet::new();
+        for config in self.configs.iter().cloned() {
+            join_set.spawn(async move {
+                exec_genesis(
+                    ExecutionArgs::new(
+                        DEFAULT_GENESIS_ARGS.batch_size,
+                        DEFAULT_GENESIS_ARGS.batch_size_error_rate,
+                        50,
+                        false,
+                        false,
+                    ),
+                    config,
+                )
+                .await
+            });
+        }
+
+        while let Some(r) = join_set.join_next().await {
+            r.unwrap()?;
+        }
+
+        // finally, insert modifications
+        let mut join_set = JoinSet::new();
+        for node in self.get_nodes().await {
+            join_set.spawn(async move {
+                node.insert_modifications(&MODIFICATIONS).await.unwrap();
+            });
+        }
+
+        while let Some(r) = join_set.join_next().await {
+            r.unwrap();
+        }
+
+        Ok(())
+    }
+
+    async fn setup_assert(&mut self) -> Result<(), TestError> {
+        let mut join_set = JoinSet::new();
+        for node in self.get_nodes().await {
+            let max_indexation_id = 50;
+            join_set.spawn(async move {
+                let num_irises = node.gpu_iris_store.count_irises().await.unwrap();
+                assert_eq!(num_irises, 100);
+
+                let num_irises = node.cpu_iris_store.count_irises().await.unwrap();
+                assert_eq!(num_irises, max_indexation_id);
+
+                let num_modifications = node.gpu_iris_store.last_modifications(100).await.unwrap();
+                assert_eq!(num_modifications.len(), MODIFICATIONS.len());
+
+                let num_modifications = node.cpu_iris_store.last_modifications(1).await.unwrap();
+                assert_eq!(num_modifications.len(), 0);
+
+                assert_eq!(
+                    max_indexation_id as u32,
+                    node.get_last_indexed_iris_id().await
+                );
+                assert_eq!(0, node.get_last_indexed_modification_id().await);
+            });
+        }
+
+        while let Some(r) = join_set.join_next().await {
+            r.unwrap();
+        }
+
+        // Assert localstack.
+
+        let config = &self.configs[0];
+        let aws_clients = get_aws_clients(config).await.unwrap();
+        let deletions = get_iris_deletions(config, &aws_clients.s3_client, 100)
+            .await
+            .unwrap();
+        assert_eq!(deletions.len(), 0);
+
+        Ok(())
+    }
+
+    async fn teardown(&mut self) -> Result<(), TestError> {
+        Ok(())
+    }
+
+    async fn teardown_assert(&mut self) -> Result<(), TestError> {
+        Ok(())
+    }
+}

--- a/iris-mpc-upgrade-hawk/tests/workflows/genesis_104/runner.rs
+++ b/iris-mpc-upgrade-hawk/tests/workflows/genesis_104/runner.rs
@@ -129,7 +129,7 @@ impl TestRun for Test {
         let plaintext_irises = get_irises();
         todo!("add modifications to the genesis simulation");
         let expected = Arc::new(
-            MpcNode::simulate_genesis(DEFAULT_GENESIS_ARGS, config, &plaintext_irises)
+            MpcNode::simulate_genesis(DEFAULT_GENESIS_ARGS, config, &plaintext_irises, vec![])
                 .await
                 .unwrap(),
         );

--- a/iris-mpc-upgrade-hawk/tests/workflows/mod.rs
+++ b/iris-mpc-upgrade-hawk/tests/workflows/mod.rs
@@ -1,2 +1,5 @@
 pub mod genesis_100;
 pub mod genesis_101;
+pub mod genesis_102;
+pub mod genesis_103;
+pub mod genesis_104;

--- a/iris-mpc-upgrade-hawk/tests/workflows/mod.rs
+++ b/iris-mpc-upgrade-hawk/tests/workflows/mod.rs
@@ -2,4 +2,4 @@ pub mod genesis_100;
 pub mod genesis_101;
 pub mod genesis_102;
 pub mod genesis_103;
-pub mod genesis_104;
+//pub mod genesis_104;


### PR DESCRIPTION
- completes POP-2713 and POP-2715 (genesis 102 and 103)
- completes POP-2704 - initialization of postgres modifications
- begins the 104 test, for POP-2717 but that requires modifications to the plaintext genesis code. 
- adds a readme detailing the test cases. 
- uses the builder pattern to run plaintext genesis, so that an argument for modifications can be added later while avoiding the need to add new functions to run plaintext genesis or modify existing tests