### PR TITLE
Release v0.20.7 to production and enable 2D anon stats for gpu

### DIFF
--- a/deploy/prod/common-values-iris-mpc.yaml
+++ b/deploy/prod/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc@sha256:32356dcc31c306823504e3571723ba8f3e6b939bff47b373ad28587a47d5bb05" # v0.20.2
+image: "ghcr.io/worldcoin/iris-mpc@sha256:f5d3c7c763ece9eef9f52d848493269eaf1c123481b9542b75de7d9cbd818594" # v0.20.7
 
 environment: prod
 replicaCount: 1

--- a/deploy/prod/smpcv2-0-prod/values-iris-mpc.yaml
+++ b/deploy/prod/smpcv2-0-prod/values-iris-mpc.yaml
@@ -113,6 +113,9 @@ env:
   - name: SMPC__ENABLE_SENDING_MIRROR_ANONYMIZED_STATS_MESSAGE
     value: "true"
 
+  - name: SMPC__ENABLE_SENDING_ANONYMIZED_STATS_2D_MESSAGE
+    value: "true"
+
   - name: SMPC__ENABLE_RESET
     value: "true"
 
@@ -159,6 +162,9 @@ env:
 
   - name: SMPC__MATCH_DISTANCES_BUFFER_SIZE_EXTRA_PERCENT
     value: "20"
+
+  - name: SMPC__MATCH_DISTANCES_2D_BUFFER_SIZE
+    value: "32768"
 
   - name: SMPC__ENABLE_MODIFICATIONS_SYNC
     value: "true"

--- a/deploy/prod/smpcv2-1-prod/values-iris-mpc.yaml
+++ b/deploy/prod/smpcv2-1-prod/values-iris-mpc.yaml
@@ -113,6 +113,12 @@ env:
   - name: SMPC__ENABLE_SENDING_MIRROR_ANONYMIZED_STATS_MESSAGE
     value: "true"
 
+  - name: SMPC__ENABLE_SENDING_ANONYMIZED_STATS_2D_MESSAGE
+    value: "true"
+
+  - name: SMPC__MATCH_DISTANCES_2D_BUFFER_SIZE
+    value: "32768"
+
   - name: SMPC__ENABLE_RESET
     value: "true"
 

--- a/deploy/prod/smpcv2-2-prod/values-iris-mpc.yaml
+++ b/deploy/prod/smpcv2-2-prod/values-iris-mpc.yaml
@@ -113,6 +113,12 @@ env:
   - name: SMPC__ENABLE_SENDING_MIRROR_ANONYMIZED_STATS_MESSAGE
     value: "true"
 
+  - name: SMPC__ENABLE_SENDING_ANONYMIZED_STATS_2D_MESSAGE
+    value: "true"
+
+  - name: SMPC__MATCH_DISTANCES_2D_BUFFER_SIZE
+    value: "32768"
+
   - name: SMPC__ENABLE_RESET
     value: "true"
 


### PR DESCRIPTION
### Description
Releasing v0.20.7 that contains 2D stats work

### Changes
- [ ] deploy image related to v0.20.7 tag
- [ ] enable the flag of sending 2d anon stats from the server to the SNS
- [ ] configure the buffer size of 2d stats to 2^15

Notes:
- The s3 bucket name is configured by the default value in the config (contains the production bucket name)
- This change also requires the permissions of the nodes to write in the above s3. handled by bumping smpcv2 module in all participants
