### PR TITLE
[POP-2714] Implement delta protocol for plaintext genesis indexer

### DIFF
--- a/iris-mpc-common/src/helpers/sync.rs
+++ b/iris-mpc-common/src/helpers/sync.rs
@@ -26,6 +26,9 @@ pub enum ModificationKey {
     RequestId(String),
 }
 
+pub const MOD_STATUS_IN_PROGRESS: &str = "IN_PROGRESS";
+pub const MOD_STATUS_COMPLETED: &str = "COMPLETED";
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ModificationStatus {
     InProgress,
@@ -35,8 +38,8 @@ pub enum ModificationStatus {
 impl Display for ModificationStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ModificationStatus::InProgress => write!(f, "IN_PROGRESS"),
-            ModificationStatus::Completed => write!(f, "COMPLETED"),
+            ModificationStatus::InProgress => write!(f, "{MOD_STATUS_IN_PROGRESS}"),
+            ModificationStatus::Completed => write!(f, "{MOD_STATUS_COMPLETED}"),
         }
     }
 }
@@ -45,8 +48,8 @@ impl FromStr for ModificationStatus {
     type Err = ();
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "IN_PROGRESS" => Ok(ModificationStatus::InProgress),
-            "COMPLETED" => Ok(ModificationStatus::Completed),
+            MOD_STATUS_IN_PROGRESS => Ok(ModificationStatus::InProgress),
+            MOD_STATUS_COMPLETED => Ok(ModificationStatus::Completed),
             _ => Err(()),
         }
     }

--- a/iris-mpc-cpu/src/genesis/plaintext.rs
+++ b/iris-mpc-cpu/src/genesis/plaintext.rs
@@ -1,7 +1,9 @@
 use std::{collections::HashMap, sync::Arc};
 
-use eyre::{OptionExt, Result};
-use iris_mpc_common::{iris_db::iris::IrisCode, IrisSerialId, IrisVectorId, IrisVersionId};
+use eyre::{bail, OptionExt, Result};
+use iris_mpc_common::{
+    helpers::smpc_request, iris_db::iris::IrisCode, IrisSerialId, IrisVectorId, IrisVersionId,
+};
 use itertools::izip;
 use rand::{thread_rng, Rng};
 
@@ -17,6 +19,10 @@ use crate::{
 
 /// Represents irises db table, mapping serial ids to version, and left and right iris codes.
 pub type IrisesTable = HashMap<IrisSerialId, (IrisVersionId, IrisCode, IrisCode)>;
+
+/// Represents modifications db table, mapping modification ids to tuples of serial id,
+/// request type, completion flag, and persisted flag.
+pub type ModificationsTable = HashMap<i64, (IrisSerialId, String, bool, bool)>;
 
 /// Represents a left/right pair of plaintext in-memory HNSW graphs.
 pub type PlaintextGraphs = BothEyes<GraphMem<PlaintextStore>>;
@@ -43,7 +49,7 @@ pub struct GenesisState {
 pub struct GenesisSrcDbState {
     pub irises: IrisesTable,
 
-    pub modifications: (),
+    pub modifications: ModificationsTable,
 }
 
 /// State of the destination database for the CPU server.
@@ -90,12 +96,20 @@ pub struct GenesisArgs {
 /// Execute the genesis indexer over a plaintext state representation, and
 /// return the resulting state.
 pub async fn run_plaintext_genesis(mut state: GenesisState) -> Result<GenesisState> {
-    // Id currently being inspected
-    let mut id = state
+    // Unpack persistent state fields
+    let last_indexed_iris_id = state
         .dst_db
         .persistent_state
         .last_indexed_iris_id
         .unwrap_or(0);
+    let last_indexed_modification_id = state
+        .dst_db
+        .persistent_state
+        .last_indexed_modification_id
+        .unwrap_or(0);
+
+    // Id currently being inspected
+    let mut id = last_indexed_iris_id;
     let target_id = state.args.max_indexation_id;
 
     let batch_size = match state.args.batch_size {
@@ -106,7 +120,7 @@ pub async fn run_plaintext_genesis(mut state: GenesisState) -> Result<GenesisSta
     // Initialize existing vector stores
     let mut left_store = PlaintextStore::new();
     let mut right_store = PlaintextStore::new();
-    for (serial_id, (version, left_iris, right_iris)) in state.dst_db.irises.iter() {
+    for (serial_id, (version, left_iris, right_iris)) in state.src_db.irises.iter() {
         let vector_id = IrisVectorId::new(*serial_id, *version);
         left_store
             .insert_at(&vector_id, &Arc::new(left_iris.clone()))
@@ -130,6 +144,104 @@ pub async fn run_plaintext_genesis(mut state: GenesisState) -> Result<GenesisSta
         .hawk_prf_key
         .map(|key_u64| (key_u64 as u128).to_le_bytes())
         .unwrap_or_else(|| thread_rng().gen());
+
+    // ⚓ Start: Delta protocol
+
+    // Filter modifications for those which apply to current genesis index
+    let mut applicable_modifications: Vec<_> = state
+        .src_db
+        .modifications
+        .iter()
+        .filter(
+            |(mod_id, (serial_id, _request_type, completed, persisted))| {
+                **mod_id > last_indexed_modification_id
+                    && *serial_id < last_indexed_iris_id
+                    && *completed
+                    && *persisted
+            },
+        )
+        .map(|(mod_id, (serial_id, request_type, _status, _persisted))| {
+            (*mod_id, *serial_id, request_type.clone())
+        })
+        .collect();
+    applicable_modifications.sort_by_key(|(mod_id, _, _)| *mod_id);
+
+    // Process applicable modifications entries
+    for (mod_id, serial_id, request_type) in applicable_modifications {
+        println!(
+            "modification: {:?}",
+            (mod_id, serial_id, request_type.clone())
+        );
+        match request_type.as_str() {
+            smpc_request::RESET_UPDATE_MESSAGE_TYPE | smpc_request::REAUTH_MESSAGE_TYPE => {
+                let (vector_id, left_iris, right_iris) = state
+                    .src_db
+                    .irises
+                    .get(&serial_id)
+                    .map(|(version, left_iris, right_iris)| {
+                        (
+                            IrisVectorId::new(serial_id, *version),
+                            left_iris.clone(),
+                            right_iris.clone(),
+                        )
+                    })
+                    .ok_or_eyre(format!(
+                        "Modified iris serial id {serial_id} not found in src_db"
+                    ))?;
+
+                for (side, store, graph, iris) in izip!(
+                    STORE_IDS,
+                    [&mut left_store, &mut right_store],
+                    &mut state.dst_db.graphs,
+                    vec![left_iris, right_iris]
+                ) {
+                    let query = Arc::new(iris);
+
+                    let identifier = (vector_id, side);
+                    let insertion_layer = searcher.select_layer_prf(&prf_key, &identifier)?;
+
+                    let (links, set_ep) = searcher
+                        .search_to_insert(store, graph, &query, insertion_layer)
+                        .await?;
+                    let insert_plan = InsertPlanV {
+                        query,
+                        links,
+                        set_ep,
+                    };
+
+                    insert::insert(
+                        store,
+                        graph,
+                        &searcher,
+                        vec![Some(insert_plan)],
+                        &vec![Some(vector_id)],
+                    )
+                    .await?;
+                }
+
+                // Insert modified iris into destination db
+                let irises = state.src_db.irises.get(&serial_id).unwrap().clone();
+                state.dst_db.irises.insert(serial_id, irises);
+
+                // Update last_indexed_modification_id in destination db
+                state.dst_db.persistent_state.last_indexed_modification_id = Some(mod_id);
+            }
+            _ => {
+                bail!("Genesis does not support modifications of type {request_type}")
+            }
+        }
+    }
+
+    let max_mod_id = state
+        .src_db
+        .modifications
+        .keys()
+        .max()
+        .cloned()
+        .unwrap_or(0);
+    state.dst_db.persistent_state.last_indexed_modification_id = Some(max_mod_id);
+
+    // ⚓ Start: Genesis indexing
 
     // Generate and process batches until we've reached the target indexation id
     while id < target_id {
@@ -231,7 +343,7 @@ mod tests {
         GenesisState {
             src_db: GenesisSrcDbState {
                 irises: src_db_irises,
-                modifications: (),
+                modifications: HashMap::new(),
             },
             dst_db: GenesisDstDbState {
                 irises: HashMap::new(),
@@ -254,6 +366,39 @@ mod tests {
             },
             s3_deletions: Vec::new(),
         }
+    }
+
+    fn apply_modification(
+        state: &mut GenesisState,
+        id: i64,
+        serial_id: IrisSerialId,
+        request_type: &str,
+    ) {
+        let mut rng = thread_rng();
+        let updated_left_iris = IrisCode::random_rng(&mut rng);
+        let updated_right_iris = IrisCode::random_rng(&mut rng);
+
+        let old_version = state.src_db.irises.get(&serial_id).unwrap().0;
+        state.src_db.irises.insert(
+            serial_id,
+            (old_version + 1, updated_left_iris, updated_right_iris),
+        );
+
+        add_modification(state, id, serial_id, request_type, true, true);
+    }
+
+    fn add_modification(
+        state: &mut GenesisState,
+        id: i64,
+        serial_id: IrisSerialId,
+        request_type: &str,
+        completed: bool,
+        persisted: bool,
+    ) {
+        state.src_db.modifications.insert(
+            id,
+            (serial_id, request_type.to_string(), completed, persisted),
+        );
     }
 
     #[tokio::test]
@@ -316,6 +461,83 @@ mod tests {
         assert_eq!(new_state.dst_db.irises.len(), 100);
         assert_eq!(new_state.dst_db.graphs[0].layers[0].links.len(), 95);
         assert_eq!(new_state.dst_db.graphs[1].layers[0].links.len(), 95);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_plaintext_genesis_delta() -> Result<()> {
+        let mut init_state = gen_base_state(200);
+        init_state.args.max_indexation_id = 50;
+
+        let mut state_1 = run_plaintext_genesis(init_state).await?;
+
+        assert_eq!(state_1.dst_db.irises.len(), 50);
+
+        apply_modification(&mut state_1, 2, 20, smpc_request::REAUTH_MESSAGE_TYPE);
+        assert_ne!(
+            state_1.dst_db.irises.get(&20),
+            state_1.src_db.irises.get(&20)
+        );
+
+        state_1.args.max_indexation_id = 100;
+
+        let state_2 = run_plaintext_genesis(state_1).await?;
+
+        assert_eq!(state_2.dst_db.irises.len(), 100);
+        assert_eq!(
+            state_2.dst_db.irises.get(&20),
+            state_2.src_db.irises.get(&20)
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_plaintext_genesis_delta_with_skipped() -> Result<()> {
+        let mut init_state = gen_base_state(200);
+
+        // Add modification that doesn't apply
+        apply_modification(
+            &mut init_state,
+            1,
+            10,
+            smpc_request::RESET_UPDATE_MESSAGE_TYPE,
+        );
+        assert_ne!(
+            init_state.dst_db.irises.get(&10),
+            init_state.src_db.irises.get(&10)
+        );
+        init_state.args.max_indexation_id = 50;
+
+        let mut state_1 = run_plaintext_genesis(init_state).await?;
+
+        assert_eq!(state_1.dst_db.irises.len(), 50);
+        assert_eq!(
+            state_1.dst_db.irises.get(&10),
+            state_1.src_db.irises.get(&10)
+        );
+
+        apply_modification(&mut state_1, 2, 20, smpc_request::REAUTH_MESSAGE_TYPE);
+        assert_ne!(
+            state_1.dst_db.irises.get(&20),
+            state_1.src_db.irises.get(&20)
+        );
+        apply_modification(&mut state_1, 3, 70, smpc_request::RESET_UPDATE_MESSAGE_TYPE);
+
+        state_1.args.max_indexation_id = 100;
+
+        let state_2 = run_plaintext_genesis(state_1).await?;
+
+        assert_eq!(state_2.dst_db.irises.len(), 100);
+        assert_eq!(
+            state_2.dst_db.irises.get(&20),
+            state_2.src_db.irises.get(&20)
+        );
+        assert_eq!(
+            state_2.dst_db.irises.get(&70),
+            state_2.src_db.irises.get(&70)
+        );
 
         Ok(())
     }

--- a/iris-mpc-cpu/src/hawkers/plaintext_store.rs
+++ b/iris-mpc-cpu/src/hawkers/plaintext_store.rs
@@ -158,6 +158,14 @@ impl VectorStore for PlaintextStore {
         debug!(event_type = CompareDistance.id());
         Ok(fraction_less_than(distance1, distance2))
     }
+
+    async fn only_valid_vectors(
+        &mut self,
+        mut vectors: Vec<Self::VectorRef>,
+    ) -> Vec<Self::VectorRef> {
+        vectors.retain(|v| self.storage.contains(v));
+        vectors
+    }
 }
 
 impl VectorStoreMut for PlaintextStore {
@@ -240,6 +248,15 @@ impl VectorStore for SharedPlaintextStore {
     ) -> Result<bool> {
         debug!(event_type = CompareDistance.id());
         Ok(fraction_less_than(distance1, distance2))
+    }
+
+    async fn only_valid_vectors(
+        &mut self,
+        mut vectors: Vec<Self::VectorRef>,
+    ) -> Vec<Self::VectorRef> {
+        let storage = self.storage.read().await;
+        vectors.retain(|v| storage.contains(v));
+        vectors
     }
 }
 

--- a/iris-mpc-upgrade-hawk/tests/utils/modifications.rs
+++ b/iris-mpc-upgrade-hawk/tests/utils/modifications.rs
@@ -1,5 +1,6 @@
-use iris_mpc_common::helpers::smpc_request::{
-    REAUTH_MESSAGE_TYPE, RESET_UPDATE_MESSAGE_TYPE, UNIQUENESS_MESSAGE_TYPE,
+use iris_mpc_common::helpers::{
+    smpc_request::{REAUTH_MESSAGE_TYPE, RESET_UPDATE_MESSAGE_TYPE, UNIQUENESS_MESSAGE_TYPE},
+    sync::{MOD_STATUS_COMPLETED, MOD_STATUS_IN_PROGRESS},
 };
 use serde::{Deserialize, Serialize};
 
@@ -53,8 +54,8 @@ impl ModificationInput {
 
     pub fn get_status(&self) -> &'static str {
         match self.completed {
-            true => "COMPLETED",
-            _ => "IN_PROGRESS",
+            true => MOD_STATUS_COMPLETED,
+            false => MOD_STATUS_IN_PROGRESS,
         }
     }
 }

--- a/iris-mpc-upgrade-hawk/tests/utils/plaintext_genesis.rs
+++ b/iris-mpc-upgrade-hawk/tests/utils/plaintext_genesis.rs
@@ -71,7 +71,7 @@ fn construct_initial_genesis_state(
     GenesisState {
         src_db: GenesisSrcDbState {
             irises: input,
-            modifications: (),
+            modifications: HashMap::new(),
         },
         dst_db: GenesisDstDbState {
             irises: HashMap::new(),


### PR DESCRIPTION
This PR adds the genesis delta sub-protocol to plaintext genesis implementation, providing support for processing modifications present in the source database.  It additionally fixes a small bug in plaintext state initialization, where the in-memory iris stores were initialized from the destination database, but should be initialized instead from the source database.