### PR TITLE
Implement genesis 106 e2e test

### DIFF
--- a/iris-mpc-upgrade-hawk/tests/e2e_genesis.rs
+++ b/iris-mpc-upgrade-hawk/tests/e2e_genesis.rs
@@ -82,3 +82,12 @@ fn test_hnsw_genesis_105() -> Result<()> {
     run_test!(105, 1)?;
     Ok(())
 }
+
+#[test]
+#[serial]
+#[ignore = "requires external setup"]
+fn test_hnsw_genesis_106() -> Result<()> {
+    use workflows::genesis_106::Test;
+    run_test!(106, 1)?;
+    Ok(())
+}

--- a/iris-mpc-upgrade-hawk/tests/utils/mpc_node.rs
+++ b/iris-mpc-upgrade-hawk/tests/utils/mpc_node.rs
@@ -7,7 +7,7 @@ use eyre::{bail, Result};
 use iris_mpc_common::{
     config::Config,
     postgres::{AccessMode, PostgresClient},
-    IrisSerialId,
+    IrisSerialId, IrisVectorId,
 };
 use iris_mpc_cpu::{
     execution::hawk_main::StoreId,
@@ -300,5 +300,9 @@ impl MpcNode {
         }
 
         Ok(())
+    }
+
+    pub async fn get_cpu_iris_vector_ids(&self, max_serial_id: i64) -> Result<Vec<IrisVectorId>> {
+        modifications::get_iris_vector_ids(&self.cpu_iris_store, max_serial_id).await
     }
 }

--- a/iris-mpc-upgrade-hawk/tests/utils/plaintext_genesis.rs
+++ b/iris-mpc-upgrade-hawk/tests/utils/plaintext_genesis.rs
@@ -3,7 +3,9 @@ use crate::utils::{
     IrisCodePair,
 };
 use eyre::{bail, OptionExt, Result};
-use iris_mpc_common::{config::Config, iris_db::iris::IrisCode, IrisSerialId, IrisVersionId};
+use iris_mpc_common::{
+    config::Config, iris_db::iris::IrisCode, IrisSerialId, IrisVectorId, IrisVersionId,
+};
 use iris_mpc_cpu::{
     genesis::plaintext::{
         run_plaintext_genesis, GenesisArgs, GenesisConfig, GenesisDstDbState, GenesisSrcDbState,
@@ -149,4 +151,13 @@ pub fn init_plaintext_config(config: &Config) -> GenesisConfig {
         hnsw_ef_search: config.hnsw_param_ef_search,
         hawk_prf_key: config.hawk_prf_key,
     }
+}
+
+pub fn get_vector_ids(irises: &IrisesTable) -> Vec<IrisVectorId> {
+    let mut ids: Vec<_> = irises
+        .iter()
+        .map(|(serial_id, data)| IrisVectorId::new(*serial_id, data.0))
+        .collect();
+    ids.sort_by_key(|id| id.serial_id());
+    ids
 }

--- a/iris-mpc-upgrade-hawk/tests/workflows/README.md
+++ b/iris-mpc-upgrade-hawk/tests/workflows/README.md
@@ -1,6 +1,7 @@
 # Test cases
 
 ## 100
+
 Preconditions:
 GPU iris database has entries from 1 to 100, inclusive
 CPU iris database and graph database is empty
@@ -20,6 +21,7 @@ CPU graph database matches the output of plaintext genesis
 There are zero deletions on S3
 
 ## 101
+
 Preconditions:
 same as 100
 
@@ -31,6 +33,7 @@ Postconditions:
 same as 100
 
 ## 102
+
 Preconditions:
 GPU iris database has entries from 1 to 100, inclusive
 CPU iris database and graph database is empty
@@ -50,6 +53,7 @@ CPU graph database matches the output of plaintext genesis
 CPU graph database at layer zero has 95 links (100 irises - 5 deletions)
 
 ## 103
+
 Preconditions:
 GPU iris database has entries from 1 to 100, inclusive
 CPU iris database and graph database is empty
@@ -71,6 +75,7 @@ CPU graph database matches the output of plaintext genesis
 There are zero deletions on S3
 
 ## 104
+
 Preconditions:
 GPU iris database has entries from 1 to 100, inclusive
 CPU iris database and graph database is empty
@@ -93,40 +98,61 @@ CPU iris database reflects irises updated by new modifications after the first r
 CPU persisted_state table shows the max indexed modification is 2 and max indexed iris is 100
 CPU graph database matches the output of plaintext genesis
 CPU graph database at layer zero has 102 links
-There are zero deletions on S3
 
 ## 105
-Preconditions:
-GPU iris database has entries from 1 to 100, inclusive
-CPU iris database and graph database is empty
-CPU modifications and persisted_state tables are empty
-GPU persisted_state table is empty
-GPU modifications table is empty
-CPU graph database at layer zero has 100 links
-There are zero deletions on S3
+
+Pre-conditions:
+- GPU iris database has entries from 1 to 100, inclusive
+- CPU iris database and graph database is empty
+- GPU modifications and persisted_state tables are empty
+- CPU modifications and persisted_state tables are empty
+- CPU graph database at layer zero has 100 links
+- S3 deletions: `[]`
 
 Test:
-update the GPU database with simulated modifications:
-- add reset_update modification id 1, for serial id 5, persisted, and increment the associated iris version
-- add uniquness modification id 2, for serial id 15, persisted, and increment the associated iris version
-- reauth modification id 3, for serial id 25, not persisted
-- uniqueness modification id 4, for serial id 55, not persisted
-index genesis up to 50
-update the GPU database with simulated modifications:
-- mark modification with id 3 as persisted, and increment the associated iris version
-- mark modification with id 4 as persisted
-- add reset_update modification id 5, for serial id 60, persisted, and increment the associated iris version
-- add reauth modification id 6, for serial id 70, persisted, and increment the associated iris version
-- add reset_update modification id 7, for serial id 10, persisted, and increment the associated iris version
-- add reauth modification id 8, for serial id 20, persisted and increment the associated iris version
-- add reset_update modification id 9, for serial id 30, not persisted
-index genesis up to 100
+- Update the GPU database with simulated modifications:
+    - Id 1: `ResetUpdate` modification for serial id 5, persisted
+    - Id 2: `Uniqueness` modification for serial id 15, persisted
+    - Id 3: `Reauth` modification for serial id 25, not persisted
+    - Id 4: `Uniqueness` modification for serial id 55, not persisted
+- Increment versions in GPU database of irises affected by persisted `ResetUpdate` and `Reauth` modifications
+- Run genesis up to serial id 50
+- Update the GPU database with simulated modifications:
+    - Persist modifications with ids 3 and 4
+    - Id 5: `ResetUpdate` modification for serial id 60, persisted
+    - Id 6: `Reauth` modification for serial id 70, persisted
+    - Id 7: `ResetUpdat` modification for serial id 10, persisted
+    - Id 8: `Reauth` modification for serial id 20, persisted
+    - Id 9: `ResetUpdate` modification for serial id 30, not persisted
+- Increment versions in GPU database of irises affected by newly persisted `ResetUpdate` and `Reauth` modifications
+- Run genesis up to serial id 100
 
-Postconditions:
-GPU iris database has 100 entries
-CPU iris database has 100 entries
-CPU iris database reflects irises updated by new and persisted modifications after the first run
-CPU persisted_state table shows the max indexed modification is 8 and max indexed iris is 100
-CPU graph database matches the output of plaintext genesis
-CPU graph database at layer zero has 103 links
-There are zero deletions on S3
+Post-conditions
+- GPU iris database has 100 entries
+- CPU iris database has 100 entries
+- CPU iris database reflects iris versions updated by modifications
+- CPU persisted_state table shows the max indexed modification is 8 and max indexed iris is 100
+- CPU graph database matches the output of plaintext genesis
+- CPU graph database at layer zero has 103 links
+
+
+## 106
+
+Pre-conditions:
+- GPU iris database has entries from 1 to 100, inclusive
+- CPU iris database and graph database is empty
+- GPU modifications and persisted_state tables are empty
+- CPU modifications and persisted_state tables are empty
+- CPU graph database at layer zero has 100 links
+- S3 deletions: `[7, 12, 39, 77, 100]`
+
+Test:
+- Run genesis process twice, using the same procedure and modifications as in test 105
+
+Post-conditions
+- GPU iris database has 100 entries
+- CPU iris database has 100 entries
+- CPU iris database reflects iris versions updated by modifications
+- CPU persisted_state table shows the max indexed modification is 8 and max indexed iris is 100
+- CPU graph database matches the output of plaintext genesis
+- CPU graph database at layer zero has 98 links

--- a/iris-mpc-upgrade-hawk/tests/workflows/genesis_103/runner.rs
+++ b/iris-mpc-upgrade-hawk/tests/workflows/genesis_103/runner.rs
@@ -6,7 +6,7 @@ use crate::utils::{
         ModificationType::{Reauth, ResetUpdate, Uniqueness},
     },
     mpc_node::{MpcNode, MpcNodes},
-    plaintext_genesis,
+    plaintext_genesis::{self, get_vector_ids},
     resources::{self},
     s3_deletions::{get_aws_clients, upload_iris_deletions},
     HawkConfigs, IrisCodePair, TestError, TestRun, TestRunContextInfo,
@@ -108,6 +108,10 @@ impl TestRun for Test {
 
                 let num_irises = node.cpu_iris_store.count_irises().await.unwrap();
                 assert_eq!(num_irises, max_indexation_id);
+
+                let cpu_vector_ids = node.get_cpu_iris_vector_ids(1000).await.unwrap();
+                let expected_vector_ids = get_vector_ids(&expected.dst_db.irises);
+                assert_eq!(cpu_vector_ids, expected_vector_ids);
 
                 let num_modifications = node.gpu_iris_store.last_modifications(100).await.unwrap();
                 assert_eq!(num_modifications.len(), MODIFICATIONS.len());

--- a/iris-mpc-upgrade-hawk/tests/workflows/genesis_104/runner.rs
+++ b/iris-mpc-upgrade-hawk/tests/workflows/genesis_104/runner.rs
@@ -6,7 +6,7 @@ use crate::utils::{
         ModificationType::{Reauth, ResetUpdate},
     },
     mpc_node::{MpcNode, MpcNodes},
-    plaintext_genesis,
+    plaintext_genesis::{self, get_vector_ids},
     resources::{self},
     s3_deletions::{get_aws_clients, upload_iris_deletions},
     HawkConfigs, IrisCodePair, TestError, TestRun, TestRunContextInfo,
@@ -159,7 +159,9 @@ impl TestRun for Test {
                 let num_irises = node.cpu_iris_store.count_irises().await.unwrap();
                 assert_eq!(num_irises, max_indexation_id);
 
-                // TODO assert CPU iris database reflects irises updated by new modifications after the first run
+                let cpu_vector_ids = node.get_cpu_iris_vector_ids(1000).await.unwrap();
+                let expected_vector_ids = get_vector_ids(&expected.dst_db.irises);
+                assert_eq!(cpu_vector_ids, expected_vector_ids);
 
                 let num_modifications = node.gpu_iris_store.last_modifications(100).await.unwrap();
                 assert_eq!(num_modifications.len(), MODIFICATIONS.len());

--- a/iris-mpc-upgrade-hawk/tests/workflows/genesis_106/mod.rs
+++ b/iris-mpc-upgrade-hawk/tests/workflows/genesis_106/mod.rs
@@ -1,0 +1,2 @@
+mod runner;
+pub use runner::Test;

--- a/iris-mpc-upgrade-hawk/tests/workflows/mod.rs
+++ b/iris-mpc-upgrade-hawk/tests/workflows/mod.rs
@@ -4,3 +4,4 @@ pub mod genesis_102;
 pub mod genesis_103;
 pub mod genesis_104;
 pub mod genesis_105;
+pub mod genesis_106;


### PR DESCRIPTION
This PR implements the final main genesis e2e test, 106, which combines both deletions and inline modifications during execution.  This PR also tidies up the README entries for tests 105 and 106, and adds functionality for comparing the vector ids of irises present in the node CPU databases and the plaintext genesis state struct.