### PR TITLE
Use different schema in hnsw e2e

### DIFF
--- a/deploy/e2e/hnsw-smpc-0.yaml.tpl
+++ b/deploy/e2e/hnsw-smpc-0.yaml.tpl
@@ -133,6 +133,9 @@ hnsw-smpc-0:
           key: DATABASE_AURORA_HNSW_URL
           name: application
 
+    - name: SMPC__HNSW_SCHEMA_NAME_SUFFIX
+      value: "_hnsw"
+
     - name: SMPC__MAX_DB_SIZE
       value: "100000"
 

--- a/deploy/e2e/hnsw-smpc-1.yaml.tpl
+++ b/deploy/e2e/hnsw-smpc-1.yaml.tpl
@@ -137,6 +137,9 @@ hnsw-smpc-1:
           key: DATABASE_AURORA_HNSW_URL
           name: application
 
+    - name: SMPC__HNSW_SCHEMA_NAME_SUFFIX
+      value: "_hnsw"
+
     - name: SMPC__MAX_DB_SIZE
       value: "100000"
 

--- a/deploy/e2e/hnsw-smpc-2.yaml.tpl
+++ b/deploy/e2e/hnsw-smpc-2.yaml.tpl
@@ -137,6 +137,9 @@ hnsw-smpc-2:
           key: DATABASE_AURORA_HNSW_URL
           name: application
 
+    - name: SMPC__HNSW_SCHEMA_NAME_SUFFIX
+      value: "_hnsw"
+
     - name: SMPC__MAX_DB_SIZE
       value: "100000"
 


### PR DESCRIPTION
## Change
- We used to use the same database instance in e2e tests. Therefore, GPU and HNSW were trying to use the same `irises` table to handle their operations which ends up with crashes due to primary key violations
- This PR lets HNSW use a different schema in the same db instance to resolve the issue