### PR TITLE
[POP-2718] Implement genesis 105 e2e test

### DIFF
--- a/.github/workflows/test-gpu.yaml
+++ b/.github/workflows/test-gpu.yaml
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   e2e:
     runs-on: arc-gpu-amd64-runner
-    timeout-minutes: 30
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -97,7 +97,7 @@ jobs:
 
       - name: GPU Dependent Tests
         if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
-        timeout-minutes: 25
+        timeout-minutes: 15
         run: cargo test -p iris-mpc-gpu --release --features gpu_dependent -- --test-threads=1
         shell: bash
         env:

--- a/.github/workflows/test-gpu.yaml
+++ b/.github/workflows/test-gpu.yaml
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   e2e:
     runs-on: arc-gpu-amd64-runner
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -97,7 +97,7 @@ jobs:
 
       - name: GPU Dependent Tests
         if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
-        timeout-minutes: 15
+        timeout-minutes: 25
         run: cargo test -p iris-mpc-gpu --release --features gpu_dependent -- --test-threads=1
         shell: bash
         env:

--- a/iris-mpc-cpu/src/genesis/plaintext.rs
+++ b/iris-mpc-cpu/src/genesis/plaintext.rs
@@ -167,11 +167,8 @@ pub async fn run_plaintext_genesis(mut state: GenesisState) -> Result<GenesisSta
         .modifications
         .iter()
         .filter(
-            |(mod_id, (serial_id, _request_type, completed, persisted))| {
-                **mod_id > last_indexed_modification_id
-                    && *serial_id < last_indexed_iris_id
-                    && *completed
-                    && *persisted
+            |(mod_id, (_serial_id, _request_type, completed, persisted))| {
+                **mod_id > last_indexed_modification_id && *completed && *persisted
             },
         )
         .map(|(mod_id, (serial_id, request_type, _status, _persisted))| {
@@ -186,74 +183,68 @@ pub async fn run_plaintext_genesis(mut state: GenesisState) -> Result<GenesisSta
             "modification: {:?}",
             (mod_id, serial_id, request_type.clone())
         );
-        match request_type.as_str() {
-            smpc_request::RESET_UPDATE_MESSAGE_TYPE | smpc_request::REAUTH_MESSAGE_TYPE => {
-                let (vector_id, left_iris, right_iris) = state
-                    .src_db
-                    .irises
-                    .get(&serial_id)
-                    .map(|(version, left_iris, right_iris)| {
-                        (
-                            IrisVectorId::new(serial_id, *version),
-                            left_iris.clone(),
-                            right_iris.clone(),
+        if serial_id < last_indexed_iris_id {
+            println!("processing mod: {mod_id}, {serial_id}, {request_type}");
+            match request_type.as_str() {
+                smpc_request::RESET_UPDATE_MESSAGE_TYPE | smpc_request::REAUTH_MESSAGE_TYPE => {
+                    let (vector_id, left_iris, right_iris) = state
+                        .src_db
+                        .irises
+                        .get(&serial_id)
+                        .map(|(version, left_iris, right_iris)| {
+                            (
+                                IrisVectorId::new(serial_id, *version),
+                                left_iris.clone(),
+                                right_iris.clone(),
+                            )
+                        })
+                        .ok_or_eyre(format!(
+                            "Modified iris serial id {serial_id} not found in src_db"
+                        ))?;
+
+                    for (side, store, graph, iris) in izip!(
+                        STORE_IDS,
+                        [&mut left_store, &mut right_store],
+                        &mut state.dst_db.graphs,
+                        vec![left_iris, right_iris]
+                    ) {
+                        let query = Arc::new(iris);
+
+                        let identifier = (vector_id, side);
+                        let insertion_layer = searcher.select_layer_prf(&prf_key, &identifier)?;
+
+                        let (links, set_ep) = searcher
+                            .search_to_insert(store, graph, &query, insertion_layer)
+                            .await?;
+                        let insert_plan = InsertPlanV {
+                            query,
+                            links,
+                            set_ep,
+                        };
+
+                        insert::insert(
+                            store,
+                            graph,
+                            &searcher,
+                            vec![Some(insert_plan)],
+                            &vec![Some(vector_id)],
                         )
-                    })
-                    .ok_or_eyre(format!(
-                        "Modified iris serial id {serial_id} not found in src_db"
-                    ))?;
-
-                for (side, store, graph, iris) in izip!(
-                    STORE_IDS,
-                    [&mut left_store, &mut right_store],
-                    &mut state.dst_db.graphs,
-                    vec![left_iris, right_iris]
-                ) {
-                    let query = Arc::new(iris);
-
-                    let identifier = (vector_id, side);
-                    let insertion_layer = searcher.select_layer_prf(&prf_key, &identifier)?;
-
-                    let (links, set_ep) = searcher
-                        .search_to_insert(store, graph, &query, insertion_layer)
                         .await?;
-                    let insert_plan = InsertPlanV {
-                        query,
-                        links,
-                        set_ep,
-                    };
+                    }
 
-                    insert::insert(
-                        store,
-                        graph,
-                        &searcher,
-                        vec![Some(insert_plan)],
-                        &vec![Some(vector_id)],
-                    )
-                    .await?;
+                    // Insert modified iris into destination db
+                    let irises = state.src_db.irises.get(&serial_id).unwrap().clone();
+                    state.dst_db.irises.insert(serial_id, irises);
                 }
-
-                // Insert modified iris into destination db
-                let irises = state.src_db.irises.get(&serial_id).unwrap().clone();
-                state.dst_db.irises.insert(serial_id, irises);
-
-                // Update last_indexed_modification_id in destination db
-                state.dst_db.persistent_state.last_indexed_modification_id = Some(mod_id);
-            }
-            _ => {
-                bail!("Genesis does not support modifications of type {request_type}")
+                _ => {
+                    bail!("Genesis does not support modifications of type {request_type}")
+                }
             }
         }
-    }
 
-    let max_mod_id = state
-        .src_db
-        .modifications
-        .keys()
-        .max()
-        .cloned()
-        .unwrap_or(0);
-    state.dst_db.persistent_state.last_indexed_modification_id = Some(max_mod_id);
+        // Update last_indexed_modification_id in destination db
+        state.dst_db.persistent_state.last_indexed_modification_id = Some(mod_id);
+    }
 
     // ⚓ Start: Genesis indexing
 

--- a/iris-mpc-cpu/src/genesis/plaintext.rs
+++ b/iris-mpc-cpu/src/genesis/plaintext.rs
@@ -179,12 +179,7 @@ pub async fn run_plaintext_genesis(mut state: GenesisState) -> Result<GenesisSta
 
     // Process applicable modifications entries
     for (mod_id, serial_id, request_type) in applicable_modifications {
-        println!(
-            "modification: {:?}",
-            (mod_id, serial_id, request_type.clone())
-        );
         if serial_id < last_indexed_iris_id {
-            println!("processing mod: {mod_id}, {serial_id}, {request_type}");
             match request_type.as_str() {
                 smpc_request::RESET_UPDATE_MESSAGE_TYPE | smpc_request::REAUTH_MESSAGE_TYPE => {
                     let (vector_id, left_iris, right_iris) = state

--- a/iris-mpc-upgrade-hawk/tests/e2e_genesis.rs
+++ b/iris-mpc-upgrade-hawk/tests/e2e_genesis.rs
@@ -73,3 +73,12 @@ fn test_hnsw_genesis_104() -> Result<()> {
     run_test!(104, 1)?;
     Ok(())
 }
+
+#[test]
+#[serial]
+#[ignore = "requires external setup"]
+fn test_hnsw_genesis_105() -> Result<()> {
+    use workflows::genesis_105::Test;
+    run_test!(105, 1)?;
+    Ok(())
+}

--- a/iris-mpc-upgrade-hawk/tests/utils/modifications.rs
+++ b/iris-mpc-upgrade-hawk/tests/utils/modifications.rs
@@ -3,13 +3,13 @@ use std::{fmt::Display, ops::DerefMut};
 use eyre::Result;
 use iris_mpc_common::helpers::{
     smpc_request::{REAUTH_MESSAGE_TYPE, RESET_UPDATE_MESSAGE_TYPE, UNIQUENESS_MESSAGE_TYPE},
-    sync::{MOD_STATUS_COMPLETED, MOD_STATUS_IN_PROGRESS},
+    sync::{Modification, MOD_STATUS_COMPLETED, MOD_STATUS_IN_PROGRESS},
 };
 use serde::{Deserialize, Serialize};
 use sqlx::{Postgres, Transaction};
 
 // from iris-mpc-common/helpers/smpc_request.rs
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum ModificationType {
     /// searches for a new iris scan and if it finds a match, overwrites the iris code
     /// in the system with the new scan. AKA reset-check plus overwrite
@@ -25,6 +25,7 @@ pub enum ModificationType {
 /// look for JobRequest::Modification in iris-mpc-cpu/src/genesis/hawk_handle.rs to see how these are handled
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModificationInput {
+    pub mod_id: i64,
     /// needs to match an existing vector id
     pub serial_id: i64,
     pub request_type: ModificationType,
@@ -33,13 +34,15 @@ pub struct ModificationInput {
 }
 
 impl ModificationInput {
-    pub fn new(
+    pub const fn new(
+        mod_id: i64,
         serial_id: i64,
         request_type: ModificationType,
         completed: bool,
         persisted: bool,
     ) -> Self {
         Self {
+            mod_id,
             serial_id,
             request_type,
             completed,
@@ -47,19 +50,29 @@ impl ModificationInput {
         }
     }
 
-    pub fn from_slice(inputs: &[(i64, ModificationType, bool, bool)]) -> Vec<Self> {
-        inputs
-            .iter()
-            .map(|(serial_id, request_type, completed, persisted)| {
-                Self::new(*serial_id, request_type.clone(), *completed, *persisted)
-            })
-            .collect()
-    }
-
     pub fn get_status(&self) -> &'static str {
         match self.completed {
             true => MOD_STATUS_COMPLETED,
             false => MOD_STATUS_IN_PROGRESS,
+        }
+    }
+
+    pub fn is_finalized(&self) -> bool {
+        self.completed && self.persisted
+    }
+}
+
+impl From<ModificationInput> for Modification {
+    fn from(value: ModificationInput) -> Self {
+        Modification {
+            id: value.mod_id,
+            serial_id: Some(value.serial_id),
+            request_type: value.request_type.to_string(),
+            s3_url: None,
+            status: value.get_status().to_string(),
+            persisted: value.persisted,
+            result_message_body: None,
+            graph_mutation: None,
         }
     }
 }
@@ -82,6 +95,61 @@ impl Display for ModificationType {
         };
         write!(f, "{}", variant)
     }
+}
+
+/// Validate that one list of modifications is a valid extension to another list.  For
+/// each modification in `start`, checks:
+/// - A modification with equal mod_id is still present in `end`
+/// - This modification has the same type as before
+/// - If the modification starts as persisted and completed, then it remains this way
+pub fn modifications_extension_is_valid(
+    start: &[ModificationInput],
+    end: &[ModificationInput],
+) -> bool {
+    for m_start in start {
+        let m_end = end.iter().find(|m| m.mod_id == m_start.mod_id);
+        if let Some(m_end) = m_end {
+            if m_end.request_type != m_start.request_type {
+                return false;
+            }
+            if !m_end.is_finalized() && m_start.is_finalized() {
+                return false;
+            }
+        } else {
+            return false;
+        }
+    }
+    true
+}
+
+/// Return a sorted list of serial ids of irises that must be updated (e.g. their version incremented)
+/// to reflect changes between the start and end modifications tables.
+pub fn modifications_extension_updates(
+    start: &[ModificationInput],
+    end: &[ModificationInput],
+) -> Vec<i64> {
+    let mut end: Vec<_> = end.into();
+
+    end.sort_by_key(|m| m.mod_id);
+    end.into_iter()
+        .filter_map(|m| {
+            // m must be finalized and updating
+            if m.is_finalized() && m.request_type.is_updating() {
+                // but no update if m was already finalized previously
+                if let Some(m_start) = start.iter().find(|m_start| m_start.mod_id == m.mod_id) {
+                    if m_start.is_finalized() {
+                        None
+                    } else {
+                        Some(m.serial_id)
+                    }
+                } else {
+                    Some(m.serial_id)
+                }
+            } else {
+                None
+            }
+        })
+        .collect()
 }
 
 /// Test functionality which updates an iris only by incrementing its version,
@@ -113,6 +181,35 @@ pub async fn persist_modification(
         "#,
     )
     .bind(modification_id);
+    query.execute(tx.deref_mut()).await?;
+
+    Ok(())
+}
+
+/// Writes a modification to the modifications table, overwriting fields if the specified
+/// modification id already exists.
+pub async fn write_modification(
+    tx: &mut Transaction<'_, Postgres>,
+    m: &Modification,
+) -> Result<()> {
+    let query = sqlx::query(
+        r#"
+        INSERT INTO modifications (id, serial_id, request_type, s3_url, status, persisted)
+        VALUES ($1, $2, $3, $4, $5, $6)
+        ON CONFLICT (id) DO UPDATE
+        SET serial_id = EXCLUDED.serial_id,
+            request_type = EXCLUDED.request_type,
+            s3_url = EXCLUDED.s3_url,
+            status = EXCLUDED.status,
+            persisted = EXCLUDED.persisted;
+        "#,
+    )
+    .bind(m.id)
+    .bind(m.serial_id)
+    .bind(m.request_type.as_str())
+    .bind(m.s3_url.as_ref())
+    .bind(m.status.as_str())
+    .bind(m.persisted);
     query.execute(tx.deref_mut()).await?;
 
     Ok(())

--- a/iris-mpc-upgrade-hawk/tests/utils/mpc_node.rs
+++ b/iris-mpc-upgrade-hawk/tests/utils/mpc_node.rs
@@ -6,6 +6,7 @@ use crate::utils::{
 use eyre::Result;
 use iris_mpc_common::{
     config::Config,
+    helpers::smpc_request::{REAUTH_MESSAGE_TYPE, RESET_UPDATE_MESSAGE_TYPE},
     postgres::{AccessMode, PostgresClient},
     IrisSerialId,
 };

--- a/iris-mpc-upgrade-hawk/tests/utils/mpc_node.rs
+++ b/iris-mpc-upgrade-hawk/tests/utils/mpc_node.rs
@@ -6,7 +6,6 @@ use crate::utils::{
 use eyre::Result;
 use iris_mpc_common::{
     config::Config,
-    helpers::smpc_request::{REAUTH_MESSAGE_TYPE, RESET_UPDATE_MESSAGE_TYPE},
     postgres::{AccessMode, PostgresClient},
     IrisSerialId,
 };

--- a/iris-mpc-upgrade-hawk/tests/utils/mpc_node.rs
+++ b/iris-mpc-upgrade-hawk/tests/utils/mpc_node.rs
@@ -1,6 +1,6 @@
 use super::constants::COUNT_OF_PARTIES;
 use crate::utils::{
-    modifications::{increment_iris_version, ModificationInput},
+    modifications::{increment_iris_version, persist_modification, ModificationInput},
     GaloisRingSharedIrisPair, HawkConfigs,
 };
 use eyre::Result;
@@ -178,6 +178,22 @@ impl MpcNode {
             }
             tx.commit().await?;
         }
+
+        Ok(())
+    }
+
+    pub async fn persist_modification(&self, id: i64) -> Result<()> {
+        let mut tx = self.gpu_iris_store.tx().await?;
+        persist_modification(&mut tx, id).await?;
+        tx.commit().await?;
+
+        Ok(())
+    } // TODO need better representation of modification id associated with iris serial id
+
+    pub async fn increment_iris_version(&self, serial_id: i64) -> Result<()> {
+        let mut tx = self.gpu_iris_store.tx().await?;
+        increment_iris_version(&mut tx, serial_id).await?;
+        tx.commit().await?;
 
         Ok(())
     }

--- a/iris-mpc-upgrade-hawk/tests/utils/plaintext_genesis.rs
+++ b/iris-mpc-upgrade-hawk/tests/utils/plaintext_genesis.rs
@@ -1,8 +1,8 @@
 use crate::utils::{
-    modifications::{ModificationInput, ModificationType},
+    modifications::{self, ModificationInput},
     IrisCodePair,
 };
-use eyre::{OptionExt, Result};
+use eyre::{bail, OptionExt, Result};
 use iris_mpc_common::{config::Config, iris_db::iris::IrisCode, IrisSerialId, IrisVersionId};
 use iris_mpc_cpu::{
     genesis::plaintext::{
@@ -102,30 +102,23 @@ pub fn init_plaintext_irises_db(pairs: &[IrisCodePair]) -> IrisesTable {
 }
 
 /// Update plaintext genesis source database state to reflect application of the
-/// specified modification inputs.  Appends modifications to the `modifications`
-/// field, and increments the version number of the associated serial ids for
-/// modifications updating an iris in the database.  Makes no change to the
-/// iris database for a uniqueness modification entry.
-pub fn apply_src_modifications(
+/// specified modifications `cur_mods`, relative to prior state `last_mods`.
+/// Appends modifications to the `modifications` field, and increments the
+/// version number of the associated serial ids for modifications updating an
+/// iris in the database which took place after `last_mods`.  Makes no change to
+/// the iris database for a uniqueness modification entry.
+pub fn apply_modifications(
     src_db: &mut GenesisSrcDbState,
-    modifications: &[ModificationInput],
+    last_mods: &[ModificationInput],
+    cur_mods: &[ModificationInput],
 ) -> Result<()> {
-    let max_modification_id = src_db.modifications.keys().cloned().max().unwrap_or(0);
+    if !modifications::modifications_extension_is_valid(last_mods, cur_mods) {
+        bail!("Specified modifications are not a valid extension of the last modifications state.")
+    }
 
-    for (idx, m) in modifications.iter().enumerate() {
-        if matches!(
-            m.request_type,
-            ModificationType::ResetUpdate | ModificationType::Reauth
-        ) {
-            let entry = src_db
-                .irises
-                .get_mut(&(m.serial_id as u32))
-                .ok_or_eyre("Modified iris serial id missing from plaintext database")?;
-            entry.0 += 1;
-        }
-
+    for m in cur_mods.iter() {
         src_db.modifications.insert(
-            max_modification_id + (idx as i64) + 1,
+            m.mod_id,
             (
                 m.serial_id as u32,
                 m.request_type.to_string(),
@@ -133,6 +126,15 @@ pub fn apply_src_modifications(
                 m.persisted,
             ),
         );
+    }
+
+    let update_serial_ids = modifications::modifications_extension_updates(last_mods, cur_mods);
+    for serial_id in update_serial_ids {
+        src_db
+            .irises
+            .get_mut(&(serial_id as u32))
+            .ok_or_eyre("Modification specifies invalid iris serial id.")?
+            .0 += 1;
     }
 
     Ok(())

--- a/iris-mpc-upgrade-hawk/tests/workflows/README.md
+++ b/iris-mpc-upgrade-hawk/tests/workflows/README.md
@@ -70,7 +70,6 @@ CPU persisted_state table shows the max indexed modification is 3 and max indexe
 CPU graph database matches the output of plaintext genesis
 There are zero deletions on S3
 
-
 ## 104
 Preconditions:
 GPU iris database has entries from 1 to 100, inclusive
@@ -81,18 +80,53 @@ GPU modifications table is empty
 CPU graph database at layer zero has 100 links
 There are zero deletions on S3
 
-
 Test:
 index genesis up to 50
-overwrite the iris code for iris id 3 in the GPU database and add a reset_update modification for it
-overwrite the version for iris id 5 in the GPU database and add a reauth modification for it
+increment the version for iris id 3 in the GPU database and add a reset_update modification for it
+increment the version for iris id 5 in the GPU database and add a reauth modification for it
 index genesis up to 100
 
 Postconditions:
 GPU iris database has 100 entries
 CPU iris database has 100 entries
 CPU iris database reflects irises updated by new modifications after the first run
-CPU persisted_state table shows the max indexed modification is 5 and max indexed iris is 100
+CPU persisted_state table shows the max indexed modification is 2 and max indexed iris is 100
 CPU graph database matches the output of plaintext genesis
+CPU graph database at layer zero has 102 links
+There are zero deletions on S3
+
+## 105
+Preconditions:
+GPU iris database has entries from 1 to 100, inclusive
+CPU iris database and graph database is empty
+CPU modifications and persisted_state tables are empty
+GPU persisted_state table is empty
+GPU modifications table is empty
 CPU graph database at layer zero has 100 links
+There are zero deletions on S3
+
+Test:
+update the GPU database with simulated modifications:
+- add reset_update modification id 1, for serial id 5, persisted, and increment the associated iris version
+- add uniquness modification id 2, for serial id 15, persisted, and increment the associated iris version
+- reauth modification id 3, for serial id 25, not persisted
+- uniqueness modification id 4, for serial id 55, not persisted
+index genesis up to 50
+update the GPU database with simulated modifications:
+- mark modification with id 3 as persisted, and increment the associated iris version
+- mark modification with id 4 as persisted
+- add reset_update modification id 5, for serial id 60, persisted, and increment the associated iris version
+- add reauth modification id 6, for serial id 70, persisted, and increment the associated iris version
+- add reset_update modification id 7, for serial id 10, persisted, and increment the associated iris version
+- add reauth modification id 8, for serial id 20, persisted and increment the associated iris version
+- add reset_update modification id 9, for serial id 30, not persisted
+index genesis up to 100
+
+Postconditions:
+GPU iris database has 100 entries
+CPU iris database has 100 entries
+CPU iris database reflects irises updated by new and persisted modifications after the first run
+CPU persisted_state table shows the max indexed modification is 8 and max indexed iris is 100
+CPU graph database matches the output of plaintext genesis
+CPU graph database at layer zero has 103 links
 There are zero deletions on S3

--- a/iris-mpc-upgrade-hawk/tests/workflows/genesis_103/runner.rs
+++ b/iris-mpc-upgrade-hawk/tests/workflows/genesis_103/runner.rs
@@ -149,10 +149,7 @@ impl TestRun for Test {
                 node.insert_modifications(&MODIFICATIONS).await.unwrap();
             });
         }
-
-        while let Some(r) = join_set.join_next().await {
-            r.unwrap();
-        }
+        join_set.join_all().await;
 
         // any config file is sufficient to connect to S3
         let config = &self.configs[0];
@@ -190,10 +187,7 @@ impl TestRun for Test {
                 assert_eq!(0, node.get_last_indexed_modification_id().await);
             });
         }
-
-        while let Some(r) = join_set.join_next().await {
-            r.unwrap();
-        }
+        join_set.join_all().await;
 
         // Assert localstack.
 

--- a/iris-mpc-upgrade-hawk/tests/workflows/genesis_104/runner.rs
+++ b/iris-mpc-upgrade-hawk/tests/workflows/genesis_104/runner.rs
@@ -201,10 +201,7 @@ impl TestRun for Test {
                 node.init_tables(&shares).await.unwrap();
             });
         }
-
-        while let Some(r) = join_set.join_next().await {
-            r.unwrap();
-        }
+        join_set.join_all().await;
 
         // any config file is sufficient to connect to S3
         let config = &self.configs[0];
@@ -244,10 +241,7 @@ impl TestRun for Test {
                 assert_eq!(0, node.get_last_indexed_modification_id().await);
             });
         }
-
-        while let Some(r) = join_set.join_next().await {
-            r.unwrap();
-        }
+        join_set.join_all().await;
 
         // Assert localstack.
 

--- a/iris-mpc-upgrade-hawk/tests/workflows/genesis_104/runner.rs
+++ b/iris-mpc-upgrade-hawk/tests/workflows/genesis_104/runner.rs
@@ -1,9 +1,10 @@
-use std::sync::LazyLock;
-
 use crate::utils::{
     constants::COUNT_OF_PARTIES,
     irises,
-    modifications::{ModificationInput, ModificationType},
+    modifications::{
+        self, ModificationInput,
+        ModificationType::{Reauth, ResetUpdate},
+    },
     mpc_node::{MpcNode, MpcNodes},
     plaintext_genesis,
     resources::{self},
@@ -19,12 +20,10 @@ use iris_mpc_upgrade_hawk::genesis::{exec as exec_genesis, ExecutionArgs};
 use itertools::izip;
 use tokio::task::JoinSet;
 
-static MODIFICATIONS: LazyLock<Vec<ModificationInput>> = LazyLock::new(|| {
-    ModificationInput::from_slice(&[
-        (3, ModificationType::Reauth, true, true),
-        (5, ModificationType::ResetUpdate, true, true),
-    ])
-});
+const MODIFICATIONS: [ModificationInput; 2] = [
+    ModificationInput::new(1, 3, Reauth, true, true),
+    ModificationInput::new(2, 5, ResetUpdate, true, true),
+];
 
 pub struct Test {
     configs: HawkConfigs,
@@ -84,24 +83,20 @@ impl TestRun for Test {
                 .unwrap()
             });
         }
+        join_set.join_all().await;
 
-        while let Some(r) = join_set.join_next().await {
-            r.unwrap();
-        }
-
+        let mut join_set = JoinSet::new();
         for node in self.get_nodes().await {
             join_set.spawn(async move {
-                node.insert_modifications(&MODIFICATIONS).await.unwrap();
+                node.apply_modifications(&[], &MODIFICATIONS).await.unwrap();
             });
         }
-
-        while let Some(r) = join_set.join_next().await {
-            r.unwrap();
-        }
+        join_set.join_all().await;
 
         // hack to get around an "address already in use" error, emitted by HawkHandle
         let service_ports = vec!["4003".into(), "4004".into(), "4005".into()];
 
+        let mut join_set = JoinSet::new();
         for mut config in self.configs.iter().cloned() {
             let genesis_args = DEFAULT_GENESIS_ARGS;
             config.service_ports = service_ports.clone();
@@ -120,10 +115,7 @@ impl TestRun for Test {
                 .unwrap()
             });
         }
-
-        while let Some(r) = join_set.join_next().await {
-            r.unwrap();
-        }
+        join_set.join_all().await;
 
         Ok(())
     }
@@ -140,21 +132,25 @@ impl TestRun for Test {
             .await
             .expect("Stage 1 of plaintext genesis execution failed");
 
-        plaintext_genesis::apply_src_modifications(&mut state_1.src_db, &MODIFICATIONS)?;
+        plaintext_genesis::apply_modifications(&mut state_1.src_db, &[], &MODIFICATIONS)?;
         state_1.args.max_indexation_id = 100;
 
         let expected = run_plaintext_genesis(state_1)
             .await
             .expect("Stage 2 of plaintext genesis execution failed");
 
+        // Number of modifications on already-indexed irises which are processed by genesis delta
+        let num_updating_modifications =
+            modifications::modifications_extension_updates(&[], &MODIFICATIONS)
+                .into_iter()
+                .filter(|serial_id| *serial_id <= 50)
+                .count();
+
         let mut join_set = JoinSet::new();
         for node in self.get_nodes().await {
             let expected = expected.clone();
             let max_indexation_id = DEFAULT_GENESIS_ARGS.max_indexation_id as usize;
-            let num_update_modifications = MODIFICATIONS
-                .iter()
-                .filter(|m| m.request_type.is_updating())
-                .count();
+
             join_set.spawn(async move {
                 // inspect the postgres tables - iris counts, modifications, and persisted_state
                 let num_irises = node.gpu_iris_store.count_irises().await.unwrap();
@@ -179,14 +175,11 @@ impl TestRun for Test {
                 // New graph entries are created for modified iris codes
                 assert_eq!(
                     expected.dst_db.graphs[0].layers[0].links.len(),
-                    max_indexation_id + num_update_modifications
+                    max_indexation_id + num_updating_modifications
                 );
             });
         }
-
-        while let Some(r) = join_set.join_next().await {
-            r.unwrap();
-        }
+        join_set.join_all().await;
 
         Ok(())
     }

--- a/iris-mpc-upgrade-hawk/tests/workflows/genesis_105/mod.rs
+++ b/iris-mpc-upgrade-hawk/tests/workflows/genesis_105/mod.rs
@@ -1,0 +1,2 @@
+mod runner;
+pub use runner::Test;

--- a/iris-mpc-upgrade-hawk/tests/workflows/genesis_105/runner.rs
+++ b/iris-mpc-upgrade-hawk/tests/workflows/genesis_105/runner.rs
@@ -1,0 +1,311 @@
+use std::sync::LazyLock;
+
+use crate::utils::{
+    constants::COUNT_OF_PARTIES,
+    irises,
+    modifications::{ModificationInput, ModificationType},
+    mpc_node::{MpcNode, MpcNodes},
+    plaintext_genesis,
+    resources::{self},
+    s3_deletions::{get_aws_clients, upload_iris_deletions},
+    HawkConfigs, IrisCodePair, TestError, TestRun, TestRunContextInfo,
+};
+use eyre::Result;
+use iris_mpc_cpu::genesis::{
+    get_iris_deletions,
+    plaintext::{run_plaintext_genesis, GenesisArgs, GenesisState},
+};
+use iris_mpc_upgrade_hawk::genesis::{exec as exec_genesis, ExecutionArgs};
+use itertools::izip;
+use tokio::task::JoinSet;
+
+static INIT_MODIFICATIONS: LazyLock<Vec<ModificationInput>> = LazyLock::new(|| {
+    ModificationInput::from_slice(&[
+        (5, ModificationType::ResetUpdate, true, true),
+        (15, ModificationType::Uniqueness, true, true),
+        (25, ModificationType::Reauth, false, false),
+        (55, ModificationType::Uniqueness, false, false),
+    ])
+});
+
+static ADDITIONAL_MODIFICATIONS: LazyLock<Vec<ModificationInput>> = LazyLock::new(|| {
+    ModificationInput::from_slice(&[
+        (60, ModificationType::ResetUpdate, true, true),
+        (70, ModificationType::Reauth, true, true),
+        (10, ModificationType::ResetUpdate, true, true),
+        (20, ModificationType::Reauth, true, true),
+        (30, ModificationType::ResetUpdate, false, false),
+    ])
+});
+
+pub struct Test {
+    configs: HawkConfigs,
+}
+
+const DEFAULT_GENESIS_ARGS: GenesisArgs = GenesisArgs {
+    max_indexation_id: 100,
+    batch_size: 1,
+    batch_size_error_rate: 250,
+};
+
+fn get_irises() -> Vec<IrisCodePair> {
+    let irises_path =
+        resources::get_resource_path("iris-shares-plaintext/20250710-synthetic-irises-1k.ndjson");
+    irises::read_irises_from_ndjson(irises_path, 100).unwrap()
+}
+
+impl Test {
+    pub fn new() -> Self {
+        let exec_env = TestRunContextInfo::new(0, 0);
+
+        let configs = (0..COUNT_OF_PARTIES)
+            .map(|idx| {
+                resources::read_node_config(&exec_env, format!("node-{idx}-genesis-0")).unwrap()
+            })
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap();
+
+        Self { configs }
+    }
+
+    async fn get_nodes(&self) -> impl Iterator<Item = MpcNode> {
+        MpcNodes::new(&self.configs).await.into_iter()
+    }
+}
+
+impl TestRun for Test {
+    async fn exec(&mut self) -> Result<(), TestError> {
+        // Insert initial modifications
+        let mut join_set = JoinSet::new();
+        for node in self.get_nodes().await {
+            join_set.spawn(async move {
+                node.insert_modifications(&INIT_MODIFICATIONS)
+                    .await
+                    .unwrap();
+            });
+        }
+        join_set.join_all().await;
+
+        // Execute initial genesis run
+        let mut join_set = JoinSet::new();
+        for config in self.configs.iter().cloned() {
+            join_set.spawn(async move {
+                exec_genesis(
+                    ExecutionArgs::new(
+                        DEFAULT_GENESIS_ARGS.batch_size,
+                        DEFAULT_GENESIS_ARGS.batch_size_error_rate,
+                        50,
+                        false,
+                        false,
+                    ),
+                    config,
+                )
+                .await
+                .unwrap()
+            });
+        }
+        join_set.join_all().await;
+
+        // Persist initial modificatgions, and insert additional modifications
+        let mut join_set = JoinSet::new();
+        for node in self.get_nodes().await {
+            join_set.spawn(async move {
+                node.persist_modification(3).await.unwrap();
+                node.persist_modification(4).await.unwrap();
+                node.increment_iris_version(25).await.unwrap();
+                node.insert_modifications(&ADDITIONAL_MODIFICATIONS)
+                    .await
+                    .unwrap();
+            });
+        }
+        join_set.join_all().await;
+
+        // hack to get around an "address already in use" error, emitted by HawkHandle
+        let service_ports = vec!["4003".into(), "4004".into(), "4005".into()];
+
+        // Execute second genesis run
+        let mut join_set = JoinSet::new();
+        for mut config in self.configs.iter().cloned() {
+            let genesis_args = DEFAULT_GENESIS_ARGS;
+            config.service_ports = service_ports.clone();
+            join_set.spawn(async move {
+                exec_genesis(
+                    ExecutionArgs::new(
+                        genesis_args.batch_size,
+                        genesis_args.batch_size_error_rate,
+                        100,
+                        false,
+                        false,
+                    ),
+                    config,
+                )
+                .await
+                .unwrap()
+            });
+        }
+        join_set.join_all().await;
+
+        Ok(())
+    }
+
+    async fn exec_assert(&mut self) -> Result<(), TestError> {
+        // Simulate genesis execution in plaintext
+        let mut state_0 = GenesisState::default();
+        state_0.src_db.irises = plaintext_genesis::init_plaintext_irises_db(&get_irises());
+        state_0.config = plaintext_genesis::init_plaintext_config(&self.configs[0]);
+        plaintext_genesis::apply_src_modifications(&mut state_0.src_db, &INIT_MODIFICATIONS)?;
+        state_0.args = DEFAULT_GENESIS_ARGS;
+        state_0.args.max_indexation_id = 50;
+
+        let mut state_1 = run_plaintext_genesis(state_0)
+            .await
+            .expect("Stage 1 of plaintext genesis execution failed");
+
+        for id in [3, 4] {
+            let m = state_1.src_db.modifications.get_mut(&id).unwrap();
+            m.2 = true;
+            m.3 = true;
+        }
+        let update_id = state_1.src_db.modifications.get(&3).unwrap().0;
+        state_1.src_db.irises.get_mut(&update_id).unwrap().0 += 1;
+
+        plaintext_genesis::apply_src_modifications(&mut state_1.src_db, &ADDITIONAL_MODIFICATIONS)?;
+        state_1.args.max_indexation_id = 100;
+
+        let expected = run_plaintext_genesis(state_1)
+            .await
+            .expect("Stage 2 of plaintext genesis execution failed");
+
+        // Number of modifications on already-indexed irises which are processed by genesis delta
+        let num_updating_modifications = 3;
+
+        let mut join_set = JoinSet::new();
+        for node in self.get_nodes().await {
+            let expected = expected.clone();
+            let max_indexation_id = DEFAULT_GENESIS_ARGS.max_indexation_id as usize;
+
+            join_set.spawn(async move {
+                // inspect the postgres tables - iris counts, modifications, and persisted_state
+                let num_irises = node.gpu_iris_store.count_irises().await.unwrap();
+                assert_eq!(num_irises, max_indexation_id);
+
+                let num_irises = node.cpu_iris_store.count_irises().await.unwrap();
+                assert_eq!(num_irises, max_indexation_id);
+
+                // TODO assert CPU iris database reflects irises updated by new modifications after the first run
+
+                let num_modifications = node.gpu_iris_store.last_modifications(100).await.unwrap();
+                assert_eq!(
+                    num_modifications.len(),
+                    INIT_MODIFICATIONS.len() + ADDITIONAL_MODIFICATIONS.len()
+                );
+
+                let num_modifications = node.cpu_iris_store.last_modifications(100).await.unwrap();
+                assert_eq!(num_modifications.len(), 0);
+
+                assert_eq!(100, node.get_last_indexed_iris_id().await);
+                assert_eq!(8, node.get_last_indexed_modification_id().await);
+
+                node.assert_graphs_match(&expected).await;
+
+                // New graph entries are created for modified iris codes
+                assert_eq!(
+                    expected.dst_db.graphs[0].layers[0].links.len(),
+                    max_indexation_id + num_updating_modifications
+                );
+            });
+        }
+
+        while let Some(r) = join_set.join_next().await {
+            r.unwrap();
+        }
+
+        Ok(())
+    }
+
+    async fn setup(&mut self, _ctx: &TestRunContextInfo) -> Result<(), TestError> {
+        let hawk_prf0 = self.configs[0].hawk_prf_key;
+        assert!(
+            self.configs.iter().all(|c| c.hawk_prf_key == hawk_prf0),
+            "All hawk_prf_key values in configs must be equal"
+        );
+
+        let plaintext_irises = get_irises();
+        let secret_shared_irises =
+            irises::share_irises_locally(&plaintext_irises, hawk_prf0.unwrap_or_default()).unwrap();
+
+        let mut join_set = JoinSet::new();
+        for (node, shares) in izip!(self.get_nodes().await, secret_shared_irises.into_iter()) {
+            join_set.spawn(async move {
+                node.init_tables(&shares).await.unwrap();
+            });
+        }
+
+        while let Some(r) = join_set.join_next().await {
+            r.unwrap();
+        }
+
+        // any config file is sufficient to connect to S3
+        let config = &self.configs[0];
+
+        let deleted_serial_ids = vec![];
+        let aws_clients = get_aws_clients(config).await.unwrap();
+        upload_iris_deletions(
+            &deleted_serial_ids,
+            &aws_clients.s3_client,
+            &config.environment,
+        )
+        .await
+        .unwrap();
+
+        Ok(())
+    }
+
+    async fn setup_assert(&mut self) -> Result<(), TestError> {
+        let mut join_set = JoinSet::new();
+        for node in self.get_nodes().await {
+            let genesis_args = DEFAULT_GENESIS_ARGS;
+            let max_indexation_id = genesis_args.max_indexation_id as usize;
+            join_set.spawn(async move {
+                let num_irises = node.gpu_iris_store.count_irises().await.unwrap();
+                assert_eq!(num_irises, max_indexation_id);
+
+                let num_irises = node.cpu_iris_store.count_irises().await.unwrap();
+                assert_eq!(num_irises, 0);
+
+                let num_modifications = node.gpu_iris_store.last_modifications(1).await.unwrap();
+                assert_eq!(num_modifications.len(), 0);
+
+                let num_modifications = node.cpu_iris_store.last_modifications(1).await.unwrap();
+                assert_eq!(num_modifications.len(), 0);
+
+                assert_eq!(0, node.get_last_indexed_iris_id().await);
+                assert_eq!(0, node.get_last_indexed_modification_id().await);
+            });
+        }
+
+        while let Some(r) = join_set.join_next().await {
+            r.unwrap();
+        }
+
+        // Assert localstack.
+
+        let config = &self.configs[0];
+        let aws_clients = get_aws_clients(config).await.unwrap();
+        let deletions = get_iris_deletions(config, &aws_clients.s3_client, 100)
+            .await
+            .unwrap();
+        assert_eq!(deletions.len(), 0);
+
+        Ok(())
+    }
+
+    async fn teardown(&mut self) -> Result<(), TestError> {
+        Ok(())
+    }
+
+    async fn teardown_assert(&mut self) -> Result<(), TestError> {
+        Ok(())
+    }
+}

--- a/iris-mpc-upgrade-hawk/tests/workflows/genesis_105/runner.rs
+++ b/iris-mpc-upgrade-hawk/tests/workflows/genesis_105/runner.rs
@@ -235,10 +235,7 @@ impl TestRun for Test {
                 node.init_tables(&shares).await.unwrap();
             });
         }
-
-        while let Some(r) = join_set.join_next().await {
-            r.unwrap();
-        }
+        join_set.join_all().await;
 
         // any config file is sufficient to connect to S3
         let config = &self.configs[0];
@@ -278,10 +275,7 @@ impl TestRun for Test {
                 assert_eq!(0, node.get_last_indexed_modification_id().await);
             });
         }
-
-        while let Some(r) = join_set.join_next().await {
-            r.unwrap();
-        }
+        join_set.join_all().await;
 
         // Assert localstack.
 

--- a/iris-mpc-upgrade-hawk/tests/workflows/mod.rs
+++ b/iris-mpc-upgrade-hawk/tests/workflows/mod.rs
@@ -3,3 +3,4 @@ pub mod genesis_101;
 pub mod genesis_102;
 pub mod genesis_103;
 pub mod genesis_104;
+pub mod genesis_105;


### PR DESCRIPTION
This PR extends the functionality for initializing and updating modifications data in a test Postgres configuration and in the plaintext genesis state struct, and implements the genesis 105 e2e test exercising mixed handling of modifications initialized before a run, and then updated prior to a second run of the genesis protocol.  The PR also fixes some small incorrect edge case behavior in the plaintext implementation of the genesis indexer (delta subprotocol), so that the `last_indexed_modification_id` is properly updated in the presence of non-finalized modifications.