### PR TITLE
Do not run key-manager in hnsw e2e pod init

### DIFF
--- a/deploy/e2e/hnsw-smpc-0.yaml.tpl
+++ b/deploy/e2e/hnsw-smpc-0.yaml.tpl
@@ -272,8 +272,10 @@ hnsw-smpc-0:
         #!/usr/bin/env bash
         set -e
 
-        key-manager --node-id 0 --env $ENV --region $AWS_REGION --endpoint-url "http://localstack:4566" rotate --public-key-bucket-name wf-$ENV-public-keys
-        key-manager --node-id 0 --env $ENV --region $AWS_REGION --endpoint-url "http://localstack:4566" rotate --public-key-bucket-name wf-$ENV-public-keys
+        # CPU and GPU versions use the same encryption keys in e2e. Commenting this out to avoid race conditions which end up with unseal errors in one of the systems.
+        # Currently, we rely on GPU pod's init container to do the key rotation. Uncomment this once GPU is deprecated.
+        # key-manager --node-id 0 --env $ENV --region $AWS_REGION --endpoint-url "http://localstack:4566" rotate --public-key-bucket-name wf-$ENV-public-keys
+        # key-manager --node-id 0 --env $ENV --region $AWS_REGION --endpoint-url "http://localstack:4566" rotate --public-key-bucket-name wf-$ENV-public-keys
 
         # Set up environment variables
         HOSTED_ZONE_ID=$(aws route53 list-hosted-zones-by-name --region $AWS_REGION --dns-name orb.e2e.test --query "HostedZones[].Id" --output text)

--- a/deploy/e2e/hnsw-smpc-1.yaml.tpl
+++ b/deploy/e2e/hnsw-smpc-1.yaml.tpl
@@ -276,8 +276,10 @@ hnsw-smpc-1:
         #!/usr/bin/env bash
         set -e
 
-        key-manager --node-id 1 --env $ENV --region $AWS_REGION --endpoint-url "http://localstack:4566" rotate --public-key-bucket-name wf-$ENV-public-keys
-        key-manager --node-id 1 --env $ENV --region $AWS_REGION --endpoint-url "http://localstack:4566" rotate --public-key-bucket-name wf-$ENV-public-keys
+        # CPU and GPU versions use the same encryption keys in e2e. Commenting this out to avoid race conditions which end up with unseal errors in one of the systems.
+        # Currently, we rely on GPU pod's init container to do the key rotation. Uncomment this once GPU is deprecated.
+        # key-manager --node-id 1 --env $ENV --region $AWS_REGION --endpoint-url "http://localstack:4566" rotate --public-key-bucket-name wf-$ENV-public-keys
+        # key-manager --node-id 1 --env $ENV --region $AWS_REGION --endpoint-url "http://localstack:4566" rotate --public-key-bucket-name wf-$ENV-public-keys
 
         # Set up environment variables
         HOSTED_ZONE_ID=$(aws route53 list-hosted-zones-by-name --region $AWS_REGION --dns-name orb.e2e.test --query "HostedZones[].Id" --output text)

--- a/deploy/e2e/hnsw-smpc-2.yaml.tpl
+++ b/deploy/e2e/hnsw-smpc-2.yaml.tpl
@@ -276,8 +276,10 @@ hnsw-smpc-2:
         #!/usr/bin/env bash
         set -e
 
-        key-manager --node-id 2 --env $ENV --region $AWS_REGION --endpoint-url "http://localstack:4566" rotate --public-key-bucket-name wf-$ENV-public-keys
-        key-manager --node-id 2 --env $ENV --region $AWS_REGION --endpoint-url "http://localstack:4566" rotate --public-key-bucket-name wf-$ENV-public-keys
+        # CPU and GPU versions use the same encryption keys in e2e. Commenting this out to avoid race conditions which end up with unseal errors in one of the systems.
+        # Currently, we rely on GPU pod's init container to do the key rotation. Uncomment this once GPU is deprecated.
+        # key-manager --node-id 2 --env $ENV --region $AWS_REGION --endpoint-url "http://localstack:4566" rotate --public-key-bucket-name wf-$ENV-public-keys
+        # key-manager --node-id 2 --env $ENV --region $AWS_REGION --endpoint-url "http://localstack:4566" rotate --public-key-bucket-name wf-$ENV-public-keys
 
         # Set up environment variables
         HOSTED_ZONE_ID=$(aws route53 list-hosted-zones-by-name --region $AWS_REGION --dns-name orb.e2e.test --query "HostedZones[].Id" --output text)


### PR DESCRIPTION
## Change
- In e2e tests, CPU and GPU versions used to run the key-manager which writes into the same localstack resources. This causes a race condition which ends up with unseal (decryption) errors in one of the versions
- This PR leaves the key-manager execution to GPU only to avoid the race condition. We can bring hnsw key-manager back once GPU is deprecated