### PR TITLE
chore: ignore RUSTSEC-2026-0097/0098/0099 advisories

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -33,6 +33,7 @@ ignore = [
     { id = "RUSTSEC-2025-0141", reason = "stable even if no longer maintained" },
     { id = "RUSTSEC-2026-0002", reason = "waiting for aws-sdk-s3 to bump this dependency" },
     { id = "RUSTSEC-2026-0097", reason = "transitive rand 0.9.2 via metrics/statrs/tower crates; UB requires a custom log::Log logger calling rand::rng(), but iris-mpc uses tracing — drop once upstream bumps rand to a safe version" },
+    { id = "RUSTSEC-2026-0098", reason = "rustls-webpki 0.101.7 / 0.103.10 pulled transitively through aws-config 1.5.x; bug silently accepts URI name constraints instead of rejecting them — only exploitable via CA misissuance of URI-constrained certs, and our TLS usage targets AWS endpoints where this isn't used. Fix requires bumping aws-config to drop the legacy rustls 0.21 chain (0.103.x fix is >=0.103.12, 0.101.x has no fix). Drop once aws-config is bumped." },
 ]
 
 [sources]

--- a/deny.toml
+++ b/deny.toml
@@ -34,6 +34,7 @@ ignore = [
     { id = "RUSTSEC-2026-0002", reason = "waiting for aws-sdk-s3 to bump this dependency" },
     { id = "RUSTSEC-2026-0097", reason = "transitive rand 0.9.2 via metrics/statrs/tower crates; UB requires a custom log::Log logger calling rand::rng(), but iris-mpc uses tracing — drop once upstream bumps rand to a safe version" },
     { id = "RUSTSEC-2026-0098", reason = "rustls-webpki 0.101.7 / 0.103.10 pulled transitively through aws-config 1.5.x; bug silently accepts URI name constraints instead of rejecting them — only exploitable via CA misissuance of URI-constrained certs, and our TLS usage targets AWS endpoints where this isn't used. Fix requires bumping aws-config to drop the legacy rustls 0.21 chain (0.103.x fix is >=0.103.12, 0.101.x has no fix). Drop once aws-config is bumped." },
+    { id = "RUSTSEC-2026-0099", reason = "same rustls-webpki 0.101.7 / 0.103.10 chain as RUSTSEC-2026-0098; sibling bug accepts DNS name constraints for wildcard-asserting certs. Same misissuance-required exploit model, same AWS-TLS-only attack surface, same fix path (bump aws-config off the legacy rustls 0.21 chain)." },
 ]
 
 [sources]

--- a/deny.toml
+++ b/deny.toml
@@ -32,6 +32,7 @@ ignore = [
     # bincode is no longer maintained, but it's considered finalized by the authors; we can switch to a maintained alternative at some point
     { id = "RUSTSEC-2025-0141", reason = "stable even if no longer maintained" },
     { id = "RUSTSEC-2026-0002", reason = "waiting for aws-sdk-s3 to bump this dependency" },
+    { id = "RUSTSEC-2026-0097", reason = "transitive rand 0.9.2 via metrics/statrs/tower crates; UB requires a custom log::Log logger calling rand::rng(), but iris-mpc uses tracing — drop once upstream bumps rand to >=0.9.3" },
 ]
 
 [sources]

--- a/deny.toml
+++ b/deny.toml
@@ -32,7 +32,7 @@ ignore = [
     # bincode is no longer maintained, but it's considered finalized by the authors; we can switch to a maintained alternative at some point
     { id = "RUSTSEC-2025-0141", reason = "stable even if no longer maintained" },
     { id = "RUSTSEC-2026-0002", reason = "waiting for aws-sdk-s3 to bump this dependency" },
-    { id = "RUSTSEC-2026-0097", reason = "transitive rand 0.9.2 via metrics/statrs/tower crates; UB requires a custom log::Log logger calling rand::rng(), but iris-mpc uses tracing — drop once upstream bumps rand to >=0.9.3" },
+    { id = "RUSTSEC-2026-0097", reason = "transitive rand 0.9.2 via metrics/statrs/tower crates; UB requires a custom log::Log logger calling rand::rng(), but iris-mpc uses tracing — drop once upstream bumps rand to a safe version" },
 ]
 
 [sources]


### PR DESCRIPTION
## Summary

Unblocks the `cargo-deny` CI job by adding three newly-published advisories to the `deny.toml` ignore list. All three are reachable only via scenarios that don't apply to iris-mpc.

### RUSTSEC-2026-0097 — `rand 0.9.2` unsoundness

- `rand 0.9.2` is a **transitive** dependency pulled in by `metrics-util`, `metrics-exporter-prometheus`, `statrs`, `tower`, and `tonic` — iris-mpc does not depend on it directly.
- The UB is only reachable when a **custom `log::Log` logger** calls `rand::rng()` / `rand::thread_rng()` and the returned `ThreadRng` attempts to reseed. iris-mpc uses `tracing` exclusively — there is no `impl log::Log for` anywhere in the codebase, nor any use of `env_logger`, `simplelog`, `fern`, or `log::set_logger`.
- The `rand` usage inside the transitive crates is for histogram reservoir sampling, not logging.
- **Drop condition:** upstream `metrics`/`tower` crates bump `rand` to `>=0.9.3`.

### RUSTSEC-2026-0098 — `rustls-webpki`: URI name constraints silently accepted

- Both `rustls-webpki 0.101.7` (via `rustls 0.21.12`) and `rustls-webpki 0.103.10` (via `rustls 0.23.35`) are pulled transitively through `aws-config 1.5.x` → `aws-smithy-http-client 1.1.5`, which enables both the `legacy-rustls-ring` and `rustls-aws-lc` features.
- The bug: URI name constraints in CA certs were ignored rather than rejected. Exploitation requires (a) a CA that issues certs with URI name constraints, (b) a misissued cert that would have otherwise been blocked. Our TLS use is limited to AWS endpoints (S3/KMS/SQS/RDS/SecretsManager), where URI name constraints are not used.
- Upstream fix is in `>=0.103.12` (0.103.x path fixable via `cargo update -p rustls-webpki`), but `0.101.x` is EOL and has no fix.
- **Drop condition:** bump `aws-config` off the legacy `rustls 0.21` chain. `aws-config 1.6.x` switches defaults to `default-https-client` (modern rustls only). Note: `aws-config 1.8.x` requires Rust 1.91.1 (we're on 1.89), so `1.6.x` is the candidate target for the follow-up bump.

### RUSTSEC-2026-0099 — `rustls-webpki`: DNS name constraints accepted for wildcard certs

- Same two affected versions, same transitive chain as -0098. Sibling bug: permitted-subtree DNS name constraints were accepted for certs asserting a wildcard name (e.g. `*.example.com` was allowed under a constraint of `accept.example.com` even though that wildcard could match `reject.example.com`).
- Same misissuance-required exploit model and same AWS-only TLS attack surface.
- **Drop condition:** same as -0098 — bump `aws-config` off the legacy `rustls 0.21` chain.

## Follow-up

Tracked separately: bump `aws-config` 1.5.10 → 1.6.x to drop the legacy `rustls 0.21` / `hyper-rustls 0.24` chain entirely, which would fix -0098 and -0099 and let us remove both ignore entries.

## Test plan

- [ ] `cargo deny check advisories` passes locally
- [ ] CI on this PR passes (specifically the `cargo-deny` job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)