### PR TITLE
INFRA-5126: deploy refactored relyance workflow to team infra repositories

### DIFF
--- a/.github/workflows/relyance-sci.yml
+++ b/.github/workflows/relyance-sci.yml
@@ -5,6 +5,9 @@ on:
     - cron: "11 0 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   execute-relyance-sci:
     name: Relyance SCI Job
@@ -13,10 +16,8 @@ jobs:
       contents: read
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Pull and run SCI binary
-        run: |-
-          docker pull gcr.io/relyance-ext/compliance_inspector:release && \
-          docker run --rm -v `pwd`:/repo --env API_KEY='${{ secrets.DPP_SCI_KEY }}' gcr.io/relyance-ext/compliance_inspector:release
+      - name: Run Relyance SCI
+        uses: worldcoin/gh-actions/relyance@main
+        # More information: https://github.com/worldcoin/gh-actions/tree/main/security/relyance
+        with:
+          secrets-dpp-sci-key: ${{ secrets.DPP_SCI_KEY }}


### PR DESCRIPTION
Requestor/Issue: INFRA-5126
Tested (yes/no): yes
Description/Why: I'm refactor how relyance workflows are deployed to github repositories. They update to often, and deploy changes to repos where commit signing is enabled is difficult. This PR add shared relyance sci workflows to gh-actions repo.