### PR TITLE
[POP-2916] Change `intra_batch_rule` to `AND`

### DIFF
--- a/iris-mpc-cpu/src/execution/hawk_main/matching.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/matching.rs
@@ -549,10 +549,10 @@ mod tests {
     #[test]
     fn test_intra_rule() {
         for x in [false, true] {
-            // Matching within a batch: OR rule.
-            assert_eq!(FILTER_INTRA.intra_rule(true, x), true);
-            assert_eq!(FILTER_INTRA.intra_rule(x, true), true);
-            assert_eq!(FILTER_INTRA.intra_rule(false, false), false);
+            // Matching within a batch: AND rule.
+            assert_eq!(FILTER_INTRA.intra_rule(false, x), false);
+            assert_eq!(FILTER_INTRA.intra_rule(x, false), false);
+            assert_eq!(FILTER_INTRA.intra_rule(true, true), true);
 
             // If intra-batch is not requested, always false.
             for y in [false, true] {


### PR DESCRIPTION
See [linear issue](https://linear.app/worldcoin/issue/POP-2916/investigate-mismatch-between-hnsw-and-gpu) for context.

See [this thread](https://inversed.slack.com/archives/C08FBFZSTHP/p1759509084751299?thread_ts=1758205823.283759&cid=C08FBFZSTHP) for discussion on `AND` being implemented by the GPU and the fact that this change does resolve the failing test case.

