### PR TITLE
feat: build and push iris-mpc-cpu to AWS ECR

### DIFF
--- a/.github/workflows/build-and-push-hawk-server-arm64.yaml
+++ b/.github/workflows/build-and-push-hawk-server-arm64.yaml
@@ -37,12 +37,24 @@ jobs:
           sudo setfacl --modify user:$USER:rw /var/run/docker.sock
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
+
       - name: Log in to the Container registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@49f33fe638c0cba4fb16037a27915a7ab7740259
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          aws-region: eu-central-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076
+
       - name: Build and Push
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
@@ -51,7 +63,10 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-arm64
+            ${{ secrets.AWS_ECR_IRIS_MPC_CPU }}:${{ github.sha }}-arm64
+            ${{ secrets.AWS_ECR_IRIS_MPC_CPU }}:latest-arm64
             ${{ github.event.release.tag_name && format('{0}/{1}:{2}', env.REGISTRY, env.IMAGE_NAME, github.event.release.tag_name) || '' }}
+            ${{ github.event.release.tag_name && format('{0}:{1}-arm64', secrets.AWS_ECR_IRIS_MPC_CPU, github.event.release.tag_name) || '' }}
           platforms: linux/arm64
           build-args: |
             ARCHITECTURE=aarch64

--- a/.github/workflows/build-and-push-hawk-server.yaml
+++ b/.github/workflows/build-and-push-hawk-server.yaml
@@ -33,12 +33,24 @@ jobs:
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
+
       - name: Log in to the Container registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@49f33fe638c0cba4fb16037a27915a7ab7740259
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          aws-region: eu-central-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076
+
       - name: Build and Push
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
@@ -47,7 +59,10 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ secrets.AWS_ECR_IRIS_MPC_CPU }}:${{ github.sha }}
+            ${{ secrets.AWS_ECR_IRIS_MPC_CPU }}:latest
             ${{ github.event.release.tag_name && format('{0}/{1}:{2}', env.REGISTRY, env.IMAGE_NAME, github.event.release.tag_name) || '' }}
+            ${{ github.event.release.tag_name && format('{0}:{1}', secrets.AWS_ECR_IRIS_MPC_CPU, github.event.release.tag_name) || '' }}
           platforms: linux/amd64
           build-args: |
             ARCHITECTURE=x86_64

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -59,10 +59,10 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-            ${{ secrets.AWS_ECR }}:${{ github.sha }}
-            ${{ secrets.AWS_ECR }}:latest
+            ${{ secrets.AWS_ECR_IRIS_MPC }}:${{ github.sha }}
+            ${{ secrets.AWS_ECR_IRIS_MPC }}:latest
             ${{ github.event.release.tag_name && format('{0}/{1}:{2}', env.REGISTRY, env.IMAGE_NAME, github.event.release.tag_name) || '' }}
-            ${{ github.event.release.tag_name && format('{0}:{1}', secrets.AWS_ECR, github.event.release.tag_name) || '' }}
+            ${{ github.event.release.tag_name && format('{0}:{1}', secrets.AWS_ECR_IRIS_MPC, github.event.release.tag_name) || '' }}
           build-args: |
             ARCHITECTURE=x86_64
           platforms: linux/amd64


### PR DESCRIPTION
We need those images in AWS ECR to provide more robust access from AWS EKS cluster.