### PR TITLE
[POP-2928] propagate network errors to HawkHandle

### DIFF
--- a/iris-mpc-common/src/helpers/shutdown_handler.rs
+++ b/iris-mpc-common/src/helpers/shutdown_handler.rs
@@ -36,6 +36,10 @@ impl ShutdownHandler {
         self.ct.cancelled().await
     }
 
+    pub fn get_cancellation_token(&self) -> CancellationToken {
+        self.ct.clone()
+    }
+
     pub async fn register_signal_handler(&self) {
         let ct = self.ct.clone();
         tokio::spawn(async move {

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -2044,7 +2044,7 @@ mod tests_db {
             disable_persistence: false,
             tls: None,
         };
-        let mut hawk_actor = HawkActor::from_cli(&args).await?;
+        let mut hawk_actor = HawkActor::from_cli(&args, CancellationToken::new()).await?;
         let (_, graph_loader) = hawk_actor.as_iris_loader().await;
         graph_loader.load_graph_store(&graph_store, 2).await?;
 

--- a/iris-mpc-cpu/src/execution/hawk_main/test_utils.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/test_utils.rs
@@ -2,7 +2,7 @@ use aes_prng::AesRng;
 use clap::Parser;
 use eyre::Result;
 use iris_mpc_common::{
-    helpers::{shutdown_handler::ShutdownHandler, smpc_request::UNIQUENESS_MESSAGE_TYPE},
+    helpers::smpc_request::UNIQUENESS_MESSAGE_TYPE,
     iris_db::db::IrisDB,
     job::{BatchMetadata, BatchQuery},
     ROTATIONS,
@@ -11,6 +11,7 @@ use itertools::Itertools;
 use rand::SeedableRng;
 use std::{sync::Arc, time::Duration};
 use tokio::time::sleep;
+use tokio_util::sync::CancellationToken;
 
 use crate::{
     execution::local::get_free_local_addresses,
@@ -42,8 +43,7 @@ pub async fn setup_hawk_actors() -> Result<Vec<HawkActor>> {
             // Make the test async.
             sleep(Duration::from_millis(index as u64)).await;
 
-            let shutdown_handler = Arc::new(ShutdownHandler::new(10));
-            HawkActor::from_cli(&args, &shutdown_handler).await
+            HawkActor::from_cli(&args, CancellationToken::new()).await
         }
     };
 

--- a/iris-mpc-cpu/src/execution/hawk_main/test_utils.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/test_utils.rs
@@ -2,7 +2,7 @@ use aes_prng::AesRng;
 use clap::Parser;
 use eyre::Result;
 use iris_mpc_common::{
-    helpers::smpc_request::UNIQUENESS_MESSAGE_TYPE,
+    helpers::{shutdown_handler::ShutdownHandler, smpc_request::UNIQUENESS_MESSAGE_TYPE},
     iris_db::db::IrisDB,
     job::{BatchMetadata, BatchQuery},
     ROTATIONS,
@@ -42,7 +42,8 @@ pub async fn setup_hawk_actors() -> Result<Vec<HawkActor>> {
             // Make the test async.
             sleep(Duration::from_millis(index as u64)).await;
 
-            HawkActor::from_cli(&args).await
+            let shutdown_handler = Arc::new(ShutdownHandler::new(10));
+            HawkActor::from_cli(&args, &shutdown_handler).await
         }
     };
 

--- a/iris-mpc-cpu/src/network/tcp/handle.rs
+++ b/iris-mpc-cpu/src/network/tcp/handle.rs
@@ -291,8 +291,10 @@ async fn manage_connection<T: NetworkConnection>(
                         if RECONNECTING.increment().await {
                             tracing::error!(e=%e, "TCP/TLS connection closed unexpectedly. reconnecting...");
                         }
+                        Evt::Disconnected
+                    } else {
+                        unreachable!();
                     }
-                    Evt::Disconnected
                 }
             },
             r = outbound_task => {
@@ -305,8 +307,7 @@ async fn manage_connection<T: NetworkConnection>(
                         }
                         Evt::Disconnected
                     } else {
-                        // new sessions were probably created
-                        Evt::Shutdown
+                        unreachable!();
                     }
                 }
             },

--- a/iris-mpc-cpu/src/network/tcp/mod.rs
+++ b/iris-mpc-cpu/src/network/tcp/mod.rs
@@ -34,7 +34,7 @@ use data::*;
 
 #[async_trait]
 pub trait NetworkHandle: Send + Sync {
-    async fn make_sessions(&mut self) -> Result<Vec<TcpSession>>;
+    async fn make_sessions(&mut self) -> Result<(Vec<TcpSession>, CancellationToken)>;
 }
 
 pub trait NetworkConnection: AsyncRead + AsyncWrite + Send + Sync + Unpin {}
@@ -269,7 +269,8 @@ pub mod testing {
         tracing::debug!("waiting for make_sessions to complete");
         let mut sessions = vec![];
         for h in handles.iter_mut() {
-            sessions.push(h.make_sessions().await?);
+            let (s, _ct) = h.make_sessions().await?;
+            sessions.push(s);
         }
 
         Ok((handles, sessions))

--- a/iris-mpc-cpu/src/network/tcp/mod.rs
+++ b/iris-mpc-cpu/src/network/tcp/mod.rs
@@ -13,14 +13,14 @@ use crate::{
 };
 use async_trait::async_trait;
 use eyre::Result;
-use iris_mpc_common::helpers::shutdown_handler::ShutdownHandler;
 use itertools::izip;
-use std::sync::{Arc, Once};
+use std::sync::Once;
 use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     time::Duration,
 };
 use tokio::io::{AsyncRead, AsyncWrite};
+use tokio_util::sync::CancellationToken;
 
 pub mod config;
 mod data;
@@ -56,7 +56,7 @@ pub trait Server: Send {
 
 pub async fn build_network_handle(
     args: &HawkArgs,
-    shutdown_handler: &Arc<ShutdownHandler>,
+    ct: CancellationToken,
     identities: &[Identity],
     sessions_per_request: usize,
 ) -> Result<Box<dyn NetworkHandle>> {
@@ -74,7 +74,6 @@ pub async fn build_network_handle(
     let my_identity = identities[my_index].clone();
     let my_address = &args.addresses[my_index];
     let my_addr = to_inaddr_any(my_address.parse::<SocketAddr>()?);
-    let ct = shutdown_handler.get_cancellation_token();
 
     let tcp_config = TcpConfig::new(
         Duration::from_secs(10),

--- a/iris-mpc-cpu/tests/e2e.rs
+++ b/iris-mpc-cpu/tests/e2e.rs
@@ -1,6 +1,5 @@
 use eyre::Result;
 use iris_mpc_common::{
-    helpers::shutdown_handler::ShutdownHandler,
     iris_db::{db::IrisDB, iris::IrisCode},
     test::{generate_full_test_db, TestCaseGenerator},
     vector_id::VectorId,
@@ -17,6 +16,7 @@ use iris_mpc_cpu::{
 };
 use rand::{rngs::StdRng, SeedableRng};
 use std::{collections::HashMap, sync::Arc, time::Duration};
+use tokio_util::sync::CancellationToken;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 const DB_SIZE: usize = 1000;
@@ -143,9 +143,8 @@ async fn start_hawk_node(
     );
     let (graph, iris_store) =
         create_graph_from_plain_dbs(args.party_index, left_db, right_db, &params).await?;
-    let shutdown_handler = Arc::new(ShutdownHandler::new(10));
     let hawk_actor =
-        HawkActor::from_cli_with_graph_and_store(args, &shutdown_handler, graph, iris_store)
+        HawkActor::from_cli_with_graph_and_store(args, CancellationToken::new(), graph, iris_store)
             .await?;
 
     let handle = HawkHandle::new(hawk_actor).await?;

--- a/iris-mpc-cpu/tests/e2e.rs
+++ b/iris-mpc-cpu/tests/e2e.rs
@@ -1,5 +1,6 @@
 use eyre::Result;
 use iris_mpc_common::{
+    helpers::shutdown_handler::ShutdownHandler,
     iris_db::{db::IrisDB, iris::IrisCode},
     test::{generate_full_test_db, TestCaseGenerator},
     vector_id::VectorId,
@@ -142,7 +143,10 @@ async fn start_hawk_node(
     );
     let (graph, iris_store) =
         create_graph_from_plain_dbs(args.party_index, left_db, right_db, &params).await?;
-    let hawk_actor = HawkActor::from_cli_with_graph_and_store(args, graph, iris_store).await?;
+    let shutdown_handler = Arc::new(ShutdownHandler::new(10));
+    let hawk_actor =
+        HawkActor::from_cli_with_graph_and_store(args, &shutdown_handler, graph, iris_store)
+            .await?;
 
     let handle = HawkHandle::new(hawk_actor).await?;
 

--- a/iris-mpc-upgrade-hawk/src/genesis/mod.rs
+++ b/iris-mpc-upgrade-hawk/src/genesis/mod.rs
@@ -896,7 +896,8 @@ async fn get_hawk_actor(config: &Config) -> Result<HawkActor> {
         hawk_args.party_index, node_addresses
     ));
 
-    HawkActor::from_cli(&hawk_args).await
+    let shutdown_handler = Arc::new(ShutdownHandler::new(10));
+    HawkActor::from_cli(&hawk_args, &shutdown_handler).await
 }
 
 /// Returns service clients used downstream.

--- a/iris-mpc-upgrade-hawk/src/genesis/mod.rs
+++ b/iris-mpc-upgrade-hawk/src/genesis/mod.rs
@@ -366,7 +366,7 @@ async fn exec_setup(
     log_info(String::from("Store consistency checks OK"));
 
     // Initialise HNSW graph from previously indexed.
-    let mut hawk_actor = get_hawk_actor(config).await?;
+    let mut hawk_actor = get_hawk_actor(config, &shutdown_handler).await?;
     init_graph_from_stores(
         config,
         &iris_store,
@@ -867,7 +867,10 @@ pub async fn exec_use_backup_as_source(
 ///
 /// * `config` - Application configuration instance.
 ///
-async fn get_hawk_actor(config: &Config) -> Result<HawkActor> {
+async fn get_hawk_actor(
+    config: &Config,
+    shutdown_handler: &Arc<ShutdownHandler>,
+) -> Result<HawkActor> {
     let node_addresses: Vec<String> = config
         .node_hostnames
         .iter()
@@ -896,8 +899,7 @@ async fn get_hawk_actor(config: &Config) -> Result<HawkActor> {
         hawk_args.party_index, node_addresses
     ));
 
-    let shutdown_handler = Arc::new(ShutdownHandler::new(10));
-    HawkActor::from_cli(&hawk_args, &shutdown_handler).await
+    HawkActor::from_cli(&hawk_args, shutdown_handler.get_cancellation_token()).await
 }
 
 /// Returns service clients used downstream.

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -422,7 +422,7 @@ async fn init_hawk_actor(
         node_addresses
     );
 
-    HawkActor::from_cli(&hawk_args, shutdown_handler).await
+    HawkActor::from_cli(&hawk_args, shutdown_handler.get_cancellation_token()).await
 }
 
 /// Loads iris code shares & HNSW graph from Postgres and/or S3.

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -131,7 +131,7 @@ pub async fn server_main(config: Config) -> Result<()> {
         return Ok(());
     }
 
-    let mut hawk_actor = init_hawk_actor(&config).await?;
+    let mut hawk_actor = init_hawk_actor(&config, &shutdown_handler).await?;
 
     load_database(
         &config,
@@ -389,7 +389,10 @@ async fn sync_sqs_queues(
 
 /// Initialize main Hawk actor process for handling query batches using HNSW
 /// approximate k-nearest neighbors graph search.
-async fn init_hawk_actor(config: &Config) -> Result<HawkActor> {
+async fn init_hawk_actor(
+    config: &Config,
+    shutdown_handler: &Arc<ShutdownHandler>,
+) -> Result<HawkActor> {
     let node_addresses: Vec<String> = config
         .node_hostnames
         .iter()
@@ -419,7 +422,7 @@ async fn init_hawk_actor(config: &Config) -> Result<HawkActor> {
         node_addresses
     );
 
-    HawkActor::from_cli(&hawk_args).await
+    HawkActor::from_cli(&hawk_args, shutdown_handler).await
 }
 
 /// Loads iris code shares & HNSW graph from Postgres and/or S3.


### PR DESCRIPTION
This PR propagates networking errors to `HawkHandle`.

Note that [this PR](https://github.com/worldcoin/iris-mpc/pull/1685) needs to be merged first. 

A `CancellationToken` is added to `HawkHandle`, which gets set by `new_sessions()`. Then when the connection manager experiences a disconnect, the cancellation token gets set, causing `handle_job()` to terminate early. `health_check()` will create new sessions, which internally waits for all reconnections to finish. 
