### PR TITLE
Temporarily remove PRF check to unblock staging

### DIFF
--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -1525,7 +1525,8 @@ impl HawkHandle {
         HawkSession::state_check([&sessions[0][LEFT][0], &sessions[0][RIGHT][0]]).await?;
 
         // validate that the RNGs have not diverged
-        HawkSession::prf_check(sessions).await?;
+        // TODO: debug serialization issues encountered with this function and then re-enable
+        // HawkSession::prf_check(sessions).await?;
 
         Ok(())
     }


### PR DESCRIPTION
Comments out the call to `HawkSession::prf_check` in the hawk actor health check function, which is causing problems in staging due to a mysterious serialization issue.  This will be re-enabled once we understand the cause of the issue and make any necessary fixes.