### PR TITLE
[POP-2885] Unify image tagging and image build pipeline trigger in GPU and CPU

### DIFF
--- a/.github/workflows/build-and-push-hawk-server.yaml
+++ b/.github/workflows/build-and-push-hawk-server.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - chore/tag-hnsw-images-with-versions
   release:
     types:
       - 'published'

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - chore/tag-hnsw-images-with-versions
   release:
     types:
       - 'published'


### PR DESCRIPTION
## Change
- Once we get a release, images are tagged with the release version. This makes it easier for us to track which version is being run in various environments. 
- HNSW pipeline does not have those version tags. This PR fixes it. 
- There was also a diff in GPU vs HNSW where we build and push after merges to main in HNSW and don't do it in GPU. Pushing it will be better for our e2e tests to fetch the latest builds