### PR TITLE
[POP-2717] Implement genesis 104 e2e test

### DIFF
--- a/iris-mpc-cpu/src/genesis/batch_generator.rs
+++ b/iris-mpc-cpu/src/genesis/batch_generator.rs
@@ -264,9 +264,7 @@ impl BatchGenerator {
         while self.range_iter.peek().is_some() && identifiers.len() < batch_size_max {
             let next_id = self.range_iter.by_ref().next().unwrap();
             identifiers_for_copying.push(next_id);
-            println!("identifiers_for_copying={:?}", identifiers_for_copying);
             if !self.exclusions.contains(&next_id) {
-                println!("identifiers={:?}", identifiers);
                 identifiers.push(next_id);
             } else {
                 log_info(format!("Excluding deletion :: iris-serial-id={}", next_id));

--- a/iris-mpc-cpu/src/genesis/plaintext.rs
+++ b/iris-mpc-cpu/src/genesis/plaintext.rs
@@ -45,7 +45,7 @@ pub type PlaintextGraphs = BothEyes<GraphMem<PlaintextStore>>;
 pub type GenesisDeletions = Vec<IrisSerialId>;
 
 /// Plaintext representation of global state of genesis indexer.
-#[derive(Clone)]
+#[derive(Default, Clone)]
 pub struct GenesisState {
     pub src_db: GenesisSrcDbState,
 
@@ -59,7 +59,7 @@ pub struct GenesisState {
 }
 
 /// State of the source database from the GPU server.
-#[derive(Clone)]
+#[derive(Default, Clone)]
 pub struct GenesisSrcDbState {
     pub irises: IrisesTable,
 
@@ -67,7 +67,7 @@ pub struct GenesisSrcDbState {
 }
 
 /// State of the destination database for the CPU server.
-#[derive(Clone)]
+#[derive(Default, Clone)]
 pub struct GenesisDstDbState {
     pub irises: IrisesTable,
 
@@ -77,7 +77,7 @@ pub struct GenesisDstDbState {
 }
 
 /// Database entries for the PersistentState table.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct PersistentState {
     pub last_indexed_iris_id: Option<IrisSerialId>,
 
@@ -85,7 +85,7 @@ pub struct PersistentState {
 }
 
 /// Logical configuration parameters of genesis `Config` struct.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 #[allow(non_snake_case)]
 pub struct GenesisConfig {
     pub hnsw_M: usize,
@@ -98,7 +98,7 @@ pub struct GenesisConfig {
 }
 
 /// Logical CLI arguments for genesis process.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct GenesisArgs {
     pub max_indexation_id: IrisSerialId,
 

--- a/iris-mpc-upgrade-hawk/tests/e2e_genesis.rs
+++ b/iris-mpc-upgrade-hawk/tests/e2e_genesis.rs
@@ -65,11 +65,11 @@ fn test_hnsw_genesis_103() -> Result<()> {
     Ok(())
 }
 
-/*#[test]
+#[test]
 #[serial]
 #[ignore = "requires external setup"]
 fn test_hnsw_genesis_104() -> Result<()> {
     use workflows::genesis_104::Test;
     run_test!(104, 1)?;
     Ok(())
-}*/
+}

--- a/iris-mpc-upgrade-hawk/tests/utils/mpc_node.rs
+++ b/iris-mpc-upgrade-hawk/tests/utils/mpc_node.rs
@@ -6,7 +6,6 @@ use crate::utils::{
 use eyre::Result;
 use iris_mpc_common::{
     config::Config,
-    helpers::smpc_request::{REAUTH_MESSAGE_TYPE, RESET_UPDATE_MESSAGE_TYPE},
     postgres::{AccessMode, PostgresClient},
     IrisSerialId,
 };
@@ -174,8 +173,7 @@ impl MpcNode {
         // increment version numbers of irises affected by update modifications
         for m in mods.iter() {
             let mut tx = self.gpu_iris_store.tx().await?;
-            if m.request_type.is_updating()
-            {
+            if m.request_type.is_updating() {
                 increment_iris_version(&mut tx, m.serial_id).await?;
             }
             tx.commit().await?;

--- a/iris-mpc-upgrade-hawk/tests/utils/plaintext_genesis.rs
+++ b/iris-mpc-upgrade-hawk/tests/utils/plaintext_genesis.rs
@@ -1,10 +1,13 @@
-use crate::utils::IrisCodePair;
-use eyre::Result;
+use crate::utils::{
+    modifications::{ModificationInput, ModificationType},
+    IrisCodePair,
+};
+use eyre::{OptionExt, Result};
 use iris_mpc_common::{config::Config, iris_db::iris::IrisCode, IrisSerialId, IrisVersionId};
 use iris_mpc_cpu::{
     genesis::plaintext::{
         run_plaintext_genesis, GenesisArgs, GenesisConfig, GenesisDstDbState, GenesisSrcDbState,
-        GenesisState, PersistentState,
+        GenesisState, IrisesTable, PersistentState,
     },
     hnsw::GraphMem,
 };
@@ -44,7 +47,7 @@ async fn simulate_genesis(
     pairs: &[IrisCodePair],
     deletions: Vec<u32>,
 ) -> Result<GenesisState> {
-    let genesis_input = get_genesis_input(pairs);
+    let genesis_input = init_plaintext_irises_db(pairs);
 
     let genesis_config = GenesisConfig {
         hnsw_M: config.hnsw_param_M,
@@ -87,14 +90,61 @@ fn construct_initial_genesis_state(
     }
 }
 
-// construct_initial_genesis_state() needs a special HashMap. Build it from the provided list of plaintext iris shares.
-fn get_genesis_input(
-    pairs: &[IrisCodePair],
-) -> HashMap<IrisSerialId, (IrisVersionId, IrisCode, IrisCode)> {
-    let mut r = HashMap::new();
-    for (idx, (left, right)) in pairs.iter().enumerate() {
-        // warning: iris id can't be zero
-        r.insert(idx as u32 + 1, (0, left.clone(), right.clone()));
+/// Create a `HashMap`` representing the irises db table for plaintext genesis
+/// execution.
+pub fn init_plaintext_irises_db(pairs: &[IrisCodePair]) -> IrisesTable {
+    pairs
+        .iter()
+        .cloned()
+        .enumerate()
+        .map(|(idx, (left, right))| (idx as u32 + 1, (0i16, left, right)))
+        .collect()
+}
+
+/// Update plaintext genesis source database state to reflect application of the
+/// specified modification inputs.  Appends modifications to the `modifications`
+/// field, and increments the version number of the associated serial ids for
+/// modifications updating an iris in the database.  Makes no change to the
+/// iris database for a uniqueness modification entry.
+pub fn apply_src_modifications(
+    src_db: &mut GenesisSrcDbState,
+    modifications: &[ModificationInput],
+) -> Result<()> {
+    let max_modification_id = src_db.modifications.keys().cloned().max().unwrap_or(0);
+
+    for (idx, m) in modifications.iter().enumerate() {
+        if matches!(
+            m.request_type,
+            ModificationType::ResetUpdate | ModificationType::Reauth
+        ) {
+            let entry = src_db
+                .irises
+                .get_mut(&(m.serial_id as u32))
+                .ok_or_eyre("Modified iris serial id missing from plaintext database")?;
+            entry.0 += 1;
+        }
+
+        src_db.modifications.insert(
+            max_modification_id + (idx as i64) + 1,
+            (
+                m.serial_id as u32,
+                m.request_type.to_string(),
+                m.completed,
+                m.persisted,
+            ),
+        );
     }
-    r
+
+    Ok(())
+}
+
+/// Initialize relevant configuration parameters for plaintext genesis execution
+/// from a full server `Config` struct.
+pub fn init_plaintext_config(config: &Config) -> GenesisConfig {
+    GenesisConfig {
+        hnsw_M: config.hnsw_param_M,
+        hnsw_ef_constr: config.hnsw_param_ef_constr,
+        hnsw_ef_search: config.hnsw_param_ef_search,
+        hawk_prf_key: config.hawk_prf_key,
+    }
 }

--- a/iris-mpc-upgrade-hawk/tests/workflows/mod.rs
+++ b/iris-mpc-upgrade-hawk/tests/workflows/mod.rs
@@ -2,4 +2,4 @@ pub mod genesis_100;
 pub mod genesis_101;
 pub mod genesis_102;
 pub mod genesis_103;
-//pub mod genesis_104;
+pub mod genesis_104;


### PR DESCRIPTION
This PR integrates the updates to the plaintext genesis simulation from #1569 (modifications support) with the genesis e2e tests, and implements the genesis 104 e2e test exercising handling of modifications applied between two runs of the protocol.