### PR TITLE
INFRA-5165 Update bucket name for ampc-hnsw-dev

### DIFF
--- a/deploy/dev/ampc-hnsw-0-dev/values-ampc-hnsw.yaml
+++ b/deploy/dev/ampc-hnsw-0-dev/values-ampc-hnsw.yaml
@@ -81,7 +81,7 @@ env:
     value: '["0.0.0.0","node.1.dev.hnsw.worldcoin.dev","node.2.dev.hnsw.worldcoin.dev"]'
 
   - name: SMPC__SHARES_BUCKET_NAME
-    value: "wf-smpcv2-dev-sns-requests"
+    value: "wf-smpcv2-dev-sns-requests-v2"
 
   - name: SMPC__ENABLE_S3_IMPORTER
     value: "false"

--- a/deploy/dev/ampc-hnsw-1-dev/values-ampc-hnsw.yaml
+++ b/deploy/dev/ampc-hnsw-1-dev/values-ampc-hnsw.yaml
@@ -81,7 +81,7 @@ env:
     value: '["node.0.dev.hnsw.worldcoin.dev", "0.0.0.0", "node.2.dev.hnsw.worldcoin.dev"]'
 
   - name: SMPC__SHARES_BUCKET_NAME
-    value: "wf-smpcv2-dev-sns-requests"
+    value: "wf-smpcv2-dev-sns-requests-v2"
 
   - name: SMPC__ENABLE_S3_IMPORTER
     value: "false"

--- a/deploy/dev/ampc-hnsw-2-dev/values-ampc-hnsw.yaml
+++ b/deploy/dev/ampc-hnsw-2-dev/values-ampc-hnsw.yaml
@@ -81,7 +81,7 @@ env:
     value: '["node.0.dev.hnsw.worldcoin.dev","node.1.dev.hnsw.worldcoin.dev","0.0.0.0"]'
 
   - name: SMPC__SHARES_BUCKET_NAME
-    value: "wf-smpcv2-dev-sns-requests"
+    value: "wf-smpcv2-dev-sns-requests-v2"
 
   - name: SMPC__ENABLE_S3_IMPORTER
     value: "false"


### PR DESCRIPTION
https://linear.app/worldcoin/issue/INFRA-5165/add-sqss-to-smpc-io-dev-for-hnsw-mpc-result

Because suggested bucket name is taken
<img width="1206" height="221" alt="image" src="https://github.com/user-attachments/assets/fc82c600-76da-42a5-a868-7002d1fb6e8e" />
