### PR TITLE
refactor: unify DistanceFn/DistanceMode into single DistanceMode conf…

### DIFF
--- a/iris-mpc-bins/bin/iris-mpc-cpu/construct_graph_ptxt.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/construct_graph_ptxt.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 
 use iris_mpc_cpu::{
     hawkers::{
-        aby3::aby3_store::{DistanceFn, DistanceOps, FhdOps, NhdOps},
+        aby3::aby3_store::{DistanceMode, DistanceOps, FhdOps, NhdOps},
         build_plaintext::plaintext_parallel_batch_insert,
         plaintext_store::SharedPlaintextStore,
     },
@@ -48,7 +48,7 @@ struct CliConfig {
     searcher: SearcherConfig,
 
     /// Distance function for comparison of iris codes.
-    distance_fn: DistanceFn,
+    distance_fn: DistanceMode,
 
     /// Selects the distance operations type (Fhd or Nhd). Defaults to Fhd.
     #[serde(default)]
@@ -117,7 +117,7 @@ impl Checkpoints {
 async fn build_graph<D: DistanceOps>(
     irises: Vec<(IrisVectorId, IrisCode)>,
     graph_spec: Option<LoadGraphConfig>,
-    distance_fn: DistanceFn,
+    distance_fn: DistanceMode,
     searcher: &HnswSearcher,
     prf_seed: &[u8; 16],
     output: OutputGraphConfig,
@@ -161,7 +161,7 @@ async fn build_graph<D: DistanceOps>(
     // insert irises which are already represented in the graph
     tracing::info!("Initializing vector store");
     let mut store = SharedPlaintextStore::<D>::new();
-    store.distance_fn = distance_fn;
+    store.distance_mode = distance_fn;
     for (id, iris) in irises[0..(graph_max_id as usize)].iter() {
         let _id = store.insert_at(id, &Arc::new(iris.clone())).await?;
     }

--- a/iris-mpc-bins/bin/iris-mpc-cpu/generate_ideal_graph.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/generate_ideal_graph.rs
@@ -86,7 +86,7 @@ async fn run_sanity_check<D: DistanceOps>(
         .expect("last layer should have at least one key");
 
     let mut store = PlaintextStore::<D>::new();
-    store.distance_fn = echoice.distance_fn();
+    store.distance_mode = echoice.distance_mode();
 
     for (i, iris) in irises.into_iter().enumerate() {
         store.insert_with_id(IrisVectorId::from_serial_id((i as u32) + 1), Arc::new(iris));
@@ -118,7 +118,7 @@ async fn run_sanity_check<D: DistanceOps>(
                     let d = D::plaintext_distance(
                         &sample_iris,
                         store.storage.get_vector(n).unwrap(),
-                        store.distance_fn,
+                        store.distance_mode,
                     );
                     matches!(D::plaintext_ordering(&d, &kth_dist), Ordering::Greater)
                 })

--- a/iris-mpc-bins/bin/iris-mpc-cpu/run_accuracy_analysis.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/run_accuracy_analysis.rs
@@ -25,11 +25,11 @@ struct Cli {
 
 async fn run_with_ops<D: DistanceOps>(config: Config, rng: &mut StdRng) -> Result<()> {
     let mut store: PlaintextStore<D> =
-        load_iris_store(config.irises, rng, config.analysis.get_distance_fn()?).await?;
+        load_iris_store(config.irises, rng, config.analysis.get_distance_mode()?).await?;
     println!(
-        "Loaded {} iris codes into PlaintextStore with distance_fn = {:?}.",
+        "Loaded {} iris codes into PlaintextStore with distance_mode = {:?}.",
         store.len(),
-        store.distance_fn
+        store.distance_mode
     );
 
     println!("Initializing graph...");

--- a/iris-mpc-cpu/src/analysis/accuracy.rs
+++ b/iris-mpc-cpu/src/analysis/accuracy.rs
@@ -1,6 +1,6 @@
 use crate::{
     hawkers::{
-        aby3::aby3_store::{DistanceFn, DistanceOps},
+        aby3::aby3_store::{DistanceMode, DistanceOps},
         plaintext_store::{PlaintextStore, SharedPlaintextStore},
     },
     hnsw::{
@@ -60,10 +60,10 @@ pub struct AnalysisConfig {
 }
 
 impl AnalysisConfig {
-    pub fn get_distance_fn(&self) -> Result<DistanceFn> {
+    pub fn get_distance_mode(&self) -> Result<DistanceMode> {
         match self.distance_fn.as_str() {
-            "simple" => Ok(DistanceFn::Simple),
-            "min_rotation" => Ok(DistanceFn::MinRotation),
+            "simple" => Ok(DistanceMode::Simple),
+            "min_rotation" => Ok(DistanceMode::MinRotation),
             _ => bail!("Unknown distance_fn: {}", self.distance_fn),
         }
     }
@@ -388,7 +388,7 @@ impl From<&HnswConfig> for HnswSearcher {
 pub async fn load_iris_store<D: DistanceOps>(
     config: IrisesInit,
     rng: &mut StdRng,
-    distance_fn: DistanceFn,
+    distance_mode: DistanceMode,
 ) -> Result<PlaintextStore<D>> {
     let irises = match config {
         IrisesInit::Random { number } => {
@@ -409,9 +409,9 @@ pub async fn load_iris_store<D: DistanceOps>(
     };
 
     let mut store = PlaintextStore::from_irises_iter(irises.into_iter());
-    // Override distance_fn;
+    // Override distance_mode;
     // This is safe, because store initialization doesn't depend on distance
-    store.distance_fn = distance_fn;
+    store.distance_mode = distance_mode;
 
     Ok(store)
 }

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -50,7 +50,7 @@
 //! - **`MinRotation`**: Obliviously finds the minimum distance across rotation
 //!   amounts `-X, -(X-1).. 0 .. (X - 1), X`.
 //!
-//! The choice of distance function is set by the constant `HAWK_DISTANCE_FN`.
+//! The choice of distance function is set by the constant `HAWK_DISTANCE_MODE`.
 //! One must also set the `HAWK_MIN_DIST_ROTATIONS` constant, which refers to the total rotations considered by MinRotation.
 //! Note that one should set it to `2 * X + 1` to work with `MinRotationX`.
 //! Finally, the constant `HAWK_BASE_ROTATIONS_MASK` should be set to indicate the set of "base rotations" for which
@@ -80,7 +80,7 @@ use crate::{
     hawkers::{
         aby3::aby3_store::{
             Aby3DistanceRef, Aby3Query, Aby3SharedIrises, Aby3SharedIrisesRef, Aby3Store,
-            Aby3VectorRef, DistanceFn, DistanceOps, FhdOps, VectorIdRegistryRef,
+            Aby3VectorRef, DistanceMode, DistanceOps, FhdOps, VectorIdRegistryRef,
         },
         shared_irises::SharedIrises,
     },
@@ -178,8 +178,8 @@ mod session_groups;
 pub mod state_check;
 use is_match_batch::is_match_batch;
 
-/// Distance function used by the HawkActor
-pub const HAWK_DISTANCE_FN: DistanceFn = DistanceFn::MinRotation;
+/// Distance mode used by the HawkActor
+pub const HAWK_DISTANCE_MODE: DistanceMode = DistanceMode::MinRotation;
 /// Number of rotations considered by the MinRotation distance.
 /// Not used for non-MinRotation distance, but must be set to `1`.
 pub const HAWK_MIN_DIST_ROTATIONS: usize = 11;
@@ -187,17 +187,17 @@ pub const HAWK_MIN_DIST_ROTATIONS: usize = 11;
 /// the HawkActor will launch independent HNSW searches.
 pub const HAWK_BASE_ROTATIONS_MASK: u32 = CENTER_AND_10_MASK;
 
-// --- Compile-time checks for HAWK_DISTANCE_FN, HAWK_MIN_DIST_ROTATIONS, HAWK_BASE_ROTATIONS_MASK ---
+// --- Compile-time checks for HAWK_DISTANCE_MODE, HAWK_MIN_DIST_ROTATIONS, HAWK_BASE_ROTATIONS_MASK ---
 const _: () = {
-    match HAWK_DISTANCE_FN {
-        DistanceFn::Simple => {
+    match HAWK_DISTANCE_MODE {
+        DistanceMode::Simple => {
             // For Simple the base rotations should consist of all 31 rotations.
             // HAWK_MIN_DIST_ROTATIONS is not actually used in this case, but it must be set to 1.
             if HAWK_MIN_DIST_ROTATIONS != 1 || HAWK_BASE_ROTATIONS_MASK != ALL_ROTATIONS_MASK {
                 panic!();
             }
         }
-        DistanceFn::MinRotation => match HAWK_MIN_DIST_ROTATIONS {
+        DistanceMode::MinRotation => match HAWK_MIN_DIST_ROTATIONS {
             // Variants correspond to "full" min-rotation, min-rotation-5 and min-rotation-6.
             // The former requires center-only as base, while the latter two
             // require -10, 0, 10 as base rotations for searches.
@@ -530,6 +530,7 @@ impl HawkActor {
             iris_worker::LocalIrisWorkerPool::new(
                 workers_handle[side].clone(),
                 iris_store[side].clone(),
+                HAWK_DISTANCE_MODE,
             )
         });
 
@@ -692,7 +693,7 @@ impl HawkActor {
                     prf,
                 },
                 workers,
-                HAWK_DISTANCE_FN,
+                HAWK_DISTANCE_MODE,
             );
 
             let hawk_session = HawkSession {

--- a/iris-mpc-cpu/src/execution/hawk_main/iris_worker.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/iris_worker.rs
@@ -1,5 +1,6 @@
 use crate::{
     execution::hawk_main::HAWK_MIN_DIST_ROTATIONS,
+    hawkers::aby3::aby3_store::DistanceMode,
     hawkers::shared_irises::SharedIrisesRef,
     protocol::{
         ops::{
@@ -502,13 +503,6 @@ impl Default for QueryId {
     }
 }
 
-/// Distance computation mode.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum DistanceMode {
-    Simple,
-    RotationAware,
-}
-
 /// Identifies a specific preprocessed variant of a cached query.
 ///
 /// Each cached iris produces 31 rotations × 2 orientations (normal + mirrored).
@@ -592,7 +586,6 @@ pub trait IrisWorkerPool: Clone + Debug + Send + Sync {
     fn compute_dot_products(
         &self,
         batches: Vec<(QuerySpec, Vec<VectorId>)>,
-        mode: DistanceMode,
     ) -> impl Future<Output = Result<Vec<Vec<RingElement<u16>>>>> + Send;
 
     /// Fetch iris data from the worker's store by vector ID.
@@ -626,7 +619,6 @@ pub trait IrisWorkerPool: Clone + Debug + Send + Sync {
     fn compute_pairwise_distances(
         &self,
         pairs: Vec<Option<(QuerySpec, QueryId)>>,
-        mode: DistanceMode,
     ) -> impl Future<Output = Result<Vec<RingElement<u16>>>> + Send;
 
     /// Evict cached queries, freeing memory.
@@ -690,6 +682,7 @@ pub struct LocalIrisWorkerPool {
     inner: IrisPoolHandle,
     query_cache: Arc<RwLock<HashMap<QueryId, CachedQuery>>>,
     iris_store: SharedIrisesRef<ArcIris>,
+    mode: DistanceMode,
 }
 
 impl Debug for LocalIrisWorkerPool {
@@ -701,19 +694,24 @@ impl Debug for LocalIrisWorkerPool {
 }
 
 impl LocalIrisWorkerPool {
-    pub fn new(inner: IrisPoolHandle, iris_store: SharedIrisesRef<ArcIris>) -> Self {
+    pub fn new(
+        inner: IrisPoolHandle,
+        iris_store: SharedIrisesRef<ArcIris>,
+        mode: DistanceMode,
+    ) -> Self {
         Self {
             inner,
             query_cache: Arc::new(RwLock::new(HashMap::new())),
             iris_store,
+            mode,
         }
     }
 
     /// Create a local worker pool for shard 0 with NUMA pinning.
     /// Standard construction for tests, benchmarks, and single-node tools.
-    pub fn new_local(iris_store: SharedIrisesRef<ArcIris>) -> Self {
+    pub fn new_local(iris_store: SharedIrisesRef<ArcIris>, mode: DistanceMode) -> Self {
         let pool = init_workers(0, iris_store.clone(), true);
-        Self::new(pool, iris_store)
+        Self::new(pool, iris_store, mode)
     }
 
     /// Access the underlying `IrisPoolHandle` for operations not on the trait
@@ -832,10 +830,10 @@ impl IrisWorkerPool for LocalIrisWorkerPool {
     fn compute_dot_products(
         &self,
         batches: Vec<(QuerySpec, Vec<VectorId>)>,
-        mode: DistanceMode,
     ) -> impl Future<Output = Result<Vec<Vec<RingElement<u16>>>>> + Send {
         let query_cache = self.query_cache.clone();
         let mut inner = self.inner.clone();
+        let mode = self.mode;
         async move {
             // Look up the correct preprocessed rotation for each batch
             let iris_batches: Vec<(ArcIris, Vec<VectorId>)> = {
@@ -865,7 +863,7 @@ impl IrisWorkerPool for LocalIrisWorkerPool {
                     }
                     Ok(results)
                 }
-                DistanceMode::RotationAware => {
+                DistanceMode::MinRotation => {
                     inner
                         .rotation_aware_dot_product_multibatch(iris_batches)
                         .await
@@ -924,10 +922,10 @@ impl IrisWorkerPool for LocalIrisWorkerPool {
     fn compute_pairwise_distances(
         &self,
         pairs: Vec<Option<(QuerySpec, QueryId)>>,
-        mode: DistanceMode,
     ) -> impl Future<Output = Result<Vec<RingElement<u16>>>> + Send {
         let query_cache = self.query_cache.clone();
         let inner = self.inner.clone();
+        let mode = self.mode;
         async move {
             // Resolve pairs to ArcIris pairs.
             // First = preprocessed rotation, second = raw (original) iris.
@@ -963,7 +961,7 @@ impl IrisWorkerPool for LocalIrisWorkerPool {
             };
             match mode {
                 DistanceMode::Simple => inner.galois_ring_pairwise_distances(iris_pairs).await,
-                DistanceMode::RotationAware => {
+                DistanceMode::MinRotation => {
                     inner.rotation_aware_pairwise_distances(iris_pairs).await
                 }
             }

--- a/iris-mpc-cpu/src/genesis/batch_generator.rs
+++ b/iris-mpc-cpu/src/genesis/batch_generator.rs
@@ -416,7 +416,7 @@ fn log_info(msg: String) {
 mod tests {
     use super::*;
     use crate::{
-        execution::hawk_main::{iris_worker::LocalIrisWorkerPool, StoreId},
+        execution::hawk_main::{iris_worker::LocalIrisWorkerPool, StoreId, HAWK_DISTANCE_MODE},
         hawkers::{
             aby3::test_utils::setup_aby3_shared_iris_stores_with_preloaded_db,
             plaintext_store::PlaintextStore,
@@ -506,8 +506,9 @@ mod tests {
                 .to_registry()
                 .to_arc()
         });
-        let worker_pools =
-            [LEFT, RIGHT].map(|side| LocalIrisWorkerPool::new_local(iris_stores[side].clone()));
+        let worker_pools = [LEFT, RIGHT].map(|side| {
+            LocalIrisWorkerPool::new_local(iris_stores[side].clone(), HAWK_DISTANCE_MODE)
+        });
         (registries, worker_pools, SIZE_OF_IRIS_DB)
     }
 

--- a/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
@@ -43,7 +43,7 @@ use tracing::instrument;
 
 mod distance_fn;
 mod distance_ops;
-pub use distance_fn::DistanceFn;
+pub use distance_fn::{DistanceFn, DistanceMode};
 pub use distance_ops::{DistanceOps, FhdOps, NhdOps};
 
 /// The number of rotations at which to switch from binary tree to round-robin minimum algorithms.
@@ -104,12 +104,12 @@ where
         registry: VectorIdRegistryRef,
         session: Session,
         workers: W,
-        distance_fn: DistanceFn,
+        distance_mode: DistanceMode,
     ) -> Self {
         Self {
             registry,
             session,
-            distance_fn,
+            distance_fn: DistanceFn::new(distance_mode),
             workers,
             _phantom: std::marker::PhantomData,
         }

--- a/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
@@ -116,32 +116,16 @@ where
     }
 
     /// Compute pairwise distances between pairs of cached queries.
-    ///
-    /// Uses the store's configured distance function (Simple or MinRotation)
-    /// and the worker pool's `compute_pairwise_distances` method.
-    /// Convention: first QuerySpec = preprocessed, second QueryId = raw (original).
+    #[instrument(level = "trace", target = "searcher::network", skip_all)]
     pub async fn eval_pairwise_distances(
         &mut self,
         pairs: Vec<Option<(QuerySpec, QueryId)>>,
     ) -> Result<Vec<DistanceShare<D::Ring>>> {
-        use crate::execution::hawk_main::iris_worker::DistanceMode;
-
         if pairs.is_empty() {
             return Ok(vec![]);
         }
-        let mode = match self.distance_fn {
-            DistanceFn::Simple => DistanceMode::Simple,
-            DistanceFn::MinRotation => DistanceMode::RotationAware,
-        };
-        let ds_and_ts = self.workers.compute_pairwise_distances(pairs, mode).await?;
-        let distances = self.gr_to_lifted_distances(ds_and_ts).await?;
-        match self.distance_fn {
-            DistanceFn::Simple => Ok(distances),
-            DistanceFn::MinRotation => {
-                self.oblivious_min_distance_batch(distance_fn::transpose_from_flat(&distances))
-                    .await
-            }
-        }
+
+        self.distance_fn.eval_pairwise_distances(self, pairs).await
     }
 
     /// Converts distances from u16 secret shares to Ring-typed distance shares.

--- a/iris-mpc-cpu/src/hawkers/aby3/aby3_store/distance_fn.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3/aby3_store/distance_fn.rs
@@ -1,5 +1,5 @@
 use crate::execution::hawk_main::{
-    iris_worker::{DistanceMode, IrisWorkerPool},
+    iris_worker::{DistanceMode, IrisWorkerPool, QueryId, QuerySpec},
     HAWK_MIN_DIST_ROTATIONS,
 };
 use crate::phase_trace;
@@ -23,6 +23,36 @@ use serde::{Deserialize, Serialize};
 use DistanceFn::{MinRotation, Simple};
 
 impl DistanceFn {
+    /// Compute pairwise distances between pairs of cached queries using the
+    /// worker pool's `compute_pairwise_distances` method.
+    pub async fn eval_pairwise_distances<D: DistanceOps, W: IrisWorkerPool>(
+        self,
+        store: &mut Aby3Store<D, W>,
+        pairs: Vec<Option<(QuerySpec, QueryId)>>,
+    ) -> Result<Vec<DistanceShare<D::Ring>>>
+    where
+        Standard: Distribution<D::Ring>,
+        VecShare<D::Ring>: Transpose64,
+    {
+        let mode = match self {
+            Simple => DistanceMode::Simple,
+            MinRotation => DistanceMode::RotationAware,
+        };
+        let ds_and_ts = store
+            .workers
+            .compute_pairwise_distances(pairs, mode)
+            .await?;
+        let distances = store.gr_to_lifted_distances(ds_and_ts).await?;
+        match self {
+            Simple => Ok(distances),
+            MinRotation => {
+                store
+                    .oblivious_min_distance_batch(transpose_from_flat(&distances))
+                    .await
+            }
+        }
+    }
+
     pub async fn eval_distance_pairs<D: DistanceOps, W: IrisWorkerPool>(
         self,
         store: &mut Aby3Store<D, W>,

--- a/iris-mpc-cpu/src/hawkers/aby3/aby3_store/distance_fn.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3/aby3_store/distance_fn.rs
@@ -1,5 +1,5 @@
 use crate::execution::hawk_main::{
-    iris_worker::{DistanceMode, IrisWorkerPool, QueryId, QuerySpec},
+    iris_worker::{IrisWorkerPool, QueryId, QuerySpec},
     HAWK_MIN_DIST_ROTATIONS,
 };
 use crate::phase_trace;
@@ -11,16 +11,33 @@ use ampc_secret_sharing::shares::{
 use clap::ValueEnum;
 use eyre::Result;
 use rand_distr::{Distribution, Standard};
+use serde::{Deserialize, Serialize};
 
+/// The two distance computation strategies.
+///
+/// This is the lightweight source-of-truth enum shared by every component
+/// that cares about the simple-vs-min-rotation distinction.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, ValueEnum)]
 #[value(rename_all = "snake_case")]
-pub enum DistanceFn {
+pub enum DistanceMode {
     Simple,
     MinRotation,
 }
 
-use serde::{Deserialize, Serialize};
-use DistanceFn::{MinRotation, Simple};
+/// MPC distance orchestration: calls the worker pool for dot products,
+/// lifts to ring distances, and (for `MinRotation`) applies oblivious-min.
+#[derive(Debug, Clone, Copy)]
+pub struct DistanceFn {
+    pub mode: DistanceMode,
+}
+
+impl DistanceFn {
+    pub const fn new(mode: DistanceMode) -> Self {
+        Self { mode }
+    }
+}
+
+use DistanceMode::{MinRotation, Simple};
 
 impl DistanceFn {
     /// Compute pairwise distances between pairs of cached queries using the
@@ -34,16 +51,9 @@ impl DistanceFn {
         Standard: Distribution<D::Ring>,
         VecShare<D::Ring>: Transpose64,
     {
-        let mode = match self {
-            Simple => DistanceMode::Simple,
-            MinRotation => DistanceMode::RotationAware,
-        };
-        let ds_and_ts = store
-            .workers
-            .compute_pairwise_distances(pairs, mode)
-            .await?;
+        let ds_and_ts = store.workers.compute_pairwise_distances(pairs).await?;
         let distances = store.gr_to_lifted_distances(ds_and_ts).await?;
-        match self {
+        match self.mode {
             Simple => Ok(distances),
             MinRotation => {
                 store
@@ -62,15 +72,11 @@ impl DistanceFn {
         Standard: Distribution<D::Ring>,
         VecShare<D::Ring>: Transpose64,
     {
-        let mode = match self {
-            Simple => DistanceMode::Simple,
-            MinRotation => DistanceMode::RotationAware,
-        };
         let batches = pairs.iter().map(|(q, v)| (*q, vec![*v])).collect();
-        let ds_and_ts_batches = store.workers.compute_dot_products(batches, mode).await?;
+        let ds_and_ts_batches = store.workers.compute_dot_products(batches).await?;
         let ds_and_ts: Vec<_> = ds_and_ts_batches.into_iter().flatten().collect();
         let distances = store.gr_to_lifted_distances(ds_and_ts).await?;
-        match self {
+        match self.mode {
             Simple => Ok(distances),
             MinRotation => {
                 store
@@ -90,15 +96,11 @@ impl DistanceFn {
         Standard: Distribution<D::Ring>,
         VecShare<D::Ring>: Transpose64,
     {
-        let mode = match self {
-            Simple => DistanceMode::Simple,
-            MinRotation => DistanceMode::RotationAware,
-        };
         let dot_start = std::time::Instant::now();
         phase_trace!("dot_product", "n_vectors" => vectors.len());
         let ds_and_ts_batches = store
             .workers
-            .compute_dot_products(vec![(*query, vectors.to_vec())], mode)
+            .compute_dot_products(vec![(*query, vectors.to_vec())])
             .await?;
         let ds_and_ts = ds_and_ts_batches.into_iter().next().unwrap_or_default();
         metrics::histogram!("eval_distance_dot_product_duration")
@@ -110,7 +112,7 @@ impl DistanceFn {
         metrics::histogram!("eval_distance_lift_duration")
             .record(lift_start.elapsed().as_secs_f64());
 
-        match self {
+        match self.mode {
             Simple => Ok(distances),
             MinRotation => {
                 let omin_start = std::time::Instant::now();
@@ -141,19 +143,11 @@ impl DistanceFn {
             return Ok(vec![]);
         }
 
-        let mode = match self {
-            Simple => DistanceMode::Simple,
-            MinRotation => DistanceMode::RotationAware,
-        };
-
         let batch_sizes: Vec<usize> = batches.iter().map(|(_, vids)| vids.len()).collect();
 
         let trait_batches: Vec<_> = batches;
 
-        let ds_and_ts_batches = store
-            .workers
-            .compute_dot_products(trait_batches, mode)
-            .await?;
+        let ds_and_ts_batches = store.workers.compute_dot_products(trait_batches).await?;
 
         // Flatten all batches into a single lift call to minimize MPC round-trips.
         let flattened_ds_and_ts: Vec<_> = ds_and_ts_batches.into_iter().flatten().collect();
@@ -164,7 +158,7 @@ impl DistanceFn {
 
         let distances = store.gr_to_lifted_distances(flattened_ds_and_ts).await?;
 
-        match self {
+        match self.mode {
             Simple => {
                 // Split results back into per-batch vectors.
                 let mut results = Vec::with_capacity(batch_sizes.len());

--- a/iris-mpc-cpu/src/hawkers/aby3/aby3_store/distance_ops.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3/aby3_store/distance_ops.rs
@@ -28,7 +28,7 @@ use iris_mpc_common::iris_db::iris::Threshold;
 use tracing::instrument;
 
 use crate::{
-    hawkers::aby3::aby3_store::DistanceFn,
+    hawkers::aby3::aby3_store::DistanceMode,
     protocol::{
         min_round_robin::{build_round_robin_pairs, select_round_robin_min},
         ops::{DistancePair, IdDistance},
@@ -226,7 +226,7 @@ pub trait DistanceOps: Send + Sync + Debug + 'static {
 
     /// Plaintext distance computation between two iris codes via distance computation strategy f,
     /// returning a fractional Hamming distance pair (dot product of iris codes, dot product of mask codes).
-    fn plaintext_distance(a: &IrisCode, b: &IrisCode, f: DistanceFn) -> (u16, u16);
+    fn plaintext_distance(a: &IrisCode, b: &IrisCode, mode: DistanceMode) -> (u16, u16);
 
     /// Shuffles batched (id, distance) pairs using the 3-party shuffle protocol.
     async fn shuffle_batch(
@@ -294,10 +294,10 @@ impl DistanceOps for FhdOps {
         ((a as u32) * (d as u32)).cmp(&((b as u32) * (c as u32)))
     }
 
-    fn plaintext_distance(a: &IrisCode, b: &IrisCode, f: DistanceFn) -> (u16, u16) {
-        match f {
-            DistanceFn::Simple => a.get_distance_fraction(b),
-            DistanceFn::MinRotation => {
+    fn plaintext_distance(a: &IrisCode, b: &IrisCode, mode: DistanceMode) -> (u16, u16) {
+        match mode {
+            DistanceMode::Simple => a.get_distance_fraction(b),
+            DistanceMode::MinRotation => {
                 a.get_min_fhd_distance_fraction_rotation_aware::<HAWK_MIN_DIST_ROTATIONS>(b)
             }
         }
@@ -352,10 +352,10 @@ impl DistanceOps for NhdOps {
         (nmr1 * (d2.1 as i64)).cmp(&(nmr2 * (d1.1 as i64)))
     }
 
-    fn plaintext_distance(a: &IrisCode, b: &IrisCode, f: DistanceFn) -> (u16, u16) {
-        match f {
-            DistanceFn::Simple => a.get_distance_fraction(b),
-            DistanceFn::MinRotation => {
+    fn plaintext_distance(a: &IrisCode, b: &IrisCode, mode: DistanceMode) -> (u16, u16) {
+        match mode {
+            DistanceMode::Simple => a.get_distance_fraction(b),
+            DistanceMode::MinRotation => {
                 a.get_min_nhd_distance_fraction_rotation_aware::<HAWK_MIN_DIST_ROTATIONS>(b)
             }
         }

--- a/iris-mpc-cpu/src/hawkers/aby3/test_utils.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3/test_utils.rs
@@ -16,7 +16,7 @@ use crate::{
     hawkers::{
         aby3::aby3_store::{Aby3SharedIrisesRef, Aby3VectorRef},
         plaintext_store::{PlaintextStore, PlaintextVectorRef},
-        TEST_DISTANCE_FN,
+        TEST_DISTANCE_MODE,
     },
     hnsw::{GraphMem, HnswSearcher, SortedNeighborhood, VectorStore},
     network::mpc::NetworkType,
@@ -77,13 +77,14 @@ pub async fn setup_local_aby3_players_with_preloaded_db<R: RngCore + CryptoRng>(
         .into_iter()
         .zip(storages.into_iter())
         .map(|(session, storage)| {
-            let workers = LocalIrisWorkerPool::new_local(storage.clone());
+            let workers =
+                LocalIrisWorkerPool::new_local(storage.clone(), plain_store.distance_mode);
             let registry = storage.data.try_read().unwrap().to_registry().to_arc();
             Ok(Arc::new(Mutex::new(Aby3Store::new(
                 registry,
                 session,
                 workers,
-                plain_store.distance_fn,
+                plain_store.distance_mode,
             ))))
         })
         .collect()
@@ -96,13 +97,13 @@ pub async fn setup_local_store_aby3_players(network_t: NetworkType) -> Result<Ve
         .into_iter()
         .map(|session| {
             let storage = Aby3Store::<FhdOps>::new_storage(None).to_arc();
-            let workers = LocalIrisWorkerPool::new_local(storage.clone());
+            let workers = LocalIrisWorkerPool::new_local(storage.clone(), TEST_DISTANCE_MODE);
             let registry = storage.data.try_read().unwrap().to_registry().to_arc();
             Ok(Arc::new(Mutex::new(Aby3Store::new(
                 registry,
                 session,
                 workers,
-                TEST_DISTANCE_FN,
+                TEST_DISTANCE_MODE,
             ))))
         })
         .collect()

--- a/iris-mpc-cpu/src/hawkers/ideal_knn_engines.rs
+++ b/iris-mpc-cpu/src/hawkers/ideal_knn_engines.rs
@@ -14,7 +14,7 @@ use rayon::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::hawkers::aby3::aby3_store::{DistanceFn, DistanceOps, FhdOps, NhdOps};
+use crate::hawkers::aby3::aby3_store::{DistanceMode, DistanceOps, FhdOps, NhdOps};
 
 #[derive(Serialize, Deserialize, Clone, Default)]
 pub struct KNNResult<V> {
@@ -69,10 +69,10 @@ pub enum EngineChoice {
 }
 
 impl EngineChoice {
-    pub fn distance_fn(&self) -> DistanceFn {
+    pub fn distance_mode(&self) -> DistanceMode {
         match self {
-            EngineChoice::NaiveFHD | EngineChoice::NaiveNHD => DistanceFn::Simple,
-            EngineChoice::NaiveMinFHD | EngineChoice::NaiveMinNHD => DistanceFn::MinRotation,
+            EngineChoice::NaiveFHD | EngineChoice::NaiveNHD => DistanceMode::Simple,
+            EngineChoice::NaiveMinFHD | EngineChoice::NaiveMinNHD => DistanceMode::MinRotation,
         }
     }
 }
@@ -90,13 +90,13 @@ impl Engine {
         next_id: IrisSerialId,
     ) -> Self {
         assert!(k < irises.len());
-        let distance_fn = which.distance_fn();
+        let distance_mode = which.distance_mode();
         match which {
             EngineChoice::NaiveFHD | EngineChoice::NaiveMinFHD => {
-                Self::Fhd(NaiveKNN::init(irises, k, next_id, distance_fn))
+                Self::Fhd(NaiveKNN::init(irises, k, next_id, distance_mode))
             }
             EngineChoice::NaiveNHD | EngineChoice::NaiveMinNHD => {
-                Self::Nhd(NaiveKNN::init(irises, k, next_id, distance_fn))
+                Self::Nhd(NaiveKNN::init(irises, k, next_id, distance_mode))
             }
         }
     }
@@ -121,7 +121,7 @@ pub struct NaiveKNN<D: DistanceOps> {
     irises: Vec<IrisCode>,
     k: usize,
     next_id: IrisSerialId,
-    distance_fn: DistanceFn,
+    distance_mode: DistanceMode,
     pool: ThreadPool,
     _phantom: PhantomData<D>,
 }
@@ -131,13 +131,13 @@ impl<D: DistanceOps> NaiveKNN<D> {
         irises: Vec<IrisCode>,
         k: usize,
         next_id: IrisSerialId,
-        distance_fn: DistanceFn,
+        distance_mode: DistanceMode,
     ) -> Self {
         NaiveKNN {
             irises,
             k,
             next_id,
-            distance_fn,
+            distance_mode,
             pool: ThreadPoolBuilder::new().build().unwrap(),
             _phantom: PhantomData,
         }
@@ -161,7 +161,7 @@ impl<D: DistanceOps> NaiveKNN<D> {
                         .flat_map(|(j, other_iris)| {
                             (i != j + 1).then_some((
                                 j + 1,
-                                D::plaintext_distance(current_iris, other_iris, self.distance_fn),
+                                D::plaintext_distance(current_iris, other_iris, self.distance_mode),
                             ))
                         })
                         .collect::<Vec<_>>();

--- a/iris-mpc-cpu/src/hawkers/mod.rs
+++ b/iris-mpc-cpu/src/hawkers/mod.rs
@@ -10,7 +10,7 @@
 //! Each store implements the `Store` trait which defines the common interface for all the stores.
 //! The `Store` trait is defined in `hnsw::vector_store.rs`.
 
-use crate::{execution::hawk_main, hawkers::aby3::aby3_store::DistanceFn};
+use crate::{execution::hawk_main, hawkers::aby3::aby3_store::DistanceMode};
 
 /// Store with vectors in secret shared form.
 /// The underlying operations are secure multi-party computation (MPC) operations.
@@ -26,4 +26,4 @@ pub mod build_plaintext;
 
 pub mod ideal_knn_engines;
 
-const TEST_DISTANCE_FN: DistanceFn = hawk_main::HAWK_DISTANCE_FN;
+const TEST_DISTANCE_MODE: DistanceMode = hawk_main::HAWK_DISTANCE_MODE;

--- a/iris-mpc-cpu/src/hawkers/plaintext_store.rs
+++ b/iris-mpc-cpu/src/hawkers/plaintext_store.rs
@@ -1,8 +1,8 @@
 use crate::{
     hawkers::{
-        aby3::aby3_store::{DistanceFn, DistanceOps, FhdOps},
+        aby3::aby3_store::{DistanceMode, DistanceOps, FhdOps},
         shared_irises::{SharedIrises, SharedIrisesRef},
-        TEST_DISTANCE_FN,
+        TEST_DISTANCE_MODE,
     },
     hnsw::{
         metrics::ops_counter::Operation::{CompareDistance, EvaluateDistance},
@@ -38,7 +38,7 @@ pub type PlaintextSharedIrisesRef = SharedIrisesRef<PlaintextStoredIris>;
 #[serde(bound(serialize = "", deserialize = ""))]
 pub struct PlaintextStore<D = FhdOps> {
     pub storage: PlaintextSharedIrises,
-    pub distance_fn: DistanceFn,
+    pub distance_mode: DistanceMode,
     #[serde(skip)]
     _phantom: PhantomData<D>,
 }
@@ -58,7 +58,7 @@ impl<D: DistanceOps> PlaintextStore<D> {
     pub fn with_storage(storage: PlaintextSharedIrises) -> Self {
         Self {
             storage,
-            distance_fn: TEST_DISTANCE_FN,
+            distance_mode: TEST_DISTANCE_MODE,
             _phantom: PhantomData,
         }
     }
@@ -164,7 +164,7 @@ impl<D: DistanceOps> VectorStore for PlaintextStore<D> {
                 vector.serial_id()
             )
         })?;
-        let distance = D::plaintext_distance(vector_code, query, self.distance_fn);
+        let distance = D::plaintext_distance(vector_code, query, self.distance_mode);
         Ok(distance)
     }
 
@@ -221,7 +221,7 @@ impl<D: DistanceOps> VectorStoreMut for PlaintextStore<D> {
 #[derive(Debug)]
 pub struct SharedPlaintextStore<D = FhdOps> {
     pub storage: PlaintextSharedIrisesRef,
-    pub distance_fn: DistanceFn,
+    pub distance_mode: DistanceMode,
     _phantom: PhantomData<D>,
 }
 
@@ -230,7 +230,7 @@ impl<D> Clone for SharedPlaintextStore<D> {
     fn clone(&self) -> Self {
         Self {
             storage: self.storage.clone(),
-            distance_fn: self.distance_fn,
+            distance_mode: self.distance_mode,
             _phantom: PhantomData,
         }
     }
@@ -240,7 +240,7 @@ impl<D: DistanceOps> Default for SharedPlaintextStore<D> {
     fn default() -> Self {
         Self {
             storage: SharedIrises::default().to_arc(),
-            distance_fn: TEST_DISTANCE_FN,
+            distance_mode: TEST_DISTANCE_MODE,
             _phantom: PhantomData,
         }
     }
@@ -264,7 +264,7 @@ impl<D: DistanceOps> From<PlaintextStore<D>> for SharedPlaintextStore<D> {
     fn from(value: PlaintextStore<D>) -> Self {
         Self {
             storage: value.storage.to_arc(),
-            distance_fn: value.distance_fn,
+            distance_mode: value.distance_mode,
             _phantom: PhantomData,
         }
     }
@@ -310,7 +310,7 @@ impl<D: DistanceOps> VectorStore for SharedPlaintextStore<D> {
             .collect::<Result<Vec<_>>>()?;
         Ok(vector_codes
             .into_iter()
-            .map(|v| D::plaintext_distance(v, query, self.distance_fn))
+            .map(|v| D::plaintext_distance(v, query, self.distance_mode))
             .collect())
     }
 
@@ -402,7 +402,7 @@ mod tests {
         let d23 = store.eval_distance(&db[2], &ids[3]).await?;
         let d30 = store.eval_distance(&db[3], &ids[0]).await?;
 
-        let distance = |a, b| FhdOps::plaintext_distance(a, b, TEST_DISTANCE_FN);
+        let distance = |a, b| FhdOps::plaintext_distance(a, b, TEST_DISTANCE_MODE);
 
         assert_eq!(
             store.less_than(&d01, &d23).await?,


### PR DESCRIPTION
## Summary

- Replaces the dynamic `DistanceMode` parameter on `IrisWorkerPool` trait methods with a per-instance configuration field on `LocalIrisWorkerPool`
- Unifies the two overlapping enums (`DistanceFn` in `distance_fn.rs` and `DistanceMode` in `iris_worker.rs`) into a single `DistanceMode` enum as the lightweight source of truth
- `DistanceFn` becomes a struct wrapping `mode: DistanceMode`, retaining the MPC orchestration methods (`eval_distance_batch`, etc.)

## Motivation

The distance mode (simple vs min-rotation) is a fixed property of an HNSW graph instance, not something that should vary per call. Passing it as a dynamic argument to every `compute_dot_products` / `compute_pairwise_distances` invocation is potentially misleading — using different modes within the same worker pool would be a logic error. This change makes that invariant explicit by storing the mode at construction time.

## Key changes

- `DistanceMode` enum (`Simple` | `MinRotation`) defined in `distance_fn.rs` with serde/clap derives
- `LocalIrisWorkerPool` gains a `mode: DistanceMode` field, set at construction
- `IrisWorkerPool` trait loses `mode` parameter from `compute_dot_products` and `compute_pairwise_distances`
- `Aby3Store::new` accepts `DistanceMode` and constructs `DistanceFn` internally
- `HAWK_DISTANCE_FN` → `HAWK_DISTANCE_MODE`, `TEST_DISTANCE_FN` → `TEST_DISTANCE_MODE`
- Plaintext stores, `NaiveKNN`, and accuracy analysis use `DistanceMode` directly
