### PR TITLE
Consolidate GPU and CPU e2e configs

### DIFF
--- a/deploy/e2e/hnsw-smpc-0.yaml.tpl
+++ b/deploy/e2e/hnsw-smpc-0.yaml.tpl
@@ -167,7 +167,7 @@ hnsw-smpc-0:
       value: "16"
 
     - name: SMPC__ENABLE_SENDING_ANONYMIZED_STATS_MESSAGE
-      value: "false"
+      value: "true"
 
     - name: SMPC__HAWK_SERVER_REAUTHS_ENABLED
       value: "false"
@@ -182,10 +182,10 @@ hnsw-smpc-0:
       value: "true"
 
     - name: SMPC__LUC_LOOKBACK_RECORDS
-      value: "5"
+      value: "0"
 
     - name: SMPC__LUC_SERIAL_IDS_FROM_SMPC_REQUEST
-      value: "false"
+      value: "true"
 
     - name: SMPC__AWS__REGION
       value: "$AWS_REGION"

--- a/deploy/e2e/hnsw-smpc-1.yaml.tpl
+++ b/deploy/e2e/hnsw-smpc-1.yaml.tpl
@@ -171,7 +171,7 @@ hnsw-smpc-1:
       value: "16"
 
     - name: SMPC__ENABLE_SENDING_ANONYMIZED_STATS_MESSAGE
-      value: "false"
+      value: "true"
 
     - name: SMPC__HAWK_SERVER_REAUTHS_ENABLED
       value: "false"
@@ -186,10 +186,10 @@ hnsw-smpc-1:
       value: "true"
 
     - name: SMPC__LUC_LOOKBACK_RECORDS
-      value: "5"
+      value: "0"
 
     - name: SMPC__LUC_SERIAL_IDS_FROM_SMPC_REQUEST
-      value: "false"
+      value: "true"
 
     - name: SMPC__AWS__REGION
       value: "$AWS_REGION"

--- a/deploy/e2e/hnsw-smpc-2.yaml.tpl
+++ b/deploy/e2e/hnsw-smpc-2.yaml.tpl
@@ -171,7 +171,7 @@ hnsw-smpc-2:
       value: "16"
 
     - name: SMPC__ENABLE_SENDING_ANONYMIZED_STATS_MESSAGE
-      value: "false"
+      value: "true"
 
     - name: SMPC__HAWK_SERVER_REAUTHS_ENABLED
       value: "false"
@@ -186,10 +186,10 @@ hnsw-smpc-2:
       value: "true"
 
     - name: SMPC__LUC_LOOKBACK_RECORDS
-      value: "5"
+      value: "0"
 
     - name: SMPC__LUC_SERIAL_IDS_FROM_SMPC_REQUEST
-      value: "false"
+      value: "true"
 
     - name: SMPC__AWS__REGION
       value: "$AWS_REGION"

--- a/deploy/e2e/iris-mpc-0.yaml.tpl
+++ b/deploy/e2e/iris-mpc-0.yaml.tpl
@@ -200,7 +200,7 @@ iris-mpc-0:
       value: "10000"
 
     - name: SMPC__MAX_BATCH_SIZE
-      value: "64"
+      value: "1"
 
     - name: SMPC__MATCH_DISTANCES_BUFFER_SIZE
       value: "64"

--- a/deploy/e2e/iris-mpc-1.yaml.tpl
+++ b/deploy/e2e/iris-mpc-1.yaml.tpl
@@ -200,7 +200,7 @@ iris-mpc-1:
       value: "10000"
 
     - name: SMPC__MAX_BATCH_SIZE
-      value: "64"
+      value: "1"
 
     - name: SMPC__MATCH_DISTANCES_BUFFER_SIZE
       value: "64"

--- a/deploy/e2e/iris-mpc-2.yaml.tpl
+++ b/deploy/e2e/iris-mpc-2.yaml.tpl
@@ -200,7 +200,7 @@ iris-mpc-2:
       value: "10000"
 
     - name: SMPC__MAX_BATCH_SIZE
-      value: "64"
+      value: "1"
 
     - name: SMPC__MATCH_DISTANCES_BUFFER_SIZE
       value: "64"


### PR DESCRIPTION
## Change
- GPU and CPU (HNSW) e2e configs were deviating and this was causing mismatches
- Updated CPU configs by copying from GPU
- Updated GPU max batch size to 1 to have healthy comparisons