### PR TITLE
Add signing job to the iris-mpc build workflow

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -72,7 +72,7 @@ jobs:
         continue-on-error: true
         env:
           WEB_PRIVATE_KEY: ${{ secrets.SMART_CONTAINER_REGISTRY_KEY}}
-          DIGEST: ${{ needs.build-and-push.outputs.digest }}
+          DIGEST: ${{ needs.docker.outputs.digest }}
         run: |
           cast send 0x0F054e3666F2e7E4Ce345f55f0d7aeE513aC5540 \
             --from 0x9A7aeeC57b8C354a0d0229f3792282f6F7004A59 \

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -86,7 +86,7 @@ jobs:
         # TODO: continue-on-error is only for the PoC phase, remove when use mainnet
         continue-on-error: true
         env:
-          WEB_PRIVATE_KEY: ${{ secrets.SMART_CONTAINER_REGISTRY_KEY}}
+          WEB_PRIVATE_KEY: ${{ secrets.SMART_CONTAINER_REGISTRY_KEY }}
           DIGEST: ${{ needs.docker.outputs.digest }}
         run: |
           cast send 0x0F054e3666F2e7E4Ce345f55f0d7aeE513aC5540 \

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -26,6 +26,8 @@ jobs:
       contents: read
       attestations: write
       id-token: write
+    outputs:
+      digest: ${{ steps.docker-build.outputs.digest }}
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
@@ -41,6 +43,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Push
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        id: docker-build
         with:
           context: .
           push: true
@@ -53,3 +56,27 @@ jobs:
           platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max
+  sign:
+    needs: docker
+    # TODO: remove comment after PoC phase
+    # if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install Foundry
+        # https://github.com/foundry-rs/foundry-toolchain/releases/tag/v1.4.0
+        uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de
+
+      - name: Sign the image digest
+        # TODO: continue-on-error is only for the PoC phase, remove when use mainnet
+        continue-on-error: true
+        env:
+          WEB_PRIVATE_KEY: ${{ secrets.SMART_CONTAINER_REGISTRY_KEY}}
+          DIGEST: ${{ needs.build-and-push.outputs.digest }}
+        run: |
+          cast send 0x0F054e3666F2e7E4Ce345f55f0d7aeE513aC5540 \
+            --from 0x9A7aeeC57b8C354a0d0229f3792282f6F7004A59 \
+            --private-key $WEB_PRIVATE_KEY \
+            --rpc-url https://worldchain-sepolia.g.alchemy.com/public \
+            "addAllowedHash(bytes32)" ${DIGEST:7}
+


### PR DESCRIPTION
This PR is adding a job to sign the image digest to the Smart Container Registry, currently published on Sepolia testnet. The goal is to verify deployment agains the signed hashes.

For now it's a PoC phase and it is using testnet. During the poc we are allowing the job to fail and signing every image build on the main branch. The target is to use mainnet and sign only released images.