### PR TITLE
test: Improve E2E tests with a mirror batch match + fix reporting

### DIFF
--- a/iris-mpc-common/src/test.rs
+++ b/iris-mpc-common/src/test.rs
@@ -374,6 +374,8 @@ pub struct TestCaseGenerator {
     /// skip invalidating requests in the current batch, since we expect
     /// them to be processed
     skip_invalidate: bool,
+    /// Do we already have a mirror of a template in the current batch?
+    have_batch_mirror: bool,
     /// duplicates in the current batch, used to test the batch
     /// deduplication mechanism
     batch_duplicates: HashMap<String, String>,
@@ -405,6 +407,7 @@ impl TestCaseGenerator {
             rng,
             new_templates_in_batch: Vec::new(),
             skip_invalidate: false,
+            have_batch_mirror: false,
             batch_duplicates: HashMap::new(),
             db_indices_used_in_current_batch: HashSet::new(),
             or_rule_matches: Vec::new(),
@@ -436,6 +439,7 @@ impl TestCaseGenerator {
         self.new_templates_in_batch.clear();
         self.db_indices_used_in_current_batch.clear();
         self.or_rule_matches.clear();
+        self.have_batch_mirror = false;
 
         for idx in 0..batch_size {
             let (request_id, e2e_template, or_rule_indices, skip_persistence, message_type) =
@@ -674,7 +678,7 @@ impl TestCaseGenerator {
         if !self.reauth_skip_persistence_templates.is_empty() {
             options.push(TestCase::MatchAfterReauthSkipPersistence);
         }
-        if !self.new_templates_in_batch.is_empty() {
+        if !self.new_templates_in_batch.is_empty() && !self.have_batch_mirror {
             options.push(TestCase::MirrorAttackInBatch);
         }
 
@@ -1142,9 +1146,11 @@ impl TestCaseGenerator {
                     self.expected_results.insert(
                         request_id.to_string(),
                         ExpectedResult::builder()
+                            .with_batch_match(true)
                             .with_full_face_mirror_attack(true)
                             .build(),
                     );
+                    self.have_batch_mirror = true;
 
                     E2ETemplate {
                         // This is swapped on purpose due to the mirror attack flow

--- a/iris-mpc-common/src/test.rs
+++ b/iris-mpc-common/src/test.rs
@@ -244,6 +244,7 @@ enum DatabaseRange {
     FullMaskOnly,
 }
 
+#[derive(Debug, Clone)]
 pub struct ExpectedResult {
     /// The returned index of the iris code in the database.
     /// It is None if the iris code is not in the database, and Some(idx) if
@@ -1271,6 +1272,12 @@ impl TestCaseGenerator {
             was_reauth_success,
             was_skip_persistence_match,
             full_face_mirror_attack_detected
+        );
+        tracing::info!(
+            "Expected results for this request_id: {:?}",
+            self.expected_results
+                .get(req_id)
+                .expect("request id not found")
         );
         let &ExpectedResult {
             db_index: expected_idx,

--- a/iris-mpc-common/src/test.rs
+++ b/iris-mpc-common/src/test.rs
@@ -197,6 +197,11 @@ pub enum TestCase {
     /// - Normal flow won't match anything in the database
     /// - But when the code is mirrored, it will match(mirrored version will be pre-inserted in the test db)
     FullFaceMirrorAttack,
+    /// Send an iris code crafted for full face mirror attack detection:
+    /// - Normal flow won't match anything in the database or batch
+    /// - Mirror flow won't match anything in the database, since it is not yet inserted
+    /// - Mirror flow should match an item in the batch.
+    MirrorAttackInBatch,
 }
 
 impl TestCase {
@@ -224,6 +229,7 @@ impl TestCase {
             TestCase::MatchAfterResetUpdate,
             TestCase::MatchAfterReauthSkipPersistence,
             TestCase::FullFaceMirrorAttack,
+            TestCase::MirrorAttackInBatch,
         ]
     }
 }
@@ -666,6 +672,9 @@ impl TestCaseGenerator {
         }
         if !self.reauth_skip_persistence_templates.is_empty() {
             options.push(TestCase::MatchAfterReauthSkipPersistence);
+        }
+        if !self.new_templates_in_batch.is_empty() {
+            options.push(TestCase::MirrorAttackInBatch);
         }
 
         options.retain(|x| self.enabled_test_cases.contains(x));
@@ -1116,6 +1125,31 @@ impl TestCaseGenerator {
                     );
                     self.skip_invalidate = true;
                     e2e_template
+                }
+                TestCase::MirrorAttackInBatch => {
+                    tracing::info!("Sending iris code crafted for mirror attack detection that should match in batch");
+                    // Get an existing template from the current batch
+                    let (internal_batch_idx, request_id, original_template) = self
+                        .new_templates_in_batch
+                        .choose(&mut self.rng)
+                        .expect("this is only called if we already have templates in batch");
+                    tracing::info!(
+                        "batch_idx used for the mirror attack in batch: {}",
+                        internal_batch_idx
+                    );
+
+                    self.expected_results.insert(
+                        request_id.to_string(),
+                        ExpectedResult::builder()
+                            .with_full_face_mirror_attack(true)
+                            .build(),
+                    );
+
+                    E2ETemplate {
+                        // This is swapped on purpose due to the mirror attack flow
+                        left: original_template.right.mirrored(),
+                        right: original_template.left.mirrored(),
+                    }
                 }
             }
         };

--- a/iris-mpc-common/src/test.rs
+++ b/iris-mpc-common/src/test.rs
@@ -1130,7 +1130,7 @@ impl TestCaseGenerator {
                 TestCase::MirrorAttackInBatch => {
                     tracing::info!("Sending iris code crafted for mirror attack detection that should match in batch");
                     // Get an existing template from the current batch
-                    let (internal_batch_idx, request_id, original_template) = self
+                    let (internal_batch_idx, _, original_template) = self
                         .new_templates_in_batch
                         .choose(&mut self.rng)
                         .expect("this is only called if we already have templates in batch");

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -1431,6 +1431,27 @@ impl ServerActor {
             })
             .collect::<Vec<_>>();
 
+        // In the normal pass of a mirror-detection-enabled batch, fold the
+        // mirror pass's intra-batch peer ids into the per-request lists so the
+        // combined result reports peers from both orientations. Matches the
+        // CPU semantics where matched_batch_request_ids covers `orient: Both`.
+        let matched_batch_request_ids = if let Some(mirror_results) = previous_results.as_ref() {
+            matched_batch_request_ids
+                .into_iter()
+                .zip(mirror_results.matched_batch_request_ids.iter())
+                .map(|(mut normal_ids, mirror_ids)| {
+                    for id in mirror_ids {
+                        if !normal_ids.contains(id) {
+                            normal_ids.push(id.clone());
+                        }
+                    }
+                    normal_ids
+                })
+                .collect::<Vec<_>>()
+        } else {
+            matched_batch_request_ids
+        };
+
         let match_ids_filtered = match_ids
             .into_iter()
             .map(|ids| {


### PR DESCRIPTION
This PR adds an E2E test case specifically for intra-batch mirror matches.
The GPU version was actually already handling this correctly, the only thing that was missing was reporting the matching request id from the mirror matches as well.
However, this is just a cosmetic/logging fix, as the real decision of `is_match` was already computed correctly.

A few more details:

In iris-mpc-gpu/src/server/actor.rs:868-885, the CompactQuery for each side is built like this:

code_query / mask_query (the "a" operand) → get_iris_interpolated_requests_preprocessed(side, orientation) — this is orientation-aware: in Mirror mode for Eye::Left it returns right_mirrored_iris_interpolated_requests_preprocessed (opposite eye, mirrored).
code_query_insert / mask_query_insert (the "b" operand) → get_iris_requests_rotated_preprocessed(side) at iris-mpc-gpu/src/server/mod.rs:180-188 — this method takes no orientation parameter and always returns the normal, same-side rotated requests.
The intra-batch self-check in actor.rs:1762-1870 calls compute_dot_products, which dots code_query against code_query_insert, which is the expected mirror - normal dot product for the mirror orientation.
