### PR TITLE
Revert e2e iris-mpc GPU max batch size to 64

### DIFF
--- a/deploy/e2e/iris-mpc-0.yaml.tpl
+++ b/deploy/e2e/iris-mpc-0.yaml.tpl
@@ -200,7 +200,7 @@ iris-mpc-0:
       value: "10000"
 
     - name: SMPC__MAX_BATCH_SIZE
-      value: "1"
+      value: "64"
 
     - name: SMPC__MATCH_DISTANCES_BUFFER_SIZE
       value: "64"

--- a/deploy/e2e/iris-mpc-1.yaml.tpl
+++ b/deploy/e2e/iris-mpc-1.yaml.tpl
@@ -200,7 +200,7 @@ iris-mpc-1:
       value: "10000"
 
     - name: SMPC__MAX_BATCH_SIZE
-      value: "1"
+      value: "64"
 
     - name: SMPC__MATCH_DISTANCES_BUFFER_SIZE
       value: "64"

--- a/deploy/e2e/iris-mpc-2.yaml.tpl
+++ b/deploy/e2e/iris-mpc-2.yaml.tpl
@@ -200,7 +200,7 @@ iris-mpc-2:
       value: "10000"
 
     - name: SMPC__MAX_BATCH_SIZE
-      value: "1"
+      value: "64"
 
     - name: SMPC__MATCH_DISTANCES_BUFFER_SIZE
       value: "64"


### PR DESCRIPTION
## Change
- iris-mpc GPU expects a certain max batch size and max rotations pair to pass [this check](https://github.com/worldcoin/iris-mpc/blob/f209e6e9b4195c766f7accf465f5d69c59e9157f/iris-mpc-gpu/src/server/actor.rs#L406-L410). With batch size = 1, we get below error:
`Panic occurred with message: assertion left == right failed: Phase2 batch chunk size must be a multiple of 64. left: 1, right: 0`
- Let's revert it back to 64. GPU execution is fast and it always uses batch size 1 in practice.


