### PR TITLE
Introduce codeowners to prod configs dir

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/deploy/prod/ @philsippl @worldcoin/proof-of-personhood


### PR DESCRIPTION
# Change
- Require review from @philsippl or @worldcoin/proof-of-personhood on prod config changes
- Keep the other folders as is - push collaborator's approval would suffice