### PR TITLE
[POP-2992] Implement construct-graph-ptxt binary

### DIFF
--- a/iris-mpc-cpu/Cargo.toml
+++ b/iris-mpc-cpu/Cargo.toml
@@ -129,3 +129,7 @@ path = "bin/local_hnsw.rs"
 [[bin]]
 name = "generate_ideal_neighborhoods"
 path = "bin/generate_ideal_neighborhoods.rs"
+
+[[bin]]
+name = "construct-graph-ptxt"
+path = "bin/construct_graph_ptxt.rs"

--- a/iris-mpc-cpu/bin/construct_graph_ptxt.rs
+++ b/iris-mpc-cpu/bin/construct_graph_ptxt.rs
@@ -1,0 +1,120 @@
+use std::{
+    fs::File,
+    io::{BufReader, BufWriter},
+    path::PathBuf,
+    sync::Arc,
+};
+
+use clap::Parser;
+use eyre::Result;
+use tracing::info;
+
+use iris_mpc_cpu::{
+    hawkers::plaintext_store::PlaintextStore,
+    hnsw::{vector_store::VectorStoreMut, GraphMem, HnswParams, HnswSearcher},
+    py_bindings::{limited_iterator, plaintext_store::Base64IrisCode},
+};
+
+#[allow(non_snake_case)]
+#[derive(Parser)]
+struct Args {
+    /// The source file for plaintext iris codes, in NDJSON file format.
+    #[clap(long("source"))]
+    iris_codes_path: PathBuf,
+
+    /// The target file for the constructed HNSW graph.
+    #[clap(long("target"))]
+    graph_path: PathBuf,
+
+    /// Target maximum number of iris codes from the source file to use for
+    /// constructing the graph.  If this parameter is omitted, then all entries
+    /// in the source iris code file will be used.
+    #[clap(short('s'), long)]
+    graph_size: Option<usize>,
+
+    /// `M` parameter for HNSW insertion.
+    ///
+    /// Specifies the base size of graph neighborhoods for newly inserted
+    /// nodes in the graph.
+    #[clap(short, long("hnsw-m"), default_value = "256")]
+    M: usize,
+
+    /// `ef` parameter for HNSW insertion.
+    ///
+    /// Specifies the size of active search neighborhood for insertion layers
+    /// during the HNSW insertion process.
+    #[clap(long("hnsw-ef"), short, default_value = "320")]
+    ef: usize,
+
+    /// The probability that an inserted element is promoted to a higher layer
+    /// of the HNSW graph hierarchy.
+    #[clap(long("hnsw-p"), short('p'))]
+    layer_probability: Option<f64>,
+
+    /// PRF key for HNSW insertion, used to select the layer at which new
+    /// elements are inserted into the hierarchical graph structure.
+    #[clap(long, default_value = "0")]
+    hnsw_prf_key: u64,
+}
+
+#[allow(non_snake_case)]
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt().init();
+
+    // parse args
+    info!("Parsing CLI arguments");
+    let args = Args::parse();
+
+    let mut params = HnswParams::new(args.ef, args.ef, args.M);
+    if let Some(q) = args.layer_probability {
+        params.layer_probability = q;
+    }
+
+    info!("Opening iris codes input stream");
+    let file = File::open(args.iris_codes_path.as_path()).unwrap();
+    let reader = BufReader::new(file);
+
+    let stream = serde_json::Deserializer::from_reader(reader).into_iter::<Base64IrisCode>();
+    let stream = limited_iterator(stream, args.graph_size);
+
+    info!("Building HNSW graph over iris codes...");
+    let searcher = HnswSearcher { params };
+    let mut counter = 0usize;
+
+    let mut vector_store = PlaintextStore::new();
+    let mut graph = GraphMem::new();
+    let prf_seed = (args.hnsw_prf_key as u128).to_le_bytes();
+
+    for json_ptxt in stream {
+        let query = Arc::new((&json_ptxt.unwrap()).into());
+
+        let inserted_id = vector_store.insert(&query).await;
+
+        let insertion_layer = searcher.select_layer_prf(&prf_seed, &inserted_id)?;
+        let (neighbors, set_ep) = searcher
+            .search_to_insert(&mut vector_store, &graph, &query, insertion_layer)
+            .await?;
+        searcher
+            .insert_from_search_results(
+                &mut vector_store,
+                &mut graph,
+                inserted_id,
+                neighbors,
+                set_ep,
+            )
+            .await?;
+
+        counter += 1;
+        if counter % 1000 == 0 {
+            info!("Inserted {} plaintext entries", counter);
+        }
+    }
+
+    info!("Persisting HNSW graph to file");
+    let file = File::create(args.graph_path.as_path()).unwrap();
+    let writer = BufWriter::new(file);
+    bincode::serialize_into(writer, &graph)?;
+
+    Ok(())
+}

--- a/iris-mpc-cpu/src/hawkers/build_plaintext.rs
+++ b/iris-mpc-cpu/src/hawkers/build_plaintext.rs
@@ -4,12 +4,16 @@ use eyre::Result;
 use iris_mpc_common::{iris_db::iris::IrisCode, IrisVectorId};
 use itertools::Itertools;
 use tokio::task::JoinSet;
+use tracing::info;
 
 use crate::{
     execution::hawk_main::insert::{self, InsertPlanV},
     hawkers::plaintext_store::{PlaintextVectorRef, SharedPlaintextStore},
     hnsw::{GraphMem, HnswSearcher},
 };
+
+/// Number of entries to insert before reporting a new info log entry
+const REPORTING_INTERVAL: usize = 1000;
 
 pub async fn plaintext_parallel_batch_insert(
     graph: Option<GraphMem<PlaintextVectorRef>>,
@@ -24,6 +28,9 @@ pub async fn plaintext_parallel_batch_insert(
     let mut store = store.unwrap_or_default();
 
     let searcher = HnswSearcher { params };
+
+    let mut inserted_count: usize = 0;
+    let mut reported_count: usize = 0;
 
     for batch in &irises.into_iter().enumerate().chunks(batch_size) {
         let mut jobs: JoinSet<Result<_>> = JoinSet::new();
@@ -50,6 +57,8 @@ pub async fn plaintext_parallel_batch_insert(
                 };
                 Ok((vector_id, insert_plan))
             });
+
+            inserted_count += 1;
         }
 
         let mut results: Vec<_> = jobs
@@ -68,6 +77,11 @@ pub async fn plaintext_parallel_batch_insert(
         let mut graph_temp = Arc::try_unwrap(graph).unwrap();
         insert::insert(&mut store, &mut graph_temp, &searcher, plans, &ids).await?;
         graph = Arc::new(graph_temp);
+
+        if inserted_count.saturating_sub(reported_count) >= REPORTING_INTERVAL {
+            info!("Inserted {inserted_count} iris codes...");
+            reported_count = inserted_count;
+        }
     }
 
     Ok((Arc::try_unwrap(graph).unwrap(), store))

--- a/iris-mpc-cpu/src/hawkers/build_plaintext.rs
+++ b/iris-mpc-cpu/src/hawkers/build_plaintext.rs
@@ -6,16 +6,10 @@ use itertools::Itertools;
 use tokio::task::JoinSet;
 
 use crate::{
-    execution::hawk_main::{
-        insert::{self, InsertPlanV},
-        BothEyes,
-    },
+    execution::hawk_main::insert::{self, InsertPlanV},
     hawkers::plaintext_store::{PlaintextVectorRef, SharedPlaintextStore},
     hnsw::{GraphMem, HnswSearcher},
 };
-
-pub type SharedPlaintextGraphs = BothEyes<GraphMem<PlaintextVectorRef>>;
-pub type SharedPlaintextStores = BothEyes<SharedPlaintextStore>;
 
 pub async fn plaintext_parallel_batch_insert(
     graph: Option<GraphMem<PlaintextVectorRef>>,

--- a/iris-mpc-cpu/src/hawkers/shared_irises.rs
+++ b/iris-mpc-cpu/src/hawkers/shared_irises.rs
@@ -284,4 +284,18 @@ impl<I: Clone> SharedIrisesRef<I> {
     pub async fn checksum(&self) -> u64 {
         self.data.read().await.set_hash.checksum()
     }
+
+    /// Attempt to unwrap this shared reference.  Succeeds if there is exactly
+    /// one strong reference remaining to the underlying data, in which case the
+    /// data is unwrapped and returned as an Ok result.  If more than one strong
+    /// reference remains, a SharedIrisesRef with the same underlying data is
+    /// returned as an Err result.
+    pub fn try_unwrap<T>(self) -> Result<SharedIrises<I>, Self> {
+        let SharedIrisesRef { data } = self;
+        let lock_ = Arc::try_unwrap(data);
+        match lock_ {
+            Err(arc) => Err(SharedIrisesRef { data: arc }),
+            Ok(lock) => Ok(lock.into_inner()),
+        }
+    }
 }


### PR DESCRIPTION
PR implements a small binary to construct an HNSW graph from plaintext iris code input, with output serialized to file using the standard "single-graph" binary output format.  This binary will be used primarily for upcoming data analysis tasks.