### PR TITLE
[POP-2659] Propagate 2D anonymized bucket statistics from actor to server and SNS

### DIFF
--- a/.github/workflows/temp-branch-build-and-push.yaml
+++ b/.github/workflows/temp-branch-build-and-push.yaml
@@ -3,7 +3,7 @@ name: Branch - Build and push docker image
 on:
   push:
     branches:
-      - "POP-2530/implement-anon-stat-change-in-hnsw-that-do-not-count-all-rotations"
+      - "leonidasnanos-pop-2659-2d-hd-and-implementation-of-the-required-wiring"
 
 concurrency:
   group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"

--- a/.test.env
+++ b/.test.env
@@ -19,6 +19,7 @@ SMPC__KMS_KEY_ARNS='["arn:aws:kms:us-east-1:000000000000:key/00000000-0000-0000-
 SMPC__SERVICE_PORTS='["4000","4001","4002"]'
 SMPC__HEALTHCHECK_PORTS='["3000","3001","3002"]'
 SMPC__SHARES_BUCKET_NAME="wf-smpcv2-dev-sns-requests"
+SMPC__SNS_BUFFER_BUCKET_NAME="wf-smpcv2-stage-sns-buffer"
 SMPC__RESULTS_TOPIC_ARN="arn:aws:sns:us-east-1:000000000000:iris-mpc-results.fifo"
 AWS_ENDPOINT_URL=http://localstack:4566
 AWS_ACCESS_KEY_ID=test

--- a/deploy/e2e/iris-mpc-0.yaml.tpl
+++ b/deploy/e2e/iris-mpc-0.yaml.tpl
@@ -187,6 +187,9 @@ iris-mpc-0:
     - name: SMPC__SHARES_BUCKET_NAME
       value: "wf-smpcv2-stage-sns-requests"
 
+    - name: SMPC__SNS_BUFFER_BUCKET_NAME
+      value: "wf-smpcv2-stage-sns-buffer"
+
     - name: SMPC__CLEAR_DB_BEFORE_INIT
       value: "true"
 

--- a/deploy/e2e/iris-mpc-1.yaml.tpl
+++ b/deploy/e2e/iris-mpc-1.yaml.tpl
@@ -187,6 +187,9 @@ iris-mpc-1:
     - name: SMPC__SHARES_BUCKET_NAME
       value: "wf-smpcv2-stage-sns-requests"
 
+    - name: SMPC__SNS_BUFFER_BUCKET_NAME
+      value: "wf-smpcv2-stage-sns-buffer"
+
     - name: SMPC__CLEAR_DB_BEFORE_INIT
       value: "true"
 

--- a/deploy/e2e/iris-mpc-2.yaml.tpl
+++ b/deploy/e2e/iris-mpc-2.yaml.tpl
@@ -187,6 +187,9 @@ iris-mpc-2:
     - name: SMPC__SHARES_BUCKET_NAME
       value: "wf-smpcv2-stage-sns-requests"
 
+    - name: SMPC__SNS_BUFFER_BUCKET_NAME
+      value: "wf-smpcv2-stage-sns-buffer"
+
     - name: SMPC__CLEAR_DB_BEFORE_INIT
       value: "true"
 

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc.yaml
@@ -49,7 +49,7 @@ env:
 
   - name: SMPC__PROCESSING_TIMEOUT_SECS
     value: "120"
-  
+
   - name: SMPC__HEARTBEAT_INITIAL_RETRIES
     value: "65"
 
@@ -70,6 +70,9 @@ env:
 
   - name: SMPC__SHARES_BUCKET_NAME
     value: "wf-smpcv2-stage-sns-requests"
+
+  - name: SMPC__SNS_BUFFER_BUCKET_NAME
+    value: "wf-smpcv2-stage-sns-buffer"
 
   - name: SMPC__ENABLE_S3_IMPORTER
     value: "true"
@@ -157,7 +160,7 @@ env:
   - name: SMPC__ENABLE_MODIFICATIONS_REPLAY
     value: "true"
 
-  - name : SMPC__ENABLE_DEBUG_TIMING
+  - name: SMPC__ENABLE_DEBUG_TIMING
     value: "true"
 
 initContainer:

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc.yaml
@@ -49,7 +49,7 @@ env:
 
   - name: SMPC__PROCESSING_TIMEOUT_SECS
     value: "120"
-  
+
   - name: SMPC__HEARTBEAT_INITIAL_RETRIES
     value: "65"
 
@@ -70,6 +70,9 @@ env:
 
   - name: SMPC__SHARES_BUCKET_NAME
     value: "wf-smpcv2-stage-sns-requests"
+
+  - name: SMPC__SNS_BUFFER_BUCKET_NAME
+    value: "wf-smpcv2-stage-sns-buffer"
 
   - name: SMPC__ENABLE_S3_IMPORTER
     value: "true"
@@ -105,7 +108,7 @@ env:
     value: "10"
 
   - name: SMPC__ENABLE_SENDING_ANONYMIZED_STATS_MESSAGE
-    value: "true"  
+    value: "true"
 
   - name: SMPC__ENABLE_SENDING_MIRROR_ANONYMIZED_STATS_MESSAGE
     value: "true"
@@ -157,7 +160,7 @@ env:
   - name: SMPC__ENABLE_MODIFICATIONS_REPLAY
     value: "true"
 
-  - name : SMPC__ENABLE_DEBUG_TIMING
+  - name: SMPC__ENABLE_DEBUG_TIMING
     value: "true"
 
 initContainer:
@@ -201,7 +204,7 @@ initContainer:
 
       # Execute AWS CLI command with the generated JSON
       aws route53 change-resource-record-sets --hosted-zone-id "$HOSTED_ZONE_ID" --change-batch "$BATCH_JSON"
-      
+
       cd /libs
       aws s3 cp s3://wf-smpcv2-stage-libs/libcublas.so.12.2.5.6 .
       aws s3 cp s3://wf-smpcv2-stage-libs/libcublasLt.so.12.2.5.6 .

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc.yaml
@@ -49,7 +49,7 @@ env:
 
   - name: SMPC__PROCESSING_TIMEOUT_SECS
     value: "120"
-  
+
   - name: SMPC__HEARTBEAT_INITIAL_RETRIES
     value: "65"
 
@@ -71,6 +71,9 @@ env:
   - name: SMPC__SHARES_BUCKET_NAME
     value: "wf-smpcv2-stage-sns-requests"
 
+  - name: SMPC__SNS_BUFFER_BUCKET_NAME
+    value: "wf-smpcv2-stage-sns-buffer"
+
   - name: SMPC__ENABLE_S3_IMPORTER
     value: "true"
 
@@ -85,7 +88,7 @@ env:
 
   - name: SMPC__LOAD_CHUNKS_BUFFER_SIZE
     value: "1024"
-  
+
   - name: SMPC__CLEAR_DB_BEFORE_INIT
     value: "true"
 
@@ -100,7 +103,7 @@ env:
 
   - name: SMPC__MATCH_DISTANCES_BUFFER_SIZE
     value: "64"
-    
+
   - name: SMPC__N_BUCKETS
     value: "10"
 
@@ -157,7 +160,7 @@ env:
   - name: SMPC__ENABLE_MODIFICATIONS_REPLAY
     value: "true"
 
-  - name : SMPC__ENABLE_DEBUG_TIMING
+  - name: SMPC__ENABLE_DEBUG_TIMING
     value: "true"
 
 initContainer:

--- a/iris-mpc-common/src/config/mod.rs
+++ b/iris-mpc-common/src/config/mod.rs
@@ -70,6 +70,9 @@ pub struct Config {
     #[serde(default = "default_shares_bucket_name")]
     pub shares_bucket_name: String,
 
+    #[serde(default = "default_sns_buffer_bucket_name")]
+    pub sns_buffer_bucket_name: String,
+
     #[serde(default)]
     pub clear_db_before_init: bool,
 
@@ -297,6 +300,10 @@ fn default_shutdown_last_results_sync_timeout_secs() -> u64 {
 
 fn default_shares_bucket_name() -> String {
     "wf-mpc-prod-smpcv2-sns-requests".to_string()
+}
+
+fn default_sns_buffer_bucket_name() -> String {
+    "wf-smpcv2-prod-sns-buffer".to_string()
 }
 
 fn default_schema_name() -> String {
@@ -578,6 +585,7 @@ pub struct CommonConfig {
     startup_sync_timeout_secs: u64,
     public_key_base_url: String,
     shares_bucket_name: String,
+    sns_buffer_bucket_name: String,
     clear_db_before_init: bool,
     init_db_size: usize,
     max_db_size: usize,
@@ -644,6 +652,7 @@ impl From<Config> for CommonConfig {
             startup_sync_timeout_secs,
             public_key_base_url,
             shares_bucket_name,
+            sns_buffer_bucket_name,
             clear_db_before_init,
             init_db_size,
             max_db_size,
@@ -712,6 +721,7 @@ impl From<Config> for CommonConfig {
             startup_sync_timeout_secs,
             public_key_base_url,
             shares_bucket_name,
+            sns_buffer_bucket_name,
             clear_db_before_init,
             init_db_size,
             max_db_size,

--- a/iris-mpc-common/src/config/mod.rs
+++ b/iris-mpc-common/src/config/mod.rs
@@ -191,6 +191,9 @@ pub struct Config {
     pub enable_sending_mirror_anonymized_stats_message: bool,
 
     #[serde(default)]
+    pub enable_sending_anonymized_stats_2d_message: bool,
+
+    #[serde(default)]
     pub enable_reauth: bool,
 
     #[serde(default)]
@@ -596,6 +599,7 @@ pub struct CommonConfig {
     n_buckets: usize,
     enable_sending_anonymized_stats_message: bool,
     enable_sending_mirror_anonymized_stats_message: bool,
+    enable_sending_anonymized_stats_2d_message: bool,
     enable_reauth: bool,
     enable_reset: bool,
     hawk_request_parallelism: usize,
@@ -674,6 +678,7 @@ impl From<Config> for CommonConfig {
             n_buckets,
             enable_sending_anonymized_stats_message,
             enable_sending_mirror_anonymized_stats_message,
+            enable_sending_anonymized_stats_2d_message,
             enable_reauth,
             enable_reset,
             hawk_request_parallelism,
@@ -728,6 +733,7 @@ impl From<Config> for CommonConfig {
             n_buckets,
             enable_sending_anonymized_stats_message,
             enable_sending_mirror_anonymized_stats_message,
+            enable_sending_anonymized_stats_2d_message,
             enable_reauth,
             enable_reset,
             hawk_request_parallelism,

--- a/iris-mpc-common/src/helpers/smpc_request.rs
+++ b/iris-mpc-common/src/helpers/smpc_request.rs
@@ -103,6 +103,7 @@ where
 
 pub const IDENTITY_DELETION_MESSAGE_TYPE: &str = "identity_deletion";
 pub const ANONYMIZED_STATISTICS_MESSAGE_TYPE: &str = "anonymized_statistics";
+pub const ANONYMIZED_STATISTICS_2D_MESSAGE_TYPE: &str = "anonymized_statistics_2d";
 pub const CIRCUIT_BREAKER_MESSAGE_TYPE: &str = "circuit_breaker";
 pub const UNIQUENESS_MESSAGE_TYPE: &str = "uniqueness";
 pub const REAUTH_MESSAGE_TYPE: &str = "reauth";

--- a/iris-mpc-common/src/helpers/sqs_s3_helper.rs
+++ b/iris-mpc-common/src/helpers/sqs_s3_helper.rs
@@ -22,10 +22,10 @@ pub async fn upload_file_to_s3(
         .await
     {
         Ok(_) => {
-            tracing::info!("File uploaded successfully.");
+            tracing::info!("File {} uploaded to s3 successfully", key);
         }
         Err(e) => {
-            tracing::error!("Error: Failed to upload file: {:?}", e);
+            tracing::error!("Failed to upload file {} to s3: {:?}", key, e);
             return Err(SharesDecodingError::UploadS3Error);
         }
     }

--- a/iris-mpc-common/src/job.rs
+++ b/iris-mpc-common/src/job.rs
@@ -6,7 +6,7 @@ use crate::helpers::batch_sync::{
 use crate::{
     galois_engine::degree4::{GaloisRingIrisCodeShare, GaloisRingTrimmedMaskCodeShare},
     helpers::{
-        statistics::BucketStatistics,
+        statistics::{BucketStatistics, BucketStatistics2D},
         sync::{Modification, ModificationKey},
     },
     ROTATIONS,
@@ -407,6 +407,9 @@ pub struct ServerJobResult<A = ()> {
     // See struct definition for more details
     pub anonymized_bucket_statistics_left: BucketStatistics,
     pub anonymized_bucket_statistics_right: BucketStatistics,
+    // 2D anonymized statistics across both eyes (only for matches on both sides)
+    // Only for Normal orientation
+    pub anonymized_bucket_statistics_2d: BucketStatistics2D,
     // Mirror orientation bucket statistics
     pub anonymized_bucket_statistics_left_mirror: BucketStatistics,
     pub anonymized_bucket_statistics_right_mirror: BucketStatistics,

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -28,7 +28,7 @@ use iris_mpc_common::{
     config::TlsConfig,
     helpers::{
         smpc_request::{REAUTH_MESSAGE_TYPE, RESET_CHECK_MESSAGE_TYPE, UNIQUENESS_MESSAGE_TYPE},
-        statistics::BucketStatistics,
+        statistics::{BucketStatistics, BucketStatistics2D},
     },
     vector_id::VectorId,
 };
@@ -1154,6 +1154,7 @@ impl HawkResult {
             anonymized_bucket_statistics_right,
             anonymized_bucket_statistics_left_mirror: BucketStatistics::default(), // TODO.
             anonymized_bucket_statistics_right_mirror: BucketStatistics::default(), // TODO.
+            anonymized_bucket_statistics_2d: BucketStatistics2D::default(),        // TODO.
 
             successful_reauths,
             reauth_target_indices: batch.reauth_target_indices,

--- a/iris-mpc/bin/server.rs
+++ b/iris-mpc/bin/server.rs
@@ -1403,6 +1403,7 @@ async fn server_main(config: Config) -> Result<()> {
             mut modifications,
             actor_data: _,
             full_face_mirror_attack_detected,
+            anonymized_bucket_statistics_2d,
         }) = rx.recv().await
         {
             let dummy_deletion_shares = get_dummy_shares_for_deletion(party_id);
@@ -1872,6 +1873,10 @@ async fn server_main(config: Config) -> Result<()> {
                 .await?;
             }
 
+            // Send 2D anonymized statistics if present with their own flag
+            // TODO: create a new message type for 2D anonymized statistics
+            // TODO: create new config flag for 2D anonymized statistics
+        
             shutdown_handler_bg.decrement_batches_pending_completion();
         }
 

--- a/iris-mpc/bin/server.rs
+++ b/iris-mpc/bin/server.rs
@@ -1895,7 +1895,7 @@ async fn server_main(config: Config) -> Result<()> {
                 let s3_key = format!("stats2d/{}_{}.json", now_ms, content_hash);
 
                 upload_file_to_s3(
-                    &config_bg.shares_bucket_name,
+                    &config_bg.sns_buffer_bucket_name,
                     &s3_key,
                     s3_client_bg.clone(),
                     serialized.as_bytes(),

--- a/iris-mpc/bin/server.rs
+++ b/iris-mpc/bin/server.rs
@@ -1890,7 +1890,7 @@ async fn server_main(config: Config) -> Result<()> {
                 )
                 .await?;
             }
-        
+
             shutdown_handler_bg.decrement_batches_pending_completion();
         }
 

--- a/iris-mpc/bin/server.rs
+++ b/iris-mpc/bin/server.rs
@@ -1874,8 +1874,22 @@ async fn server_main(config: Config) -> Result<()> {
             }
 
             // Send 2D anonymized statistics if present with their own flag
-            // TODO: create a new message type for 2D anonymized statistics
-            // TODO: create new config flag for 2D anonymized statistics
+            if config_bg.enable_sending_anonymized_stats_2d_message
+                && !anonymized_bucket_statistics_2d.buckets.is_empty()
+            {
+                tracing::info!("Sending 2D anonymized stats results");
+                let serialized = serde_json::to_string(&anonymized_bucket_statistics_2d)
+                    .wrap_err("failed to serialize 2D anonymized statistics result")?;
+                send_results_to_sns(
+                    vec![serialized],
+                    &metadata,
+                    &sns_client_bg,
+                    &config_bg,
+                    &anonymized_statistics_attributes,
+                    ANONYMIZED_STATISTICS_MESSAGE_TYPE, // TODO: decide on the message type for 2D anonymized statistics
+                )
+                .await?;
+            }
         
             shutdown_handler_bg.decrement_batches_pending_completion();
         }

--- a/iris-mpc/bin/server.rs
+++ b/iris-mpc/bin/server.rs
@@ -1891,7 +1891,7 @@ async fn server_main(config: Config) -> Result<()> {
                 // with 2D stats we were exceeding the SNS message size limit
                 let now_ms = Utc::now().timestamp_millis();
                 let sha = iris_mpc_common::helpers::sha256::sha256_bytes(&serialized);
-                let content_hash =  hex::encode(&sha);
+                let content_hash =  hex::encode(sha);
                 let s3_key = format!("stats2d/{}_{}.json", now_ms, content_hash);
 
                 upload_file_to_s3(

--- a/iris-mpc/bin/server.rs
+++ b/iris-mpc/bin/server.rs
@@ -37,9 +37,9 @@ use iris_mpc_common::{
             decrypt_iris_share, get_iris_data_by_party_id, validate_iris_share,
             CircuitBreakerRequest, IdentityDeletionRequest, ReAuthRequest, ReceiveRequestError,
             ResetCheckRequest, ResetUpdateRequest, SQSMessage, UniquenessRequest,
-            ANONYMIZED_STATISTICS_MESSAGE_TYPE, CIRCUIT_BREAKER_MESSAGE_TYPE,
-            IDENTITY_DELETION_MESSAGE_TYPE, REAUTH_MESSAGE_TYPE, RESET_CHECK_MESSAGE_TYPE,
-            RESET_UPDATE_MESSAGE_TYPE, UNIQUENESS_MESSAGE_TYPE,
+            ANONYMIZED_STATISTICS_2D_MESSAGE_TYPE, ANONYMIZED_STATISTICS_MESSAGE_TYPE,
+            CIRCUIT_BREAKER_MESSAGE_TYPE, IDENTITY_DELETION_MESSAGE_TYPE, REAUTH_MESSAGE_TYPE,
+            RESET_CHECK_MESSAGE_TYPE, RESET_UPDATE_MESSAGE_TYPE, UNIQUENESS_MESSAGE_TYPE,
         },
         smpc_response::{
             create_message_type_attribute_map, IdentityDeletionResult, ReAuthResult,
@@ -892,6 +892,8 @@ async fn server_main(config: Config) -> Result<()> {
         create_message_type_attribute_map(RESET_UPDATE_MESSAGE_TYPE);
     let anonymized_statistics_attributes =
         create_message_type_attribute_map(ANONYMIZED_STATISTICS_MESSAGE_TYPE);
+    let anonymized_statistics_2d_attributes =
+        create_message_type_attribute_map(ANONYMIZED_STATISTICS_2D_MESSAGE_TYPE);
     let identity_deletion_result_attributes =
         create_message_type_attribute_map(IDENTITY_DELETION_MESSAGE_TYPE);
 
@@ -1885,8 +1887,8 @@ async fn server_main(config: Config) -> Result<()> {
                     &metadata,
                     &sns_client_bg,
                     &config_bg,
-                    &anonymized_statistics_attributes,
-                    ANONYMIZED_STATISTICS_MESSAGE_TYPE, // TODO: decide on the message type for 2D anonymized statistics
+                    &anonymized_statistics_2d_attributes,
+                    ANONYMIZED_STATISTICS_2D_MESSAGE_TYPE,
                 )
                 .await?;
             }


### PR DESCRIPTION
### Description
Follow-up PR on the actual implementation of the collection and calculation of the 2D anon stats

### Changes
- Introduced a 2D anonymized statistics data model to represent joint left/right distance buckets.
- Extended the GPU actor to compute, clear between batches, and include 2D stats in its result payload.
- Updated the server to receive the 2D stats and prepare them for SNS publishing.
        - Decided to go with a new message type and attributes so we can forward the 2D messages on their own queue to be consumed by signup-service-worker independently. 
- Scoped to Normal flow; mirror flow and existing 1D stats behavior remain unchanged.

[edit]
- Serialize the computed 2D anonymized statistics into a file and offload this file to S3 to avoid violating the SNS message size limit(256KB). I discovered during testing that with the 2D stats we go over this limit. Solution for this is to offload the paylod in S3 and only publish the key in the SNS message.


(We could try minimizing the size of the 2D stats that need to be sent, by either keep only the ones with count >=1 or use compression. But since we already have an existing S3 bucket for SNS requests (used for shares), which has a cleaning lifecycle policy, its not big of an overhead to proceed with the classic offload-to-S3 pattern )