### PR TITLE
INFRA-5122 Update ampc-hnsw-dev requests and limits

### DIFF
--- a/deploy/dev/common-values-ampc-hnsw.yaml
+++ b/deploy/dev/common-values-ampc-hnsw.yaml
@@ -56,10 +56,10 @@ startupProbe:
 resources:
   limits:
     cpu: "3.5"
-    memory: 120Gi
+    memory: 110Gi
   requests:
     cpu: "3.5"
-    memory: 120Gi
+    memory: 110Gi
 
 imagePullSecrets:
   - name: github-secret


### PR DESCRIPTION
https://linear.app/worldcoin/issue/INFRA-5122/set-up-argocd-for-branch-deployments

Updating due to overreaching instance capabilities

```
Events:
  Type     Reason            Age                 From               Message
  ----     ------            ----                ----               -------
  Warning  FailedScheduling  37m                 default-scheduler  0/4 nodes are available: 2 node(s) had untolerated taint {critical: }, 2 node(s) were unschedulable. preemption: 0/4 nodes are available: 4 Preemption is not helpful for scheduling.
  Warning  FailedScheduling  112s (x7 over 31m)  default-scheduler  0/4 nodes are available: 2 node(s) had untolerated taint {critical: }, 2 node(s) were unschedulable. preemption: 0/4 nodes are available: 4 Preemption is not helpful for scheduling.
  Warning  FailedScheduling  99s (x8 over 37m)   karpenter          Failed to schedule pod, incompatible with nodepool "main-arm64", daemonset overhead={"cpu":"190m","memory":"140Mi","pods":"7"}, incompatible requirements, key kubernetes.io/arch, kubernetes.io/arch In [amd64] not in kubernetes.io/arch In [arm64]; incompatible with nodepool "main-amd64", daemonset overhead={"cpu":"190m","memory":"140Mi","pods":"7"}, no instance type satisfied resources {"cpu":"3690m","memory":"123020Mi","pods":"8","vpc.amazonaws.com/pod-eni":"1"} and requirements karpenter.k8s.aws/ec2nodeclass In [default], karpenter.k8s.aws/instance-category In [c m r], karpenter.k8s.aws/instance-cpu In [16 2 32 4 48 and 1 others], karpenter.k8s.aws/instance-hypervisor In [nitro], karpenter.sh/capacity-type In [on-demand], karpenter.sh/nodepool In [main-amd64], kubernetes.io/arch In [amd64], kubernetes.io/os In [linux], node.kubernetes.io/instance-type In [x2iedn.xlarge] (no instance type met all requirements); incompatible with nodepool "hnsw-arm64", daemonset overhead={"cpu":"190m","memory":"140Mi","pods":"7"}, incompatible requirements, key kubernetes.io/arch, kubernetes.io/arch In [amd64] not in kubernetes.io/arch In [arm64]; incompatible with nodepool "hnsw-amd64", daemonset overhead={"cpu":"190m","memory":"140Mi","pods":"7"}, no instance type satisfied resources {"cpu":"3690m","memory":"123020Mi","pods":"8","vpc.amazonaws.com/pod-eni":"1"} and requirements karpenter.k8s.aws/ec2nodeclass In [default], karpenter.k8s.aws/instance-category In [x], karpenter.k8s.aws/instance-cpu In [128 16 32 4 48 and 3 others], karpenter.k8s.aws/instance-hypervisor In [nitro], karpenter.sh/capacity-type In [on-demand], karpenter.sh/nodepool In [hnsw-amd64], kubernetes.io/arch In [amd64], kubernetes.io/os In [linux], node.kubernetes.io/instance-type In [x2iedn.xlarge] (no instance type which had enough resources and the required offering met the scheduling requirements)
```