### PR TITLE
Fix genesis Docker image name and entrypoint

### DIFF
--- a/.github/workflows/build-and-push-upgrade-hawk.yaml
+++ b/.github/workflows/build-and-push-upgrade-hawk.yaml
@@ -15,7 +15,7 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: "${{ github.repository }}-genesis"
+  IMAGE_NAME: "iris-mpc-genesis"
 
 jobs:
   docker:

--- a/Dockerfile.arm64.genesis.hawk
+++ b/Dockerfile.arm64.genesis.hawk
@@ -63,6 +63,8 @@ RUN update-ca-certificates
 COPY --from=build-app /src/iris-mpc-upgrade-hawk/target/aarch64-unknown-linux-gnu/release/iris-mpc-hawk-genesis /bin/iris-mpc-hawk-genesis
 COPY --from=build-app /src/iris-mpc-upgrade-hawk/target/aarch64-unknown-linux-gnu/release/db-sanity-check /bin/db-sanity-check
 
+COPY scripts/run-genesis.sh /bin/run-genesis.sh
+
 USER 65534
 
-ENTRYPOINT ["/bin/iris-mpc-hawk-genesis"]
+ENTRYPOINT ["/bin/run-genesis.sh"]


### PR DESCRIPTION
## Summary
- **Fix double org prefix in IMAGE_NAME**: `github.repository` already includes `worldcoin/`, so the image name resolved to `worldcoin/worldcoin/iris-mpc-genesis`. Changed to literal `"iris-mpc-genesis"`.
- **Add missing `run-genesis.sh` to arm64 Dockerfile**: the bare binary entrypoint can't translate `GENESIS_*` env vars into CLI args. Adds the `run-genesis.sh` wrapper script (matching the non-arm64 Dockerfile).

## Test plan
- [ ] CI passes
- [ ] Verify genesis image builds correctly with the new name

🤖 Generated with [Claude Code](https://claude.com/claude-code)