### PR TITLE
Use x86_64 arch in CPU pipeline

### DIFF
--- a/.github/workflows/build-and-push-hawk-server.yaml
+++ b/.github/workflows/build-and-push-hawk-server.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - e2e/templates-for-hnsw-e2e
+      - chore/fix-cpu-pipeline
   release:
     types:
       - 'published'
@@ -50,7 +50,7 @@ jobs:
             ${{ env.REGISTRY }}/worldcoin/${{ env.IMAGE_NAME }}:latest
           platforms: linux/amd64
           build-args: |
-            ARCHITECTURE=aarch64
+            ARCHITECTURE=x86_64
           cache-from: type=gha
           cache-to: type=gha,mode=max
           file: Dockerfile.hawk


### PR DESCRIPTION
## Change
- CPU seems to use processors with x86_64 arch rather than arm processors. This PR updates it