### PR TITLE
au/borrow-iris: Avoid Arc::clone and Vec in dot product workers (POP-2853)

### DIFF
--- a/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
@@ -359,12 +359,7 @@ mod tests {
 
         for i in 0..database_size {
             let vector_id = VectorId::from_0_index(i as u32);
-            let query = cleartext_data
-                .0
-                .storage
-                .get_vector(&vector_id)
-                .unwrap()
-                .clone();
+            let query = cleartext_data.0.storage.get_vector(&vector_id).unwrap();
             let cleartext_neighbors = hawk_searcher
                 .search(&mut cleartext_data.0, &cleartext_data.1, &query, 1)
                 .await?;

--- a/iris-mpc-cpu/src/hawkers/plaintext_store.rs
+++ b/iris-mpc-cpu/src/hawkers/plaintext_store.rs
@@ -128,7 +128,7 @@ impl VectorStore for PlaintextStore {
     async fn vectors_as_queries(&mut self, vectors: Vec<Self::VectorRef>) -> Vec<Self::QueryRef> {
         vectors
             .iter()
-            .map(|id| self.storage.get_vector(id).unwrap().clone())
+            .map(|id| self.storage.get_vector(id).unwrap())
             .collect()
     }
 
@@ -139,9 +139,9 @@ impl VectorStore for PlaintextStore {
     ) -> Result<Self::DistanceRef> {
         debug!(event_type = EvaluateDistance.id());
         let serial_id = vector.serial_id();
-        let vector_code = &self
+        let vector_code = self
             .storage
-            .get_vector(vector)
+            .borrow_vector(vector)
             .ok_or_else(|| eyre::eyre!("Vector ID not found in store for serial {}", serial_id))?;
         Ok(query.get_distance_fraction(vector_code))
     }
@@ -227,7 +227,7 @@ impl VectorStore for SharedPlaintextStore {
         let store = self.storage.read().await;
         vectors
             .iter()
-            .map(|id| store.get_vector(id).unwrap().clone())
+            .map(|id| store.get_vector(id).unwrap())
             .collect()
     }
 
@@ -240,9 +240,9 @@ impl VectorStore for SharedPlaintextStore {
         let store = self.storage.read().await;
         let serial_id = vector.serial_id();
         let vector_code = store
-            .get_vector(vector)
+            .borrow_vector(vector)
             .ok_or_else(|| eyre::eyre!("Vector ID not found in store for serial {}", serial_id))?;
-        Ok(query.get_distance_fraction(&vector_code))
+        Ok(query.get_distance_fraction(vector_code))
     }
 
     async fn is_match(&mut self, distance: &Self::DistanceRef) -> Result<bool> {
@@ -370,7 +370,7 @@ mod tests {
         for i in 0..database_size {
             let serial_id = i as u32 + 1;
             let vector_id = VectorId::from_serial_id(serial_id);
-            let query = ptxt_vector.storage.get_vector(&vector_id).unwrap().clone();
+            let query = ptxt_vector.storage.get_vector(&vector_id).unwrap();
             let cleartext_neighbors = searcher
                 .search(&mut ptxt_vector, &ptxt_graph, &query, 1)
                 .await?;

--- a/iris-mpc-cpu/src/hawkers/shared_irises.rs
+++ b/iris-mpc-cpu/src/hawkers/shared_irises.rs
@@ -110,8 +110,12 @@ impl<I: Clone> SharedIrises<I> {
     }
 
     pub fn get_vector(&self, vector: &VectorId) -> Option<I> {
+        self.borrow_vector(vector).cloned()
+    }
+
+    pub fn borrow_vector(&self, vector: &VectorId) -> Option<&I> {
         match self.points.get(&vector.serial_id()) {
-            Some((version, iris)) if vector.version_matches(*version) => Some(iris.clone()),
+            Some((version, iris)) if vector.version_matches(*version) => Some(iris),
             _ => None,
         }
     }

--- a/iris-mpc-cpu/src/protocol/ops.rs
+++ b/iris-mpc-cpu/src/protocol/ops.rs
@@ -396,17 +396,29 @@ pub async fn cross_compare_and_swap(
     conditionally_select_distance(session, distances, u32_bits.as_slice()).await
 }
 
-/// Computes the dot product between the iris pairs; for both the code and the
-/// mask of the irises. We pack the dot products of the code and mask into one
-/// vector to be able to reshare it later.
+/// See pairwise_distance.
+/// This variant takes as input a Vec of Arc.
 pub fn galois_ring_pairwise_distance(
     pairs: Vec<Option<(ArcIris, ArcIris)>>,
 ) -> Vec<RingElement<u16>> {
-    let start = Instant::now();
+    pairwise_distance(pairs.iter().map(|opt| opt.as_ref().map(|(x, y)| (x, y))))
+}
 
+/// Computes the dot product between the iris pairs; for both the code and the
+/// mask of the irises. We pack the dot products of the code and mask into one
+/// vector to be able to reshare it later.
+/// This function takes an iterator of known size.
+pub fn pairwise_distance<'a, I>(pairs: I) -> Vec<RingElement<u16>>
+where
+    I: Iterator<Item = Option<(&'a ArcIris, &'a ArcIris)>> + ExactSizeIterator,
+{
+    let start = Instant::now();
+    let mut count = 0;
     let mut additive_shares = Vec::with_capacity(2 * pairs.len());
-    for pair in pairs.iter() {
+
+    for pair in pairs {
         let (code_dist, mask_dist) = if let Some((x, y)) = pair {
+            count += 1;
             let (a, b) = (x.code.trick_dot(&y.code), x.mask.trick_dot(&y.mask));
             (RingElement(a), RingElement(2) * RingElement(b))
         } else {
@@ -421,7 +433,7 @@ pub fn galois_ring_pairwise_distance(
         additive_shares.push(mask_dist);
     }
 
-    let batch_size = pairs.iter().filter(|x| x.is_some()).count() as f64;
+    let batch_size = count as f64;
     let duration = start.elapsed().as_secs_f64() / batch_size;
     histogram!("pairwise_distance.batch_size", "histogram" => "histogram").record(batch_size);
     histogram!("pairwise_distance.per_pair_duration", "histogram" => "histogram").record(duration);


### PR DESCRIPTION
Avoid costly `Arc::clone` and `Vec` allocations in Iris workers. We can use iterators and references instead.