### PR TITLE
Allow predefined batch sizes to be sent for testing [POP-2890]

### DIFF
--- a/.github/workflows/temp-branch-build-and-push-hawk.yaml
+++ b/.github/workflows/temp-branch-build-and-push-hawk.yaml
@@ -3,7 +3,7 @@ name: Branch - Hawk Build and push docker image
 on:
   push:
     branches:
-      - "profiling-server-v2"
+      - "chore/recreate-hnsw-batch"
 
 concurrency:
   group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"

--- a/iris-mpc-common/src/config/mod.rs
+++ b/iris-mpc-common/src/config/mod.rs
@@ -85,6 +85,13 @@ pub struct Config {
     #[serde(default = "default_max_batch_size")]
     pub max_batch_size: usize,
 
+    // used for testing to recreate batch sequence
+    #[serde(
+        default = "default_predefined_batch_sizes",
+        deserialize_with = "deserialize_usize_vec"
+    )]
+    pub predefined_batch_sizes: Vec<usize>,
+
     #[serde(default = "default_heartbeat_interval_secs")]
     pub heartbeat_interval_secs: u64,
 
@@ -317,6 +324,13 @@ fn default_startup_sync_timeout_secs() -> u64 {
 
 fn default_max_batch_size() -> usize {
     64
+}
+
+fn default_predefined_batch_sizes() -> Vec<usize> {
+    vec![
+        1, 1, 4, 3, 4, 3, 6, 1, 5, 4, 3, 3, 5, 4, 3, 4, 3, 4, 3, 5, 4, 3, 3, 4, 3, 3, 4, 5, 4, 3,
+        3, 3, 3, 4, 3, 3, 3, 4, 3, 3, 6, 3, 4, 3, 3, 3, 5, 4, 3, 4, 5, 3, 3, 4, 3, 3, 4,
+    ]
 }
 
 fn default_heartbeat_interval_secs() -> u64 {
@@ -646,6 +660,14 @@ where
     serde_json::from_str(&value).map_err(serde::de::Error::custom)
 }
 
+fn deserialize_usize_vec<'de, D>(deserializer: D) -> Result<Vec<usize>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value: String = Deserialize::deserialize(deserializer)?;
+    serde_json::from_str(&value).map_err(serde::de::Error::custom)
+}
+
 /// This struct is used to extract the common configuration for all servers from their respective configs.
 /// It is later used to to hash the config and check if it is the same across all servers as a basic sanity check during startup.
 #[allow(non_snake_case)]
@@ -662,6 +684,7 @@ pub struct CommonConfig {
     init_db_size: usize,
     max_db_size: usize,
     max_batch_size: usize,
+    predefined_batch_sizes: Vec<usize>,
     heartbeat_interval_secs: u64,
     heartbeat_initial_retries: u64,
     fake_db_size: usize,
@@ -729,6 +752,7 @@ impl From<Config> for CommonConfig {
             init_db_size,
             max_db_size,
             max_batch_size,
+            predefined_batch_sizes,
             heartbeat_interval_secs,
             heartbeat_initial_retries,
             fake_db_size,
@@ -809,6 +833,7 @@ impl From<Config> for CommonConfig {
             clear_db_before_init,
             init_db_size,
             max_db_size,
+            predefined_batch_sizes,
             max_batch_size,
             heartbeat_interval_secs,
             heartbeat_initial_retries,

--- a/iris-mpc-common/src/config/mod.rs
+++ b/iris-mpc-common/src/config/mod.rs
@@ -327,10 +327,7 @@ fn default_max_batch_size() -> usize {
 }
 
 fn default_predefined_batch_sizes() -> Vec<usize> {
-    vec![
-        1, 1, 4, 3, 4, 3, 6, 1, 5, 4, 3, 3, 5, 4, 3, 4, 3, 4, 3, 5, 4, 3, 3, 4, 3, 3, 4, 5, 4, 3,
-        3, 3, 3, 4, 3, 3, 3, 4, 3, 3, 6, 3, 4, 3, 3, 3, 5, 4, 3, 4, 5, 3, 3, 4, 3, 3, 4,
-    ]
+    Vec::new()
 }
 
 fn default_heartbeat_interval_secs() -> u64 {

--- a/iris-mpc-common/src/helpers/batch_sync.rs
+++ b/iris-mpc-common/src/helpers/batch_sync.rs
@@ -124,7 +124,7 @@ pub async fn get_own_batch_sync_state(
             config.predefined_batch_sizes[index],
             current_batch_id
         );
-        config.predefined_batch_sizes[index] as u32
+        std::cmp::min(config.predefined_batch_sizes[index], config.max_batch_size) as u32
     } else {
         std::cmp::min(approximate_visible_messages, config.max_batch_size as u32)
     };

--- a/iris-mpc-common/src/helpers/batch_sync.rs
+++ b/iris-mpc-common/src/helpers/batch_sync.rs
@@ -119,6 +119,7 @@ pub async fn get_own_batch_sync_state(
     let index = (current_batch_id - 1) as usize;
 
     let messages_to_poll = if config.predefined_batch_sizes.len() > index {
+        // predefined_batch_sizes are only used in test environments to reproduce specific scenarios
         tracing::info!(
             "Using predefined batch size {} for batch ID {}",
             config.predefined_batch_sizes[index],
@@ -126,6 +127,7 @@ pub async fn get_own_batch_sync_state(
         );
         std::cmp::min(config.predefined_batch_sizes[index], config.max_batch_size) as u32
     } else {
+        // Use the dynamic batch size calculation based on SQS approximate visible messages
         std::cmp::min(approximate_visible_messages, config.max_batch_size as u32)
     };
 

--- a/iris-mpc-common/src/helpers/batch_sync.rs
+++ b/iris-mpc-common/src/helpers/batch_sync.rs
@@ -116,8 +116,22 @@ pub async fn get_own_batch_sync_state(
         approximate_visible_messages
     );
 
-    let messages_to_poll =
-        std::cmp::min(approximate_visible_messages, config.max_batch_size as u32);
+    let index = if current_batch_id > 0 {
+        current_batch_id - 1
+    } else {
+        0
+    } as usize;
+
+    let messages_to_poll = if config.predefined_batch_sizes.len() > index {
+        tracing::info!(
+            "Using predefined batch size {} for batch ID {}",
+            config.predefined_batch_sizes[index],
+            current_batch_id
+        );
+        config.predefined_batch_sizes[index] as u32
+    } else {
+        std::cmp::min(approximate_visible_messages, config.max_batch_size as u32)
+    };
 
     let batch_sync_state = BatchSyncState {
         messages_to_poll,

--- a/iris-mpc-common/src/helpers/batch_sync.rs
+++ b/iris-mpc-common/src/helpers/batch_sync.rs
@@ -116,11 +116,7 @@ pub async fn get_own_batch_sync_state(
         approximate_visible_messages
     );
 
-    let index = if current_batch_id > 0 {
-        current_batch_id - 1
-    } else {
-        0
-    } as usize;
+    let index = (current_batch_id - 1) as usize;
 
     let messages_to_poll = if config.predefined_batch_sizes.len() > index {
         tracing::info!(


### PR DESCRIPTION
## Change
- We observed that a certain batch sequence caused results to differ and re-created the same sequence to see if it's a one time issue or not. To do that, we used predefined batch sizes.
- This functionality could be needed again in the future. So, it'd make sense to keep it