### PR TITLE
[POP-2956] rotation aware trick dot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2584,11 +2584,9 @@ dependencies = [
  "itertools 0.13.0",
  "metrics 0.22.3",
  "metrics-logger",
- "num-format",
  "num-traits",
  "num_cpus",
  "num_enum",
- "perf-event",
  "prost 0.13.3",
  "rand",
  "rand_chacha",
@@ -3577,25 +3575,6 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
-
-[[package]]
-name = "perf-event"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4d6393d9238342159080d79b78cb59c67399a8e7ecfa5d410bd614169e4e823"
-dependencies = [
- "libc",
- "perf-event-open-sys",
-]
-
-[[package]]
-name = "perf-event-open-sys"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c44fb1c7651a45a3652c4afc6e754e40b3d6e6556f1487e2b230bfc4f33c2a8"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "pest"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2584,9 +2584,11 @@ dependencies = [
  "itertools 0.13.0",
  "metrics 0.22.3",
  "metrics-logger",
+ "num-format",
  "num-traits",
  "num_cpus",
  "num_enum",
+ "perf-event",
  "prost 0.13.3",
  "rand",
  "rand_chacha",
@@ -3575,6 +3577,25 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "perf-event"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4d6393d9238342159080d79b78cb59c67399a8e7ecfa5d410bd614169e4e823"
+dependencies = [
+ "libc",
+ "perf-event-open-sys",
+]
+
+[[package]]
+name = "perf-event-open-sys"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c44fb1c7651a45a3652c4afc6e754e40b3d6e6556f1487e2b230bfc4f33c2a8"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "pest"

--- a/iris-mpc-common/src/galois_engine.rs
+++ b/iris-mpc-common/src/galois_engine.rs
@@ -52,17 +52,11 @@ pub mod degree4 {
     }
 
     fn trick_dot<const D: usize>(left: &[u16; D], right: &[u16; D]) -> u16 {
-        let mut sum0 = 0u16;
-        let mut sum1 = 0u16;
-        let half = IRIS_CODE_LENGTH / 2;
-
-        // create two memory streams to exploit memory level parallelism.
-        // this improves performance when the computation is RAM bound.
-        for i in 0..half {
-            sum0 = sum0.wrapping_add(left[i].wrapping_mul(right[i]));
-            sum1 = sum1.wrapping_add(left[half + i].wrapping_mul(right[half + i]));
+        let mut sum = 0u16;
+        for i in 0..D {
+            sum = sum.wrapping_add(left[i].wrapping_mul(right[i]));
         }
-        sum0.wrapping_add(sum1)
+        sum
     }
 
     // iterate over other.coefs as though it has been rotated according to the iris rotation.
@@ -74,7 +68,7 @@ pub mod degree4 {
         rotation: &IrisRotation,
     ) -> u16 {
         let skip = match rotation {
-            IrisRotation::Center => return trick_dot(left, right),
+            IrisRotation::Center => 0,
             IrisRotation::Left(rot) => rot * 4,
             IrisRotation::Right(rot) => (CODE_COLS * 4) - (rot * 4),
         };
@@ -704,7 +698,7 @@ pub mod degree4 {
 
                 // do rotation aware trick dot first
                 let mut dots = vec![];
-                for rotation in IrisRotatoin::all() {
+                for rotation in IrisRotation::all() {
                     dots.push(left.rotation_aware_trick_dot(right, &rotation));
                 }
 

--- a/iris-mpc-common/src/galois_engine.rs
+++ b/iris-mpc-common/src/galois_engine.rs
@@ -389,8 +389,8 @@ pub mod degree4 {
             {
                 // Split the rotation into two contiguous loops,
                 // allowing the compiler to vectorize
-                let (other1, other2) = other_slice.split_at(skip);
                 let (self1, self2) = self_slice.split_at(chunk_size - skip);
+                let (other1, other2) = other_slice.split_at(skip);
 
                 for (l, r) in self1.iter().zip(other2.iter()) {
                     sum = sum.wrapping_add(l.wrapping_mul(*r));

--- a/iris-mpc-common/src/galois_engine.rs
+++ b/iris-mpc-common/src/galois_engine.rs
@@ -382,10 +382,10 @@ pub mod degree4 {
             let mut sum = 0u16;
             let chunk_size = CODE_COLS * 4;
 
-            for (self_slice, other_slice) in other
+            for (self_slice, other_slice) in self
                 .coefs
                 .chunks_exact(chunk_size)
-                .zip(self.coefs.chunks_exact(chunk_size))
+                .zip(other.coefs.chunks_exact(chunk_size))
             {
                 // Split the rotation into two contiguous loops,
                 // allowing the compiler to vectorize

--- a/iris-mpc-common/src/galois_engine.rs
+++ b/iris-mpc-common/src/galois_engine.rs
@@ -382,20 +382,21 @@ pub mod degree4 {
             let mut sum = 0u16;
             let chunk_size = CODE_COLS * 4;
 
-            for (chunk_idx, chunk) in other.coefs.chunks_exact(chunk_size).enumerate() {
-                let left_start = chunk_idx * chunk_size;
-                let left_slice = &self.coefs[left_start..left_start + chunk_size];
-
+            for (self_slice, other_slice) in other
+                .coefs
+                .chunks_exact(chunk_size)
+                .zip(self.coefs.chunks_exact(chunk_size))
+            {
                 // Split the rotation into two contiguous loops,
                 // allowing the compiler to vectorize
-                let (part1, part2) = chunk.split_at(skip);
-                let (left1, left2) = left_slice.split_at(chunk_size - skip);
+                let (other1, other2) = other_slice.split_at(skip);
+                let (self1, self2) = self_slice.split_at(chunk_size - skip);
 
-                for (l, r) in left1.iter().zip(part2.iter()) {
+                for (l, r) in self1.iter().zip(other2.iter()) {
                     sum = sum.wrapping_add(l.wrapping_mul(*r));
                 }
 
-                for (l, r) in left2.iter().zip(part1.iter()) {
+                for (l, r) in self2.iter().zip(other1.iter()) {
                     sum = sum.wrapping_add(l.wrapping_mul(*r));
                 }
             }

--- a/iris-mpc-common/src/lib.rs
+++ b/iris-mpc-common/src/lib.rs
@@ -20,6 +20,13 @@ pub const IRIS_CODE_LENGTH: usize = 12_800;
 pub const MASK_CODE_LENGTH: usize = 6_400;
 pub const ROTATIONS: usize = 31;
 
+pub const PRE_PROC_ROW_PADDING: usize = 120;
+pub const IRIS_CODE_ROWS: usize = 16;
+// 16 = 12800 / 800 = (IRIS_CODE_LENGTH) / (CODE_COLS * 4)
+pub const PRE_PROC_IRIS_CODE_LENGTH: usize =
+    IRIS_CODE_LENGTH + (IRIS_CODE_ROWS * PRE_PROC_ROW_PADDING);
+pub const PRE_PROC_MASK_CODE_LENGTH: usize = MASK_CODE_LENGTH + (8 * PRE_PROC_ROW_PADDING);
+
 /// Iris code database type; .0 = iris code, .1 = mask
 pub type IrisCodeDb = (Vec<u16>, Vec<u16>);
 /// Borrowed version of iris database; .0 = iris code, .1 = mask

--- a/iris-mpc-cpu/benches/dot.rs
+++ b/iris-mpc-cpu/benches/dot.rs
@@ -348,7 +348,7 @@ pub fn search_layer_like_calls(c: &mut Criterion) {
 
 pub fn bench_trick_dot(c: &mut Criterion) {
     let mut g = c.benchmark_group("trick_dot_vs_rotation_aware");
-    g.sample_size(10);
+    g.sample_size(50);
 
     let rng = &mut thread_rng();
     let iris_db = IrisCodeArray::random_rng(rng);

--- a/iris-mpc-cpu/benches/dot.rs
+++ b/iris-mpc-cpu/benches/dot.rs
@@ -1,8 +1,7 @@
 use std::sync::Arc;
 
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion, Throughput};
-use iris_mpc_common::galois_engine::degree4::{GaloisRingIrisCodeShare, IrisRotation};
-use iris_mpc_common::iris_db::iris::IrisCodeArray;
+use iris_mpc_common::galois_engine::degree4::IrisRotation;
 use iris_mpc_common::{
     iris_db::iris::IrisCode, IRIS_CODE_LENGTH, MASK_CODE_LENGTH, PRE_PROC_IRIS_CODE_LENGTH,
 };

--- a/iris-mpc-cpu/benches/dot.rs
+++ b/iris-mpc-cpu/benches/dot.rs
@@ -401,7 +401,7 @@ pub fn bench_trick_dot(c: &mut Criterion) {
                 for (l, r) in pairs {
                     black_box(
                         l.code
-                            .rotation_aware_trick_dot(&r.code, IrisRotation::Left(12)),
+                            .rotation_aware_trick_dot(&r.code, &IrisRotation::Left(12)),
                     );
                 }
             },
@@ -422,7 +422,7 @@ pub fn bench_trick_dot(c: &mut Criterion) {
                 for (l, arr) in pairs {
                     black_box(
                         l.code
-                            .rotation_aware_trick_dot_padded(arr, IrisRotation::Left(12)),
+                            .rotation_aware_trick_dot_padded(arr, &IrisRotation::Left(12)),
                     );
                 }
             },
@@ -467,7 +467,7 @@ pub fn bench_trick_dot(c: &mut Criterion) {
                 for (l, r, rot) in triples {
                     black_box(
                         l.code
-                            .rotation_aware_trick_dot(&r.code, IrisRotation::Left(rot)),
+                            .rotation_aware_trick_dot(&r.code, &IrisRotation::Left(rot)),
                     );
                 }
             },
@@ -491,7 +491,7 @@ pub fn bench_trick_dot(c: &mut Criterion) {
                 for (l, arr, rot) in triples {
                     black_box(
                         l.code
-                            .rotation_aware_trick_dot_padded(arr, IrisRotation::Left(rot)),
+                            .rotation_aware_trick_dot_padded(arr, &IrisRotation::Left(rot)),
                     );
                 }
             },

--- a/iris-mpc-cpu/benches/dot.rs
+++ b/iris-mpc-cpu/benches/dot.rs
@@ -422,7 +422,7 @@ pub fn bench_trick_dot(c: &mut Criterion) {
                 for (preprocessed_data, right) in pairs {
                     black_box(rotation_aware_trick_dot_padded(
                         preprocessed_data,
-                        &right,
+                        right,
                         &IrisRotation::Left(12),
                     ));
                 }


### PR DESCRIPTION
adds two new versions of `trick_dot()`:
- `rotation_aware_trick_dot()`: associates `self` with a rotation, and performs the dot product as if `self` has previously been pre-processed by `rotate_coefs_left()` or `rotate_coefs_right()`.
- `rotation_aware_trick_dot_padded()`: adds padding to each row so that, for example, a rotation of -15 (or `Left(15)` is achieved by selecting index 0..800 from the padded row.

a unit test was used to verify correctness of `rotation_aware_trick_dot()`

a benchmark was added to compare the 3 versions of `trick_dot()` in two scenarios: CPU bound and RAM bound

`trick_dot()` was refactored to be shared by `GaloisRingIrisCodeShare` and `GaloisRingTrimmedMaskCodeShare`