### PR TITLE
Fix off-by-one error in serial ids for init-test-dbs graphs

### DIFF
--- a/iris-mpc-cpu/bin/init_test_dbs.rs
+++ b/iris-mpc-cpu/bin/init_test_dbs.rs
@@ -370,7 +370,7 @@ async fn main() -> Result<()> {
                 }
                 let query = Arc::new(raw_query.iris_code);
 
-                let inserted_id = IrisVectorId::from_0_index(serial_id);
+                let inserted_id = IrisVectorId::from_serial_id(serial_id);
                 vector_store.insert_with_id(inserted_id, query.clone());
 
                 let insertion_layer = searcher.select_layer_prf(&prf_seed, &(inserted_id, side))?;


### PR DESCRIPTION
In the `init-test-dbs` binary, the use of an incorrect function for defining serial ids during graph construction resulted in serial ids for graphs being incremented one time too many, so that recorded serial ids for graph nodes started at 2 rather than 1.  (Constructed graphs seem to still be valid up to this re-labeling.)  This bug appears to have been introduced when support for insertion of nodes with specified serial ids was added, so graphs generated using older versions of the binary would not have been affected.