### PR TITLE
au/simplify-eval: In eval_distance_batch, support a single query

### DIFF
--- a/iris-mpc-cpu/src/execution/hawk_main/insert.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/insert.rs
@@ -92,9 +92,7 @@ async fn add_batch_neighbors<V: VectorStore>(
 ) -> Result<Vec<SortedNeighborhoodV<V>>> {
     if let Some(bottom_layer) = links.first_mut() {
         if bottom_layer.len() < target_n_neighbors {
-            let distances = store
-                .eval_distance_batch(&[query.clone()], extra_ids)
-                .await?;
+            let distances = store.eval_distance_batch(query, extra_ids).await?;
 
             let ids_dists = izip!(extra_ids.iter().cloned(), distances)
                 .map(|(id, dist)| (id, dist))

--- a/iris-mpc-cpu/src/execution/hawk_main/is_match_batch.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/is_match_batch.rs
@@ -106,7 +106,7 @@ async fn per_query(
     vector_ids: &[VectorId],
     store: &mut Aby3Store,
 ) -> Result<MapEdges<bool>> {
-    let distances = store.eval_distance_batch(&[query], vector_ids).await?;
+    let distances = store.eval_distance_batch(&query, vector_ids).await?;
 
     let is_matches = store.is_match_batch(&distances).await?;
 

--- a/iris-mpc-cpu/src/hnsw/searcher.rs
+++ b/iris-mpc-cpu/src/hnsw/searcher.rs
@@ -784,9 +784,7 @@ impl HnswSearcher {
 
         let valid_neighbors = store.only_valid_vectors(unvisited_neighbors).await;
 
-        let distances = store
-            .eval_distance_batch(&[query.clone()], &valid_neighbors)
-            .await?;
+        let distances = store.eval_distance_batch(query, &valid_neighbors).await?;
 
         Ok(valid_neighbors
             .into_iter()

--- a/iris-mpc-cpu/src/hnsw/vector_store.rs
+++ b/iris-mpc-cpu/src/hnsw/vector_store.rs
@@ -82,19 +82,17 @@ pub trait VectorStore: Debug {
         Ok(results)
     }
 
-    /// Evaluate the distances between all queries and all vectors (cartesian product).
+    /// Evaluate the distances between the query and a batch of vectors.
     /// The default implementation is a loop over `eval_distance`.
     /// Override for more efficient batch distance evaluations.
     async fn eval_distance_batch(
         &mut self,
-        queries: &[Self::QueryRef],
+        query: &Self::QueryRef,
         vectors: &[Self::VectorRef],
     ) -> Result<Vec<Self::DistanceRef>> {
-        let mut results = Vec::with_capacity(queries.len() * vectors.len());
-        for query in queries {
-            for vector in vectors {
-                results.push(self.eval_distance(query, vector).await?);
-            }
+        let mut results = Vec::with_capacity(vectors.len());
+        for vector in vectors {
+            results.push(self.eval_distance(query, vector).await?);
         }
         Ok(results)
     }


### PR DESCRIPTION
Separate PR to simplify an API that’s being reimplemented.