### PR TITLE
au/phase-metrics-2: Reduce amount of metrics with "histogram"

### DIFF
--- a/iris-mpc-cpu/src/hnsw/searcher.rs
+++ b/iris-mpc-cpu/src/hnsw/searcher.rs
@@ -502,7 +502,10 @@ impl HnswSearcher {
         ef: usize,
         lc: usize,
     ) -> Result<()> {
-        let metrics_labels = [("layer", lc.to_string())];
+        let metrics_labels = [
+            ("histogram", "histogram".to_string()), // Record max/avg/sum.
+            ("layer", lc.to_string()),              // Group metrics by layer.
+        ];
 
         // The set of vectors which have been considered as potential neighbors
         let mut visited = HashSet::<V::VectorRef>::from_iter(W.iter().map(|(e, _eq)| e.clone()));


### PR DESCRIPTION
Follow-up to #1567 

Avoid spamming DataDog with low-level metrics. Instead send aggregations (max / avg / median / sum). See [metrics_exporter_statsd docs](https://docs.rs/metrics-exporter-statsd/latest/metrics_exporter_statsd/#histograms).

We only do this for low-level / high-volume metrics. The other `histogram!` calls report raw values.