### PR TITLE
Au/dev tune

### DIFF
--- a/deploy/dev/ampc-hnsw-0-dev/values-ampc-hnsw.yaml
+++ b/deploy/dev/ampc-hnsw-0-dev/values-ampc-hnsw.yaml
@@ -58,10 +58,10 @@ env:
     value: "240"  # 2 minutes per batch in dev, bump to 4 in prod
 
   - name: SMPC__HAWK_REQUEST_PARALLELISM
-    value: "1024"
+    value: "32"
 
   - name: SMPC__HAWK_CONNECTION_PARALLELISM
-    value: "48"
+    value: "8"
 
   - name: SMPC__HAWK_STREAM_PARALLELISM
     value: "32"

--- a/deploy/dev/ampc-hnsw-1-dev/values-ampc-hnsw.yaml
+++ b/deploy/dev/ampc-hnsw-1-dev/values-ampc-hnsw.yaml
@@ -58,10 +58,10 @@ env:
     value: "240"  # 2 minutes per batch in dev, bump to 4 in prod
 
   - name: SMPC__HAWK_REQUEST_PARALLELISM
-    value: "1024"
+    value: "32"
 
   - name: SMPC__HAWK_CONNECTION_PARALLELISM
-    value: "48"
+    value: "8"
 
   - name: SMPC__HAWK_STREAM_PARALLELISM
     value: "32"

--- a/deploy/dev/ampc-hnsw-2-dev/values-ampc-hnsw.yaml
+++ b/deploy/dev/ampc-hnsw-2-dev/values-ampc-hnsw.yaml
@@ -58,10 +58,10 @@ env:
     value: "240"  # 2 minutes per batch in dev, bump to 4 in prod
 
   - name: SMPC__HAWK_REQUEST_PARALLELISM
-    value: "1024"
+    value: "32"
 
   - name: SMPC__HAWK_CONNECTION_PARALLELISM
-    value: "48"
+    value: "8"
 
   - name: SMPC__HAWK_STREAM_PARALLELISM
     value: "32"


### PR DESCRIPTION
Less is more.

Testing this tuning:

**Request parallelism**

Equal to batch size 32. The actual number of sessions is derived from that for max utilization. Sessions beyond that will be unused, and it should not hurt, but 1024 is excessive.

**Connection parallelism**

Now with 8. Fewer means larger packets and less buffering latency. In staging we saw ~6MB/s per connection/thread, so even 6 times more is easily manageable.