### PR TITLE
Move eval_pairwise_distances from Aby3Store to DistanceFn

### DIFF
--- a/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
@@ -116,32 +116,16 @@ where
     }
 
     /// Compute pairwise distances between pairs of cached queries.
-    ///
-    /// Uses the store's configured distance function (Simple or MinRotation)
-    /// and the worker pool's `compute_pairwise_distances` method.
-    /// Convention: first QuerySpec = preprocessed, second QueryId = raw (original).
+    #[instrument(level = "trace", target = "searcher::network", skip_all)]
     pub async fn eval_pairwise_distances(
         &mut self,
         pairs: Vec<Option<(QuerySpec, QueryId)>>,
     ) -> Result<Vec<DistanceShare<D::Ring>>> {
-        use crate::execution::hawk_main::iris_worker::DistanceMode;
-
         if pairs.is_empty() {
             return Ok(vec![]);
         }
-        let mode = match self.distance_fn {
-            DistanceFn::Simple => DistanceMode::Simple,
-            DistanceFn::MinRotation => DistanceMode::RotationAware,
-        };
-        let ds_and_ts = self.workers.compute_pairwise_distances(pairs, mode).await?;
-        let distances = self.gr_to_lifted_distances(ds_and_ts).await?;
-        match self.distance_fn {
-            DistanceFn::Simple => Ok(distances),
-            DistanceFn::MinRotation => {
-                self.oblivious_min_distance_batch(distance_fn::transpose_from_flat(&distances))
-                    .await
-            }
-        }
+
+        self.distance_fn.eval_pairwise_distances(self, pairs).await
     }
 
     /// Converts distances from u16 secret shares to Ring-typed distance shares.

--- a/iris-mpc-cpu/src/hawkers/aby3/aby3_store/distance_fn.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3/aby3_store/distance_fn.rs
@@ -1,5 +1,5 @@
 use crate::execution::hawk_main::{
-    iris_worker::{DistanceMode, IrisWorkerPool},
+    iris_worker::{DistanceMode, IrisWorkerPool, QueryId, QuerySpec},
     HAWK_MIN_DIST_ROTATIONS,
 };
 use crate::phase_trace;
@@ -23,6 +23,36 @@ use serde::{Deserialize, Serialize};
 use DistanceFn::{MinRotation, Simple};
 
 impl DistanceFn {
+    /// Compute pairwise distances between pairs of cached queries using the
+    /// worker pool's `compute_pairwise_distances` method.
+    pub async fn eval_pairwise_distances<D: DistanceOps, W: IrisWorkerPool>(
+        self,
+        store: &mut Aby3Store<D, W>,
+        pairs: Vec<Option<(QuerySpec, QueryId)>>,
+    ) -> Result<Vec<DistanceShare<D::Ring>>>
+    where
+        Standard: Distribution<D::Ring>,
+        VecShare<D::Ring>: Transpose64,
+    {
+        let mode = match self {
+            Simple => DistanceMode::Simple,
+            MinRotation => DistanceMode::RotationAware,
+        };
+        let ds_and_ts = store
+            .workers
+            .compute_pairwise_distances(pairs, mode)
+            .await?;
+        let distances = store.gr_to_lifted_distances(ds_and_ts).await?;
+        match self {
+            Simple => Ok(distances),
+            MinRotation => {
+                store
+                    .oblivious_min_distance_batch(transpose_from_flat(&distances))
+                    .await
+            }
+        }
+    }
+
     pub async fn eval_distance_pairs<D: DistanceOps, W: IrisWorkerPool>(
         self,
         store: &mut Aby3Store<D, W>,


### PR DESCRIPTION
PR #2053 introduced `eval_pairwise_distances` as an inline method on `Aby3Store` with its own `DistanceFn → DistanceMode` conversion, while the other three `eval_*` methods lived on `DistanceFn`. This commit makes the pattern consistent: all distance evaluation orchestration lives in `DistanceFn`.

Summary of changes:
- Moves the `eval_pairwise_distances` implementation from an inline method on `Aby3Store` to `DistanceFn`, matching the pattern already used by `eval_distance_pairs`, `eval_distance_batch`, and `eval_distance_multibatch`
- `Aby3Store::eval_pairwise_distances` becomes a thin delegation to `self.distance_fn.eval_pairwise_distances(self, pairs)`