### PR TITLE
Fix doc comments to eliminate old check annotations

### DIFF
--- a/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
@@ -97,7 +97,7 @@ impl Aby3Store {
     /// The input irises are given in the Shamir secret sharing scheme, while the output distances are additive replicated secret shares used in the ABY3 framework.
     ///
     /// Assumes that the first iris of each pair is preprocessed.
-    /// This first iris is usually preprocessed when a related query is created, see [prepare_query] for more details.
+    /// This first iris is usually preprocessed when a related query is created, see [Aby3Query] for more details.
     #[instrument(level = "trace", target = "searcher::network", skip_all)]
     pub(crate) async fn eval_pairwise_distances(
         &mut self,

--- a/iris-mpc-cpu/src/network/tcp/mod.rs
+++ b/iris-mpc-cpu/src/network/tcp/mod.rs
@@ -288,7 +288,7 @@ pub mod testing {
     }
 
     /// Interleaves a Vec of Vecs into a single Vec by taking one element from each inner Vec in turn.
-    /// For example, interleaving [[1,2,3],[4,5,6],[7,8,9]] yields [1,4,7,2,5,8,3,6,9].
+    /// For example, interleaving `[[1,2,3],[4,5,6],[7,8,9]]` yields `[1,4,7,2,5,8,3,6,9]`.
     pub fn interleave_vecs<T>(vecs: Vec<Vec<T>>) -> Vec<T> {
         let mut result = Vec::new();
         let mut iters: Vec<_> = vecs.into_iter().map(|v| v.into_iter()).collect();


### PR DESCRIPTION
This PR fixes a few doc comments which have been eliciting check annotations for a while.