### PR TITLE
feat: provide certs for stage and comment out production one

### DIFF
--- a/Dockerfile.dev.hawk
+++ b/Dockerfile.dev.hawk
@@ -35,13 +35,13 @@ FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y ca-certificates awscli curl
-RUN curl -o /usr/local/share/ca-certificates/ca_party_stage_0.crt https://wf-ampc-hnsw-ca-stage-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_stage_0.pem && \
-    curl -o /usr/local/share/ca-certificates/ca_party_stage_1.crt https://wf-ampc-hnsw-ca-stage-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_stage_1.pem && \
-    curl -o /usr/local/share/ca-certificates/ca_party_stage_2.crt https://wf-ampc-hnsw-ca-stage-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_stage_2.pem
+RUN curl -o /usr/local/share/ca-certificates/ca_party_stage_0.crt https://wf-ampc-hnsw-ca-stage-eu-central-1.s3.eu-central-1.amazonaws.com/ca_party_stage_0.pem && \
+    curl -o /usr/local/share/ca-certificates/ca_party_stage_1.crt https://wf-ampc-hnsw-ca-stage-eu-central-1.s3.eu-central-1.amazonaws.com/ca_party_stage_1.pem && \
+    curl -o /usr/local/share/ca-certificates/ca_party_stage_2.crt https://wf-ampc-hnsw-ca-stage-eu-central-1.s3.eu-central-1.amazonaws.com/ca_party_stage_2.pem
 
-RUN curl -o /usr/local/share/ca-certificates/ca_party_prod_0.crt https://wf-ampc-hnsw-ca-prod-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_prod_0.pem && \
-    curl -o /usr/local/share/ca-certificates/ca_party_prod_1.crt https://wf-ampc-hnsw-ca-prod-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_prod_1.pem && \
-    curl -o /usr/local/share/ca-certificates/ca_party_prod_2.crt https://wf-ampc-hnsw-ca-prod-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_prod_2.pem
+#RUN curl -o /usr/local/share/ca-certificates/ca_party_prod_0.crt https://wf-ampc-hnsw-ca-prod-eu-central-1.s3.eu-central-1.amazonaws.com/ca_party_prod_0.pem && \
+#    curl -o /usr/local/share/ca-certificates/ca_party_prod_1.crt https://wf-ampc-hnsw-ca-prod-eu-central-1.s3.eu-central-1.amazonaws.com/ca_party_prod_1.pem && \
+#    curl -o /usr/local/share/ca-certificates/ca_party_prod_2.crt https://wf-ampc-hnsw-ca-prod-eu-central-1.s3.eu-central-1.amazonaws.com/ca_party_prod_2.pem
 
 COPY certs /usr/local/share/ca-certificates/
 RUN update-ca-certificates

--- a/Dockerfile.genesis.dev.hawk
+++ b/Dockerfile.genesis.dev.hawk
@@ -35,13 +35,13 @@ FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y ca-certificates awscli curl
-RUN curl -o /usr/local/share/ca-certificates/ca_party_stage_0.crt https://wf-ampc-hnsw-ca-stage-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_stage_0.pem && \
-    curl -o /usr/local/share/ca-certificates/ca_party_stage_1.crt https://wf-ampc-hnsw-ca-stage-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_stage_1.pem && \
-    curl -o /usr/local/share/ca-certificates/ca_party_stage_2.crt https://wf-ampc-hnsw-ca-stage-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_stage_2.pem
+RUN curl -o /usr/local/share/ca-certificates/ca_party_stage_0.crt https://wf-ampc-hnsw-ca-stage-eu-central-1.s3.eu-central-1.amazonaws.com/ca_party_stage_0.pem && \
+    curl -o /usr/local/share/ca-certificates/ca_party_stage_1.crt https://wf-ampc-hnsw-ca-stage-eu-central-1.s3.eu-central-1.amazonaws.com/ca_party_stage_1.pem && \
+    curl -o /usr/local/share/ca-certificates/ca_party_stage_2.crt https://wf-ampc-hnsw-ca-stage-eu-central-1.s3.eu-central-1.amazonaws.com/ca_party_stage_2.pem
 
-RUN curl -o /usr/local/share/ca-certificates/ca_party_prod_0.crt https://wf-ampc-hnsw-ca-prod-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_prod_0.pem && \
-    curl -o /usr/local/share/ca-certificates/ca_party_prod_1.crt https://wf-ampc-hnsw-ca-prod-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_prod_1.pem && \
-    curl -o /usr/local/share/ca-certificates/ca_party_prod_2.crt https://wf-ampc-hnsw-ca-prod-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_prod_2.pem
+#RUN curl -o /usr/local/share/ca-certificates/ca_party_prod_0.crt https://wf-ampc-hnsw-ca-prod-eu-central-1.s3.eu-central-1.amazonaws.com/ca_party_prod_0.pem && \
+#    curl -o /usr/local/share/ca-certificates/ca_party_prod_1.crt https://wf-ampc-hnsw-ca-prod-eu-central-1.s3.eu-central-1.amazonaws.com/ca_party_prod_1.pem && \
+#    curl -o /usr/local/share/ca-certificates/ca_party_prod_2.crt https://wf-ampc-hnsw-ca-prod-eu-central-1.s3.eu-central-1.amazonaws.com/ca_party_prod_2.pem
 
 COPY certs /usr/local/share/ca-certificates/
 RUN update-ca-certificates

--- a/Dockerfile.genesis.hawk
+++ b/Dockerfile.genesis.hawk
@@ -35,13 +35,13 @@ FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y ca-certificates awscli curl
-RUN curl -o /usr/local/share/ca-certificates/ca_party_stage_0.crt https://wf-ampc-hnsw-ca-stage-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_stage_0.pem && \
-    curl -o /usr/local/share/ca-certificates/ca_party_stage_1.crt https://wf-ampc-hnsw-ca-stage-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_stage_1.pem && \
-    curl -o /usr/local/share/ca-certificates/ca_party_stage_2.crt https://wf-ampc-hnsw-ca-stage-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_stage_2.pem
+RUN curl -o /usr/local/share/ca-certificates/ca_party_stage_0.crt https://wf-ampc-hnsw-ca-stage-eu-central-1.s3.eu-central-1.amazonaws.com/ca_party_stage_0.pem && \
+    curl -o /usr/local/share/ca-certificates/ca_party_stage_1.crt https://wf-ampc-hnsw-ca-stage-eu-central-1.s3.eu-central-1.amazonaws.com/ca_party_stage_1.pem && \
+    curl -o /usr/local/share/ca-certificates/ca_party_stage_2.crt https://wf-ampc-hnsw-ca-stage-eu-central-1.s3.eu-central-1.amazonaws.com/ca_party_stage_2.pem
 
-RUN curl -o /usr/local/share/ca-certificates/ca_party_prod_0.crt https://wf-ampc-hnsw-ca-prod-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_prod_0.pem && \
-    curl -o /usr/local/share/ca-certificates/ca_party_prod_1.crt https://wf-ampc-hnsw-ca-prod-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_prod_1.pem && \
-    curl -o /usr/local/share/ca-certificates/ca_party_prod_2.crt https://wf-ampc-hnsw-ca-prod-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_prod_2.pem
+#RUN curl -o /usr/local/share/ca-certificates/ca_party_prod_0.crt https://wf-ampc-hnsw-ca-prod-eu-central-1.s3.eu-central-1.amazonaws.com/ca_party_prod_0.pem && \
+#    curl -o /usr/local/share/ca-certificates/ca_party_prod_1.crt https://wf-ampc-hnsw-ca-prod-eu-central-1.s3.eu-central-1.amazonaws.com/ca_party_prod_1.pem && \
+#    curl -o /usr/local/share/ca-certificates/ca_party_prod_2.crt https://wf-ampc-hnsw-ca-prod-eu-central-1.s3.eu-central-1.amazonaws.com/ca_party_prod_2.pem
 
 COPY certs /usr/local/share/ca-certificates/
 RUN update-ca-certificates

--- a/Dockerfile.hawk
+++ b/Dockerfile.hawk
@@ -35,13 +35,13 @@ FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y ca-certificates awscli curl
-RUN curl -o /usr/local/share/ca-certificates/ca_party_stage_0.crt https://wf-ampc-hnsw-ca-stage-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_stage_0.pem && \
-    curl -o /usr/local/share/ca-certificates/ca_party_stage_1.crt https://wf-ampc-hnsw-ca-stage-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_stage_1.pem && \
-    curl -o /usr/local/share/ca-certificates/ca_party_stage_2.crt https://wf-ampc-hnsw-ca-stage-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_stage_2.pem
+RUN curl -o /usr/local/share/ca-certificates/ca_party_stage_0.crt https://wf-ampc-hnsw-ca-stage-eu-central-1.s3.eu-central-1.amazonaws.com/ca_party_stage_0.pem && \
+    curl -o /usr/local/share/ca-certificates/ca_party_stage_1.crt https://wf-ampc-hnsw-ca-stage-eu-central-1.s3.eu-central-1.amazonaws.com/ca_party_stage_1.pem && \
+    curl -o /usr/local/share/ca-certificates/ca_party_stage_2.crt https://wf-ampc-hnsw-ca-stage-eu-central-1.s3.eu-central-1.amazonaws.com/ca_party_stage_2.pem
 
-RUN curl -o /usr/local/share/ca-certificates/ca_party_prod_0.crt https://wf-ampc-hnsw-ca-prod-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_prod_0.pem && \
-    curl -o /usr/local/share/ca-certificates/ca_party_prod_1.crt https://wf-ampc-hnsw-ca-prod-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_prod_1.pem && \
-    curl -o /usr/local/share/ca-certificates/ca_party_prod_2.crt https://wf-ampc-hnsw-ca-prod-eu-north-1.s3.eu-north-1.amazonaws.com/ca_party_prod_2.pem
+#RUN curl -o /usr/local/share/ca-certificates/ca_party_prod_0.crt https://wf-ampc-hnsw-ca-prod-eu-central-1.s3.eu-central-1.amazonaws.com/ca_party_prod_0.pem && \
+#    curl -o /usr/local/share/ca-certificates/ca_party_prod_1.crt https://wf-ampc-hnsw-ca-prod-eu-central-1.s3.eu-central-1.amazonaws.com/ca_party_prod_1.pem && \
+#    curl -o /usr/local/share/ca-certificates/ca_party_prod_2.crt https://wf-ampc-hnsw-ca-prod-eu-central-1.s3.eu-central-1.amazonaws.com/ca_party_prod_2.pem
 
 COPY certs /usr/local/share/ca-certificates/
 RUN update-ca-certificates


### PR DESCRIPTION
We changed the region of the S3 bucket with CA certs, so we must update URLs to get those new certificates. For the production environment, the certs are not ready yet, so I commented out the lines that download them.