### PR TITLE
[POP-2845] Less alloc in MPC primitives 

### DIFF
--- a/iris-mpc-cpu/src/protocol/binary.rs
+++ b/iris-mpc-cpu/src/protocol/binary.rs
@@ -752,9 +752,12 @@ where
         // We anticipate concatenations to allocate vecs with the correct capacity
         // and minimize cloning/collecting
 
-        let mut even_p_with_even_g = Vec::with_capacity(temp_p.len() / 2 + temp_g.len() / 2 + 1);
+        // To assess correctness of these sizes, note that the encompassing while loop
+        // maintains the invariant `temp_g.len() - 1 = temp_p.len()`
+
+        let mut even_p_with_even_g = Vec::with_capacity(temp_g.len() - 1);
         let mut odd_p_temp = Vec::with_capacity(temp_p.len() / 2 + 1);
-        let mut odd_g = Vec::with_capacity(temp_g.len() / 2 + 1);
+        let mut odd_g = Vec::with_capacity(temp_g.len() / 2);
 
         for (i, p) in temp_p.into_iter().enumerate() {
             if i % 2 == 1 {

--- a/iris-mpc-cpu/src/protocol/binary.rs
+++ b/iris-mpc-cpu/src/protocol/binary.rs
@@ -738,6 +738,56 @@ where
     let mut temp_p = p.drain(1..).collect::<Vec<_>>();
     let mut temp_g = g;
 
+    // while temp_g.len() != 1 {
+    //     let (maybe_extra_p, maybe_extra_g) = if temp_g.len() % 2 == 1 {
+    //         (temp_p.pop(), temp_g.pop())
+    //     } else {
+    //         (None, None)
+    //     };
+
+    //     // Split the vectors into even and odd indexed elements
+    //     // Note that the starting index of temp_p is 1 due to removal of p0 above
+    //     let (even_p, odd_p): (Vec<_>, Vec<_>) = temp_p
+    //         .clone()
+    //         .into_iter()
+    //         .enumerate()
+    //         .partition(|(i, _)| i % 2 == 1);
+    //     let even_p: Vec<_> = even_p.into_iter().map(|(_, x)| x).collect();
+    //     let odd_p: Vec<_> = odd_p.into_iter().map(|(_, x)| x).collect();
+    //     let (even_g, odd_g): (Vec<_>, Vec<_>) = temp_g
+    //         .clone()
+    //         .into_iter()
+    //         .enumerate()
+    //         .partition(|(i, _)| i % 2 == 0);
+    //     let even_g: Vec<_> = even_g.into_iter().map(|(_, x)| x).collect();
+    //     let odd_g: Vec<_> = odd_g.into_iter().map(|(_, x)| x).collect();
+
+    //     // Merge even_p and even_g to multiply them by odd_p at once
+    //     // This corresponds to computing
+    //     //            (p2 AND p3, p4 AND p5,...) and
+    //     // (g0 AND p1, g2 AND p3, g4 AND p5,...) as above
+    //     let mut even_p_with_even_g = even_p;
+    //     let new_p_len = even_p_with_even_g.len();
+    //     even_p_with_even_g.extend(even_g);
+    //     // Remove p1 to multiply even_p with odd_p
+    //     let mut odd_p_doubled = odd_p[1..].to_vec();
+    //     odd_p_doubled.extend(odd_p);
+
+    //     let mut tmp = transposed_pack_and(session, even_p_with_even_g, odd_p_doubled).await?;
+
+    //     // Update p
+    //     temp_p = tmp.drain(..new_p_len).collect();
+    //     if let Some(extra_p) = maybe_extra_p {
+    //         temp_p.push(extra_p);
+    //     }
+
+    //     // Finish computing (g1 XOR g0 AND p1, g3 XOR g2 AND p3,...) and update g
+    //     temp_g = transposed_pack_xor(&tmp, &odd_g);
+    //     if let Some(extra_g) = maybe_extra_g {
+    //         temp_g.push(extra_g);
+    //     }
+    // }
+
     while temp_g.len() != 1 {
         let (maybe_extra_p, maybe_extra_g) = if temp_g.len() % 2 == 1 {
             (temp_p.pop(), temp_g.pop())
@@ -745,33 +795,41 @@ where
             (None, None)
         };
 
-        // Split the vectors into even and odd indexed elements
-        // Note that the starting index of temp_p is 1 due to removal of p0 above
-        let (even_p, odd_p): (Vec<_>, Vec<_>) = temp_p
-            .clone()
-            .into_iter()
-            .enumerate()
-            .partition(|(i, _)| i % 2 == 1);
-        let even_p: Vec<_> = even_p.into_iter().map(|(_, x)| x).collect();
-        let odd_p: Vec<_> = odd_p.into_iter().map(|(_, x)| x).collect();
-        let (even_g, odd_g): (Vec<_>, Vec<_>) = temp_g
-            .clone()
-            .into_iter()
-            .enumerate()
-            .partition(|(i, _)| i % 2 == 0);
-        let even_g: Vec<_> = even_g.into_iter().map(|(_, x)| x).collect();
-        let odd_g: Vec<_> = odd_g.into_iter().map(|(_, x)| x).collect();
+        // --- Optimized Section ---
 
-        // Merge even_p and even_g to multiply them by odd_p at once
-        // This corresponds to computing
-        //            (p2 AND p3, p4 AND p5,...) and
-        // (g0 AND p1, g2 AND p3, g4 AND p5,...) as above
-        let mut even_p_with_even_g = even_p;
+        // Pre-allocate vectors with calculated capacity to avoid reallocations.
+        let mut even_p_with_even_g = Vec::with_capacity(temp_p.len() / 2 + temp_g.len() / 2 + 1);
+        let mut odd_p_temp = Vec::with_capacity(temp_p.len() / 2 + 1);
+        let mut odd_g = Vec::with_capacity(temp_g.len() / 2 + 1);
+
+        // Consume temp_p once to populate even_p and odd_p parts.
+        for (i, p) in temp_p.into_iter().enumerate() {
+            if i % 2 == 1 {
+                // This corresponds to the original `even_p`
+                even_p_with_even_g.push(p);
+            } else {
+                odd_p_temp.push(p);
+            }
+        }
         let new_p_len = even_p_with_even_g.len();
-        even_p_with_even_g.extend(even_g);
-        // Remove p1 to multiply even_p with odd_p
-        let mut odd_p_doubled = odd_p[1..].to_vec();
-        odd_p_doubled.extend(odd_p);
+
+        // Consume temp_g once to populate even_g and odd_g parts.
+        for (i, g) in temp_g.into_iter().enumerate() {
+            if i % 2 == 0 {
+                // This corresponds to the original `even_g`
+                even_p_with_even_g.push(g);
+            } else {
+                odd_g.push(g);
+            }
+        }
+
+        // Build `odd_p_doubled` efficiently from `odd_p_temp`.
+        // This avoids creating an intermediate vector from a slice.
+        let mut odd_p_doubled = Vec::with_capacity(odd_p_temp.len() * 2 - 1);
+        odd_p_doubled.extend(odd_p_temp.iter().skip(1).cloned());
+        odd_p_doubled.extend(odd_p_temp); // `odd_p_temp` is moved here
+
+        // --- End Optimized Section ---
 
         let mut tmp = transposed_pack_and(session, even_p_with_even_g, odd_p_doubled).await?;
 
@@ -781,7 +839,7 @@ where
             temp_p.push(extra_p);
         }
 
-        // Finish computing (g1 XOR g0 AND p1, g3 XOR g2 AND p3,...) and update g
+        // Finish computing and update g
         temp_g = transposed_pack_xor(&tmp, &odd_g);
         if let Some(extra_g) = maybe_extra_g {
             temp_g.push(extra_g);

--- a/iris-mpc-cpu/src/shares/vecshare.rs
+++ b/iris-mpc-cpu/src/shares/vecshare.rs
@@ -148,10 +148,8 @@ impl<T: IntRing2k> VecShare<T> {
         Self { shares }
     }
 
-    pub fn flatten(inp: Vec<Self>) -> Self {
-        Self {
-            shares: inp.into_iter().flat_map(|x| x.shares).collect(),
-        }
+    pub fn flatten(inp: Vec<Self>) -> impl Iterator<Item = Share<T>> {
+        inp.into_iter().flat_map(|x| x.shares)
     }
 
     pub fn convert_to_bits(self) -> VecShare<Bit> {

--- a/iris-mpc-cpu/src/shares/vecshare.rs
+++ b/iris-mpc-cpu/src/shares/vecshare.rs
@@ -148,6 +148,14 @@ impl<T: IntRing2k> VecShare<T> {
         Self { shares }
     }
 
+    pub fn from_iter_ab(
+        a: impl Iterator<Item = RingElement<T>>,
+        b: impl Iterator<Item = RingElement<T>>,
+    ) -> Self {
+        let shares = a.zip(b).map(|(a_, b_)| Share::new(a_, b_)).collect();
+        Self { shares }
+    }
+
     pub fn flatten(inp: Vec<Self>) -> impl Iterator<Item = Share<T>> {
         inp.into_iter().flat_map(|x| x.shares)
     }


### PR DESCRIPTION
See [POP-2845](https://linear.app/worldcoin/issue/POP-2845/less-allocation-in-mpc-primitives).