### PR TITLE
[POP-2965] Compute minimal distance over rotations 

### DIFF
--- a/deploy/dev/common-values-ampc-hnsw.yaml
+++ b/deploy/dev/common-values-ampc-hnsw.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc-cpu:04dc776bc0a4c046e9ecbaad797e8605328cb121"
+image: "ghcr.io/worldcoin/iris-mpc-cpu:3a53d9a1a90136baac6c72f5cfe32ef98dac1db9"
 
 environment: dev
 replicaCount: 1

--- a/iris-mpc-common/src/vector_id.rs
+++ b/iris-mpc-common/src/vector_id.rs
@@ -8,7 +8,9 @@ pub type SerialId = u32;
 pub type VersionId = i16;
 
 /// Unique identifier for an immutable pair of iris codes.
-#[derive(Copy, Default, Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(
+    Copy, Default, Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, PartialOrd, Ord,
+)]
 pub struct VectorId {
     id: SerialId,
     version: VersionId,

--- a/iris-mpc-cpu/Cargo.toml
+++ b/iris-mpc-cpu/Cargo.toml
@@ -33,6 +33,7 @@ num-traits.workspace = true
 prost = "0.13"
 rand.workspace = true
 rand_distr = "0.4.3"
+rayon.workspace = true
 rstest = "0.23.0"
 serde.workspace = true
 serde_json.workspace = true
@@ -124,3 +125,7 @@ path = "bin/init_test_dbs.rs"
 [[bin]]
 name = "local_hnsw"
 path = "bin/local_hnsw.rs"
+
+[[bin]]
+name = "generate_ideal_neighborhoods"
+path = "bin/generate_ideal_neighborhoods.rs"

--- a/iris-mpc-cpu/bin/generate_ideal_neighborhoods.rs
+++ b/iris-mpc-cpu/bin/generate_ideal_neighborhoods.rs
@@ -1,0 +1,229 @@
+use std::{
+    fs::{File, OpenOptions},
+    io::{BufRead, BufReader, Write},
+    path::PathBuf,
+};
+
+use clap::{Parser, ValueEnum};
+use iris_mpc_common::{iris_db::iris::IrisCode, IrisSerialId};
+use iris_mpc_cpu::{
+    hawkers::naive_knn_plaintext::{naive_knn, KNNResult},
+    py_bindings::plaintext_store::Base64IrisCode,
+};
+use metrics::IntoF64;
+use rayon::ThreadPoolBuilder;
+use serde::{Deserialize, Serialize};
+use serde_json::Deserializer;
+use std::time::Instant;
+
+#[derive(Clone, Debug, ValueEnum, Copy, Serialize, Deserialize, PartialEq)]
+enum IrisSelection {
+    All,
+    Even,
+    Odd,
+}
+
+/// A struct to hold the metadata stored in the first line of the results file.
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+struct ResultsHeader {
+    iris_selection: IrisSelection,
+    num_irises: usize,
+    k: usize,
+}
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Number of irises to process
+    #[arg(long, default_value_t = 1000)]
+    num_irises: usize,
+
+    /// Number of threads to use
+    #[arg(long, default_value_t = 1)]
+    num_threads: usize,
+
+    /// Path to the iris codes file
+    #[arg(long, default_value = "iris-mpc-cpu/data/store.ndjson")]
+    path_to_iris_codes: PathBuf,
+
+    /// The k for k-NN
+    #[arg(long)]
+    k: usize,
+
+    /// Path to the results file
+    #[arg(long)]
+    results_file: PathBuf,
+
+    /// Selection of irises to process
+    #[arg(long, value_enum, default_value_t = IrisSelection::All)]
+    irises_selection: IrisSelection,
+}
+#[tokio::main]
+async fn main() {
+    let args = Args::parse();
+
+    let (num_already_processed, nodes) = match File::open(&args.results_file) {
+        Ok(file) => {
+            let reader = BufReader::new(file);
+            let mut lines = reader.lines();
+
+            // 1. Read and validate the header line
+            let header_line = match lines.next() {
+                Some(Ok(line)) => line,
+                Some(Err(e)) => {
+                    eprintln!("Error: Could not read header from results file: {}", e);
+                    std::process::exit(1);
+                }
+                None => {
+                    eprintln!(
+                        "Error: Results file '{}' is empty. Please fix or delete it.",
+                        args.results_file.display()
+                    );
+                    std::process::exit(1);
+                }
+            };
+
+            let file_header: ResultsHeader = match serde_json::from_str(&header_line) {
+                Ok(h) => h,
+                Err(e) => {
+                    eprintln!("Error: Could not parse header in results file: {}", e);
+                    eprintln!(
+                        " -> Please fix or delete the file '{}' and restart.",
+                        args.results_file.display()
+                    );
+                    std::process::exit(1);
+                }
+            };
+
+            // 2. Check for configuration mismatches with a single comparison
+            let expected_header = ResultsHeader {
+                iris_selection: args.irises_selection,
+                num_irises: args.num_irises,
+                k: args.k,
+            };
+
+            if file_header != expected_header {
+                eprintln!("Error: Mismatch in results file configuration.");
+                eprintln!(" -> Expected parameters: {:?}", expected_header);
+                eprintln!(" -> Parameters found in file: {:?}", file_header);
+                eprintln!(" -> Please use a different results file or adjust the command-line arguments to match.");
+                std::process::exit(1);
+            }
+
+            // 3. Process the rest of the lines as KNN results
+            let results: Result<Vec<KNNResult>, _> = lines
+                .map(|line_result| {
+                    let line = line_result.map_err(|e| e.to_string())?;
+                    serde_json::from_str::<KNNResult>(&line).map_err(|e| e.to_string())
+                })
+                .collect();
+
+            let deserialized_results = match results {
+                Ok(res) => res,
+                Err(e) => {
+                    eprintln!("Error: Failed to deserialize a result from the file.");
+                    eprintln!("It may be corrupted from an abrupt shutdown.");
+                    eprintln!(" -> Error details: {}", e);
+                    eprintln!(
+                        " -> Please fix or delete the file '{}' and restart.",
+                        args.results_file.display()
+                    );
+                    std::process::exit(1);
+                }
+            };
+
+            let nodes: Vec<IrisSerialId> = deserialized_results
+                .into_iter()
+                .map(|result| result.node)
+                .collect();
+            (nodes.len(), nodes)
+        }
+        Err(_) => {
+            // File doesn't exist, create it and write the header.
+            let mut file = File::create(&args.results_file).expect("Unable to create results file");
+            let header = ResultsHeader {
+                iris_selection: args.irises_selection,
+                num_irises: args.num_irises,
+                k: args.k,
+            };
+            let header_str =
+                serde_json::to_string(&header).expect("Failed to serialize ResultsHeader");
+            writeln!(file, "{}", header_str).expect("Failed to write header to new results file");
+            (0, Vec::new())
+        }
+    };
+
+    if num_already_processed > 0 {
+        let expected_nodes: Vec<IrisSerialId> = (1..(num_already_processed + 1) as u32).collect();
+        if nodes != expected_nodes {
+            eprintln!(
+                "Error: The result nodes in the file are not a contiguous sequence from 1 to N."
+            );
+            eprintln!(
+                " -> Please fix or delete the file '{}' and restart.",
+                args.results_file.display()
+            );
+            std::process::exit(1);
+        }
+    }
+
+    let num_irises = args.num_irises;
+    let path_to_iris_codes = args.path_to_iris_codes;
+
+    assert!(num_irises > args.k);
+
+    let file = File::open(path_to_iris_codes.as_path()).unwrap();
+    let reader = BufReader::new(file);
+
+    let stream = Deserializer::from_reader(reader).into_iter::<Base64IrisCode>();
+    let mut irises: Vec<IrisCode> = Vec::with_capacity(num_irises);
+
+    let (limit, skip, step) = match args.irises_selection {
+        IrisSelection::All => (num_irises, 0, 1),
+        IrisSelection::Even => (num_irises * 2, 0, 2),
+        IrisSelection::Odd => (num_irises * 2, 1, 2),
+    };
+
+    let stream_iterator = stream
+        .take(limit)
+        .skip(skip)
+        .step_by(step)
+        .map(|json_pt| (&json_pt.unwrap()).into());
+    irises.extend(stream_iterator);
+    assert!(irises.len() == num_irises);
+
+    let start_t = Instant::now();
+    let pool = ThreadPoolBuilder::new()
+        .num_threads(args.num_threads)
+        .build()
+        .unwrap();
+
+    let mut start = num_already_processed + 1;
+    let chunk_size = 1000;
+    println!("Starting work at serial id: {}", start);
+    let mut evaluated_pairs = 0usize;
+
+    while start < num_irises {
+        let end = (start + chunk_size).min(num_irises);
+        let results = naive_knn(&irises, args.k, start, end, &pool);
+        evaluated_pairs += (end - start) * num_irises;
+
+        let mut file = OpenOptions::new()
+            .append(true)
+            .open(&args.results_file)
+            .expect("Unable to open results file for appending");
+
+        println!("Appending iris results from {} to {}", start, end);
+        for result in &results {
+            let json_line = serde_json::to_string(result).expect("Failed to serialize KNNResult");
+            writeln!(file, "{}", json_line).expect("Failed to write to results file");
+        }
+
+        start = end;
+    }
+    let duration = start_t.elapsed();
+    println!(
+        "naive_knn took {:?} (per evaluated pair)",
+        duration.into_f64() / (evaluated_pairs as f64)
+    );
+}

--- a/iris-mpc-cpu/src/hawkers/mod.rs
+++ b/iris-mpc-cpu/src/hawkers/mod.rs
@@ -21,3 +21,5 @@ pub mod plaintext_store;
 pub mod shared_irises;
 
 pub mod build_plaintext;
+
+pub mod naive_knn_plaintext;

--- a/iris-mpc-cpu/src/hawkers/naive_knn_plaintext.rs
+++ b/iris-mpc-cpu/src/hawkers/naive_knn_plaintext.rs
@@ -1,0 +1,52 @@
+use iris_mpc_common::{iris_db::iris::IrisCode, IrisSerialId};
+use rayon::{
+    iter::{IntoParallelIterator, ParallelIterator},
+    ThreadPool,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::hawkers::plaintext_store::fraction_ordering;
+
+#[derive(Serialize, Deserialize)]
+pub struct KNNResult {
+    pub node: IrisSerialId,
+    neighbors: Vec<IrisSerialId>,
+}
+
+pub fn naive_knn(
+    irises: &[IrisCode],
+    k: usize,
+    start: usize,
+    end: usize,
+    pool: &ThreadPool,
+) -> Vec<KNNResult> {
+    pool.install(|| {
+        (start..end)
+            .collect::<Vec<_>>()
+            .into_par_iter()
+            .map(|i| {
+                let current_iris = &irises[i - 1];
+                let mut neighbors = irises
+                    .iter()
+                    .enumerate()
+                    .flat_map(|(j, other_iris)| {
+                        (i != j + 1).then_some((
+                            (j + 1) as u32,
+                            current_iris.get_distance_fraction(other_iris),
+                        ))
+                    })
+                    .collect::<Vec<_>>();
+                neighbors
+                    .select_nth_unstable_by(k - 1, |lhs, rhs| fraction_ordering(&lhs.1, &rhs.1));
+                let mut neighbors = neighbors.drain(0..k).collect::<Vec<_>>();
+                neighbors.shrink_to_fit(); // just to make sure
+                neighbors.sort_by(|lhs, rhs| fraction_ordering(&lhs.1, &rhs.1));
+                let neighbors = neighbors.into_iter().map(|(i, _)| i).collect::<Vec<_>>();
+                KNNResult {
+                    node: i as u32,
+                    neighbors,
+                }
+            })
+            .collect::<Vec<_>>()
+    })
+}

--- a/iris-mpc-cpu/src/hawkers/plaintext_store.rs
+++ b/iris-mpc-cpu/src/hawkers/plaintext_store.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{cmp::Ordering, sync::Arc};
 
 use crate::{
     hawkers::shared_irises::{SharedIrises, SharedIrisesRef},
@@ -122,6 +122,12 @@ fn fraction_less_than(dist_1: &(u16, u16), dist_2: &(u16, u16)) -> bool {
     let (a, b) = *dist_1; // a/b
     let (c, d) = *dist_2; // c/d
     (a as u32) * (d as u32) < (b as u32) * (c as u32)
+}
+
+pub fn fraction_ordering(dist_1: &(u16, u16), dist_2: &(u16, u16)) -> Ordering {
+    let (a, b) = *dist_1; // a/b
+    let (c, d) = *dist_2; // c/d
+    ((a as u32) * (d as u32)).cmp(&((b as u32) * (c as u32)))
 }
 
 impl VectorStore for PlaintextStore {

--- a/iris-mpc-cpu/src/hnsw/graph/graph_diff/explicit.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/graph_diff/explicit.rs
@@ -1,0 +1,135 @@
+use std::{
+    collections::HashSet,
+    fmt::{Display, Formatter, Result},
+    str::FromStr,
+};
+
+use super::{jaccard::JaccardState, Differ};
+use crate::hnsw::{graph::neighborhood::SortedEdgeIds, vector_store::Ref};
+
+#[derive(Debug, Clone)]
+pub enum SortBy {
+    /// Sorts nodes by their natural order (e.g., index).
+    Index,
+    /// Sorts nodes by Jaccard similarity, from least similar to most similar.
+    Jaccard,
+}
+
+/// Contains the explicit differences between two neighborhoods for a single node.
+#[derive(Debug, Clone)]
+pub struct NeighborhoodDiff<V: Ref> {
+    pub only_in_lhs: HashSet<V>,
+    pub only_in_rhs: HashSet<V>,
+    pub jaccard_state: JaccardState,
+}
+
+#[derive(Debug, Clone)]
+pub struct ExplicitDiff<V: Ref>(pub Vec<LayerDiffResult<V>>);
+
+#[derive(Debug, Clone)]
+pub struct LayerDiffResult<V: Ref> {
+    pub layer_index: usize,
+    pub diffs: Vec<(V, NeighborhoodDiff<V>)>,
+}
+
+impl<V: Ref + Display> Display for ExplicitDiff<V> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        for layer_result in &self.0 {
+            writeln!(f, "--- Layer {} ---", layer_result.layer_index)?;
+            if layer_result.diffs.is_empty() {
+                writeln!(f, "No differences found.")?;
+            }
+            for (node, diff) in &layer_result.diffs {
+                // Only print nodes that actually have differences.
+                if !diff.only_in_lhs.is_empty() || !diff.only_in_rhs.is_empty() {
+                    writeln!(
+                        f,
+                        "Node: {} (Jaccard: {:.4})",
+                        node,
+                        diff.jaccard_state.compute()
+                    )?;
+                    for neighbor in &diff.only_in_lhs {
+                        writeln!(f, "  + {}", neighbor)?;
+                    }
+                    for neighbor in &diff.only_in_rhs {
+                        writeln!(f, "  - {}", neighbor)?;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// A differ that returns the explicit lists of node differences between neighborhoods.
+pub struct ExplicitNeighborhoodDiffer<V: Ref> {
+    sort_by: SortBy,
+    per_layer_results: Vec<LayerDiffResult<V>>,
+    current_layer_diffs: Vec<(V, NeighborhoodDiff<V>)>,
+}
+
+impl<V: Ref> ExplicitNeighborhoodDiffer<V> {
+    pub fn new(sort_by: SortBy) -> Self {
+        Self {
+            sort_by,
+            per_layer_results: Vec::new(),
+            current_layer_diffs: Vec::new(),
+        }
+    }
+}
+
+impl<V: Ref + Display + FromStr + Ord> Differ<V> for ExplicitNeighborhoodDiffer<V> {
+    type Output = ExplicitDiff<V>;
+
+    fn start_layer(&mut self, _layer_index: usize) {
+        self.current_layer_diffs.clear();
+    }
+
+    fn diff_neighborhood(
+        &mut self,
+        _layer_index: usize,
+        node: &V,
+        lhs: &SortedEdgeIds<V>,
+        rhs: &SortedEdgeIds<V>,
+    ) {
+        let lhs_set: HashSet<_> = lhs.0.iter().cloned().collect();
+        let rhs_set: HashSet<_> = rhs.0.iter().cloned().collect();
+
+        let only_in_lhs: HashSet<_> = lhs_set.difference(&rhs_set).cloned().collect();
+        let only_in_rhs: HashSet<_> = rhs_set.difference(&lhs_set).cloned().collect();
+
+        let intersection = lhs_set.intersection(&rhs_set).count();
+        let union = lhs_set.union(&rhs_set).count();
+        let jaccard_state = JaccardState::new(intersection, union);
+
+        let diff = NeighborhoodDiff {
+            only_in_lhs,
+            only_in_rhs,
+            jaccard_state,
+        };
+
+        self.current_layer_diffs.push((node.clone(), diff));
+    }
+
+    fn end_layer(&mut self, layer_index: usize) {
+        if !self.current_layer_diffs.is_empty() {
+            match self.sort_by {
+                SortBy::Jaccard => {
+                    self.current_layer_diffs
+                        .sort_by(|a, b| a.1.jaccard_state.compare_as_fractions(&b.1.jaccard_state));
+                }
+                SortBy::Index => {
+                    self.current_layer_diffs.sort_by(|a, b| a.0.cmp(&b.0));
+                }
+            }
+            self.per_layer_results.push(LayerDiffResult {
+                layer_index,
+                diffs: std::mem::take(&mut self.current_layer_diffs),
+            });
+        }
+    }
+
+    fn finish(self) -> Self::Output {
+        ExplicitDiff(self.per_layer_results)
+    }
+}

--- a/iris-mpc-cpu/src/hnsw/graph/graph_diff/jaccard.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/graph_diff/jaccard.rs
@@ -1,0 +1,140 @@
+use super::Differ;
+use crate::hnsw::{graph::neighborhood::SortedEdgeIds, vector_store::Ref};
+use std::{collections::HashSet, fmt::Display, ops::Add, str::FromStr};
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct JaccardState {
+    pub intersection: usize,
+    pub union: usize,
+}
+
+impl JaccardState {
+    pub fn new(intersection: usize, union: usize) -> Self {
+        Self {
+            intersection,
+            union,
+        }
+    }
+    /// Calculates the Jaccard similarity, a value between 0.0 and 1.0.
+    pub fn compute(&self) -> f64 {
+        if self.union == 0 {
+            1.0
+        } else {
+            self.intersection as f64 / self.union as f64
+        }
+    }
+
+    pub fn is_one(&self) -> bool {
+        self.union == self.intersection
+    }
+
+    pub fn compare_as_fractions(&self, other: &Self) -> std::cmp::Ordering {
+        // Compare a/b vs c/d as a*d vs c*b
+        (self.intersection * other.union).cmp(&(other.intersection * self.union))
+    }
+}
+impl Add for JaccardState {
+    type Output = Self;
+    fn add(self, rhs: Self) -> Self::Output {
+        Self {
+            intersection: self.intersection + rhs.intersection,
+            union: self.union + rhs.union,
+        }
+    }
+}
+
+impl Display for JaccardState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{:.4} ({}/{})",
+            self.compute(),
+            self.intersection,
+            self.union
+        )
+    }
+}
+
+/// A differ that computes detailed Jaccard similarity, including the `n` most dissimilar nodes per layer.
+pub struct DetailedJaccardDiffer<V: Ref> {
+    n: usize,
+    graph_state: JaccardState,
+    current_layer_details: Vec<(V, JaccardState)>,
+    per_layer_results: Vec<(JaccardState, Vec<(V, JaccardState)>)>,
+}
+
+impl<V: Ref> DetailedJaccardDiffer<V> {
+    pub fn new(n: usize) -> Self {
+        Self {
+            n,
+            graph_state: JaccardState::default(),
+            current_layer_details: Vec::new(),
+            per_layer_results: Vec::new(),
+        }
+    }
+}
+
+pub struct DetailedJaccardReport<V>(
+    #[allow(clippy::type_complexity)]
+    pub  (JaccardState, Vec<(JaccardState, Vec<(V, JaccardState)>)>),
+);
+
+impl<V: Ref + Display> Display for DetailedJaccardReport<V> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let (graph_state, per_layer_results) = &self.0;
+        writeln!(f, "GRAPH aggregate: {}", graph_state)?;
+        for (layer_idx, layer_result) in per_layer_results.iter().enumerate() {
+            writeln!(f, "  LAYER {} aggregate: {}", layer_idx, layer_result.0)?;
+            writeln!(f, "  Top {} most dissimilar nodes:", layer_result.1.len())?;
+            for (node, node_state) in &layer_result.1 {
+                writeln!(f, "    Node {}: {}", node, node_state)?;
+            }
+            writeln!(f)?;
+        }
+        Ok(())
+    }
+}
+
+impl<V: Ref + Display + FromStr> Differ<V> for DetailedJaccardDiffer<V> {
+    type Output = DetailedJaccardReport<V>;
+
+    fn start_layer(&mut self, _layer_index: usize) {
+        self.current_layer_details.clear();
+    }
+
+    fn diff_neighborhood(
+        &mut self,
+        _layer_index: usize,
+        node: &V,
+        lhs: &SortedEdgeIds<V>,
+        rhs: &SortedEdgeIds<V>,
+    ) {
+        let lhs_set: HashSet<_> = lhs.0.iter().collect();
+        let rhs_set: HashSet<_> = rhs.0.iter().collect();
+        let intersection = lhs_set.intersection(&rhs_set).count();
+        let union = lhs_set.union(&rhs_set).count();
+        let node_state = JaccardState::new(intersection, union);
+        self.current_layer_details.push((node.clone(), node_state));
+    }
+
+    fn end_layer(&mut self, _layer_index: usize) {
+        let layer_total_state = self
+            .current_layer_details
+            .iter()
+            .fold(JaccardState::default(), |acc, (_, state)| acc + *state);
+        self.graph_state = self.graph_state + layer_total_state;
+
+        self.current_layer_details
+            .sort_by(|a, b| a.1.compare_as_fractions(&b.1));
+        self.current_layer_details.truncate(self.n);
+
+        self.per_layer_results.push((
+            layer_total_state,
+            std::mem::take(&mut self.current_layer_details),
+        ));
+    }
+
+    fn finish(self) -> Self::Output {
+        DetailedJaccardReport((self.graph_state, self.per_layer_results))
+    }
+}

--- a/iris-mpc-cpu/src/hnsw/graph/graph_diff/mod.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/graph_diff/mod.rs
@@ -1,0 +1,63 @@
+use std::fmt::Display;
+use std::str::FromStr;
+
+use crate::hnsw::graph::neighborhood::SortedEdgeIds;
+use crate::hnsw::{vector_store::Ref, GraphMem};
+
+pub mod explicit;
+pub mod jaccard;
+pub mod node_equiv;
+
+/// A trait that defines a graph diffing strategy using a visitor pattern.
+///
+/// A `Differ` implementation can maintain internal state and update it as the
+/// `run_diff` function traverses the layers and nodes of the graphs.
+pub trait Differ<V: Ref + Display + FromStr> {
+    /// The final output type of the diffing operation.
+    type Output: Display;
+
+    /// Called once before graph traversal begins.
+    fn start_graph(&mut self) {}
+
+    /// Called before traversing each layer.
+    fn start_layer(&mut self, _layer_index: usize) {}
+
+    /// Called for each node that exists in both the `lhs` and `rhs` layer.
+    fn diff_neighborhood(
+        &mut self,
+        layer_index: usize,
+        node: &V,
+        lhs: &SortedEdgeIds<V>,
+        rhs: &SortedEdgeIds<V>,
+    );
+
+    /// Called after traversing each layer.
+    fn end_layer(&mut self, _layer_index: usize) {}
+
+    /// Called at the very end to consume the differ and produce the final result.
+    fn finish(self) -> Self::Output;
+}
+
+/// Traverses two graphs and applies a `Differ` to compute a result.
+///
+/// It's recommended to run `ensure_node_equivalence` before using this function
+/// to ensure the graphs have a comparable structure.
+pub fn run_diff<V, D>(lhs: &GraphMem<V>, rhs: &GraphMem<V>, mut differ: D) -> D::Output
+where
+    V: Ref + Display + FromStr,
+    D: Differ<V>,
+{
+    differ.start_graph();
+
+    for (i, (lhs_layer, rhs_layer)) in lhs.layers.iter().zip(rhs.layers.iter()).enumerate() {
+        differ.start_layer(i);
+        for (node, lhs_nbhd) in lhs_layer.links.iter() {
+            if let Some(rhs_nbhd) = rhs_layer.links.get(node) {
+                differ.diff_neighborhood(i, node, lhs_nbhd, rhs_nbhd);
+            }
+        }
+        differ.end_layer(i);
+    }
+
+    differ.finish()
+}

--- a/iris-mpc-cpu/src/hnsw/graph/graph_diff/node_equiv.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/graph_diff/node_equiv.rs
@@ -1,0 +1,63 @@
+use std::collections::HashSet;
+use std::fmt::Display;
+use std::str::FromStr;
+
+use crate::hnsw::vector_store::Ref;
+use crate::hnsw::GraphMem;
+
+/// Describes how the node and layer structure of two graphs are not equivalent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NodeEquivalenceError<V> {
+    /// The graphs have a different number of layers.
+    LayerCountMismatch { lhs_count: usize, rhs_count: usize },
+    /// A node was found in the left-hand graph's layer that was not in the right's.
+    NodeMissingInRhs { layer_index: usize, node: V },
+    /// A node was found in the right-hand graph's layer that was not in the left's.
+    NodeMissingInLhs { layer_index: usize, node: V },
+}
+
+/// Diffs the node and layer structure of two graphs.
+///
+/// This function ensures that two graphs have the same number of layers and the
+/// same (unordered) set of nodes in each corresponding layer.
+///
+/// # Returns
+/// - `Ok(())` if the graphs are equivalent in their node and layer structure.
+/// - `Err(NodeEquivalenceError)` if they are not, with a reason for the failure.
+pub fn ensure_node_equivalence<V: Ref + Display + FromStr>(
+    lhs: &GraphMem<V>,
+    rhs: &GraphMem<V>,
+) -> Result<(), NodeEquivalenceError<V>> {
+    // First, check if the number of layers is the same.
+    if lhs.layers.len() != rhs.layers.len() {
+        return Err(NodeEquivalenceError::LayerCountMismatch {
+            lhs_count: lhs.layers.len(),
+            rhs_count: rhs.layers.len(),
+        });
+    }
+
+    // Iterate over each pair of layers to compare their nodes.
+    for (i, (lhs_layer, rhs_layer)) in lhs.layers.iter().zip(rhs.layers.iter()).enumerate() {
+        let lhs_nodes: HashSet<_> = lhs_layer.links.keys().cloned().collect();
+        let rhs_nodes: HashSet<_> = rhs_layer.links.keys().cloned().collect();
+
+        // Check for any node that exists in the left layer but not the right.
+        if let Some(missing_node) = lhs_nodes.difference(&rhs_nodes).next() {
+            return Err(NodeEquivalenceError::NodeMissingInRhs {
+                layer_index: i,
+                node: missing_node.clone(),
+            });
+        }
+
+        // Check for any node that exists in the right layer but not the left.
+        if let Some(missing_node) = rhs_nodes.difference(&lhs_nodes).next() {
+            return Err(NodeEquivalenceError::NodeMissingInLhs {
+                layer_index: i,
+                node: missing_node.clone(),
+            });
+        }
+    }
+
+    // If all checks pass, the graphs are equivalent.
+    Ok(())
+}

--- a/iris-mpc-cpu/src/hnsw/graph/mod.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/mod.rs
@@ -1,3 +1,4 @@
+pub mod graph_diff;
 pub mod graph_store;
 pub mod layered_graph;
 pub mod neighborhood;

--- a/iris-mpc-cpu/src/hnsw/vector_store.rs
+++ b/iris-mpc-cpu/src/hnsw/vector_store.rs
@@ -102,9 +102,16 @@ pub trait VectorStore: Debug {
     /// Evaluate the minimal distance over all distances between rotations of the query and a vector in the input batch.
     /// The default implementation is a simple iterative minimum search of linear depth.
     /// Override for more efficient minimum distance evaluations.
-    async fn eval_minimal_rotation_distance_batch(&mut self, query: &[Self::QueryRef; ROTATIONS], vectors: &[Self::VectorRef]) -> Result<Vec<Self::DistanceRef>> {
+    async fn eval_minimal_rotation_distance_batch(
+        &mut self,
+        query: &[Self::QueryRef; ROTATIONS],
+        vectors: &[Self::VectorRef],
+    ) -> Result<Vec<Self::DistanceRef>> {
         // pairs (Query, Vector) where each vector is paired with all ROTATIONS queries
-        let pairs = vectors.iter().flat_map(|v| query.iter().map(|q| (q.clone(),v.clone())).collect_vec()).collect_vec();
+        let pairs = vectors
+            .iter()
+            .flat_map(|v| query.iter().map(|q| (q.clone(), v.clone())).collect_vec())
+            .collect_vec();
         let distances = self.eval_distance_pairs(&pairs).await?;
         let mut results = Vec::with_capacity(vectors.len());
         for rot_dists in distances.chunks(ROTATIONS) {

--- a/iris-mpc-utils/bin/graph_mem_cli.rs
+++ b/iris-mpc-utils/bin/graph_mem_cli.rs
@@ -1,6 +1,6 @@
 use clap::{Parser, Subcommand};
 use eyre::Result;
-use iris_mpc_cpu::hnsw::graph::test_utils::DbContext;
+use iris_mpc_cpu::hnsw::graph::test_utils::{DbContext, DiffMethod};
 use std::path::PathBuf;
 
 #[derive(Parser)]
@@ -34,7 +34,11 @@ enum Command {
     /// (testing only) verify that Load/Store works as expected
     VerifyBackup,
     /// Load a graph from a file and compare it to the graph stored in the database.
-    CompareToDb,
+    CompareToDb {
+        /// The diffing method to use for the comparison.
+        #[arg(long, value_enum, default_value_t = DiffMethod::DetailedJaccard)]
+        diff_method: DiffMethod,
+    },
 }
 
 #[tokio::main]
@@ -65,12 +69,12 @@ async fn main() -> Result<()> {
             db_context.store_random_graph().await?;
             db_context.write_graph_to_file(&file, dbg).await?;
         }
-        Command::CompareToDb => {
-            db_context.compare_to_db(&file, dbg).await?;
+        Command::CompareToDb { diff_method } => {
+            db_context.compare_to_db(&file, diff_method, dbg).await?;
         }
     }
     // this command has it own output
-    if !matches!(command, Command::CompareToDb) {
+    if !matches!(command, Command::CompareToDb { diff_method: _ }) {
         println!("Command succeeded");
     }
 


### PR DESCRIPTION
This adds a new method to `VectorStore` that takes rotations of a query iris, computes the distances between them and a given iris vector and returns the minimal distance lifted to 32-bit shares for further comparisons. Batching is supported. `Aby3Store` contains an optimized implementation via oblivious minimal trees.