### PR TITLE
Oblivious swap network

### DIFF
--- a/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
@@ -3,10 +3,17 @@ use crate::{
     hawkers::shared_irises::{SharedIrises, SharedIrisesRef},
     hnsw::{vector_store::VectorStoreMut, VectorStore},
     protocol::{
-        ops::{batch_signed_lift_vec, cross_compare, galois_ring_to_rep3, lte_threshold_and_open},
+        ops::{
+            batch_signed_lift_vec, conditionally_swap_distances,
+            conditionally_swap_distances_plain_ids, cross_compare, galois_ring_to_rep3,
+            lte_threshold_and_open, oblivious_cross_compare,
+        },
         shared_iris::{ArcIris, GaloisRingSharedIris},
     },
-    shares::share::{DistanceShare, Share},
+    shares::{
+        bit::Bit,
+        share::{DistanceShare, Share},
+    },
 };
 use eyre::Result;
 use iris_mpc_common::vector_id::VectorId;
@@ -55,6 +62,7 @@ impl Aby3Query {
 }
 
 pub type Aby3VectorRef = <Aby3Store as VectorStore>::VectorRef;
+pub type Aby3DistanceRef = <Aby3Store as VectorStore>::DistanceRef;
 
 pub type Aby3SharedIrises = SharedIrises<ArcIris>;
 pub type Aby3SharedIrisesRef = SharedIrisesRef<ArcIris>;
@@ -121,6 +129,48 @@ impl Aby3Store {
 
     pub async fn checksum(&self) -> u64 {
         self.storage.checksum().await
+    }
+
+    /// Obliviously swaps the elements in `list` at the given `indices` according to the `swap_bits`.
+    /// If bit is 0, the elements are swapped, otherwise they are left unchanged.
+    /// Note that unchanged elements of the list are propagated as secret-shares.
+    pub async fn oblivious_swap_batch_plain_ids(
+        &mut self,
+        swap_bits: Vec<Share<Bit>>,
+        list: &[(u32, Aby3DistanceRef)],
+        indices: &[(usize, usize)],
+    ) -> Result<Vec<(Share<u32>, Aby3DistanceRef)>> {
+        if list.is_empty() {
+            return Ok(vec![]);
+        }
+
+        conditionally_swap_distances_plain_ids(&mut self.session, swap_bits, list, indices).await
+    }
+
+    /// Obliviously compares pairs of distances in batch and returns a secret shared bit a < b for each pair.
+    pub async fn oblivious_less_than_batch(
+        &mut self,
+        distances: &[(Aby3DistanceRef, Aby3DistanceRef)],
+    ) -> Result<Vec<Share<Bit>>> {
+        if distances.is_empty() {
+            return Ok(vec![]);
+        }
+        oblivious_cross_compare(&mut self.session, distances).await
+    }
+
+    /// Obliviously swaps the elements in `list` at the given `indices` according to the `swap_bits`.
+    /// If bit is 0, the elements are swapped, otherwise they are left unchanged.
+    pub async fn oblivious_swap_batch(
+        &mut self,
+        swap_bits: Vec<Share<Bit>>,
+        list: &[(Share<u32>, Aby3DistanceRef)],
+        indices: &[(usize, usize)],
+    ) -> Result<Vec<(Share<u32>, Aby3DistanceRef)>> {
+        if list.is_empty() {
+            return Ok(vec![]);
+        }
+
+        conditionally_swap_distances(&mut self.session, swap_bits, list, indices).await
     }
 }
 
@@ -251,7 +301,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        execution::hawk_main::scheduler::parallelize,
+        execution::{hawk_main::scheduler::parallelize, session::SessionHandles},
         hawkers::{
             aby3::test_utils::{
                 eval_vector_distance, get_owner_index, lazy_random_setup,
@@ -524,6 +574,91 @@ mod tests {
                 }
             }
         }
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[traced_test]
+    async fn test_oblivious_swap() -> Result<()> {
+        let list_len = 6_u32;
+        let plain_list = (0..list_len)
+            .map(|i| (VectorId::from_0_index(i), (i, i)))
+            .collect_vec();
+        let swap_bits_for_plain = vec![true, false];
+        let indices_for_plain = vec![(0, 1), (4, 5)];
+        let swap_bits_for_secret = vec![true, false, false];
+        let indices_for_secret = vec![(1, 2), (0, 4), (3, 5)];
+
+        let mut local_stores = setup_local_store_aby3_players(NetworkType::Local).await?;
+        let mut jobs = JoinSet::new();
+        for store in local_stores.iter_mut() {
+            let store = store.clone();
+            let swap_bits_for_plain = swap_bits_for_plain.clone();
+            let swap_bits_for_secret = swap_bits_for_secret.clone();
+            let plain_list = plain_list.clone();
+            let indices_for_plain = indices_for_plain.clone();
+            let indices_for_secret = indices_for_secret.clone();
+            jobs.spawn(async move {
+                let mut store_lock = store.lock().await;
+                let role = store_lock.session.own_role();
+                let swap_bits1 = swap_bits_for_plain
+                    .iter()
+                    .map(|b| Share::from_const(Bit::new(*b), role))
+                    .collect_vec();
+                let swap_bits2 = swap_bits_for_secret
+                    .iter()
+                    .map(|b| Share::from_const(Bit::new(*b), role))
+                    .collect_vec();
+                let list = plain_list
+                    .iter()
+                    .map(|(v, d)| {
+                        (
+                            v.index(),
+                            DistanceShare::new(
+                                Share::from_const(d.0, role),
+                                Share::from_const(d.1, role),
+                            ),
+                        )
+                    })
+                    .collect_vec();
+                let tmp_list = store_lock
+                    .oblivious_swap_batch_plain_ids(swap_bits1, &list, &indices_for_plain)
+                    .await?;
+                store_lock
+                    .oblivious_swap_batch(swap_bits2, &tmp_list, &indices_for_secret)
+                    .await
+            });
+        }
+        let res = jobs
+            .join_all()
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>>>()?;
+        let mut expected_list = plain_list.clone();
+        expected_list.swap(4, 5);
+        expected_list.swap(0, 4);
+        expected_list.swap(3, 5);
+
+        for (i, exp) in expected_list.iter().enumerate() {
+            let id = (res[0][i].clone().0 + &res[1][i].0 + &res[2][i].0)
+                .get_a()
+                .convert();
+            assert_eq!(id, exp.0.index());
+
+            let distance = {
+                let code_dot =
+                    (res[0][i].clone().1.code_dot + &res[1][i].1.code_dot + &res[2][i].1.code_dot)
+                        .get_a()
+                        .convert();
+                let mask_dot =
+                    (res[0][i].clone().1.mask_dot + &res[1][i].1.mask_dot + &res[2][i].1.mask_dot)
+                        .get_a()
+                        .convert();
+                (code_dot, mask_dot)
+            };
+            assert_eq!(distance, exp.1);
+        }
+
         Ok(())
     }
 

--- a/iris-mpc-cpu/src/protocol/ops.rs
+++ b/iris-mpc-cpu/src/protocol/ops.rs
@@ -353,6 +353,186 @@ async fn conditionally_select_distance(
         .collect())
 }
 
+/// Conditionally swaps the distance shares based on control bits.
+/// Given the ith pair of indices (i1, i2), the function does the following.
+/// If the control bit is 0, it swaps tuples (32-bit id, distance share) with index i1 and i2,
+/// otherwise it does nothing.
+/// Assumes that the input shares are originally 16-bit and lifted to u32.
+/// The vector ids are in plaintext and propagated in secret shared form.
+#[instrument(level = "trace", target = "searcher::network", skip_all)]
+pub async fn conditionally_swap_distances_plain_ids(
+    session: &mut Session,
+    swap_bits: Vec<Share<Bit>>,
+    list: &[(u32, DistanceShare<u32>)],
+    indices: &[(usize, usize)],
+) -> Result<Vec<(Share<u32>, DistanceShare<u32>)>> {
+    if swap_bits.len() != indices.len() {
+        eyre::bail!("swap bits and indices must have the same length");
+    }
+    let role = session.own_role();
+    // Convert vector ids into trivial shares
+    let mut encrypted_list = list
+        .iter()
+        .map(|(id, d)| {
+            let shared_index = Share::from_const(*id, role);
+            (shared_index, d.clone())
+        })
+        .collect_vec();
+    // Lift swap bits to u32 shares
+    let swap_bits_u32 = bit_inject_ot_2round(session, VecShare::<Bit>::new_vec(swap_bits))
+        .await?
+        .inner();
+
+    let distances_to_swap = indices
+        .iter()
+        .filter_map(|(idx1, idx2)| match (list.get(*idx1), list.get(*idx2)) {
+            (Some((_, d1)), Some((_, d2))) => Some((d1.clone(), d2.clone())),
+            _ => None,
+        })
+        .collect_vec();
+    // Select the first distance in each pair based on the control bits
+    let first_distances =
+        conditionally_select_distance(session, &distances_to_swap, &swap_bits_u32).await?;
+    // Select the second distance in each pair as sum of both distances minus the first selected distance
+    let second_distances = distances_to_swap
+        .into_iter()
+        .zip(first_distances.iter())
+        .map(|(d_pair, first_d)| {
+            DistanceShare::new(
+                d_pair.0.code_dot + d_pair.1.code_dot - &first_d.code_dot,
+                d_pair.0.mask_dot + d_pair.1.mask_dot - &first_d.mask_dot,
+            )
+        })
+        .collect_vec();
+
+    for (bit, (idx1, idx2), first_d, second_d) in izip!(
+        swap_bits_u32.iter(),
+        indices.iter(),
+        first_distances,
+        second_distances
+    ) {
+        let mut not_bit = -bit;
+        not_bit.add_assign_const_role(1, role);
+        let id1 = list[*idx1].0;
+        let id2 = list[*idx2].0;
+        // Only propagate index and skip version id.
+        // This computation is local as indices are public.
+        let first_id = bit * id1 + not_bit.clone() * id2;
+        let second_id = bit * id2 + not_bit * id1;
+        encrypted_list[*idx1] = (first_id, first_d);
+        encrypted_list[*idx2] = (second_id, second_d);
+    }
+    Ok(encrypted_list)
+}
+
+/// Conditionally swaps the distance shares based on control bits.
+/// Given the ith pair of indices (i1, i2), the function does the following.
+/// If the ith control bit is 0, it swaps tuples (0-indexed vector id, distance share) with index i1 and i2,
+/// otherwise it does nothing.
+/// Assumes that the input shares are originally 16-bit and lifted to u32.
+/// The vector ids are 0-indexed and given in secret shared form.
+#[instrument(level = "trace", target = "searcher::network", skip_all)]
+pub async fn conditionally_swap_distances(
+    session: &mut Session,
+    swap_bits: Vec<Share<Bit>>,
+    list: &[(Share<u32>, DistanceShare<u32>)],
+    indices: &[(usize, usize)],
+) -> Result<Vec<(Share<u32>, DistanceShare<u32>)>> {
+    if swap_bits.len() != indices.len() {
+        return Err(eyre!("swap bits and indices must have the same length"));
+    }
+    // Lift bits to u32 shares
+    let swap_bits_u32 = bit_inject_ot_2round(session, VecShare::<Bit>::new_vec(swap_bits))
+        .await?
+        .inner();
+
+    // A helper closure to compute the difference of two input shares and prepare the a part of the product of this difference and the control bit.
+    let mut mul_share_a = |x: Share<u32>, y: Share<u32>, sb: &Share<u32>| -> RingElement<u32> {
+        let diff = x - y;
+        session.prf.gen_zero_share() + sb.a * diff.a + sb.b * diff.a + sb.a * diff.b
+    };
+
+    // Conditional swapping:
+    // If control bit c is 1, return (d1, d2); otherwise, (d2, d1), which can be computed as:
+    // - first tuple element = c * (d1 - d2) + d2;
+    // - second tuple element = d1 - c * (d1 - d2).
+    // We need to do it for ids, code_dot and mask_dot.
+
+    // Compute c * (d1-d2)
+    let res_a: Vec<RingElement<u32>> = indices
+        .iter()
+        .zip(swap_bits_u32.iter())
+        .flat_map(|((idx1, idx2), sb)| {
+            let (id1, d1) = &list[*idx1];
+            let (id2, d2) = &list[*idx2];
+
+            let id = mul_share_a(id1.clone(), id2.clone(), sb);
+            let code_dot_a = mul_share_a(d1.code_dot.clone(), d2.code_dot.clone(), sb);
+            let mask_dot_a = mul_share_a(d1.mask_dot.clone(), d2.mask_dot.clone(), sb);
+            [id, code_dot_a, mask_dot_a]
+        })
+        .collect();
+
+    let network = &mut session.network_session;
+
+    let message = if res_a.len() == 1 {
+        NetworkValue::RingElement32(res_a[0])
+    } else {
+        NetworkValue::VecRing32(res_a.clone())
+    };
+    network.send_next(message).await?;
+
+    let res_b = match network.receive_prev().await {
+        Ok(NetworkValue::RingElement32(element)) => vec![element],
+        Ok(NetworkValue::VecRing32(elements)) => elements,
+        _ => bail!("Could not deserialize RingElement32"),
+    };
+
+    // Finally compute the swapped tuples.
+    let swapped_distances = izip!(res_a, res_b)
+        // combine a and b part into shares
+        .map(|(a, b)| Share::new(a, b))
+        // combine the code and mask parts into DistanceShare
+        .tuples()
+        .map(|(id, code, mask)| {
+            (
+                id,
+                DistanceShare {
+                    code_dot: code,
+                    mask_dot: mask,
+                },
+            )
+        })
+        .zip(indices.iter())
+        .map(|((res_id, res_dist), (idx1, idx2))| {
+            let (id1, dist1) = &list[*idx1];
+            let (id2, dist2) = &list[*idx2];
+            // first tuple element = c * (d1 - d2) + d2
+            // second tuple element = d1 - c * (d1 - d2)
+            let first_id = res_id.clone() + id2;
+            let second_id = id1.clone() - res_id;
+            let first_distance = DistanceShare {
+                code_dot: res_dist.code_dot.clone() + &dist2.code_dot,
+                mask_dot: res_dist.mask_dot.clone() + &dist2.mask_dot,
+            };
+            let second_distance = DistanceShare {
+                code_dot: dist1.code_dot.clone() - res_dist.code_dot,
+                mask_dot: dist1.mask_dot.clone() - res_dist.mask_dot,
+            };
+            ((first_id, first_distance), (second_id, second_distance))
+        })
+        .collect_vec();
+
+    // Update the input list with the swapped tuples.
+    let mut swapped_list = list.to_vec();
+    for (((id1, d1), (id2, d2)), (idx1, idx2)) in swapped_distances.into_iter().zip(indices) {
+        swapped_list[*idx1] = (id1, d1);
+        swapped_list[*idx2] = (id2, d2);
+    }
+
+    Ok(swapped_list)
+}
+
 /// For every pair of distance shares (d1, d2), this computes the bit d2 < d1 and opens it.
 ///
 /// The less-than operator is implemented in 2 steps:
@@ -360,8 +540,7 @@ async fn conditionally_select_distance(
 /// 1. d2.code_dot * d1.mask_dot - d1.code_dot * d2.mask_dot is computed, which is a numerator of the fraction difference d2.code_dot / d2.mask_dot - d1.code_dot / d1.mask_dot.
 /// 2. The most significant bit of the result is extracted.
 ///
-/// Input values are assumed to be 16-bit shares that have been lifted to
-/// 32-bit.
+/// Input values are assumed to be 16-bit shares that have been lifted to 32 bits.
 pub async fn cross_compare(
     session: &mut Session,
     distances: &[(DistanceShare<u32>, DistanceShare<u32>)],
@@ -375,10 +554,27 @@ pub async fn cross_compare(
     opened_b.into_iter().map(|x| Ok(x.convert())).collect()
 }
 
+/// For every pair of distance shares (d1, d2), this computes the secret-shared bit d2 < d1 .
+///
+/// The less-than operator is implemented in 2 steps:
+///
+/// 1. d2.code_dot * d1.mask_dot - d1.code_dot * d2.mask_dot is computed, which is a numerator of the fraction difference d2.code_dot / d2.mask_dot - d1.code_dot / d1.mask_dot.
+/// 2. The most significant bit of the result is extracted.
+///
+/// Input values are assumed to be 16-bit shares that have been lifted to 32 bits.
+pub async fn oblivious_cross_compare(
+    session: &mut Session,
+    distances: &[(DistanceShare<u32>, DistanceShare<u32>)],
+) -> Result<Vec<Share<Bit>>> {
+    // d2.code_dot * d1.mask_dot - d1.code_dot * d2.mask_dot
+    let diff = cross_mul(session, distances).await?;
+    // Compute the MSB of the above
+    extract_msb_u32_batch(session, &diff).await
+}
+
 /// For every pair of distance shares (d1, d2), this computes the bit d2 < d1 uses it to return the lower of the two distances.
 ///
-/// Input values are assumed to be 16-bit shares that have been lifted to
-/// 32-bit.
+/// Input values are assumed to be 16-bit shares that have been lifted to 32 bits.
 pub async fn cross_compare_and_swap(
     session: &mut Session,
     distances: &[(DistanceShare<u32>, DistanceShare<u32>)],

--- a/iris-mpc-cpu/src/shares/share.rs
+++ b/iris-mpc-cpu/src/shares/share.rs
@@ -19,6 +19,12 @@ impl<T: IntRing2k> Share<T> {
         Self { a, b }
     }
 
+    pub fn from_const(value: T, role: Role) -> Self {
+        let mut res = Self::zero();
+        res.add_assign_const_role(value, role);
+        res
+    }
+
     pub fn add_assign_const_role(&mut self, other: T, role: Role) {
         match role.index() {
             0 => self.a += RingElement(other),


### PR DESCRIPTION
See [POP-2938](https://linear.app/worldcoin/issue/POP-2938/oblivious-swap-network).

This is an implementation of `apply_swap_network`, where comparison bits remain secret shared. The number of rounds per layer is 11 where 8 belong to the oblivious comparison subroutine and 3 are reserved by the swapping procedure. More details about the communication complexity of this algorithm can be found [here](https://www.notion.so/inversed/Oblivious-minimum-via-tournament-method-271a3b540bfe8019a020d9be253288c5?source=copy_link).