### PR TITLE
Wire types crate + strawman worker for remote IrisWorkerPool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3236,6 +3236,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "iris-mpc-worker-protocol"
+version = "0.1.0"
+dependencies = [
+ "bincode",
+ "iris-mpc-common",
+ "serde",
+ "thiserror 1.0.65",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3041,6 +3041,7 @@ dependencies = [
  "futures",
  "iris-mpc-common",
  "iris-mpc-store",
+ "iris-mpc-worker-protocol",
  "itertools 0.13.0",
  "metrics",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "iris-mpc-upgrade",
     "iris-mpc-upgrade-hawk",
     "iris-mpc-utils",
+    "iris-mpc-worker-protocol",
 ]
  default-members = [
     "iris-mpc",
@@ -21,6 +22,7 @@ members = [
     "iris-mpc-upgrade",
     "iris-mpc-upgrade-hawk",
     "iris-mpc-utils",
+    "iris-mpc-worker-protocol",
 ]
 resolver = "2"
 

--- a/iris-mpc-bins/Cargo.toml
+++ b/iris-mpc-bins/Cargo.toml
@@ -176,6 +176,10 @@ path = "bin/iris-mpc-cpu/graph_utils.rs"
 name = "db-sanity-check"
 path = "bin/iris-mpc-cpu/db_sanity_check.rs"
 
+[[bin]]
+name = "strawman-worker"
+path = "bin/iris-mpc-cpu/strawman_worker.rs"
+
 # ---------------------
 # binaries for iris-mpc-gpu
 # ---------------------

--- a/iris-mpc-bins/bin/iris-mpc-cpu/strawman_worker.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/strawman_worker.rs
@@ -1,0 +1,100 @@
+#![recursion_limit = "256"]
+
+use clap::{Parser, ValueEnum};
+use eyre::Result;
+use iris_mpc_cpu::{
+    hawkers::aby3::aby3_store::DistanceMode,
+    strawman_worker::{run_local, StrawmanWorkerArgs},
+};
+use std::process::exit;
+use tokio::signal;
+use tokio_util::sync::CancellationToken;
+
+#[derive(Parser, Debug)]
+#[command(
+    about = "Strawman worker for the remote IrisWorkerPool. Throwaway dev/test \
+             companion until the production worker binary lands; expected to \
+             match its wire behavior via iris-mpc-worker-protocol."
+)]
+struct Cli {
+    /// Identity of this worker (free-form string passed to ampc-actor-utils).
+    #[arg(long)]
+    worker_id: String,
+    /// `host:port` this worker listens on.
+    #[arg(long)]
+    worker_address: String,
+    /// Identity of the leader (Hawk Main) connecting in.
+    #[arg(long)]
+    leader_id: String,
+    /// `host:port` of the leader, used for handshake validation.
+    #[arg(long)]
+    leader_address: String,
+    /// 0-based party id; drives the dummy iris used for `delete_irises`.
+    #[arg(long)]
+    party_id: usize,
+    /// Distance mode for `compute_dot_products` and pairwise distances.
+    /// Must match what Hawk Main is configured with — silent divergence
+    /// here corrupts results.
+    #[arg(long, value_enum, default_value_t = DistanceModeArg::MinRotation)]
+    distance_mode: DistanceModeArg,
+    /// Pin worker threads to NUMA-local cores. Off by default for dev.
+    #[arg(long, default_value_t = false)]
+    numa: bool,
+    /// Reserved for future shard routing. Ignored by v1.
+    #[arg(long, default_value_t = 0)]
+    shard_index: usize,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum DistanceModeArg {
+    Simple,
+    MinRotation,
+}
+
+impl From<DistanceModeArg> for DistanceMode {
+    fn from(v: DistanceModeArg) -> Self {
+        match v {
+            DistanceModeArg::Simple => DistanceMode::Simple,
+            DistanceModeArg::MinRotation => DistanceMode::MinRotation,
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+    let cli = Cli::parse();
+
+    let args = StrawmanWorkerArgs {
+        worker_id: cli.worker_id,
+        worker_address: cli.worker_address,
+        leader_id: cli.leader_id,
+        leader_address: cli.leader_address,
+        party_id: cli.party_id,
+        distance_mode: cli.distance_mode.into(),
+        numa: cli.numa,
+        shard_index: cli.shard_index,
+    };
+
+    let shutdown_ct = CancellationToken::new();
+    let ct_for_signal = shutdown_ct.clone();
+    let signal_task = tokio::spawn(async move {
+        if signal::ctrl_c().await.is_ok() {
+            tracing::info!("SIGINT received, shutting down strawman worker");
+            ct_for_signal.cancel();
+        }
+    });
+
+    match run_local(args, shutdown_ct).await {
+        Ok(()) => {
+            tracing::info!("strawman worker exited cleanly");
+        }
+        Err(e) => {
+            tracing::error!("strawman worker error: {e}");
+            signal_task.abort();
+            exit(1);
+        }
+    }
+    signal_task.abort();
+    Ok(())
+}

--- a/iris-mpc-common/src/test.rs
+++ b/iris-mpc-common/src/test.rs
@@ -197,6 +197,11 @@ pub enum TestCase {
     /// - Normal flow won't match anything in the database
     /// - But when the code is mirrored, it will match(mirrored version will be pre-inserted in the test db)
     FullFaceMirrorAttack,
+    /// Send an iris code crafted for full face mirror attack detection:
+    /// - Normal flow won't match anything in the database or batch
+    /// - Mirror flow won't match anything in the database, since it is not yet inserted
+    /// - Mirror flow should match an item in the batch.
+    MirrorAttackInBatch,
 }
 
 impl TestCase {
@@ -224,6 +229,7 @@ impl TestCase {
             TestCase::MatchAfterResetUpdate,
             TestCase::MatchAfterReauthSkipPersistence,
             TestCase::FullFaceMirrorAttack,
+            TestCase::MirrorAttackInBatch,
         ]
     }
 }
@@ -238,6 +244,7 @@ enum DatabaseRange {
     FullMaskOnly,
 }
 
+#[derive(Debug, Clone)]
 pub struct ExpectedResult {
     /// The returned index of the iris code in the database.
     /// It is None if the iris code is not in the database, and Some(idx) if
@@ -367,6 +374,8 @@ pub struct TestCaseGenerator {
     /// skip invalidating requests in the current batch, since we expect
     /// them to be processed
     skip_invalidate: bool,
+    /// Do we already have a mirror of a template in the current batch?
+    have_batch_mirror: bool,
     /// duplicates in the current batch, used to test the batch
     /// deduplication mechanism
     batch_duplicates: HashMap<String, String>,
@@ -398,6 +407,7 @@ impl TestCaseGenerator {
             rng,
             new_templates_in_batch: Vec::new(),
             skip_invalidate: false,
+            have_batch_mirror: false,
             batch_duplicates: HashMap::new(),
             db_indices_used_in_current_batch: HashSet::new(),
             or_rule_matches: Vec::new(),
@@ -429,6 +439,7 @@ impl TestCaseGenerator {
         self.new_templates_in_batch.clear();
         self.db_indices_used_in_current_batch.clear();
         self.or_rule_matches.clear();
+        self.have_batch_mirror = false;
 
         for idx in 0..batch_size {
             let (request_id, e2e_template, or_rule_indices, skip_persistence, message_type) =
@@ -666,6 +677,9 @@ impl TestCaseGenerator {
         }
         if !self.reauth_skip_persistence_templates.is_empty() {
             options.push(TestCase::MatchAfterReauthSkipPersistence);
+        }
+        if !self.new_templates_in_batch.is_empty() && !self.have_batch_mirror {
+            options.push(TestCase::MirrorAttackInBatch);
         }
 
         options.retain(|x| self.enabled_test_cases.contains(x));
@@ -1117,6 +1131,33 @@ impl TestCaseGenerator {
                     self.skip_invalidate = true;
                     e2e_template
                 }
+                TestCase::MirrorAttackInBatch => {
+                    tracing::info!("Sending iris code crafted for mirror attack detection that should match in batch");
+                    // Get an existing template from the current batch
+                    let (internal_batch_idx, _, original_template) = self
+                        .new_templates_in_batch
+                        .choose(&mut self.rng)
+                        .expect("this is only called if we already have templates in batch");
+                    tracing::info!(
+                        "batch_idx used for the mirror attack in batch: {}",
+                        internal_batch_idx
+                    );
+
+                    self.expected_results.insert(
+                        request_id.to_string(),
+                        ExpectedResult::builder()
+                            .with_batch_match(true)
+                            .with_full_face_mirror_attack(true)
+                            .build(),
+                    );
+                    self.have_batch_mirror = true;
+
+                    E2ETemplate {
+                        // This is swapped on purpose due to the mirror attack flow
+                        left: original_template.right.mirrored(),
+                        right: original_template.left.mirrored(),
+                    }
+                }
             }
         };
         (
@@ -1237,6 +1278,12 @@ impl TestCaseGenerator {
             was_reauth_success,
             was_skip_persistence_match,
             full_face_mirror_attack_detected
+        );
+        tracing::info!(
+            "Expected results for this request_id: {:?}",
+            self.expected_results
+                .get(req_id)
+                .expect("request id not found")
         );
         let &ExpectedResult {
             db_index: expected_idx,

--- a/iris-mpc-cpu/Cargo.toml
+++ b/iris-mpc-cpu/Cargo.toml
@@ -28,6 +28,7 @@ eyre.workspace = true
 futures.workspace = true
 iris-mpc-common = { path = "../iris-mpc-common" }
 iris-mpc-store = { path = "../iris-mpc-store" }
+iris-mpc-worker-protocol = { path = "../iris-mpc-worker-protocol" }
 itertools.workspace = true
 num-traits.workspace = true
 rand.workspace = true

--- a/iris-mpc-cpu/benches/hnsw.rs
+++ b/iris-mpc-cpu/benches/hnsw.rs
@@ -284,9 +284,10 @@ fn bench_gr_ready_made_hnsw(c: &mut Criterion) {
                         for (vector_store, graph_store) in vectors_graphs.into_iter() {
                             let player_index = get_owner_index(&vector_store).await.unwrap();
                             let iris = Arc::new(raw_query[player_index].clone());
-                            let query = cache_iris(&vector_store.lock().await.workers, iris)
-                                .await
-                                .unwrap();
+                            let query =
+                                cache_iris(vector_store.lock().await.workers.as_ref(), iris)
+                                    .await
+                                    .unwrap();
                             let searcher = searcher.clone();
                             let mut rng = rng.clone();
 
@@ -331,9 +332,10 @@ fn bench_gr_ready_made_hnsw(c: &mut Criterion) {
                         for (vector_store, graph_store) in vectors_graphs.into_iter() {
                             let player_index = get_owner_index(&vector_store).await.unwrap();
                             let iris = Arc::new(raw_query[player_index].clone());
-                            let query = cache_iris(&vector_store.lock().await.workers, iris)
-                                .await
-                                .unwrap();
+                            let query =
+                                cache_iris(vector_store.lock().await.workers.as_ref(), iris)
+                                    .await
+                                    .unwrap();
                             let searcher = searcher.clone();
                             let vector_store = vector_store.clone();
                             jobs.spawn(async move {

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -329,9 +329,23 @@ pub struct HawkActor {
     /// remote sharded pool in the future.
     pub(crate) worker_pools: BothEyes<Arc<dyn IrisWorkerPool>>,
     /// Handles to the underlying iris worker threads, used by the startup
-    /// loader to populate the in-memory iris store directly. Tied to the
-    /// local single-node deployment; a future remote pool will load its
-    /// own shards from the DB and this field will be refactored.
+    /// loader to populate the in-memory iris store directly.
+    ///
+    /// **Invariant:** for each side, `loader_handles[side]` references the
+    /// same worker channels as the `LocalIrisWorkerPool` inside
+    /// `worker_pools[side]`, and both reference the same `iris_store`.
+    /// This is currently established by `HawkActor::new_inner` cloning a
+    /// single `workers_handle` into both fields. If you change construction
+    /// (e.g., to wire a `RemoteIrisWorkerPool` into `worker_pools`), you
+    /// must either (a) keep the local handles in `loader_handles` so the
+    /// startup loader still populates the live in-memory store the trait
+    /// pool reads from, or (b) replace `as_iris_loader` to drive the new
+    /// pool's loading protocol. Silently swapping `worker_pools` without
+    /// touching `loader_handles` will leave the loader writing to an
+    /// orphaned store.
+    ///
+    /// This field is local-deployment-only and will be refactored when the
+    /// remote sharded pool's loading protocol is designed.
     pub(crate) loader_handles: BothEyes<IrisPoolHandle>,
 
     /// Store for persisting detailed anonymized statistics.
@@ -1367,7 +1381,7 @@ impl HawkRequest {
     ///
     /// Each physical iris is cached once (deduplicated by QueryId).
     /// Cache all queries from this request into the given worker pools.
-    pub async fn cache_into(&self, worker_pools: &BothEyes<Arc<dyn IrisWorkerPool>>) -> Result<()> {
+    pub async fn cache_into<W: IrisWorkerPool>(&self, worker_pools: &BothEyes<W>) -> Result<()> {
         let to_cache = self.all_queries_for_cache();
         // Cache all irises in both worker pools (mirror queries cross eyes).
         futures::try_join!(

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -108,11 +108,6 @@ use identity_update::{
 };
 use intra_batch::intra_batch_is_match;
 use iris_mpc_common::{
-    helpers::inmemory_store::InMemoryStore,
-    job::{BatchQuery, JobSubmissionHandle},
-    ROTATIONS,
-};
-use iris_mpc_common::{
     helpers::smpc_request::{
         REAUTH_MESSAGE_TYPE, RECOVERY_CHECK_MESSAGE_TYPE, RESET_CHECK_MESSAGE_TYPE,
         UNIQUENESS_MESSAGE_TYPE,
@@ -120,6 +115,10 @@ use iris_mpc_common::{
     vector_id::VectorId,
 };
 use iris_mpc_common::{helpers::sync::ModificationKey, job::RequestIndex};
+use iris_mpc_common::{
+    job::{BatchQuery, JobSubmissionHandle},
+    ROTATIONS,
+};
 use itertools::{izip, Itertools};
 use matching::{
     Decision, Filter, MatchId,
@@ -176,6 +175,7 @@ pub(crate) mod scheduler;
 pub(crate) mod search;
 mod session_groups;
 pub mod state_check;
+pub mod worker_pool_initializer;
 use is_match_batch::is_match_batch;
 
 /// Distance mode used by the HawkActor
@@ -312,8 +312,6 @@ pub struct HawkActor {
     /// See `get_or_init_prf_key`.
     prf_key: Option<Arc<[u8; 16]>>,
     // ---- Core State ----
-    /// A size used by the start-up loader.
-    loader_db_size: usize,
     /// In-memory storage for the secret-shared iris codes for both left and right eyes.
     /// Used by workers for distance computation and by external mutation paths (deletions).
     iris_store: BothEyes<Aby3SharedIrisesRef>,
@@ -328,25 +326,12 @@ pub struct HawkActor {
     /// Type-erased so a single binary can hold the local pool today and a
     /// remote sharded pool in the future.
     pub(crate) worker_pools: BothEyes<Arc<dyn IrisWorkerPool>>,
-    /// Handles to the underlying iris worker threads, used by the startup
-    /// loader to populate the in-memory iris store directly.
-    ///
-    /// **Invariant:** for each side, `loader_handles[side]` references the
-    /// same worker channels as the `LocalIrisWorkerPool` inside
-    /// `worker_pools[side]`, and both reference the same `iris_store`.
-    /// This is currently established by `HawkActor::new_inner` cloning a
-    /// single `workers_handle` into both fields. If you change construction
-    /// (e.g., to wire a `RemoteIrisWorkerPool` into `worker_pools`), you
-    /// must either (a) keep the local handles in `loader_handles` so the
-    /// startup loader still populates the live in-memory store the trait
-    /// pool reads from, or (b) replace `as_iris_loader` to drive the new
-    /// pool's loading protocol. Silently swapping `worker_pools` without
-    /// touching `loader_handles` will leave the loader writing to an
-    /// orphaned store.
-    ///
-    /// This field is local-deployment-only and will be refactored when the
-    /// remote sharded pool's loading protocol is designed.
-    pub(crate) loader_handles: BothEyes<IrisPoolHandle>,
+    /// Local worker handles, retained for paths that load iris data after
+    /// actor construction (genesis: iris load runs after `sync_peers` and
+    /// a possible iris-DB rollback). `None` when the actor is built with a
+    /// non-local pool — those load through their own bootstrap protocol on
+    /// the wire and don't accept post-construction loads.
+    pub(crate) loader_handles: Option<BothEyes<IrisPoolHandle>>,
 
     /// Store for persisting detailed anonymized statistics.
     anon_stats_store: Option<AnonStatsStore>,
@@ -495,21 +480,63 @@ pub struct HawkInsertPlan {
 pub type ConnectPlan = ConnectPlanV<Aby3Store<HawkOps>>;
 
 impl HawkActor {
+    /// Empty-store, empty-graph constructor. Test convenience.
     pub async fn from_cli(args: &HawkArgs, shutdown_ct: CancellationToken) -> Result<Self> {
-        Self::from_cli_with_graph_and_store(
-            args,
-            shutdown_ct,
-            [(); 2].map(|_| GraphMem::new()),
-            [(); 2].map(|_| Aby3Store::<HawkOps>::new_storage(None)),
-        )
-        .await
+        let initializer = Box::new(
+            worker_pool_initializer::LocalWorkerPoolInitializer::new_empty(
+                args.party_index,
+                HAWK_DISTANCE_MODE,
+                args.numa,
+            ),
+        );
+        Self::from_cli_with_initializer(args, shutdown_ct, initializer).await
     }
 
+    /// Test/seeded constructor. Builds a `Seeded` initializer from the given
+    /// iris stores so call sites that pre-populate stores still work without
+    /// touching DB or fake-db plumbing.
     pub async fn from_cli_with_graph_and_store(
         args: &HawkArgs,
         shutdown_ct: CancellationToken,
         graph: BothEyes<GraphMem<Aby3VectorRef>>,
         iris_store: BothEyes<Aby3SharedIrises>,
+    ) -> Result<Self> {
+        use worker_pool_initializer::WorkerPoolInitializer;
+        let initializer = Box::new(
+            worker_pool_initializer::LocalWorkerPoolInitializer::new_seeded(
+                args.party_index,
+                HAWK_DISTANCE_MODE,
+                args.numa,
+                iris_store,
+            ),
+        );
+        let initialized = initializer.initialize().await?;
+        Self::from_initialized_workers(args, shutdown_ct, initialized, graph).await
+    }
+
+    /// Drive an initializer to completion (loading iris data into worker
+    /// pools), then build the actor with an empty graph. Production paths
+    /// that need to load the graph too should call
+    /// `from_initialized_workers` directly so they can run iris and graph
+    /// loads in parallel.
+    pub async fn from_cli_with_initializer(
+        args: &HawkArgs,
+        shutdown_ct: CancellationToken,
+        initializer: Box<dyn worker_pool_initializer::WorkerPoolInitializer>,
+    ) -> Result<Self> {
+        let initialized = initializer.initialize().await?;
+        let graph = [(); 2].map(|_| GraphMem::new());
+        Self::from_initialized_workers(args, shutdown_ct, initialized, graph).await
+    }
+
+    /// Primary constructor: build the actor from already-prepared worker
+    /// pools and a pre-loaded graph. Callers that want iris and graph
+    /// loading to overlap run them in parallel and feed the results here.
+    pub async fn from_initialized_workers(
+        args: &HawkArgs,
+        shutdown_ct: CancellationToken,
+        initialized: worker_pool_initializer::InitializedWorkers,
+        graph: BothEyes<GraphMem<Aby3VectorRef>>,
     ) -> Result<Self> {
         let searcher = {
             let mut searcher_ = HnswSearcher::new_linear_scan(
@@ -541,38 +568,66 @@ impl HawkActor {
             tls: args.tls.clone(),
         };
         let networking = build_network_handle(network_args, shutdown_ct).await?;
+
+        let worker_pool_initializer::InitializedWorkers {
+            pools,
+            iris_stores,
+            post_load_checksums,
+            db_size,
+            local_pool_handles,
+        } = initialized;
+
+        tracing::info!(
+            "Workers initialized. Checksums: L={:#x} R={:#x}, db_size={}",
+            post_load_checksums[LEFT],
+            post_load_checksums[RIGHT],
+            db_size,
+        );
+
         let graph_store = graph.map(GraphMem::to_arc);
-        let iris_store = iris_store.map(SharedIrises::to_arc);
         let registry = [
-            iris_store[LEFT].read().await.to_registry().to_arc(),
-            iris_store[RIGHT].read().await.to_registry().to_arc(),
+            iris_stores[LEFT].read().await.to_registry().to_arc(),
+            iris_stores[RIGHT].read().await.to_registry().to_arc(),
         ];
-        let workers_handle = [LEFT, RIGHT]
-            .map(|side| iris_worker::init_workers(side, iris_store[side].clone(), args.numa));
-        let worker_pools: BothEyes<Arc<dyn IrisWorkerPool>> = [LEFT, RIGHT].map(|side| {
-            Arc::new(iris_worker::LocalIrisWorkerPool::new(
-                workers_handle[side].clone(),
-                iris_store[side].clone(),
-                HAWK_DISTANCE_MODE,
-                args.party_index,
-            )) as Arc<dyn IrisWorkerPool>
-        });
 
         Ok(HawkActor {
             args: args.clone(),
             searcher,
             prf_key: None,
-            loader_db_size: 0,
-            iris_store,
+            iris_store: iris_stores,
             registry,
             graph_store,
             anon_stats_store: None,
             networking,
             party_id: args.party_index,
             error_ct: CancellationToken::new(),
-            worker_pools,
-            loader_handles: workers_handle,
+            worker_pools: pools,
+            loader_handles: local_pool_handles,
         })
+    }
+
+    /// Run `load_iris_db` against the actor's local worker pool, populating
+    /// the iris store in-place. Used by genesis, where iris loading must
+    /// happen after `sync_peers` and an optional DB rollback (so the data
+    /// must enter the running actor's pool, not a fresh one). After this
+    /// completes, callers should call `refresh_registries()` so sessions
+    /// see the loaded VectorIds.
+    ///
+    /// Errors when the actor was built with a non-local pool — remote
+    /// pools load through their own bootstrap protocol at construction
+    /// time and don't accept post-hoc loads.
+    pub async fn load_iris_db_in_place(
+        &mut self,
+        params: worker_pool_initializer::DbLoadParams,
+    ) -> Result<usize> {
+        let handles = self.loader_handles.as_ref().ok_or_else(|| {
+            eyre!(
+                "load_iris_db_in_place: actor's worker pool is not local; \
+                 use a `LoadFromDb` initializer at construction instead"
+            )
+        })?;
+        worker_pool_initializer::load_iris_db_through_pools(self.party_id, handles.clone(), params)
+            .await
     }
 
     pub fn set_anon_stats_store(&mut self, store: Option<AnonStatsStore>) {
@@ -1053,22 +1108,14 @@ impl HawkActor {
         Ok(())
     }
 
-    /// Borrow the in-memory iris and graph stores to modify them.
-    pub async fn as_iris_loader(&mut self) -> (IrisLoader<'_>, GraphLoader<'_>) {
-        (
-            IrisLoader {
-                party_id: self.party_id,
-                db_size: &mut self.loader_db_size,
-                iris_pools: [
-                    self.loader_handles[LEFT].clone(),
-                    self.loader_handles[RIGHT].clone(),
-                ],
-            },
-            GraphLoader([
-                self.graph_store[0].write().await,
-                self.graph_store[1].write().await,
-            ]),
-        )
+    /// Borrow the in-memory graph stores to populate them post-construction.
+    /// Used by paths that build the actor first (with the iris load already
+    /// done by the initializer) and then load the graph from PG/S3.
+    pub async fn as_graph_loader(&mut self) -> GraphLoader<'_> {
+        GraphLoader([
+            self.graph_store[0].write().await,
+            self.graph_store[1].write().await,
+        ])
     }
 }
 
@@ -1081,75 +1128,40 @@ pub fn session_seeded_rng(base_seed: u64, store_id: StoreId, session_id: Session
 
 pub type Aby3SharedIrisesMut<'a> = RwLockWriteGuard<'a, Aby3SharedIrises>;
 
-/// Extra space to reserve in the iris store to avoid reallocations during insertion.
-const IRIS_STORE_RESERVE_EXTRA: f64 = 0.2;
-
-pub struct IrisLoader<'a> {
-    party_id: usize,
-    db_size: &'a mut usize,
-    iris_pools: BothEyes<IrisPoolHandle>,
-}
-
-impl IrisLoader<'_> {
-    pub async fn wait_completion(self) -> Result<()> {
-        try_join!(
-            self.iris_pools[LEFT].wait_completion(),
-            self.iris_pools[RIGHT].wait_completion(),
-        )?;
-        Ok(())
-    }
-}
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> InMemoryStore for IrisLoader<'a> {
-    fn load_single_record_from_db(
-        &mut self,
-        _index: usize, // TODO: Map.
-        vector_id: VectorId,
-        left_code: &[u16],
-        left_mask: &[u16],
-        right_code: &[u16],
-        right_mask: &[u16],
-    ) {
-        for (pool, code, mask) in izip!(
-            &self.iris_pools,
-            [left_code, right_code],
-            [left_mask, right_mask]
-        ) {
-            let iris = GaloisRingSharedIris::try_from_buffers(self.party_id, code, mask)
-                .expect("Wrong code or mask size");
-            pool.insert(vector_id, iris).unwrap();
-        }
-    }
-
-    fn increment_db_size(&mut self, _index: usize) {
-        *self.db_size += 1;
-    }
-
-    fn reserve(&mut self, additional: usize) {
-        let additional = additional + (additional as f64 * IRIS_STORE_RESERVE_EXTRA) as usize;
-        for side in &self.iris_pools {
-            side.reserve(additional).unwrap();
-        }
-    }
-
-    fn current_db_sizes(&self) -> impl std::fmt::Debug {
-        *self.db_size
-    }
-
-    fn fake_db(&mut self, size: usize) {
-        *self.db_size = size;
-        let iris = Arc::new(GaloisRingSharedIris::default_for_party(self.party_id));
-        for side in &self.iris_pools {
-            for i in 0..size {
-                side.insert(VectorId::from_serial_id(i as u32), iris.clone())
-                    .unwrap();
-            }
-        }
-    }
-}
-
 pub struct GraphLoader<'a>(BothEyes<GraphMut<'a>>);
+
+/// Free helper for callers that need to load both eyes' graphs from PG
+/// before a `HawkActor` exists — used to overlap iris loading (via
+/// `WorkerPoolInitializer::initialize`) with graph loading at startup.
+pub async fn load_graphs_from_pg(
+    graph_store: &GraphStore,
+    parallelism: usize,
+) -> Result<BothEyes<GraphMem<VectorId>>> {
+    let now = Instant::now();
+    let (graph_left, graph_right) = join!(
+        async {
+            let mut graph_tx = graph_store.tx().await?;
+            graph_tx
+                .with_graph(StoreId::Left)
+                .load_to_mem(graph_store.pool(), parallelism)
+                .await
+        },
+        async {
+            let mut graph_tx = graph_store.tx().await?;
+            graph_tx
+                .with_graph(StoreId::Right)
+                .load_to_mem(graph_store.pool(), parallelism)
+                .await
+        }
+    );
+    let graph_left = graph_left?;
+    let graph_right = graph_right?;
+    tracing::info!(
+        "GraphLoader: Loaded left and right graphs in {:?}",
+        now.elapsed()
+    );
+    Ok([graph_left, graph_right])
+}
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> GraphLoader<'a> {
@@ -1158,35 +1170,10 @@ impl<'a> GraphLoader<'a> {
         graph_store: &GraphStore,
         parallelism: usize,
     ) -> Result<()> {
-        let now = Instant::now();
-
-        // Spawn two independent transactions and load each graph in parallel.
-        let (graph_left, graph_right) = join!(
-            async {
-                let mut graph_tx = graph_store.tx().await?;
-                graph_tx
-                    .with_graph(StoreId::Left)
-                    .load_to_mem(graph_store.pool(), parallelism)
-                    .await
-            },
-            async {
-                let mut graph_tx = graph_store.tx().await?;
-                graph_tx
-                    .with_graph(StoreId::Right)
-                    .load_to_mem(graph_store.pool(), parallelism)
-                    .await
-            }
-        );
-        let graph_left = graph_left.expect("Could not load left graph");
-        let graph_right = graph_right.expect("Could not load right graph");
-
+        let [graph_left, graph_right] = load_graphs_from_pg(graph_store, parallelism).await?;
         let GraphLoader(mut graphs) = self;
         *graphs[LEFT] = graph_left;
         *graphs[RIGHT] = graph_right;
-        tracing::info!(
-            "GraphLoader: Loaded left and right graphs in {:?}",
-            now.elapsed()
-        );
         Ok(())
     }
 
@@ -2242,33 +2229,25 @@ mod tests {
     use futures::future::JoinAll;
     use iris_mpc_common::{
         helpers::smpc_request::UNIQUENESS_MESSAGE_TYPE, iris_db::db::IrisDB, job::BatchMetadata,
-        IRIS_CODE_LENGTH, MASK_CODE_LENGTH,
     };
     use rand::SeedableRng;
     use std::{ops::Not, time::Duration};
     use tokio::time::sleep;
     use tracing_test::traced_test;
 
-    /// Regression guard for the load → registry wiring in `iris-mpc/src/server/mod.rs::load_database`.
-    ///
-    /// `IrisLoader::load_single_record_from_db` writes through the worker
-    /// pool's iris store, which is the same `Arc` as `HawkActor.iris_store`.
-    /// But `HawkActor.registry` is a separate snapshot taken from `iris_store`
-    /// at construction time (i.e. empty). Sessions read from `registry`, so
-    /// without an explicit `refresh_registries()` call after the load:
-    ///
-    /// - `registry.contains(v)` returns false for every loaded vector →
-    ///   search has no visibility into the loaded graph.
-    /// - `registry.next_id` stays at the construction default → fresh inserts
-    ///   allocate VectorIds that collide with the loaded ones, producing
-    ///   `Attempted to add graph edge which was already present` warnings and
-    ///   eventually `Update entry layer not present` panics.
-    ///
-    /// The test mimics what `load_iris_db` does and asserts both halves of
-    /// the contract: the registry is stale before refresh, and correctly
-    /// reflects the load afterwards.
+    /// Construction-time invariant: when the actor is built with a `Seeded`
+    /// initializer (or from any path that hands the stores to the constructor
+    /// already populated), the registries reflect the loaded vectors without
+    /// any post-hoc `refresh_registries` call. This replaces the older
+    /// regression guard for the post-load `refresh_registries` requirement,
+    /// which became impossible to violate once iris loading moved into the
+    /// initializer.
     #[tokio::test]
-    async fn test_iris_loader_requires_refresh_registries() -> Result<()> {
+    async fn test_seeded_initializer_populates_registry() -> Result<()> {
+        use crate::hawkers::aby3::aby3_store::Aby3Store;
+        use crate::protocol::shared_iris::GaloisRingSharedIris;
+        use std::collections::HashMap;
+
         let addresses = vec![
             "0.0.0.0:21340".to_string(),
             "0.0.0.0:21341".to_string(),
@@ -2293,70 +2272,49 @@ mod tests {
             hnsw_disable_memory_persistence: false,
             tls: None,
         };
-        let mut hawk_actor = HawkActor::from_cli(&args, CancellationToken::new()).await?;
 
-        // Sanity: registry starts empty, next_id at the SharedIrises default of 1.
-        assert_eq!(hawk_actor.registry[LEFT].read().await.db_size(), 0);
-        assert_eq!(hawk_actor.registry[LEFT].read().await.next_id, 1);
-
-        // Mimic `load_iris_db`: write records via `IrisLoader` for sparse
-        // serial IDs. Use zero buffers — only metadata wiring is under test.
-        let zero_code = vec![0u16; IRIS_CODE_LENGTH];
-        let zero_mask = vec![0u16; MASK_CODE_LENGTH];
         let serial_ids = [0u32, 1, 2, 5];
-        {
-            let (mut iris_loader, _graph_loader) = hawk_actor.as_iris_loader().await;
-            for (idx, sid) in serial_ids.iter().enumerate() {
-                iris_loader.load_single_record_from_db(
-                    idx,
-                    VectorId::from_serial_id(*sid),
-                    &zero_code,
-                    &zero_mask,
-                    &zero_code,
-                    &zero_mask,
-                );
-                iris_loader.increment_db_size(idx);
+        let dummy = Arc::new(GaloisRingSharedIris::default_for_party(args.party_index));
+        let make_store = || {
+            let mut points = HashMap::new();
+            for sid in serial_ids {
+                points.insert(VectorId::from_serial_id(sid), dummy.clone());
             }
-            iris_loader.wait_completion().await?;
-        }
+            Aby3Store::<HawkOps>::new_storage(Some(points))
+        };
+        let iris_store = [make_store(), make_store()];
+        let graph = [(); 2].map(|_| GraphMem::new());
 
-        // Before `refresh_registries`: registry is the construction snapshot.
-        assert_eq!(
-            hawk_actor.registry[LEFT].read().await.db_size(),
-            0,
-            "registry must not see loaded vectors before refresh_registries"
-        );
-        assert_eq!(
-            hawk_actor.registry[LEFT].read().await.next_id,
-            1,
-            "registry next_id must not advance before refresh_registries — \
-             this is the bug that caused VectorId collisions on dev"
-        );
+        let hawk_actor = HawkActor::from_cli_with_graph_and_store(
+            &args,
+            CancellationToken::new(),
+            graph,
+            iris_store,
+        )
+        .await?;
 
-        hawk_actor.refresh_registries().await;
-
-        // After `refresh_registries`: registry sees every loaded vector and
-        // `next_id` advances past the highest loaded serial.
+        // No explicit `refresh_registries` call — registry must already match
+        // the seeded stores after construction.
         for sid in serial_ids {
             assert!(
                 hawk_actor.registry[LEFT]
                     .read()
                     .await
                     .contains(&VectorId::from_serial_id(sid)),
-                "registry must contain loaded VectorId {sid} after refresh"
+                "left registry must contain seeded VectorId {sid} after construction"
             );
             assert!(
                 hawk_actor.registry[RIGHT]
                     .read()
                     .await
                     .contains(&VectorId::from_serial_id(sid)),
-                "right registry must contain loaded VectorId {sid} after refresh"
+                "right registry must contain seeded VectorId {sid} after construction"
             );
         }
         assert_eq!(
             hawk_actor.registry[LEFT].read().await.next_id,
             *serial_ids.last().unwrap() + 1,
-            "registry next_id must advance to (max loaded serial_id + 1)"
+            "registry next_id must reflect (max seeded serial_id + 1)"
         );
 
         Ok(())
@@ -2679,7 +2637,7 @@ mod tests_db {
             tls: None,
         };
         let mut hawk_actor = HawkActor::from_cli(&args, CancellationToken::new()).await?;
-        let (_, graph_loader) = hawk_actor.as_iris_loader().await;
+        let graph_loader = hawk_actor.as_graph_loader().await;
         graph_loader.load_graph_store(&graph_store, 2).await?;
 
         // Check the loaded graph.

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -325,8 +325,14 @@ pub struct HawkActor {
     graph_store: BothEyes<GraphRef>,
     /// Shared worker pools with query caches (one per eye). Cloned into each
     /// `HawkSession` so all sessions for the same eye share the same cache.
-    /// Use `.inner()` to access the underlying `IrisPoolHandle`.
-    pub(crate) worker_pools: BothEyes<iris_worker::LocalIrisWorkerPool>,
+    /// Type-erased so a single binary can hold the local pool today and a
+    /// remote sharded pool in the future.
+    pub(crate) worker_pools: BothEyes<Arc<dyn IrisWorkerPool>>,
+    /// Handles to the underlying iris worker threads, used by the startup
+    /// loader to populate the in-memory iris store directly. Tied to the
+    /// local single-node deployment; a future remote pool will load its
+    /// own shards from the DB and this field will be refactored.
+    pub(crate) loader_handles: BothEyes<IrisPoolHandle>,
 
     /// Store for persisting detailed anonymized statistics.
     anon_stats_store: Option<AnonStatsStore>,
@@ -529,13 +535,13 @@ impl HawkActor {
         ];
         let workers_handle = [LEFT, RIGHT]
             .map(|side| iris_worker::init_workers(side, iris_store[side].clone(), args.numa));
-        let worker_pools = [LEFT, RIGHT].map(|side| {
-            iris_worker::LocalIrisWorkerPool::new(
+        let worker_pools: BothEyes<Arc<dyn IrisWorkerPool>> = [LEFT, RIGHT].map(|side| {
+            Arc::new(iris_worker::LocalIrisWorkerPool::new(
                 workers_handle[side].clone(),
                 iris_store[side].clone(),
                 HAWK_DISTANCE_MODE,
                 args.party_index,
-            )
+            )) as Arc<dyn IrisWorkerPool>
         });
 
         Ok(HawkActor {
@@ -551,6 +557,7 @@ impl HawkActor {
             party_id: args.party_index,
             error_ct: CancellationToken::new(),
             worker_pools,
+            loader_handles: workers_handle,
         })
     }
 
@@ -626,7 +633,7 @@ impl HawkActor {
         }
     }
 
-    pub fn worker_pool(&self, store_id: StoreId) -> iris_worker::LocalIrisWorkerPool {
+    pub fn worker_pool(&self, store_id: StoreId) -> Arc<dyn IrisWorkerPool> {
         self.worker_pools[store_id as usize].clone()
     }
 
@@ -1039,8 +1046,8 @@ impl HawkActor {
                 party_id: self.party_id,
                 db_size: &mut self.loader_db_size,
                 iris_pools: [
-                    self.worker_pools[LEFT].inner().clone(),
-                    self.worker_pools[RIGHT].inner().clone(),
+                    self.loader_handles[LEFT].clone(),
+                    self.loader_handles[RIGHT].clone(),
                 ],
             },
             GraphLoader([
@@ -1360,10 +1367,7 @@ impl HawkRequest {
     ///
     /// Each physical iris is cached once (deduplicated by QueryId).
     /// Cache all queries from this request into the given worker pools.
-    pub async fn cache_into(
-        &self,
-        worker_pools: &BothEyes<iris_worker::LocalIrisWorkerPool>,
-    ) -> Result<()> {
+    pub async fn cache_into(&self, worker_pools: &BothEyes<Arc<dyn IrisWorkerPool>>) -> Result<()> {
         let to_cache = self.all_queries_for_cache();
         // Cache all irises in both worker pools (mirror queries cross eyes).
         futures::try_join!(

--- a/iris-mpc-cpu/src/execution/hawk_main/identity_update.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/identity_update.rs
@@ -5,11 +5,7 @@ use super::{
     search::{self, SearchParams, SearchQueries, SearchResults},
     BothEyes, HawkActor, HawkRequest, HawkSession, LEFT, RIGHT,
 };
-use crate::execution::hawk_main::{
-    iris_worker::{IrisWorkerPool, QueryId},
-    search::SearchIds,
-    NEIGHBORHOOD_MODE,
-};
+use crate::execution::hawk_main::{iris_worker::QueryId, search::SearchIds, NEIGHBORHOOD_MODE};
 use eyre::Result;
 use iris_mpc_common::vector_id::VectorId;
 

--- a/iris-mpc-cpu/src/execution/hawk_main/iris_worker.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/iris_worker.rs
@@ -15,7 +15,7 @@ use ampc_actor_utils::fast_metrics::FastHistogram;
 use core_affinity::CoreId;
 use crossbeam::channel::{Receiver, Sender};
 use eyre::Result;
-use futures::future::try_join_all;
+use futures::future::{try_join_all, BoxFuture};
 use iris_mpc_common::{
     galois_engine::degree4::{GaloisRingIrisCodeShare, GaloisRingTrimmedMaskCodeShare},
     vector_id::VectorId,
@@ -24,7 +24,6 @@ use itertools::{izip, Itertools};
 use std::{
     collections::HashMap,
     fmt::Debug,
-    future::Future,
     iter,
     sync::{
         atomic::{AtomicU64, Ordering},
@@ -570,7 +569,7 @@ pub const CENTER_ROTATION: usize = 15;
 /// - **fetch_irises**: pull iris data from the worker's store
 /// - **insert_irises**: persist cached iris into the worker's store
 /// - **evict_queries**: free cached query data
-pub trait IrisWorkerPool: Clone + Debug + Send + Sync {
+pub trait IrisWorkerPool: Debug + Send + Sync {
     /// Cache query irises for subsequent computation.
     ///
     /// The worker performs the full preprocessing pipeline on each iris:
@@ -590,27 +589,23 @@ pub trait IrisWorkerPool: Clone + Debug + Send + Sync {
     // would let LocalIrisWorkerPool skip generating + NUMA-reallocating unused
     // variants. This is the main remaining performance gap vs the old design
     // (which only preprocessed the selected rotations).
-    fn cache_queries(
-        &self,
-        queries: Vec<(QueryId, ArcIris)>,
-    ) -> impl Future<Output = Result<()>> + Send;
+    fn cache_queries<'a>(&'a self, queries: Vec<(QueryId, ArcIris)>) -> BoxFuture<'a, Result<()>>;
 
     /// Compute dot products for batches of (query_spec, targets).
     ///
     /// Each `QuerySpec` selects a specific preprocessed rotation from the
     /// cache. Returns one `Vec<RingElement<u16>>` per batch.
-    fn compute_dot_products(
-        &self,
+    fn compute_dot_products<'a>(
+        &'a self,
         batches: Vec<(QuerySpec, Vec<VectorId>)>,
-    ) -> impl Future<Output = Result<Vec<Vec<RingElement<u16>>>>> + Send;
+    ) -> BoxFuture<'a, Result<Vec<Vec<RingElement<u16>>>>>;
 
     /// Fetch iris data from the worker's store by vector ID.
     ///
     /// Returns one `ArcIris` per input ID in the same order.  Missing
     /// entries produce the store's default empty iris (which yields
     /// max-distance in dot products).
-    fn fetch_irises(&self, ids: Vec<VectorId>)
-        -> impl Future<Output = Result<Vec<ArcIris>>> + Send;
+    fn fetch_irises<'a>(&'a self, ids: Vec<VectorId>) -> BoxFuture<'a, Result<Vec<ArcIris>>>;
 
     /// Insert a cached iris into the worker's persistent store.
     ///
@@ -618,10 +613,8 @@ pub trait IrisWorkerPool: Clone + Debug + Send + Sync {
     /// by `QueryId` and inserts it at the given `VectorId`.
     ///
     /// Returns the store checksum after all inserts are applied.
-    fn insert_irises(
-        &self,
-        inserts: Vec<(QueryId, VectorId)>,
-    ) -> impl Future<Output = Result<u64>> + Send;
+    fn insert_irises<'a>(&'a self, inserts: Vec<(QueryId, VectorId)>)
+        -> BoxFuture<'a, Result<u64>>;
 
     /// Compute pairwise distances between pairs of cached queries.
     ///
@@ -632,32 +625,68 @@ pub trait IrisWorkerPool: Clone + Debug + Send + Sync {
     /// the second `QueryId` selects the **raw (original)** iris (only the
     /// query identity matters — rotation/mirrored are not applicable for the
     /// raw operand). This matches `trick_dot` (one preprocessed, one raw).
-    fn compute_pairwise_distances(
-        &self,
+    fn compute_pairwise_distances<'a>(
+        &'a self,
         pairs: Vec<Option<(QuerySpec, QueryId)>>,
-    ) -> impl Future<Output = Result<Vec<RingElement<u16>>>> + Send;
+    ) -> BoxFuture<'a, Result<Vec<RingElement<u16>>>>;
 
     /// Evict cached queries, freeing memory.
-    fn evict_queries(&self, query_ids: Vec<QueryId>) -> impl Future<Output = Result<()>> + Send;
+    fn evict_queries<'a>(&'a self, query_ids: Vec<QueryId>) -> BoxFuture<'a, Result<()>>;
 
     /// Delete irises by replacing them with party-specific dummy sentinels
     /// that produce max-distance in dot products. The party_id is a config
     /// field on the implementer.
-    fn delete_irises(&self, ids: Vec<VectorId>) -> impl Future<Output = Result<()>> + Send;
+    fn delete_irises<'a>(&'a self, ids: Vec<VectorId>) -> BoxFuture<'a, Result<()>>;
+}
+
+/// Blanket impl so any `Arc<T: IrisWorkerPool>` (including
+/// `Arc<dyn IrisWorkerPool>`) can be passed wherever an `impl IrisWorkerPool`
+/// or `&dyn IrisWorkerPool` is expected.
+impl<T: ?Sized + IrisWorkerPool> IrisWorkerPool for Arc<T> {
+    fn cache_queries<'a>(&'a self, queries: Vec<(QueryId, ArcIris)>) -> BoxFuture<'a, Result<()>> {
+        (**self).cache_queries(queries)
+    }
+    fn compute_dot_products<'a>(
+        &'a self,
+        batches: Vec<(QuerySpec, Vec<VectorId>)>,
+    ) -> BoxFuture<'a, Result<Vec<Vec<RingElement<u16>>>>> {
+        (**self).compute_dot_products(batches)
+    }
+    fn fetch_irises<'a>(&'a self, ids: Vec<VectorId>) -> BoxFuture<'a, Result<Vec<ArcIris>>> {
+        (**self).fetch_irises(ids)
+    }
+    fn insert_irises<'a>(
+        &'a self,
+        inserts: Vec<(QueryId, VectorId)>,
+    ) -> BoxFuture<'a, Result<u64>> {
+        (**self).insert_irises(inserts)
+    }
+    fn compute_pairwise_distances<'a>(
+        &'a self,
+        pairs: Vec<Option<(QuerySpec, QueryId)>>,
+    ) -> BoxFuture<'a, Result<Vec<RingElement<u16>>>> {
+        (**self).compute_pairwise_distances(pairs)
+    }
+    fn evict_queries<'a>(&'a self, query_ids: Vec<QueryId>) -> BoxFuture<'a, Result<()>> {
+        (**self).evict_queries(query_ids)
+    }
+    fn delete_irises<'a>(&'a self, ids: Vec<VectorId>) -> BoxFuture<'a, Result<()>> {
+        (**self).delete_irises(ids)
+    }
 }
 
 /// Cache a single iris and return a query handle (center rotation, non-mirrored).
 /// Helper used by tests, benches, and example bins — production code paths
 /// manage the cache lifecycle explicitly via `cache_queries` / `evict_queries`.
-pub async fn cache_iris<W: IrisWorkerPool>(pool: &W, iris: ArcIris) -> Result<QuerySpec> {
+pub async fn cache_iris(pool: &dyn IrisWorkerPool, iris: ArcIris) -> Result<QuerySpec> {
     let qid = QueryId::new();
     pool.cache_queries(vec![(qid, iris)]).await?;
     Ok(QuerySpec::new(qid))
 }
 
 /// Cache multiple irises and return query handles in input order.
-pub async fn cache_irises<W: IrisWorkerPool>(
-    pool: &W,
+pub async fn cache_irises(
+    pool: &dyn IrisWorkerPool,
     irises: Vec<ArcIris>,
 ) -> Result<Vec<QuerySpec>> {
     let pairs: Vec<_> = irises
@@ -750,13 +779,10 @@ fn zip_rotations(
 }
 
 impl IrisWorkerPool for LocalIrisWorkerPool {
-    fn cache_queries(
-        &self,
-        queries: Vec<(QueryId, ArcIris)>,
-    ) -> impl Future<Output = Result<()>> + Send {
+    fn cache_queries<'a>(&'a self, queries: Vec<(QueryId, ArcIris)>) -> BoxFuture<'a, Result<()>> {
         let query_cache = self.query_cache.clone();
         let inner = self.inner.clone();
-        async move {
+        Box::pin(async move {
             let start = Instant::now();
             // Filter out already-cached queries.
             let new_queries: Vec<_> = {
@@ -838,17 +864,17 @@ impl IrisWorkerPool for LocalIrisWorkerPool {
             }
             metrics::histogram!("cache_queries_duration").record(start.elapsed().as_secs_f64());
             Ok(())
-        }
+        })
     }
 
-    fn compute_dot_products(
-        &self,
+    fn compute_dot_products<'a>(
+        &'a self,
         batches: Vec<(QuerySpec, Vec<VectorId>)>,
-    ) -> impl Future<Output = Result<Vec<Vec<RingElement<u16>>>>> + Send {
+    ) -> BoxFuture<'a, Result<Vec<Vec<RingElement<u16>>>>> {
         let query_cache = self.query_cache.clone();
         let mut inner = self.inner.clone();
         let mode = self.mode;
-        async move {
+        Box::pin(async move {
             // Look up the correct preprocessed rotation for each batch
             let iris_batches: Vec<(ArcIris, Vec<VectorId>)> = {
                 let cache = query_cache.read().unwrap();
@@ -883,30 +909,27 @@ impl IrisWorkerPool for LocalIrisWorkerPool {
                         .await
                 }
             }
-        }
+        })
     }
 
-    fn fetch_irises(
-        &self,
-        ids: Vec<VectorId>,
-    ) -> impl Future<Output = Result<Vec<ArcIris>>> + Send {
+    fn fetch_irises<'a>(&'a self, ids: Vec<VectorId>) -> BoxFuture<'a, Result<Vec<ArcIris>>> {
         let iris_store = self.iris_store.clone();
-        async move {
+        Box::pin(async move {
             let store = iris_store.data.read().await;
             Ok(ids
                 .iter()
                 .map(|id| store.get_vector_or_empty(id).clone())
                 .collect())
-        }
+        })
     }
 
-    fn insert_irises(
-        &self,
+    fn insert_irises<'a>(
+        &'a self,
         inserts: Vec<(QueryId, VectorId)>,
-    ) -> impl Future<Output = Result<u64>> + Send {
+    ) -> BoxFuture<'a, Result<u64>> {
         let query_cache = self.query_cache.clone();
         let iris_store = self.iris_store.clone();
-        async move {
+        Box::pin(async move {
             // Resolve query IDs to irises (release cache lock before await).
             let resolved: Vec<_> = {
                 let cache = query_cache.read().unwrap();
@@ -930,17 +953,17 @@ impl IrisWorkerPool for LocalIrisWorkerPool {
                 store.insert(vector_id, iris);
             }
             Ok(store.set_hash.checksum())
-        }
+        })
     }
 
-    fn compute_pairwise_distances(
-        &self,
+    fn compute_pairwise_distances<'a>(
+        &'a self,
         pairs: Vec<Option<(QuerySpec, QueryId)>>,
-    ) -> impl Future<Output = Result<Vec<RingElement<u16>>>> + Send {
+    ) -> BoxFuture<'a, Result<Vec<RingElement<u16>>>> {
         let query_cache = self.query_cache.clone();
         let inner = self.inner.clone();
         let mode = self.mode;
-        async move {
+        Box::pin(async move {
             // Resolve pairs to ArcIris pairs.
             // First = preprocessed rotation, second = raw (original) iris.
             let iris_pairs: Vec<Option<(ArcIris, ArcIris)>> = {
@@ -979,31 +1002,31 @@ impl IrisWorkerPool for LocalIrisWorkerPool {
                     inner.rotation_aware_pairwise_distances(iris_pairs).await
                 }
             }
-        }
+        })
     }
 
-    fn evict_queries(&self, query_ids: Vec<QueryId>) -> impl Future<Output = Result<()>> + Send {
+    fn evict_queries<'a>(&'a self, query_ids: Vec<QueryId>) -> BoxFuture<'a, Result<()>> {
         let query_cache = self.query_cache.clone();
-        async move {
+        Box::pin(async move {
             let mut cache = query_cache.write().unwrap();
             for qid in query_ids {
                 cache.remove(&qid);
             }
             Ok(())
-        }
+        })
     }
 
-    fn delete_irises(&self, ids: Vec<VectorId>) -> impl Future<Output = Result<()>> + Send {
+    fn delete_irises<'a>(&'a self, ids: Vec<VectorId>) -> BoxFuture<'a, Result<()>> {
         let iris_store = self.iris_store.clone();
         let party_id = self.party_id;
-        async move {
+        Box::pin(async move {
             let dummy = Arc::new(GaloisRingSharedIris::dummy_for_party(party_id));
             let mut store = iris_store.data.write().await;
             for id in ids {
                 store.update(id, dummy.clone());
             }
             Ok(())
-        }
+        })
     }
 }
 

--- a/iris-mpc-cpu/src/execution/hawk_main/iris_worker.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/iris_worker.rs
@@ -11,15 +11,17 @@ use crate::{
     },
     shares::RingElement,
 };
-use ampc_actor_utils::fast_metrics::FastHistogram;
+use ampc_actor_utils::{fast_metrics::FastHistogram, network::workpool::leader::LeaderHandle};
+use bytes::Bytes;
 use core_affinity::CoreId;
 use crossbeam::channel::{Receiver, Sender};
-use eyre::Result;
+use eyre::{eyre, Result};
 use futures::future::{try_join_all, BoxFuture};
 use iris_mpc_common::{
     galois_engine::degree4::{GaloisRingIrisCodeShare, GaloisRingTrimmedMaskCodeShare},
     vector_id::VectorId,
 };
+use iris_mpc_worker_protocol as wire;
 use itertools::{izip, Itertools};
 use std::{
     collections::HashMap,
@@ -1045,4 +1047,332 @@ pub fn select_core_ids(shard_index: usize) -> Vec<CoreId> {
     );
 
     cpu_ids.into_iter().map(|id| CoreId { id }).collect()
+}
+
+// ---------------------------------------------------------------------------
+// RemoteIrisWorkerPool — drives a fleet of remote workers via the
+// ampc-actor-utils workpool `LeaderHandle`. Wire types come from
+// `iris-mpc-worker-protocol`. The strawman worker (and, eventually, the
+// production worker binary) sit on the other end of these calls.
+//
+// **v1 scope: single-shard only.** `num_shards == 1` is enforced at
+// construction. Once the sharding-key hash is settled with the worker
+// author, scatter-gather routing of `VectorId`s and per-shard checksum
+// combination land in a follow-up. Until then, broadcast and
+// scatter-gather collapse to "send to the one worker we have."
+// ---------------------------------------------------------------------------
+
+/// Distance computations farmed out to remote workers over TCP.
+pub struct RemoteIrisWorkerPool {
+    leader: Arc<LeaderHandle>,
+    /// Number of worker shards. v1 enforces == 1.
+    num_shards: usize,
+    /// Drives `delete_irises`'s dummy iris choice and is forwarded to
+    /// workers via construction config (not on the wire).
+    party_id: usize,
+}
+
+impl Debug for RemoteIrisWorkerPool {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RemoteIrisWorkerPool")
+            .field("num_shards", &self.num_shards)
+            .field("party_id", &self.party_id)
+            .finish()
+    }
+}
+
+impl RemoteIrisWorkerPool {
+    /// Wrap a connected `LeaderHandle` as an `IrisWorkerPool`.
+    ///
+    /// The caller is responsible for calling
+    /// `LeaderHandle::wait_for_all_connections` *before* wrapping in `Arc`,
+    /// since that method requires `&mut`. After this returns, the pool is
+    /// ready to dispatch.
+    pub fn new(leader: Arc<LeaderHandle>, num_shards: usize, party_id: usize) -> Self {
+        assert_eq!(
+            num_shards, 1,
+            "RemoteIrisWorkerPool currently requires num_shards == 1; \
+             multi-shard routing lands in a follow-up PR"
+        );
+        Self {
+            leader,
+            num_shards,
+            party_id,
+        }
+    }
+
+    pub fn party_id(&self) -> usize {
+        self.party_id
+    }
+
+    pub fn num_shards(&self) -> usize {
+        self.num_shards
+    }
+}
+
+/// Broadcast `req` to every worker, decode each response with `extract`,
+/// and fail loudly on any worker error / protocol error / wrong variant.
+async fn broadcast_each<F, T>(
+    leader: &LeaderHandle,
+    req: wire::WorkerRequest,
+    method_name: &'static str,
+    mut extract: F,
+) -> Result<Vec<T>>
+where
+    F: FnMut(wire::WorkerResponse) -> Result<T>,
+{
+    let bytes = wire::encode_request(&req).map_err(|e| eyre!("encode {method_name}: {e}"))?;
+    let job = leader
+        .broadcast(Bytes::from(bytes))
+        .await
+        .map_err(|e| eyre!("broadcast {method_name}: {e:?}"))?;
+    let responses = job
+        .await
+        .map_err(|e| eyre!("workpool {method_name}: {e:?}"))?;
+    let mut out = Vec::with_capacity(responses.len());
+    for rsp in responses {
+        let payload = rsp
+            .payload
+            .map_err(|e| eyre!("worker {method_name}: {e:?}"))?;
+        let response = wire::decode_response(&payload.to_bytes())
+            .map_err(|e| eyre!("decode {method_name}: {e}"))?;
+        if let wire::WorkerResponse::ProtocolError(msg) = &response {
+            return Err(eyre!("{method_name} protocol error: {msg}"));
+        }
+        out.push(extract(response)?);
+    }
+    Ok(out)
+}
+
+fn share_to_arc_iris(s: wire::IrisShare) -> ArcIris {
+    Arc::new(GaloisRingSharedIris {
+        code: s.code,
+        mask: s.mask,
+    })
+}
+
+fn arc_iris_to_share(arc: &ArcIris) -> wire::IrisShare {
+    wire::IrisShare {
+        code: arc.code.clone(),
+        mask: arc.mask.clone(),
+    }
+}
+
+fn qid_to_wire(q: QueryId) -> wire::QueryId {
+    wire::QueryId(q.0)
+}
+
+fn spec_to_wire(s: QuerySpec) -> wire::QuerySpec {
+    let rotation =
+        u8::try_from(s.rotation).expect("rotation index fits in u8 (max 30 in the codebase)");
+    wire::QuerySpec {
+        query_id: qid_to_wire(s.query_id),
+        rotation,
+        mirrored: s.mirrored,
+    }
+}
+
+fn wrap_u16_vec(v: Vec<u16>) -> Vec<RingElement<u16>> {
+    v.into_iter().map(RingElement).collect()
+}
+
+impl IrisWorkerPool for RemoteIrisWorkerPool {
+    fn cache_queries<'a>(&'a self, queries: Vec<(QueryId, ArcIris)>) -> BoxFuture<'a, Result<()>> {
+        Box::pin(async move {
+            let wire_queries = queries
+                .into_iter()
+                .map(|(qid, iris)| (qid_to_wire(qid), arc_iris_to_share(&iris)))
+                .collect();
+            let req = wire::WorkerRequest::CacheQueries {
+                queries: wire_queries,
+            };
+            broadcast_each(
+                &self.leader,
+                req,
+                "cache_queries",
+                |response| match response {
+                    wire::WorkerResponse::CacheQueries(Ok(())) => Ok(()),
+                    wire::WorkerResponse::CacheQueries(Err(msg)) => {
+                        Err(eyre!("cache_queries: {msg}"))
+                    }
+                    other => Err(eyre!("cache_queries: unexpected variant {other:?}")),
+                },
+            )
+            .await?;
+            Ok(())
+        })
+    }
+
+    fn compute_dot_products<'a>(
+        &'a self,
+        batches: Vec<(QuerySpec, Vec<VectorId>)>,
+    ) -> BoxFuture<'a, Result<Vec<Vec<RingElement<u16>>>>> {
+        Box::pin(async move {
+            // Single-shard v1: all batches go to the one worker as-is.
+            // Multi-shard v2 will partition each batch's `VectorId`s by
+            // shard and reassemble per-target outputs back into input
+            // order; the hash function is part of the worker-author
+            // contract.
+            let wire_batches = batches
+                .into_iter()
+                .map(|(spec, vids)| (spec_to_wire(spec), vids))
+                .collect();
+            let req = wire::WorkerRequest::ComputeDotProducts {
+                batches: wire_batches,
+            };
+            let mut all =
+                broadcast_each(
+                    &self.leader,
+                    req,
+                    "compute_dot_products",
+                    |response| match response {
+                        wire::WorkerResponse::ComputeDotProducts(Ok(batches)) => Ok(batches),
+                        wire::WorkerResponse::ComputeDotProducts(Err(msg)) => {
+                            Err(eyre!("compute_dot_products: {msg}"))
+                        }
+                        other => Err(eyre!("compute_dot_products: unexpected variant {other:?}")),
+                    },
+                )
+                .await?;
+            // v1: one worker → one set of batches. Take it directly.
+            let batches = all
+                .pop()
+                .ok_or_else(|| eyre!("compute_dot_products: no responses"))?;
+            Ok(batches.into_iter().map(wrap_u16_vec).collect())
+        })
+    }
+
+    fn fetch_irises<'a>(&'a self, ids: Vec<VectorId>) -> BoxFuture<'a, Result<Vec<ArcIris>>> {
+        Box::pin(async move {
+            let req = wire::WorkerRequest::FetchIrises { ids };
+            let mut all =
+                broadcast_each(
+                    &self.leader,
+                    req,
+                    "fetch_irises",
+                    |response| match response {
+                        wire::WorkerResponse::FetchIrises(Ok(irises)) => Ok(irises),
+                        wire::WorkerResponse::FetchIrises(Err(msg)) => {
+                            Err(eyre!("fetch_irises: {msg}"))
+                        }
+                        other => Err(eyre!("fetch_irises: unexpected variant {other:?}")),
+                    },
+                )
+                .await?;
+            let irises = all
+                .pop()
+                .ok_or_else(|| eyre!("fetch_irises: no responses"))?;
+            Ok(irises.into_iter().map(share_to_arc_iris).collect())
+        })
+    }
+
+    fn insert_irises<'a>(
+        &'a self,
+        inserts: Vec<(QueryId, VectorId)>,
+    ) -> BoxFuture<'a, Result<u64>> {
+        Box::pin(async move {
+            let wire_inserts = inserts
+                .into_iter()
+                .map(|(qid, vid)| (qid_to_wire(qid), vid))
+                .collect();
+            let req = wire::WorkerRequest::InsertIrises {
+                inserts: wire_inserts,
+            };
+            let mut all =
+                broadcast_each(
+                    &self.leader,
+                    req,
+                    "insert_irises",
+                    |response| match response {
+                        wire::WorkerResponse::InsertIrises(Ok(checksum)) => Ok(checksum),
+                        wire::WorkerResponse::InsertIrises(Err(msg)) => {
+                            Err(eyre!("insert_irises: {msg}"))
+                        }
+                        other => Err(eyre!("insert_irises: unexpected variant {other:?}")),
+                    },
+                )
+                .await?;
+            // v1: single shard → single checksum.
+            // v2 with multi-shard will need to combine per-shard
+            // `set_hash` checksums; combining policy is TBD and depends
+            // on the SetHash algebra (XOR if it's order-independent).
+            all.pop()
+                .ok_or_else(|| eyre!("insert_irises: no responses"))
+        })
+    }
+
+    fn compute_pairwise_distances<'a>(
+        &'a self,
+        pairs: Vec<Option<(QuerySpec, QueryId)>>,
+    ) -> BoxFuture<'a, Result<Vec<RingElement<u16>>>> {
+        Box::pin(async move {
+            let wire_pairs = pairs
+                .into_iter()
+                .map(|p| p.map(|(spec, qid)| (spec_to_wire(spec), qid_to_wire(qid))))
+                .collect();
+            let req = wire::WorkerRequest::ComputePairwiseDistances { pairs: wire_pairs };
+            let mut all = broadcast_each(
+                &self.leader,
+                req,
+                "compute_pairwise_distances",
+                |response| match response {
+                    wire::WorkerResponse::ComputePairwiseDistances(Ok(values)) => Ok(values),
+                    wire::WorkerResponse::ComputePairwiseDistances(Err(msg)) => {
+                        Err(eyre!("compute_pairwise_distances: {msg}"))
+                    }
+                    other => Err(eyre!(
+                        "compute_pairwise_distances: unexpected variant {other:?}"
+                    )),
+                },
+            )
+            .await?;
+            let values = all
+                .pop()
+                .ok_or_else(|| eyre!("compute_pairwise_distances: no responses"))?;
+            Ok(wrap_u16_vec(values))
+        })
+    }
+
+    fn evict_queries<'a>(&'a self, query_ids: Vec<QueryId>) -> BoxFuture<'a, Result<()>> {
+        Box::pin(async move {
+            let wire_ids = query_ids.into_iter().map(qid_to_wire).collect();
+            let req = wire::WorkerRequest::EvictQueries {
+                query_ids: wire_ids,
+            };
+            broadcast_each(
+                &self.leader,
+                req,
+                "evict_queries",
+                |response| match response {
+                    wire::WorkerResponse::EvictQueries(Ok(())) => Ok(()),
+                    wire::WorkerResponse::EvictQueries(Err(msg)) => {
+                        Err(eyre!("evict_queries: {msg}"))
+                    }
+                    other => Err(eyre!("evict_queries: unexpected variant {other:?}")),
+                },
+            )
+            .await?;
+            Ok(())
+        })
+    }
+
+    fn delete_irises<'a>(&'a self, ids: Vec<VectorId>) -> BoxFuture<'a, Result<()>> {
+        Box::pin(async move {
+            let req = wire::WorkerRequest::DeleteIrises { ids };
+            broadcast_each(
+                &self.leader,
+                req,
+                "delete_irises",
+                |response| match response {
+                    wire::WorkerResponse::DeleteIrises(Ok(())) => Ok(()),
+                    wire::WorkerResponse::DeleteIrises(Err(msg)) => {
+                        Err(eyre!("delete_irises: {msg}"))
+                    }
+                    other => Err(eyre!("delete_irises: unexpected variant {other:?}")),
+                },
+            )
+            .await?;
+            Ok(())
+        })
+    }
 }

--- a/iris-mpc-cpu/src/execution/hawk_main/test_utils.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/test_utils.rs
@@ -21,9 +21,8 @@ use crate::{
 };
 
 use super::{
-    iris_worker::{IrisWorkerPool, QueryId},
-    scheduler::parallelize,
-    HawkActor, HawkArgs, HawkRequest, VectorId, LEFT, RIGHT,
+    iris_worker::QueryId, scheduler::parallelize, HawkActor, HawkArgs, HawkRequest, VectorId, LEFT,
+    RIGHT,
 };
 
 pub async fn setup_hawk_actors() -> Result<Vec<HawkActor>> {

--- a/iris-mpc-cpu/src/execution/hawk_main/worker_pool_initializer.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/worker_pool_initializer.rs
@@ -1,0 +1,389 @@
+//! Setup-time abstraction for building worker pools and (optionally)
+//! loading iris data into them. The runtime trait `IrisWorkerPool` stays
+//! narrow (compute only); loading is a one-shot bootstrap step that does
+//! not appear on the wire.
+//!
+//! See `.claude/plans/worker-pool-initializer.md` for design context.
+//!
+//! # Concrete impls
+//! - [`LocalWorkerPoolInitializer`] — builds in-process worker pools and
+//!   either pre-seeds them, fills with `fake_db`, or runs `load_iris_db`.
+//! - [`RemoteWorkerPoolInitializer`] — stub. The wire variant
+//!   (`WorkerRequest::LoadDb`) and `LoadDirective` shape are unblocked by
+//!   coordination with the production worker author; until then, calling
+//!   `initialize` panics.
+
+use crate::execution::hawk_main::iris_worker::{
+    init_workers, IrisPoolHandle, IrisWorkerPool, LocalIrisWorkerPool,
+};
+use crate::execution::hawk_main::{BothEyes, HawkOps, LEFT, RIGHT};
+use crate::hawkers::aby3::aby3_store::{
+    Aby3SharedIrises, Aby3SharedIrisesRef, Aby3Store, DistanceMode,
+};
+use crate::hawkers::shared_irises::SharedIrises;
+use crate::protocol::shared_iris::GaloisRingSharedIris;
+use ampc_actor_utils::network::workpool::leader::LeaderHandle;
+use ampc_server_utils::shutdown_handler::ShutdownHandler;
+use async_trait::async_trait;
+use eyre::Result;
+use iris_mpc_common::config::Config;
+use iris_mpc_common::helpers::inmemory_store::InMemoryStore;
+use iris_mpc_common::vector_id::VectorId;
+use iris_mpc_store::loader::load_iris_db;
+use iris_mpc_store::Store;
+use itertools::izip;
+use std::sync::Arc;
+use tokio::try_join;
+
+/// Result of `WorkerPoolInitializer::initialize`. Contains ready-to-serve
+/// worker pools (one per eye), the underlying iris stores (so the actor
+/// can build registries / expose snapshots), and per-eye load checksums.
+pub struct InitializedWorkers {
+    pub pools: BothEyes<Arc<dyn IrisWorkerPool>>,
+    /// Iris stores backing each pool. The actor uses these to build the
+    /// registry and to read iris snapshots; for `RemoteIrisWorkerPool`
+    /// they are not the canonical store (the worker holds that).
+    pub iris_stores: BothEyes<Aby3SharedIrisesRef>,
+    /// `set_hash` checksum per eye after load. Logged by the actor for
+    /// ops cross-check; future work may compare against an expected value.
+    pub post_load_checksums: BothEyes<u64>,
+    /// Total irises loaded across both eyes' loaders. Mirrors what
+    /// `IrisLoader::increment_db_size` accumulated under the old API.
+    pub db_size: usize,
+    /// Local worker handles, retained for paths that load iris data after
+    /// actor construction (genesis: iris load runs after `sync_peers` and
+    /// optional DB rollback). `None` for remote pools — those load via
+    /// their own bootstrap protocol on the wire and don't accept
+    /// post-construction loads.
+    pub local_pool_handles: Option<BothEyes<IrisPoolHandle>>,
+}
+
+/// One-shot setup for the per-eye worker pools.
+#[async_trait]
+pub trait WorkerPoolInitializer: Send {
+    /// Build both eyes' worker pools, populate their stores, and return
+    /// the ready handles. Consumes the initializer.
+    async fn initialize(self: Box<Self>) -> Result<InitializedWorkers>;
+}
+
+/// Inputs for `iris_mpc_store::loader::load_iris_db`. Lifted into a
+/// struct so the initializer can carry a single owned bundle.
+pub struct DbLoadParams {
+    pub store: Store,
+    pub config: Arc<Config>,
+    pub max_serial_id: usize,
+    pub parallelism: usize,
+    pub s3_max_serial_id: Option<usize>,
+    pub shutdown_handler: Arc<ShutdownHandler>,
+}
+
+/// Strategy for populating the local pools' iris stores at startup.
+pub enum LocalInitMode {
+    /// Build empty stores; do not load. Used when persistence is
+    /// disabled or by tests that don't care about the data.
+    Empty,
+    /// Install pre-built iris stores (e.g. tests that seed irises via
+    /// `Aby3Store::new_storage(Some(...))` before construction).
+    Seeded(BothEyes<Aby3SharedIrises>),
+    /// Run `load_iris_db` against the empty stores.
+    LoadFromDb(DbLoadParams),
+    /// Fill each store with `n` copies of the party's default iris —
+    /// the production `fake_db_size > 0` path.
+    FakeDb(usize),
+}
+
+pub struct LocalWorkerPoolInitializer {
+    pub party_id: usize,
+    pub distance_mode: DistanceMode,
+    pub numa: bool,
+    pub mode: LocalInitMode,
+}
+
+impl LocalWorkerPoolInitializer {
+    pub fn new_empty(party_id: usize, distance_mode: DistanceMode, numa: bool) -> Self {
+        Self {
+            party_id,
+            distance_mode,
+            numa,
+            mode: LocalInitMode::Empty,
+        }
+    }
+
+    pub fn new_seeded(
+        party_id: usize,
+        distance_mode: DistanceMode,
+        numa: bool,
+        seed_stores: BothEyes<Aby3SharedIrises>,
+    ) -> Self {
+        Self {
+            party_id,
+            distance_mode,
+            numa,
+            mode: LocalInitMode::Seeded(seed_stores),
+        }
+    }
+
+    pub fn new_load_from_db(
+        party_id: usize,
+        distance_mode: DistanceMode,
+        numa: bool,
+        params: DbLoadParams,
+    ) -> Self {
+        Self {
+            party_id,
+            distance_mode,
+            numa,
+            mode: LocalInitMode::LoadFromDb(params),
+        }
+    }
+
+    pub fn new_fake_db(
+        party_id: usize,
+        distance_mode: DistanceMode,
+        numa: bool,
+        size: usize,
+    ) -> Self {
+        Self {
+            party_id,
+            distance_mode,
+            numa,
+            mode: LocalInitMode::FakeDb(size),
+        }
+    }
+}
+
+#[async_trait]
+impl WorkerPoolInitializer for LocalWorkerPoolInitializer {
+    async fn initialize(self: Box<Self>) -> Result<InitializedWorkers> {
+        let LocalWorkerPoolInitializer {
+            party_id,
+            distance_mode,
+            numa,
+            mode,
+        } = *self;
+
+        // Materialize the iris stores. `Empty`, `LoadFromDb`, and `FakeDb`
+        // all start from the same blank-slate `new_storage(None)` shape;
+        // `Seeded` installs caller-provided stores wholesale.
+        let iris_stores: BothEyes<Aby3SharedIrisesRef> = match &mode {
+            LocalInitMode::Seeded(seeds) => {
+                let [left, right] = seeds.clone();
+                [SharedIrises::to_arc(left), SharedIrises::to_arc(right)]
+            }
+            _ => [
+                Aby3Store::<HawkOps>::new_storage(None).to_arc(),
+                Aby3Store::<HawkOps>::new_storage(None).to_arc(),
+            ],
+        };
+
+        // Build worker thread pools backed by these stores. The same
+        // `IrisPoolHandle` is used both for loading (via the fan-out
+        // adapter) and for serving — there is no separate "loader pool"
+        // anymore.
+        let workers_handle: BothEyes<IrisPoolHandle> =
+            [LEFT, RIGHT].map(|side| init_workers(side, iris_stores[side].clone(), numa));
+
+        let mut db_size: usize = 0;
+
+        match mode {
+            LocalInitMode::Empty | LocalInitMode::Seeded(_) => {}
+            LocalInitMode::LoadFromDb(params) => {
+                let DbLoadParams {
+                    store,
+                    config,
+                    max_serial_id,
+                    parallelism,
+                    s3_max_serial_id,
+                    shutdown_handler,
+                } = params;
+                let mut adapter = FanoutLoader {
+                    party_id,
+                    iris_pools: workers_handle.clone(),
+                    db_size: 0,
+                };
+                load_iris_db(
+                    &mut adapter,
+                    &store,
+                    max_serial_id,
+                    parallelism,
+                    s3_max_serial_id,
+                    &config,
+                    shutdown_handler,
+                )
+                .await?;
+                // Drain the worker channels so every fire-and-forget
+                // `Insert` lands in the store before we read `set_hash`.
+                try_join!(
+                    workers_handle[LEFT].wait_completion(),
+                    workers_handle[RIGHT].wait_completion(),
+                )?;
+                db_size = adapter.db_size;
+            }
+            LocalInitMode::FakeDb(size) => {
+                let dummy = Arc::new(GaloisRingSharedIris::default_for_party(party_id));
+                for side in [LEFT, RIGHT] {
+                    for i in 0..size {
+                        workers_handle[side]
+                            .insert(VectorId::from_serial_id(i as u32), dummy.clone())?;
+                    }
+                }
+                try_join!(
+                    workers_handle[LEFT].wait_completion(),
+                    workers_handle[RIGHT].wait_completion(),
+                )?;
+                db_size = size;
+            }
+        }
+
+        let pools: BothEyes<Arc<dyn IrisWorkerPool>> = [LEFT, RIGHT].map(|side| {
+            Arc::new(LocalIrisWorkerPool::new(
+                workers_handle[side].clone(),
+                iris_stores[side].clone(),
+                distance_mode,
+                party_id,
+            )) as Arc<dyn IrisWorkerPool>
+        });
+
+        let post_load_checksums = [
+            iris_stores[LEFT].data.read().await.set_hash.checksum(),
+            iris_stores[RIGHT].data.read().await.set_hash.checksum(),
+        ];
+
+        Ok(InitializedWorkers {
+            pools,
+            iris_stores,
+            post_load_checksums,
+            db_size,
+            local_pool_handles: Some(workers_handle),
+        })
+    }
+}
+
+/// Run `load_iris_db` against an already-constructed pair of local worker
+/// handles, fanning each PG record into both eyes. Used by genesis, where
+/// iris loading must happen after the actor has been built (so `sync_peers`
+/// and a possible iris-DB rollback can run first).
+///
+/// Returns the number of records loaded.
+pub async fn load_iris_db_through_pools(
+    party_id: usize,
+    iris_pools: BothEyes<IrisPoolHandle>,
+    params: DbLoadParams,
+) -> Result<usize> {
+    let DbLoadParams {
+        store,
+        config,
+        max_serial_id,
+        parallelism,
+        s3_max_serial_id,
+        shutdown_handler,
+    } = params;
+    let mut adapter = FanoutLoader {
+        party_id,
+        iris_pools: iris_pools.clone(),
+        db_size: 0,
+    };
+    load_iris_db(
+        &mut adapter,
+        &store,
+        max_serial_id,
+        parallelism,
+        s3_max_serial_id,
+        &config,
+        shutdown_handler,
+    )
+    .await?;
+    try_join!(
+        iris_pools[LEFT].wait_completion(),
+        iris_pools[RIGHT].wait_completion(),
+    )?;
+    Ok(adapter.db_size)
+}
+
+/// `InMemoryStore` adapter that fans a single PG read into both eyes'
+/// worker pools. Mirrors the old `IrisLoader` body, kept private to the
+/// initializer.
+struct FanoutLoader {
+    party_id: usize,
+    iris_pools: BothEyes<IrisPoolHandle>,
+    db_size: usize,
+}
+
+const IRIS_STORE_RESERVE_EXTRA: f64 = 0.2;
+
+impl InMemoryStore for FanoutLoader {
+    fn load_single_record_from_db(
+        &mut self,
+        _index: usize,
+        vector_id: VectorId,
+        left_code: &[u16],
+        left_mask: &[u16],
+        right_code: &[u16],
+        right_mask: &[u16],
+    ) {
+        for (pool, code, mask) in izip!(
+            &self.iris_pools,
+            [left_code, right_code],
+            [left_mask, right_mask]
+        ) {
+            let iris = GaloisRingSharedIris::try_from_buffers(self.party_id, code, mask)
+                .expect("Wrong code or mask size");
+            pool.insert(vector_id, iris).unwrap();
+        }
+    }
+
+    fn increment_db_size(&mut self, _index: usize) {
+        self.db_size += 1;
+    }
+
+    fn reserve(&mut self, additional: usize) {
+        let additional = additional + (additional as f64 * IRIS_STORE_RESERVE_EXTRA) as usize;
+        for side in &self.iris_pools {
+            side.reserve(additional).unwrap();
+        }
+    }
+
+    fn current_db_sizes(&self) -> impl std::fmt::Debug {
+        self.db_size
+    }
+
+    fn fake_db(&mut self, size: usize) {
+        self.db_size = size;
+        let iris = Arc::new(GaloisRingSharedIris::default_for_party(self.party_id));
+        for side in &self.iris_pools {
+            for i in 0..size {
+                side.insert(VectorId::from_serial_id(i as u32), iris.clone())
+                    .unwrap();
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Remote initializer — stubbed. Lands once `LoadDirective` / `LoadDb` wire
+// types are settled with the production worker author.
+// ---------------------------------------------------------------------------
+
+#[allow(dead_code)]
+pub struct RemoteWorkerPoolInitializer {
+    pub leaders: BothEyes<Arc<LeaderHandle>>,
+    pub num_shards: usize,
+    pub party_id: usize,
+    pub distance_mode: DistanceMode,
+    // TODO: `pub directive: LoadDirective` once the wire variant ships.
+}
+
+#[async_trait]
+impl WorkerPoolInitializer for RemoteWorkerPoolInitializer {
+    async fn initialize(self: Box<Self>) -> Result<InitializedWorkers> {
+        // TODO: Send `WorkerRequest::LoadDb { directive }` to every worker
+        // across both eyes' leaders, await `LoadAck`s, combine per-shard
+        // checksums, and wrap each leader as `RemoteIrisWorkerPool`. The
+        // wire variant + `LoadDirective` shape are open questions tracked
+        // in `.claude/plans/worker-pool-initializer.md` (Wire surface).
+        unimplemented!(
+            "RemoteWorkerPoolInitializer is stubbed pending LoadDirective \
+             coordination with the production worker author"
+        )
+    }
+}

--- a/iris-mpc-cpu/src/genesis/hawk_handle.rs
+++ b/iris-mpc-cpu/src/genesis/hawk_handle.rs
@@ -1,11 +1,9 @@
 use super::hawk_job::{Job, JobRequest, JobResult, SYNC_DONE, SYNC_ERROR, SYNC_RUNNING};
 use crate::{
     execution::hawk_main::{
-        insert::insert,
-        iris_worker::{IrisWorkerPool, QueryId},
-        scheduler::parallelize,
-        search::search_single_query_no_match_count,
-        BothEyes, HawkActor, HawkSession, LEFT, RIGHT, STORE_IDS,
+        insert::insert, iris_worker::QueryId, scheduler::parallelize,
+        search::search_single_query_no_match_count, BothEyes, HawkActor, HawkSession, LEFT, RIGHT,
+        STORE_IDS,
     },
     hawkers::aby3::aby3_store::Aby3Query,
 };

--- a/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
@@ -1,8 +1,6 @@
 use crate::{
     execution::{
-        hawk_main::iris_worker::{
-            cache_iris, IrisWorkerPool, LocalIrisWorkerPool, QueryId, QuerySpec,
-        },
+        hawk_main::iris_worker::{cache_iris, IrisWorkerPool, QueryId, QuerySpec},
         session::{Session, SessionHandles},
     },
     hawkers::shared_irises::{SharedIrises, SharedIrisesRef},
@@ -74,14 +72,13 @@ pub type VectorIdRegistryRef = SharedIrisesRef<()>;
 
 /// Implementation of VectorStore based on the ABY3 framework (<https://eprint.iacr.org/2018/403.pdf>).
 ///
-/// Generic over `D` (distance operations, e.g. `FhdOps`/`NhdOps`) and `W`
-/// (worker pool implementation). The default `W = LocalIrisWorkerPool` is the
-/// single-node implementation; future remote implementations will enable
-/// horizontal scaling.
+/// Generic over `D` (distance operations, e.g. `FhdOps`/`NhdOps`). The worker
+/// pool is type-erased as `Arc<dyn IrisWorkerPool>` so a single binary can
+/// hold either the local single-node pool or a remote sharded pool.
 ///
 /// Note that all SMPC operations are performed in a single session.
 #[derive(Debug)]
-pub struct Aby3Store<D = FhdOps, W: IrisWorkerPool = LocalIrisWorkerPool> {
+pub struct Aby3Store<D = FhdOps> {
     /// VectorId registry — tracks presence, versions, and checksums.
     /// Does **not** hold iris data; all iris reads go through `workers`.
     pub registry: VectorIdRegistryRef,
@@ -90,14 +87,14 @@ pub struct Aby3Store<D = FhdOps, W: IrisWorkerPool = LocalIrisWorkerPool> {
     pub session: Session,
 
     /// Worker pool for CPU-bound distance computations.
-    pub workers: W,
+    pub workers: Arc<dyn IrisWorkerPool>,
 
     distance_fn: distance_fn::DistanceFn,
 
     _phantom: std::marker::PhantomData<D>,
 }
 
-impl<D: DistanceOps, W: IrisWorkerPool> Aby3Store<D, W>
+impl<D: DistanceOps> Aby3Store<D>
 where
     Standard: Distribution<D::Ring>,
     VecShare<D::Ring>: Transpose64,
@@ -105,7 +102,7 @@ where
     pub fn new(
         registry: VectorIdRegistryRef,
         session: Session,
-        workers: W,
+        workers: Arc<dyn IrisWorkerPool>,
         distance_mode: DistanceMode,
     ) -> Self {
         Self {
@@ -175,7 +172,7 @@ where
             .into_iter()
             .next()
             .ok_or_eyre("fetch_irises did not return expected iris or empty default")?;
-        cache_iris(&self.workers, iris).await
+        cache_iris(self.workers.as_ref(), iris).await
     }
 
     /// Obliviously swaps the elements in `list` at the given `indices` according to the `swap_bits`.
@@ -564,7 +561,7 @@ where
     }
 }
 
-impl<D: DistanceOps, W: IrisWorkerPool> VectorStore for Aby3Store<D, W>
+impl<D: DistanceOps> VectorStore for Aby3Store<D>
 where
     Standard: Distribution<D::Ring>,
     VecShare<D::Ring>: Transpose64,
@@ -719,7 +716,7 @@ where
     }
 }
 
-impl<D: DistanceOps, W: IrisWorkerPool> VectorStoreMut for Aby3Store<D, W>
+impl<D: DistanceOps> VectorStoreMut for Aby3Store<D>
 where
     Standard: Distribution<D::Ring>,
     VecShare<D::Ring>: Transpose64,
@@ -804,7 +801,7 @@ mod tests {
             let irises: Vec<ArcIris> = (0..database_size)
                 .map(|id| Arc::new(shared_irises[id][player_index].clone()))
                 .collect();
-            let queries = cache_irises(&store.lock().await.workers, irises).await?;
+            let queries = cache_irises(store.lock().await.workers.as_ref(), irises).await?;
             let mut rng = rng.clone();
             let store = store.clone();
             jobs.spawn(async move {
@@ -1003,7 +1000,7 @@ mod tests {
             let mut player_inserts = vec![];
             let mut store_lock = store.lock().await;
             for iris in player_irises.iter() {
-                let query = cache_iris(&store_lock.workers, iris.clone()).await?;
+                let query = cache_iris(store_lock.workers.as_ref(), iris.clone()).await?;
                 let vid = store_lock.insert(&query).await;
                 player_inserts.push(vid);
             }
@@ -1376,7 +1373,7 @@ mod tests {
                 .map(|id| Arc::new(shared_irises[id][player_index].clone()))
                 .collect();
             let mut store_lock = store.lock().await;
-            let player_preps = cache_irises(&store_lock.workers, irises).await?;
+            let player_preps = cache_irises(store_lock.workers.as_ref(), irises).await?;
             queries.push(player_preps.clone());
             let mut player_inserts = vec![];
             for p in player_preps.iter() {
@@ -1572,7 +1569,7 @@ mod tests {
             let searcher = searcher.clone();
             jobs.spawn(async move {
                 let mut store = store.lock().await;
-                let queries = cache_irises(&store.workers, irises).await?;
+                let queries = cache_irises(store.workers.as_ref(), irises).await?;
                 let mut graph: GraphMem<VectorId> = GraphMem::new();
                 for (query, &layer) in queries.iter().zip(layers.iter()) {
                     searcher

--- a/iris-mpc-cpu/src/hawkers/aby3/aby3_store/distance_fn.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3/aby3_store/distance_fn.rs
@@ -1,5 +1,5 @@
 use crate::execution::hawk_main::{
-    iris_worker::{IrisWorkerPool, QueryId, QuerySpec},
+    iris_worker::{QueryId, QuerySpec},
     HAWK_MIN_DIST_ROTATIONS,
 };
 use crate::phase_trace;
@@ -42,9 +42,9 @@ use DistanceMode::{MinRotation, Simple};
 impl DistanceFn {
     /// Compute pairwise distances between pairs of cached queries using the
     /// worker pool's `compute_pairwise_distances` method.
-    pub async fn eval_pairwise_distances<D: DistanceOps, W: IrisWorkerPool>(
+    pub async fn eval_pairwise_distances<D: DistanceOps>(
         self,
-        store: &mut Aby3Store<D, W>,
+        store: &mut Aby3Store<D>,
         pairs: Vec<Option<(QuerySpec, QueryId)>>,
     ) -> Result<Vec<DistanceShare<D::Ring>>>
     where
@@ -63,9 +63,9 @@ impl DistanceFn {
         }
     }
 
-    pub async fn eval_distance_pairs<D: DistanceOps, W: IrisWorkerPool>(
+    pub async fn eval_distance_pairs<D: DistanceOps>(
         self,
-        store: &mut Aby3Store<D, W>,
+        store: &mut Aby3Store<D>,
         pairs: &[(Aby3Query, VectorId)],
     ) -> Result<Vec<DistanceShare<D::Ring>>>
     where
@@ -86,9 +86,9 @@ impl DistanceFn {
         }
     }
 
-    pub async fn eval_distance_batch<D: DistanceOps, W: IrisWorkerPool>(
+    pub async fn eval_distance_batch<D: DistanceOps>(
         self,
-        store: &mut Aby3Store<D, W>,
+        store: &mut Aby3Store<D>,
         query: &Aby3Query,
         vectors: &[VectorId],
     ) -> Result<Vec<DistanceShare<D::Ring>>>
@@ -130,9 +130,9 @@ impl DistanceFn {
     /// Evaluates distances for multiple (query, vectors) batches.
     ///
     /// For MinRotation, this enables prerotation buffer reuse within each batch.
-    pub async fn eval_distance_multibatch<D: DistanceOps, W: IrisWorkerPool>(
+    pub async fn eval_distance_multibatch<D: DistanceOps>(
         self,
-        store: &mut Aby3Store<D, W>,
+        store: &mut Aby3Store<D>,
         batches: Vec<(Aby3Query, Vec<VectorId>)>,
     ) -> Result<Vec<Vec<DistanceShare<D::Ring>>>>
     where

--- a/iris-mpc-cpu/src/hawkers/aby3/test_utils.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3/test_utils.rs
@@ -78,11 +78,11 @@ pub async fn setup_local_aby3_players_with_preloaded_db<R: RngCore + CryptoRng>(
         .zip(storages)
         .map(|(session, storage)| {
             let party_id = session.network_session.own_role.index();
-            let workers = LocalIrisWorkerPool::new_local(
+            let workers: Arc<dyn IrisWorkerPool> = Arc::new(LocalIrisWorkerPool::new_local(
                 storage.clone(),
                 plain_store.distance_mode,
                 party_id,
-            );
+            ));
             let registry = storage.data.try_read().unwrap().to_registry().to_arc();
             Ok(Arc::new(Mutex::new(Aby3Store::new(
                 registry,
@@ -102,8 +102,11 @@ pub async fn setup_local_store_aby3_players(network_t: NetworkType) -> Result<Ve
         .map(|session| {
             let party_id = session.network_session.own_role.index();
             let storage = Aby3Store::<FhdOps>::new_storage(None).to_arc();
-            let workers =
-                LocalIrisWorkerPool::new_local(storage.clone(), TEST_DISTANCE_MODE, party_id);
+            let workers: Arc<dyn IrisWorkerPool> = Arc::new(LocalIrisWorkerPool::new_local(
+                storage.clone(),
+                TEST_DISTANCE_MODE,
+                party_id,
+            ));
             let registry = storage.data.try_read().unwrap().to_registry().to_arc();
             Ok(Arc::new(Mutex::new(Aby3Store::new(
                 registry,
@@ -341,7 +344,7 @@ pub async fn shared_random_setup<R: RngCore + Clone + CryptoRng>(
         let task: JoinHandle<Result<(Aby3StoreRef, GraphMem<Aby3VectorRef>)>> =
             tokio::spawn(async move {
                 let mut store_lock = store.lock().await;
-                let queries = cache_irises(&store_lock.workers, irises).await?;
+                let queries = cache_irises(store_lock.workers.as_ref(), irises).await?;
                 let mut graph_store = GraphMem::new();
                 let searcher = HnswSearcher::new_with_test_parameters();
                 for query in queries.iter() {

--- a/iris-mpc-cpu/src/hnsw/sorting/swap_network.rs
+++ b/iris-mpc-cpu/src/hnsw/sorting/swap_network.rs
@@ -1,5 +1,4 @@
 use crate::{
-    execution::hawk_main::iris_worker::IrisWorkerPool,
     hawkers::aby3::aby3_store::{Aby3Store, DistanceOps},
     hnsw::VectorStore,
     shares::{share::DistanceShare, Share},
@@ -178,8 +177,8 @@ pub async fn apply_swap_network<V: VectorStore>(
 /// which might introduce an additional throughput overhead.
 /// For example, for a swap network implementing the tournament method to find the minimum of a list of length N,
 /// this throughput overhead is O(1).
-pub async fn apply_oblivious_swap_network<D: DistanceOps, W: IrisWorkerPool>(
-    store: &mut Aby3Store<D, W>,
+pub async fn apply_oblivious_swap_network<D: DistanceOps>(
+    store: &mut Aby3Store<D>,
     list: &[(u32, DistanceShare<D::Ring>)],
     network: &SwapNetwork,
 ) -> Result<Vec<(Share<D::Ring>, DistanceShare<D::Ring>)>>

--- a/iris-mpc-cpu/src/lib.rs
+++ b/iris-mpc-cpu/src/lib.rs
@@ -12,6 +12,7 @@ pub mod hawkers;
 pub mod hnsw;
 pub mod protocol;
 pub mod py_bindings;
+pub mod strawman_worker;
 pub mod utils;
 
 pub use ampc_actor_utils::network;

--- a/iris-mpc-cpu/src/strawman_worker.rs
+++ b/iris-mpc-cpu/src/strawman_worker.rs
@@ -1,0 +1,242 @@
+//! Strawman worker process for the remote `IrisWorkerPool`.
+//!
+//! Wraps `LocalIrisWorkerPool` with the ampc-actor-utils workpool worker
+//! protocol so a leader (Hawk Main) can drive iris computations over TCP
+//! using the wire types from `iris-mpc-worker-protocol`. Used as a
+//! development stand-in until the production worker binary lands; it is
+//! also the conformance baseline that the production worker must match.
+//!
+//! ## Throwaway scope
+//!
+//! When the production worker arrives, this module + its bin go away.
+//! Until then, this is the only complete, runnable end-to-end remote
+//! pool that can drive integration tests.
+//!
+//! ## v1 limitations (intentional)
+//!
+//! - **Single shard.** `shard_index` is accepted as a knob but not used
+//!   for routing; the worker serves the entire `VectorId` space it sees.
+//!   Sharding lives on the leader for the cross-machine case and will be
+//!   layered in once `RemoteIrisWorkerPool` exists.
+//! - **No TLS.** Plain TCP only. Fine for loopback tests and dev
+//!   clusters; production swaps in `TlsConfig`.
+//! - **No persistence.** The store is in-memory. Tests pre-seed by
+//!   either calling `insert_irises` over the wire or constructing a
+//!   `SharedIrisesRef` directly via `run_local_with_store`.
+//! - **No readiness signal.** The worker accepts jobs as soon as TCP is
+//!   up; tests that require seeded state pre-populate before the leader
+//!   dispatches.
+
+use ampc_actor_utils::network::workpool::{
+    worker::{build_worker_handle, Job, WorkerArgs},
+    Payload,
+};
+use eyre::{eyre, Result};
+use iris_mpc_worker_protocol::{
+    decode_request, encode_response, IrisShare, QueryId as WireQueryId, QuerySpec as WireQuerySpec,
+    WorkerRequest, WorkerResponse,
+};
+use std::{collections::HashMap, sync::Arc};
+use tokio_util::sync::CancellationToken;
+
+use crate::{
+    execution::hawk_main::iris_worker::{
+        init_workers, IrisWorkerPool, LocalIrisWorkerPool, QueryId, QuerySpec,
+    },
+    hawkers::{
+        aby3::aby3_store::DistanceMode,
+        shared_irises::{SharedIrises, SharedIrisesRef},
+    },
+    protocol::shared_iris::{ArcIris, GaloisRingSharedIris},
+};
+
+/// Configuration for spawning a strawman worker.
+#[derive(Clone, Debug)]
+pub struct StrawmanWorkerArgs {
+    pub worker_id: String,
+    pub worker_address: String,
+    pub leader_id: String,
+    pub leader_address: String,
+    pub party_id: usize,
+    pub distance_mode: DistanceMode,
+    pub numa: bool,
+    /// Reserved for future shard routing. v1 strawman ignores this.
+    pub shard_index: usize,
+}
+
+/// Run a strawman worker that delegates each request to the given pool.
+///
+/// Useful for tests that want to wrap an arbitrary `IrisWorkerPool` impl
+/// (e.g. a pre-populated `LocalIrisWorkerPool`) and expose it over the
+/// wire. Returns when `shutdown_ct` is cancelled or the worker handle's
+/// job channel closes.
+pub async fn run_with_pool(
+    args: StrawmanWorkerArgs,
+    pool: Arc<dyn IrisWorkerPool>,
+    shutdown_ct: CancellationToken,
+) -> Result<()> {
+    let mut handle = build_worker_handle(
+        WorkerArgs {
+            worker_id: args.worker_id.into(),
+            worker_address: args.worker_address,
+            leader_id: args.leader_id.into(),
+            leader_address: args.leader_address,
+            tls: None,
+        },
+        shutdown_ct.clone(),
+    )
+    .await
+    .map_err(|e| eyre!("worker handle setup failed: {e:?}"))?;
+
+    loop {
+        tokio::select! {
+            _ = shutdown_ct.cancelled() => break,
+            maybe_job = handle.recv() => match maybe_job {
+                None => break,
+                Some(job) => {
+                    let pool = pool.clone();
+                    tokio::spawn(handle_job(pool, job));
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Convenience: build a `LocalIrisWorkerPool` over an empty store and
+/// run the strawman against it. Intended for the bin entry point and
+/// for tests that don't need to pre-seed.
+pub async fn run_local(args: StrawmanWorkerArgs, shutdown_ct: CancellationToken) -> Result<()> {
+    let empty_iris: ArcIris = Arc::new(GaloisRingSharedIris::default_for_party(args.party_id));
+    let store = SharedIrises::<ArcIris>::new(HashMap::new(), empty_iris).to_arc();
+    run_local_with_store(args, store, shutdown_ct).await
+}
+
+/// Build a `LocalIrisWorkerPool` over the given (possibly pre-seeded)
+/// store and run the strawman against it. Useful for tests that want a
+/// hot worker without going through `insert_irises`.
+pub async fn run_local_with_store(
+    args: StrawmanWorkerArgs,
+    store: SharedIrisesRef<ArcIris>,
+    shutdown_ct: CancellationToken,
+) -> Result<()> {
+    let inner = init_workers(args.shard_index, store.clone(), args.numa);
+    let pool: Arc<dyn IrisWorkerPool> = Arc::new(LocalIrisWorkerPool::new(
+        inner,
+        store,
+        args.distance_mode,
+        args.party_id,
+    ));
+    run_with_pool(args, pool, shutdown_ct).await
+}
+
+async fn handle_job(pool: Arc<dyn IrisWorkerPool>, job: Job) {
+    let mut job = job;
+    let bytes = job.take_payload().to_bytes();
+    let response = match decode_request(&bytes) {
+        Ok(req) => dispatch(&pool, req).await,
+        Err(e) => WorkerResponse::ProtocolError(format!("decode: {e}")),
+    };
+    let encoded = match encode_response(&response) {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::error!("encode_response failed: {e}");
+            return;
+        }
+    };
+    job.send_result(Payload::Bytes(encoded.into()));
+}
+
+async fn dispatch(pool: &Arc<dyn IrisWorkerPool>, req: WorkerRequest) -> WorkerResponse {
+    match req {
+        WorkerRequest::CacheQueries { queries } => {
+            let mapped = queries
+                .into_iter()
+                .map(|(qid, iris)| (to_qid(qid), to_arc_iris(iris)))
+                .collect();
+            WorkerResponse::CacheQueries(
+                pool.cache_queries(mapped).await.map_err(|e| e.to_string()),
+            )
+        }
+        WorkerRequest::ComputeDotProducts { batches } => {
+            let mapped = batches
+                .into_iter()
+                .map(|(spec, vids)| (to_spec(spec), vids))
+                .collect();
+            WorkerResponse::ComputeDotProducts(
+                pool.compute_dot_products(mapped)
+                    .await
+                    .map(|results| {
+                        results
+                            .into_iter()
+                            .map(|inner| inner.into_iter().map(|r| r.0).collect())
+                            .collect()
+                    })
+                    .map_err(|e| e.to_string()),
+            )
+        }
+        WorkerRequest::FetchIrises { ids } => WorkerResponse::FetchIrises(
+            pool.fetch_irises(ids)
+                .await
+                .map(|irises| irises.into_iter().map(arc_iris_to_share).collect())
+                .map_err(|e| e.to_string()),
+        ),
+        WorkerRequest::InsertIrises { inserts } => {
+            let mapped = inserts
+                .into_iter()
+                .map(|(qid, vid)| (to_qid(qid), vid))
+                .collect();
+            WorkerResponse::InsertIrises(
+                pool.insert_irises(mapped).await.map_err(|e| e.to_string()),
+            )
+        }
+        WorkerRequest::ComputePairwiseDistances { pairs } => {
+            let mapped = pairs
+                .into_iter()
+                .map(|opt| opt.map(|(spec, qid)| (to_spec(spec), to_qid(qid))))
+                .collect();
+            WorkerResponse::ComputePairwiseDistances(
+                pool.compute_pairwise_distances(mapped)
+                    .await
+                    .map(|res| res.into_iter().map(|r| r.0).collect())
+                    .map_err(|e| e.to_string()),
+            )
+        }
+        WorkerRequest::EvictQueries { query_ids } => {
+            let mapped = query_ids.into_iter().map(to_qid).collect();
+            WorkerResponse::EvictQueries(
+                pool.evict_queries(mapped).await.map_err(|e| e.to_string()),
+            )
+        }
+        WorkerRequest::DeleteIrises { ids } => {
+            WorkerResponse::DeleteIrises(pool.delete_irises(ids).await.map_err(|e| e.to_string()))
+        }
+    }
+}
+
+fn to_qid(q: WireQueryId) -> QueryId {
+    QueryId(q.0)
+}
+
+fn to_spec(s: WireQuerySpec) -> QuerySpec {
+    QuerySpec {
+        query_id: to_qid(s.query_id),
+        rotation: s.rotation as usize,
+        mirrored: s.mirrored,
+    }
+}
+
+fn to_arc_iris(iris: IrisShare) -> ArcIris {
+    Arc::new(GaloisRingSharedIris {
+        code: iris.code,
+        mask: iris.mask,
+    })
+}
+
+fn arc_iris_to_share(arc: ArcIris) -> IrisShare {
+    IrisShare {
+        code: arc.code.clone(),
+        mask: arc.mask.clone(),
+    }
+}

--- a/iris-mpc-cpu/tests/aby3_store_remote_conformance.rs
+++ b/iris-mpc-cpu/tests/aby3_store_remote_conformance.rs
@@ -1,0 +1,233 @@
+#![recursion_limit = "256"]
+//! Conformance test: drive the existing `Aby3Store` HNSW flow through
+//! `RemoteIrisWorkerPool` instead of `LocalIrisWorkerPool`. Mirrors the
+//! existing `test_gr_hnsw` from `aby3_store.rs::tests` end-to-end; if this
+//! passes, the wire path (encode → broadcast → strawman → LocalIrisWorkerPool
+//! → encode → decode) is observably equivalent to the in-process path for
+//! the production-shaped configuration.
+//!
+//! When the production worker binary lands, the only thing that should
+//! change is which binary the strawman spawn is replaced with — the rest
+//! of the test stays as-is. That's the conformance guarantee we need.
+
+use ampc_actor_utils::{
+    execution::player::Identity,
+    network::{
+        mpc::NetworkType,
+        workpool::leader::{build_leader, LeaderArgs, LeaderHandle},
+    },
+};
+use eyre::Result;
+use iris_mpc_common::iris_db::db::IrisDB;
+use iris_mpc_cpu::{
+    execution::{
+        hawk_main::{
+            iris_worker::{cache_irises, IrisWorkerPool, RemoteIrisWorkerPool},
+            HAWK_DISTANCE_MODE,
+        },
+        local::LocalRuntime,
+    },
+    hawkers::aby3::{
+        aby3_store::{Aby3Store, FhdOps},
+        test_utils::get_owner_index,
+    },
+    hnsw::{GraphMem, HnswSearcher, SortedNeighborhood},
+    protocol::shared_iris::{ArcIris, GaloisRingSharedIris},
+};
+use std::{sync::Arc, time::Duration};
+use tokio::{sync::Mutex, task::JoinHandle, task::JoinSet};
+use tokio_util::sync::CancellationToken;
+
+/// Local mirror of the (private) `test_utils::Aby3StoreRef` so this
+/// integration test doesn't need to crack open crate internals.
+type Aby3StoreRef = Arc<Mutex<Aby3Store>>;
+
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
+
+fn find_free_ports(n: usize) -> Vec<u16> {
+    let listeners: Vec<std::net::TcpListener> = (0..n)
+        .map(|_| std::net::TcpListener::bind("127.0.0.1:0").unwrap())
+        .collect();
+    listeners
+        .iter()
+        .map(|l| l.local_addr().unwrap().port())
+        .collect()
+}
+
+/// Spin up one strawman worker + one leader per party, plug a
+/// `RemoteIrisWorkerPool` into each `Aby3Store`. Returns the stores and a
+/// guard that keeps worker tasks alive + cancels them on drop.
+async fn setup_remote_store_aby3_players(
+    network_t: NetworkType,
+) -> Result<(Vec<Aby3StoreRef>, RemoteClusterGuard)> {
+    let runtime = LocalRuntime::mock_setup(network_t).await?;
+    let n_parties = runtime.sessions.len();
+
+    let ports = find_free_ports(2 * n_parties);
+    let shutdown = CancellationToken::new();
+    let mut worker_tasks: Vec<JoinHandle<()>> = Vec::with_capacity(n_parties);
+    let mut stores: Vec<Aby3StoreRef> = Vec::with_capacity(n_parties);
+
+    for (idx, session) in runtime.sessions.into_iter().enumerate() {
+        let party_id = session.network_session.own_role.index();
+        let leader_addr = format!("127.0.0.1:{}", ports[idx * 2]);
+        let worker_addr = format!("127.0.0.1:{}", ports[idx * 2 + 1]);
+        let leader_id_str = format!("party-{idx}");
+        // Workpool naming convention: each leader's workers must announce
+        // `{leader_id}-w-{worker_index}`.
+        let worker_id_str = format!("{leader_id_str}-w-0");
+
+        // Strawman worker for this party — empty in-memory store; tests
+        // load through cache_queries / insert_irises like normal.
+        let strawman_args = iris_mpc_cpu::strawman_worker::StrawmanWorkerArgs {
+            worker_id: worker_id_str.clone(),
+            worker_address: worker_addr.clone(),
+            leader_id: leader_id_str.clone(),
+            leader_address: leader_addr.clone(),
+            party_id,
+            distance_mode: HAWK_DISTANCE_MODE,
+            numa: false,
+            shard_index: 0,
+        };
+        let worker_shutdown = shutdown.clone();
+        worker_tasks.push(tokio::spawn(async move {
+            iris_mpc_cpu::strawman_worker::run_local(strawman_args, worker_shutdown)
+                .await
+                .expect("strawman worker exited with error");
+        }));
+
+        // Leader for this party.
+        let leader: LeaderHandle = {
+            let mut l = build_leader(
+                LeaderArgs {
+                    leader_id: Identity(leader_id_str),
+                    leader_address: leader_addr,
+                    worker_addresses: vec![worker_addr],
+                    tls: None,
+                },
+                shutdown.clone(),
+            )
+            .await
+            .expect("failed to build leader");
+            l.wait_for_all_connections(Some(CONNECT_TIMEOUT))
+                .await
+                .expect("worker failed to connect");
+            l
+        };
+
+        let workers: Arc<dyn IrisWorkerPool> =
+            Arc::new(RemoteIrisWorkerPool::new(Arc::new(leader), 1, party_id));
+
+        // Empty leader-side registry. The actual iris data lives on the
+        // strawman worker; the registry only tracks `VectorId` presence
+        // for `only_valid_vectors`, which Aby3Store keeps locally.
+        let storage = Aby3Store::<FhdOps>::new_storage(None).to_arc();
+        let registry = storage.read().await.to_registry().to_arc();
+
+        stores.push(Arc::new(Mutex::new(Aby3Store::new(
+            registry,
+            session,
+            workers,
+            HAWK_DISTANCE_MODE,
+        ))));
+    }
+
+    Ok((
+        stores,
+        RemoteClusterGuard {
+            worker_tasks,
+            shutdown,
+        },
+    ))
+}
+
+/// RAII guard for a remote test cluster. On drop, cancels the shutdown
+/// token and joins worker tasks.
+struct RemoteClusterGuard {
+    worker_tasks: Vec<JoinHandle<()>>,
+    shutdown: CancellationToken,
+}
+
+impl Drop for RemoteClusterGuard {
+    fn drop(&mut self) {
+        self.shutdown.cancel();
+        for task in self.worker_tasks.drain(..) {
+            task.abort();
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn test_gr_hnsw_through_remote_pool() -> Result<()> {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    use aes_prng::AesRng;
+    use rand::SeedableRng;
+
+    let mut rng = AesRng::seed_from_u64(0_u64);
+    // Smaller than the in-process equivalent (10) — the wire round-trips
+    // make this longer per insert. 5 is enough to cover insert + search +
+    // is_match across the trait surface. Bump if we want stress coverage.
+    let database_size = 5;
+    let cleartext_database = IrisDB::new_random_rng(database_size, &mut rng).db;
+    let shared_irises: Vec<_> = cleartext_database
+        .iter()
+        .map(|iris| GaloisRingSharedIris::generate_shares_locally(&mut rng, iris.clone()))
+        .collect();
+
+    let (stores, _guard) = setup_remote_store_aby3_players(NetworkType::Local).await?;
+
+    let mut jobs = JoinSet::new();
+    for store in stores.iter() {
+        let player_index = get_owner_index(store).await?;
+        let irises: Vec<ArcIris> = (0..database_size)
+            .map(|id| Arc::new(shared_irises[id][player_index].clone()))
+            .collect();
+        let queries = cache_irises(store.lock().await.workers.as_ref(), irises).await?;
+        let mut rng = rng.clone();
+        let store = store.clone();
+        jobs.spawn(async move {
+            let mut store = store.lock().await;
+            let mut aby3_graph = GraphMem::new();
+            let db = HnswSearcher::new_with_test_parameters();
+
+            let mut inserted = vec![];
+            for query in queries.iter() {
+                let insertion_layer = db.gen_layer_rng(&mut rng).unwrap();
+                let inserted_vector = db
+                    .insert::<_, SortedNeighborhood<_>>(
+                        &mut *store,
+                        &mut aby3_graph,
+                        query,
+                        insertion_layer,
+                    )
+                    .await
+                    .unwrap();
+                inserted.push(inserted_vector)
+            }
+
+            let mut matching_results = vec![];
+            for v in inserted.into_iter() {
+                let query = store.cache_query_from_store(&v).await.unwrap();
+                let neighbors = db
+                    .search::<_, SortedNeighborhood<_>>(&mut *store, &aby3_graph, &query, 1)
+                    .await
+                    .unwrap();
+                matching_results.push(db.is_match(&mut *store, &[neighbors]).await.unwrap())
+            }
+            matching_results
+        });
+    }
+    let matching_results = jobs.join_all().await;
+    for (party_id, party_results) in matching_results.iter().enumerate() {
+        for (index, result) in party_results.iter().enumerate() {
+            assert!(
+                *result,
+                "party {party_id} index {index}: expected match for inserted vector \
+                 (this would indicate a wire-path divergence from LocalIrisWorkerPool)"
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/iris-mpc-cpu/tests/remote_iris_worker_pool_smoke.rs
+++ b/iris-mpc-cpu/tests/remote_iris_worker_pool_smoke.rs
@@ -1,0 +1,175 @@
+//! Smoke test for `RemoteIrisWorkerPool` driving the strawman worker.
+//!
+//! Production-shaped configuration: `DistanceMode::MinRotation`, party 0,
+//! single shard over loopback. Exercises the full trait through the wire:
+//! `cache_queries → insert_irises → cache_queries → compute_dot_products
+//! → fetch_irises → evict_queries`.
+//!
+//! This is the closest thing to a conformance test we have until the
+//! production worker arrives — when that happens, the same flow can run
+//! against the real worker by changing only the binary that's spawned.
+
+use ampc_actor_utils::{
+    execution::player::Identity,
+    network::workpool::leader::{build_leader, LeaderArgs},
+};
+use iris_mpc_common::{
+    galois_engine::degree4::{GaloisRingIrisCodeShare, GaloisRingTrimmedMaskCodeShare},
+    vector_id::VectorId,
+};
+use iris_mpc_cpu::{
+    execution::hawk_main::{
+        iris_worker::{IrisWorkerPool, QueryId, QuerySpec, RemoteIrisWorkerPool, CENTER_ROTATION},
+        HAWK_DISTANCE_MODE, HAWK_MIN_DIST_ROTATIONS,
+    },
+    protocol::shared_iris::{ArcIris, GaloisRingSharedIris},
+    strawman_worker::{run_local, StrawmanWorkerArgs},
+};
+use std::{sync::Arc, time::Duration};
+use tokio::time::timeout;
+use tokio_util::sync::CancellationToken;
+
+const PARTY_ID: usize = 0;
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+fn find_free_ports(n: usize) -> Vec<u16> {
+    let listeners: Vec<std::net::TcpListener> = (0..n)
+        .map(|_| std::net::TcpListener::bind("127.0.0.1:0").unwrap())
+        .collect();
+    listeners
+        .iter()
+        .map(|l| l.local_addr().unwrap().port())
+        .collect()
+}
+
+fn fresh_iris() -> ArcIris {
+    Arc::new(GaloisRingSharedIris {
+        code: GaloisRingIrisCodeShare::default_for_party(PARTY_ID),
+        mask: GaloisRingTrimmedMaskCodeShare::default_for_party(PARTY_ID),
+    })
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn remote_pool_full_trait_roundtrip_min_rotation() {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let ports = find_free_ports(2);
+    let leader_addr = format!("127.0.0.1:{}", ports[0]);
+    let worker_addr = format!("127.0.0.1:{}", ports[1]);
+
+    let leader_id = Identity("leader".to_string());
+    // Workpool naming convention: workers must announce `{leader_id}-w-{idx}`.
+    let worker_id = "leader-w-0".to_string();
+
+    let shutdown = CancellationToken::new();
+
+    // Spawn the strawman worker against an empty in-memory store.
+    let strawman_args = StrawmanWorkerArgs {
+        worker_id: worker_id.clone(),
+        worker_address: worker_addr.clone(),
+        leader_id: leader_id.0.clone(),
+        leader_address: leader_addr.clone(),
+        party_id: PARTY_ID,
+        // Production HawkActor uses MinRotation; test the realistic path.
+        distance_mode: HAWK_DISTANCE_MODE,
+        numa: false,
+        shard_index: 0,
+    };
+    let worker_shutdown = shutdown.clone();
+    let worker_task = tokio::spawn(async move {
+        run_local(strawman_args, worker_shutdown).await.unwrap();
+    });
+
+    // Build leader, gate dispatch on TCP-up.
+    let mut leader = build_leader(
+        LeaderArgs {
+            leader_id,
+            leader_address: leader_addr,
+            worker_addresses: vec![worker_addr],
+            tls: None,
+        },
+        shutdown.clone(),
+    )
+    .await
+    .expect("failed to build leader");
+    leader
+        .wait_for_all_connections(Some(CONNECT_TIMEOUT))
+        .await
+        .expect("worker failed to connect");
+
+    let pool: Arc<dyn IrisWorkerPool> = Arc::new(RemoteIrisWorkerPool::new(
+        Arc::new(leader),
+        1, // num_shards
+        PARTY_ID,
+    ));
+
+    // ── 1. cache + insert ────────────────────────────────────────────────
+    let query_a = QueryId(1);
+    let iris_a = fresh_iris();
+    pool.cache_queries(vec![(query_a, iris_a.clone())])
+        .await
+        .expect("cache_queries(a) failed");
+
+    let vid_0 = VectorId::from_serial_id(0);
+    let checksum_after_insert = pool
+        .insert_irises(vec![(query_a, vid_0)])
+        .await
+        .expect("insert_irises failed");
+    // We can't assert a specific checksum value (depends on SetHash), but
+    // it must be stable across redundant calls — `insert(vid, iris)` is
+    // idempotent at the store level. Re-inserting the same content
+    // should leave the checksum unchanged.
+    let checksum_after_redundant_insert = pool
+        .insert_irises(vec![(query_a, vid_0)])
+        .await
+        .expect("redundant insert_irises failed");
+    assert_eq!(
+        checksum_after_insert, checksum_after_redundant_insert,
+        "redundant insert should not change set_hash checksum"
+    );
+
+    // ── 2. cache another query, compute distance against the inserted iris
+    let query_b = QueryId(2);
+    pool.cache_queries(vec![(query_b, fresh_iris())])
+        .await
+        .expect("cache_queries(b) failed");
+
+    let spec_b = QuerySpec {
+        query_id: query_b,
+        rotation: CENTER_ROTATION,
+        mirrored: false,
+    };
+    let dp = pool
+        .compute_dot_products(vec![(spec_b, vec![vid_0])])
+        .await
+        .expect("compute_dot_products failed");
+    assert_eq!(dp.len(), 1, "one batch in, one batch out");
+    // MinRotation packs `2 * HAWK_MIN_DIST_ROTATIONS` elements per target.
+    assert_eq!(dp[0].len(), 2 * HAWK_MIN_DIST_ROTATIONS);
+
+    // ── 3. fetch the inserted iris back, byte-equality with the original
+    let fetched = pool
+        .fetch_irises(vec![vid_0])
+        .await
+        .expect("fetch_irises failed");
+    assert_eq!(fetched.len(), 1);
+    assert_eq!(
+        *fetched[0], *iris_a,
+        "fetch should return the iris we inserted, byte-for-byte"
+    );
+
+    // ── 4. evict, then assert dot product against the now-evicted query fails
+    pool.evict_queries(vec![query_b])
+        .await
+        .expect("evict_queries failed");
+
+    let after_evict = pool.compute_dot_products(vec![(spec_b, vec![vid_0])]).await;
+    assert!(
+        after_evict.is_err(),
+        "compute_dot_products should fail after the query is evicted, got {after_evict:?}"
+    );
+
+    // ── shutdown ─────────────────────────────────────────────────────────
+    shutdown.cancel();
+    let _ = timeout(Duration::from_secs(2), worker_task).await;
+}

--- a/iris-mpc-cpu/tests/strawman_worker_smoke.rs
+++ b/iris-mpc-cpu/tests/strawman_worker_smoke.rs
@@ -1,0 +1,177 @@
+//! End-to-end smoke test for the strawman worker.
+//!
+//! Spins up one strawman worker against a fresh `LocalIrisWorkerPool` over
+//! localhost TCP, drives a `LeaderHandle` against it, and verifies that
+//! `cache_queries` and `compute_dot_products` round-trip through the wire
+//! protocol successfully. This is the minimum proof that the wire types
+//! and the strawman dispatch agree end-to-end. The full conformance suite
+//! (running the existing `LocalIrisWorkerPool` test fixtures through
+//! `RemoteIrisWorkerPool`) lands with the remote pool itself.
+
+use ampc_actor_utils::{
+    execution::player::Identity,
+    network::workpool::leader::{build_leader, LeaderArgs},
+};
+use bytes::Bytes;
+use iris_mpc_common::{
+    galois_engine::degree4::{GaloisRingIrisCodeShare, GaloisRingTrimmedMaskCodeShare},
+    vector_id::VectorId,
+};
+use iris_mpc_cpu::{
+    hawkers::aby3::aby3_store::DistanceMode,
+    strawman_worker::{run_local, StrawmanWorkerArgs},
+};
+use iris_mpc_worker_protocol::{
+    decode_response, encode_request, IrisShare, QueryId, QuerySpec, WorkerRequest, WorkerResponse,
+    CENTER_ROTATION,
+};
+use std::time::Duration;
+use tokio::time::timeout;
+use tokio_util::sync::CancellationToken;
+
+const PARTY_ID: usize = 0;
+const JOB_TIMEOUT: Duration = Duration::from_secs(10);
+
+fn find_free_ports(n: usize) -> Vec<u16> {
+    let listeners: Vec<std::net::TcpListener> = (0..n)
+        .map(|_| std::net::TcpListener::bind("127.0.0.1:0").unwrap())
+        .collect();
+    listeners
+        .iter()
+        .map(|l| l.local_addr().unwrap().port())
+        .collect()
+}
+
+fn sample_iris() -> IrisShare {
+    IrisShare {
+        code: GaloisRingIrisCodeShare::default_for_party(PARTY_ID),
+        mask: GaloisRingTrimmedMaskCodeShare::default_for_party(PARTY_ID),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn strawman_cache_and_dot_product_roundtrip() {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let ports = find_free_ports(2);
+    let leader_port = ports[0];
+    let worker_port = ports[1];
+    let leader_addr = format!("127.0.0.1:{leader_port}");
+    let worker_addr = format!("127.0.0.1:{worker_port}");
+
+    let leader_id = Identity("leader".to_string());
+    // Workpool requires worker identities to follow `{leader_id}-w-{idx}`.
+    let worker_id = "leader-w-0".to_string();
+
+    let shutdown = CancellationToken::new();
+
+    // Start the strawman worker. It builds an empty `LocalIrisWorkerPool`
+    // and serves over loopback.
+    let strawman_args = StrawmanWorkerArgs {
+        worker_id: worker_id.clone(),
+        worker_address: worker_addr.clone(),
+        leader_id: leader_id.0.clone(),
+        leader_address: leader_addr.clone(),
+        party_id: PARTY_ID,
+        distance_mode: DistanceMode::Simple,
+        numa: false,
+        shard_index: 0,
+    };
+    let worker_shutdown = shutdown.clone();
+    let worker_task = tokio::spawn(async move {
+        run_local(strawman_args, worker_shutdown).await.unwrap();
+    });
+
+    // Build the leader. wait_for_all_connections gates dispatch.
+    let mut leader = build_leader(
+        LeaderArgs {
+            leader_id,
+            leader_address: leader_addr,
+            worker_addresses: vec![worker_addr],
+            tls: None,
+        },
+        shutdown.clone(),
+    )
+    .await
+    .expect("failed to build leader");
+
+    leader
+        .wait_for_all_connections(Some(JOB_TIMEOUT))
+        .await
+        .expect("worker failed to connect");
+
+    // ── 1. cache_queries ─────────────────────────────────────────────────
+    let req = WorkerRequest::CacheQueries {
+        queries: vec![(QueryId(1), sample_iris())],
+    };
+    let bytes: Bytes = encode_request(&req).unwrap().into();
+
+    let job = leader
+        .broadcast(bytes)
+        .await
+        .expect("broadcast submit failed");
+    let responses = timeout(JOB_TIMEOUT, job)
+        .await
+        .expect("cache_queries timed out")
+        .expect("cache_queries job failed");
+
+    assert_eq!(responses.len(), 1);
+    let payload = responses
+        .into_iter()
+        .next()
+        .unwrap()
+        .payload
+        .expect("worker returned error");
+    let response = decode_response(&payload.to_bytes()).expect("decode_response failed");
+    match response {
+        WorkerResponse::CacheQueries(Ok(())) => {}
+        other => panic!("expected CacheQueries(Ok), got {other:?}"),
+    }
+
+    // ── 2. compute_dot_products ──────────────────────────────────────────
+    // The store is empty, so `compute_dot_products` against any VectorId
+    // should fall through `get_vector_or_empty` and return one
+    // RingElement per target. We don't assert the value (it's a function
+    // of the empty iris and the cached query), only the shape.
+    let req = WorkerRequest::ComputeDotProducts {
+        batches: vec![(
+            QuerySpec {
+                query_id: QueryId(1),
+                rotation: CENTER_ROTATION,
+                mirrored: false,
+            },
+            vec![VectorId::from_serial_id(0), VectorId::from_serial_id(1)],
+        )],
+    };
+    let bytes: Bytes = encode_request(&req).unwrap().into();
+
+    let job = leader
+        .broadcast(bytes)
+        .await
+        .expect("broadcast submit failed");
+    let responses = timeout(JOB_TIMEOUT, job)
+        .await
+        .expect("dot_products timed out")
+        .expect("dot_products job failed");
+    let payload = responses
+        .into_iter()
+        .next()
+        .unwrap()
+        .payload
+        .expect("worker returned error");
+    let response = decode_response(&payload.to_bytes()).expect("decode_response failed");
+    match response {
+        WorkerResponse::ComputeDotProducts(Ok(batches)) => {
+            assert_eq!(batches.len(), 1);
+            // Simple mode packs (code_dist, mask_dist) per target — see
+            // `protocol::ops::pairwise_distance` — so 2 targets → 4 ring
+            // elements.
+            assert_eq!(batches[0].len(), 4);
+        }
+        other => panic!("expected ComputeDotProducts(Ok), got {other:?}"),
+    }
+
+    // ── shutdown ─────────────────────────────────────────────────────────
+    shutdown.cancel();
+    let _ = timeout(Duration::from_secs(2), worker_task).await;
+}

--- a/iris-mpc-cpu/tests/strawman_worker_smoke.rs
+++ b/iris-mpc-cpu/tests/strawman_worker_smoke.rs
@@ -73,7 +73,9 @@ async fn strawman_cache_and_dot_product_roundtrip() {
         leader_id: leader_id.0.clone(),
         leader_address: leader_addr.clone(),
         party_id: PARTY_ID,
-        distance_mode: DistanceMode::Simple,
+        // Match HAWK_DISTANCE_MODE — the production HawkActor uses
+        // MinRotation, so the wire path needs to handle it.
+        distance_mode: DistanceMode::MinRotation,
         numa: false,
         shard_index: 0,
     };
@@ -163,10 +165,11 @@ async fn strawman_cache_and_dot_product_roundtrip() {
     match response {
         WorkerResponse::ComputeDotProducts(Ok(batches)) => {
             assert_eq!(batches.len(), 1);
-            // Simple mode packs (code_dist, mask_dist) per target — see
-            // `protocol::ops::pairwise_distance` — so 2 targets → 4 ring
-            // elements.
-            assert_eq!(batches[0].len(), 4);
+            // MinRotation mode packs `2 * HAWK_MIN_DIST_ROTATIONS` elements
+            // per target — code & mask shares for each rotation. With 2
+            // targets that's `2 * 11 * 2 = 44`. See
+            // `protocol::ops::rotation_aware_pairwise_distance_rowmajor`.
+            assert_eq!(batches[0].len(), 44);
         }
         other => panic!("expected ComputeDotProducts(Ok), got {other:?}"),
     }

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -1431,6 +1431,27 @@ impl ServerActor {
             })
             .collect::<Vec<_>>();
 
+        // In the normal pass of a mirror-detection-enabled batch, fold the
+        // mirror pass's intra-batch peer ids into the per-request lists so the
+        // combined result reports peers from both orientations. Matches the
+        // CPU semantics where matched_batch_request_ids covers `orient: Both`.
+        let matched_batch_request_ids = if let Some(mirror_results) = previous_results.as_ref() {
+            matched_batch_request_ids
+                .into_iter()
+                .zip(mirror_results.matched_batch_request_ids.iter())
+                .map(|(mut normal_ids, mirror_ids)| {
+                    for id in mirror_ids {
+                        if !normal_ids.contains(id) {
+                            normal_ids.push(id.clone());
+                        }
+                    }
+                    normal_ids
+                })
+                .collect::<Vec<_>>()
+        } else {
+            matched_batch_request_ids
+        };
+
         let match_ids_filtered = match_ids
             .into_iter()
             .map(|ids| {

--- a/iris-mpc-upgrade-hawk/src/genesis/mod.rs
+++ b/iris-mpc-upgrade-hawk/src/genesis/mod.rs
@@ -24,8 +24,8 @@ use iris_mpc_common::{
 pub use iris_mpc_cpu::genesis::BatchSizeConfig;
 use iris_mpc_cpu::{
     execution::hawk_main::{
-        iris_worker::LocalIrisWorkerPool, BothEyes, GraphRef, GraphStore, HawkActor, HawkArgs,
-        HawkOps, StoreId, LEFT, RIGHT,
+        iris_worker::IrisWorkerPool, BothEyes, GraphRef, GraphStore, HawkActor, HawkArgs, HawkOps,
+        StoreId, LEFT, RIGHT,
     },
     genesis::{
         state_accessor::{
@@ -264,7 +264,7 @@ async fn exec_setup(
     RDSClient,
     Arc<BothEyes<Aby3SharedIrisesRef>>,
     BothEyes<VectorIdRegistryRef>,
-    BothEyes<LocalIrisWorkerPool>,
+    BothEyes<Arc<dyn IrisWorkerPool>>,
     Arc<BothEyes<GraphRef>>,
     GenesisHawkHandle,
     Sender<JobResult>,
@@ -726,7 +726,7 @@ async fn exec_indexation(
     ctx: &ExecutionContextInfo,
     s3_client: &S3Client,
     registries: &BothEyes<VectorIdRegistryRef>,
-    worker_pools: &BothEyes<LocalIrisWorkerPool>,
+    worker_pools: &BothEyes<Arc<dyn IrisWorkerPool>>,
     imem_graph_stores: &Arc<BothEyes<GraphRef>>,
     mut hawk_handle: GenesisHawkHandle,
     tx_results: &Sender<JobResult>,

--- a/iris-mpc-upgrade-hawk/src/genesis/mod.rs
+++ b/iris-mpc-upgrade-hawk/src/genesis/mod.rs
@@ -24,8 +24,8 @@ use iris_mpc_common::{
 pub use iris_mpc_cpu::genesis::BatchSizeConfig;
 use iris_mpc_cpu::{
     execution::hawk_main::{
-        iris_worker::IrisWorkerPool, BothEyes, GraphRef, GraphStore, HawkActor, HawkArgs, HawkOps,
-        StoreId, LEFT, RIGHT,
+        iris_worker::IrisWorkerPool, worker_pool_initializer::DbLoadParams, BothEyes, GraphRef,
+        GraphStore, HawkActor, HawkArgs, HawkOps, StoreId, LEFT, RIGHT,
     },
     genesis::{
         state_accessor::{
@@ -43,7 +43,7 @@ use iris_mpc_cpu::{
     hawkers::aby3::aby3_store::{Aby3SharedIrisesRef, Aby3Store, VectorIdRegistryRef},
     hnsw::graph::graph_store::GraphPg,
 };
-use iris_mpc_store::{loader::load_iris_db, Store as IrisStore, StoredIrisRef};
+use iris_mpc_store::{Store as IrisStore, StoredIrisRef};
 use std::{
     sync::Arc,
     time::{Duration, Instant},
@@ -1535,8 +1535,6 @@ async fn init_graph_from_stores(
 ) -> Result<()> {
     tracing::info!("⚓️ ANCHOR: Load the database");
 
-    let (mut iris_loader, graph_loader) = hawk_actor.as_iris_loader().await;
-
     let iris_db_parallelism = config
         .database
         .as_ref()
@@ -1563,20 +1561,23 @@ async fn init_graph_from_stores(
     let store_len = iris_store.count_irises().await?;
     let max_index = std::cmp::min(max_indexation_id, store_len);
 
-    // Load iris data from database
-    load_iris_db(
-        &mut iris_loader,
-        iris_store,
-        max_index,
-        iris_db_parallelism,
-        Some(max_index),
-        config,
-        shutdown_handler,
-    )
-    .await
-    .expect("Failed to load DB");
+    // Load iris data into the actor's existing local worker pool. Iris
+    // loading must happen here (not at actor construction) because
+    // `sync_peers` and the optional iris-DB rollback above run against
+    // the empty actor first.
+    hawk_actor
+        .load_iris_db_in_place(DbLoadParams {
+            store: iris_store.clone(),
+            config: Arc::new(config.clone()),
+            max_serial_id: max_index,
+            parallelism: iris_db_parallelism,
+            s3_max_serial_id: Some(max_index),
+            shutdown_handler,
+        })
+        .await
+        .expect("Failed to load DB");
 
-    iris_loader.wait_completion().await?;
+    let graph_loader = hawk_actor.as_graph_loader().await;
 
     // Try to load graph from S3 checkpoint first
     if let Some(state) = checkpoint {

--- a/iris-mpc-worker-protocol/Cargo.toml
+++ b/iris-mpc-worker-protocol/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "iris-mpc-worker-protocol"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+bincode.workspace = true
+iris-mpc-common = { path = "../iris-mpc-common" }
+serde.workspace = true
+thiserror.workspace = true

--- a/iris-mpc-worker-protocol/src/lib.rs
+++ b/iris-mpc-worker-protocol/src/lib.rs
@@ -1,0 +1,321 @@
+//! Wire protocol for the iris-mpc remote worker pool.
+//!
+//! Defines the request/response types exchanged between Hawk Main (the
+//! `LeaderHandle` side of the ampc-actor-utils workpool) and remote worker
+//! processes that own iris store shards. Each `WorkerRequest` variant maps
+//! 1:1 to a method on the `IrisWorkerPool` trait
+//! (`iris-mpc-cpu::execution::hawk_main::iris_worker`); the worker side is
+//! expected to implement those semantics faithfully — see the per-variant
+//! doc comments and the trait docstring for the rules that aren't visible
+//! from the wire types alone.
+//!
+//! ## Encoding
+//!
+//! v1 uses bincode with a single leading version byte. Encode helpers
+//! produce `Vec<u8>` suitable for wrapping in a workpool `Payload::Bytes`.
+//! Decode helpers reject mismatched versions up front — this is intentional;
+//! we deploy the leader and workers from the same release.
+//!
+//! ## Sharding
+//!
+//! The wire protocol is shard-agnostic. `VectorId`-routing is the leader's
+//! responsibility: scatter-gather requests are partitioned by
+//! `hash(VectorId) % num_shards` before being put on the wire. The worker
+//! sees only the slice intended for it and is expected to error (not silently
+//! no-op) if it receives a `VectorId` outside its shard.
+//!
+//! ## Idempotency
+//!
+//! Most methods are idempotent under retry (`cache_queries` no-ops on
+//! known QueryIds, `evict_queries` silently skips unknown ones,
+//! `delete_irises` writes the same dummy sentinel, reads are pure).
+//! `insert_irises` is idempotent at the store level (`(VectorId, iris)`
+//! re-insert is a no-op for `set_hash`), but the leader must not call
+//! `evict_queries` on a `QueryId` until all `insert_irises` referencing
+//! it have been ack'd.
+
+use iris_mpc_common::{
+    galois_engine::degree4::{GaloisRingIrisCodeShare, GaloisRingTrimmedMaskCodeShare},
+    vector_id::VectorId,
+};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Wire-protocol version. Bump for any breaking change to the bincode
+/// shape of `WorkerRequest` / `WorkerResponse`.
+pub const PROTOCOL_VERSION: u8 = 1;
+
+/// Opaque identifier for a cached query. Allocated by the leader, opaque
+/// to the worker beyond cache lookup. Mirrors `iris_worker::QueryId`.
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub struct QueryId(pub u64);
+
+/// Selects a specific preprocessed variant of a cached query.
+///
+/// Each cached iris produces 31 rotations × 2 orientations (normal +
+/// mirrored) — `QuerySpec` picks one of those 62 variants for distance
+/// computation. Rotation index 15 (`CENTER_ROTATION`) is the identity.
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub struct QuerySpec {
+    pub query_id: QueryId,
+    /// Rotation index in `[0, 31)`. `CENTER_ROTATION = 15` is identity.
+    pub rotation: u8,
+    /// If true, the worker uses the mirrored-then-preprocessed variant.
+    pub mirrored: bool,
+}
+
+/// Center (identity) rotation index.
+pub const CENTER_ROTATION: u8 = 15;
+
+/// An iris share: code + mask. Wire-equivalent to
+/// `iris_mpc_cpu::protocol::shared_iris::GaloisRingSharedIris` (same fields
+/// in the same order, both serde-derived). A future refactor that moves
+/// `GaloisRingSharedIris` into a shared crate would let us reuse it
+/// directly; until then this mirror keeps the wire crate independent of
+/// `iris-mpc-cpu`.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct IrisShare {
+    pub code: GaloisRingIrisCodeShare,
+    pub mask: GaloisRingTrimmedMaskCodeShare,
+}
+
+/// Request from the leader to a worker.
+///
+/// Each variant maps to an `IrisWorkerPool` trait method. Field shapes
+/// match the trait signatures; see the trait for full semantics.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum WorkerRequest {
+    /// `cache_queries`. Worker preprocesses + rotates each iris into 62
+    /// variants and stores them under the given `QueryId`. Re-caching an
+    /// already-cached id is a no-op.
+    CacheQueries { queries: Vec<(QueryId, IrisShare)> },
+
+    /// `compute_dot_products`. For each batch, computes the dot product
+    /// of the cached query's selected rotation against each `VectorId`
+    /// in the worker's iris store. Returns one inner `Vec<u16>` per
+    /// batch.
+    ComputeDotProducts {
+        batches: Vec<(QuerySpec, Vec<VectorId>)>,
+    },
+
+    /// `fetch_irises`. Returns one `IrisShare` per requested id, in
+    /// input order. Missing entries return the worker's default empty
+    /// iris (which yields max-distance under dot products).
+    FetchIrises { ids: Vec<VectorId> },
+
+    /// `insert_irises`. Resolves each `QueryId` to its cached original
+    /// iris and inserts at the given `VectorId`. Returns the
+    /// **per-shard** `set_hash` checksum after all inserts are applied;
+    /// the leader combines across shards.
+    InsertIrises { inserts: Vec<(QueryId, VectorId)> },
+
+    /// `compute_pairwise_distances`. Each pair: first operand is a
+    /// preprocessed rotation (`QuerySpec`), second is the **raw**
+    /// (unpreprocessed) iris of a cached query (`QueryId`). `None`
+    /// pairs produce a max-distance sentinel.
+    ComputePairwiseDistances {
+        pairs: Vec<Option<(QuerySpec, QueryId)>>,
+    },
+
+    /// `evict_queries`. Frees cached query data. Unknown ids are
+    /// silently skipped.
+    EvictQueries { query_ids: Vec<QueryId> },
+
+    /// `delete_irises`. Replaces each id with the party's dummy
+    /// sentinel iris (max-distance under dot products).
+    DeleteIrises { ids: Vec<VectorId> },
+}
+
+/// Response from a worker to the leader.
+///
+/// Variants 1:1 with `WorkerRequest`. Per-method failures are conveyed
+/// as `Err(message)` inside the variant; transport-level failures
+/// (worker crash, lost in transit) are surfaced by the workpool layer
+/// as `WorkpoolError::JobsLost`, not by this enum.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum WorkerResponse {
+    CacheQueries(Result<(), String>),
+    ComputeDotProducts(Result<Vec<Vec<u16>>, String>),
+    FetchIrises(Result<Vec<IrisShare>, String>),
+    InsertIrises(Result<u64, String>),
+    ComputePairwiseDistances(Result<Vec<u16>, String>),
+    EvictQueries(Result<(), String>),
+    DeleteIrises(Result<(), String>),
+}
+
+#[derive(Debug, Error)]
+pub enum CodecError {
+    #[error("empty payload")]
+    Empty,
+    #[error("unsupported protocol version: got {got}, expected {expected}")]
+    VersionMismatch { got: u8, expected: u8 },
+    #[error("bincode: {0}")]
+    Bincode(#[from] bincode::Error),
+}
+
+/// Encode a `WorkerRequest` to a byte vector with the leading version byte.
+pub fn encode_request(req: &WorkerRequest) -> Result<Vec<u8>, CodecError> {
+    encode_with_version(req)
+}
+
+/// Decode a `WorkerRequest`, validating the leading version byte.
+pub fn decode_request(bytes: &[u8]) -> Result<WorkerRequest, CodecError> {
+    decode_with_version(bytes)
+}
+
+/// Encode a `WorkerResponse` to a byte vector with the leading version byte.
+pub fn encode_response(rsp: &WorkerResponse) -> Result<Vec<u8>, CodecError> {
+    encode_with_version(rsp)
+}
+
+/// Decode a `WorkerResponse`, validating the leading version byte.
+pub fn decode_response(bytes: &[u8]) -> Result<WorkerResponse, CodecError> {
+    decode_with_version(bytes)
+}
+
+fn encode_with_version<T: Serialize>(value: &T) -> Result<Vec<u8>, CodecError> {
+    let body = bincode::serialize(value)?;
+    let mut out = Vec::with_capacity(1 + body.len());
+    out.push(PROTOCOL_VERSION);
+    out.extend_from_slice(&body);
+    Ok(out)
+}
+
+fn decode_with_version<T: for<'de> Deserialize<'de>>(bytes: &[u8]) -> Result<T, CodecError> {
+    let (&version, body) = bytes.split_first().ok_or(CodecError::Empty)?;
+    if version != PROTOCOL_VERSION {
+        return Err(CodecError::VersionMismatch {
+            got: version,
+            expected: PROTOCOL_VERSION,
+        });
+    }
+    Ok(bincode::deserialize(body)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use iris_mpc_common::galois_engine::degree4::{
+        GaloisRingIrisCodeShare, GaloisRingTrimmedMaskCodeShare,
+    };
+
+    fn sample_iris() -> IrisShare {
+        IrisShare {
+            code: GaloisRingIrisCodeShare::default_for_party(0),
+            mask: GaloisRingTrimmedMaskCodeShare::default_for_party(0),
+        }
+    }
+
+    fn sample_vid(serial: u32) -> VectorId {
+        VectorId::from_serial_id(serial)
+    }
+
+    #[test]
+    fn cache_queries_roundtrip() {
+        let req = WorkerRequest::CacheQueries {
+            queries: vec![(QueryId(1), sample_iris()), (QueryId(2), sample_iris())],
+        };
+        let bytes = encode_request(&req).unwrap();
+        let decoded = decode_request(&bytes).unwrap();
+        match decoded {
+            WorkerRequest::CacheQueries { queries } => {
+                assert_eq!(queries.len(), 2);
+                assert_eq!(queries[0].0, QueryId(1));
+                assert_eq!(queries[1].0, QueryId(2));
+            }
+            other => panic!("wrong variant: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn compute_dot_products_roundtrip() {
+        let req = WorkerRequest::ComputeDotProducts {
+            batches: vec![(
+                QuerySpec {
+                    query_id: QueryId(7),
+                    rotation: CENTER_ROTATION,
+                    mirrored: false,
+                },
+                vec![sample_vid(0), sample_vid(1), sample_vid(2)],
+            )],
+        };
+        let bytes = encode_request(&req).unwrap();
+        let decoded = decode_request(&bytes).unwrap();
+        match decoded {
+            WorkerRequest::ComputeDotProducts { batches } => {
+                assert_eq!(batches.len(), 1);
+                assert_eq!(batches[0].0.query_id, QueryId(7));
+                assert_eq!(batches[0].1.len(), 3);
+            }
+            other => panic!("wrong variant: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn pairwise_with_none_pairs_roundtrip() {
+        let req = WorkerRequest::ComputePairwiseDistances {
+            pairs: vec![
+                Some((
+                    QuerySpec {
+                        query_id: QueryId(1),
+                        rotation: CENTER_ROTATION,
+                        mirrored: true,
+                    },
+                    QueryId(2),
+                )),
+                None,
+            ],
+        };
+        let bytes = encode_request(&req).unwrap();
+        let decoded = decode_request(&bytes).unwrap();
+        match decoded {
+            WorkerRequest::ComputePairwiseDistances { pairs } => {
+                assert_eq!(pairs.len(), 2);
+                assert!(pairs[0].is_some());
+                assert!(pairs[1].is_none());
+            }
+            other => panic!("wrong variant: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn response_ok_and_err_roundtrip() {
+        let ok = WorkerResponse::InsertIrises(Ok(0xDEAD_BEEF));
+        let bytes = encode_response(&ok).unwrap();
+        match decode_response(&bytes).unwrap() {
+            WorkerResponse::InsertIrises(Ok(v)) => assert_eq!(v, 0xDEAD_BEEF),
+            other => panic!("wrong variant: {:?}", other),
+        }
+
+        let err = WorkerResponse::ComputeDotProducts(Err("missing query".into()));
+        let bytes = encode_response(&err).unwrap();
+        match decode_response(&bytes).unwrap() {
+            WorkerResponse::ComputeDotProducts(Err(msg)) => assert_eq!(msg, "missing query"),
+            other => panic!("wrong variant: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn version_mismatch_rejected() {
+        let req = WorkerRequest::EvictQueries {
+            query_ids: vec![QueryId(1)],
+        };
+        let mut bytes = encode_request(&req).unwrap();
+        bytes[0] = PROTOCOL_VERSION.wrapping_add(1);
+        match decode_request(&bytes) {
+            Err(CodecError::VersionMismatch { got, expected }) => {
+                assert_eq!(got, PROTOCOL_VERSION.wrapping_add(1));
+                assert_eq!(expected, PROTOCOL_VERSION);
+            }
+            other => panic!("expected VersionMismatch, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn empty_payload_rejected() {
+        match decode_request(&[]) {
+            Err(CodecError::Empty) => {}
+            other => panic!("expected Empty, got {:?}", other),
+        }
+    }
+}

--- a/iris-mpc-worker-protocol/src/lib.rs
+++ b/iris-mpc-worker-protocol/src/lib.rs
@@ -128,10 +128,17 @@ pub enum WorkerRequest {
 
 /// Response from a worker to the leader.
 ///
-/// Variants 1:1 with `WorkerRequest`. Per-method failures are conveyed
-/// as `Err(message)` inside the variant; transport-level failures
-/// (worker crash, lost in transit) are surfaced by the workpool layer
-/// as `WorkpoolError::JobsLost`, not by this enum.
+/// First seven variants are 1:1 with `WorkerRequest`. Per-method failures
+/// are conveyed as `Err(message)` inside the variant.
+///
+/// `ProtocolError` is the variant-agnostic escape hatch: returned when the
+/// worker can't even decode the request (version mismatch, truncated bytes)
+/// and therefore doesn't know which response shape the leader expected. The
+/// leader treats it as a hard failure regardless of the original method.
+///
+/// Transport-level failures (worker crash, message lost in transit) are
+/// surfaced by the workpool layer as `WorkpoolError::JobsLost`, not by
+/// this enum.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum WorkerResponse {
     CacheQueries(Result<(), String>),
@@ -141,6 +148,7 @@ pub enum WorkerResponse {
     ComputePairwiseDistances(Result<Vec<u16>, String>),
     EvictQueries(Result<(), String>),
     DeleteIrises(Result<(), String>),
+    ProtocolError(String),
 }
 
 #[derive(Debug, Error)]
@@ -291,6 +299,13 @@ mod tests {
         let bytes = encode_response(&err).unwrap();
         match decode_response(&bytes).unwrap() {
             WorkerResponse::ComputeDotProducts(Err(msg)) => assert_eq!(msg, "missing query"),
+            other => panic!("wrong variant: {:?}", other),
+        }
+
+        let proto = WorkerResponse::ProtocolError("bad bytes".into());
+        let bytes = encode_response(&proto).unwrap();
+        match decode_response(&bytes).unwrap() {
+            WorkerResponse::ProtocolError(msg) => assert_eq!(msg, "bad bytes"),
             other => panic!("wrong variant: {:?}", other),
         }
     }

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -19,7 +19,6 @@ use ampc_server_utils::{
 use chrono::Utc;
 use eyre::{bail, eyre, Report, Result};
 use iris_mpc_common::config::{CommonConfig, Config};
-use iris_mpc_common::helpers::inmemory_store::InMemoryStore;
 use iris_mpc_common::helpers::key_pair::SharesEncryptionKeyPairs;
 use iris_mpc_common::helpers::sha256::sha256_bytes;
 use iris_mpc_common::helpers::smpc_request::{
@@ -32,12 +31,15 @@ use iris_mpc_common::helpers::sqs_s3_helper::upload_file_to_s3;
 use iris_mpc_common::helpers::sync::{SyncResult, SyncState};
 use iris_mpc_common::job::JobSubmissionHandle;
 use iris_mpc_common::postgres::{AccessMode, PostgresClient};
+use iris_mpc_cpu::execution::hawk_main::worker_pool_initializer::{
+    DbLoadParams, LocalWorkerPoolInitializer, WorkerPoolInitializer,
+};
 use iris_mpc_cpu::execution::hawk_main::{
-    GraphStore, HawkActor, HawkArgs, HawkHandle, HawkOps, ServerJobResult,
+    load_graphs_from_pg, GraphStore, HawkActor, HawkArgs, HawkHandle, HawkOps, ServerJobResult,
+    HAWK_DISTANCE_MODE,
 };
 use iris_mpc_cpu::hawkers::aby3::aby3_store::Aby3Store;
 use iris_mpc_cpu::hnsw::graph::graph_store::GraphPg;
-use iris_mpc_store::loader::load_iris_db;
 use iris_mpc_store::Store;
 use pprof::protos::Message;
 use pprof::ProfilerGuardBuilder;
@@ -144,7 +146,8 @@ pub async fn server_main(config: Config) -> Result<()> {
         return Ok(());
     }
 
-    let mut hawk_actor = init_hawk_actor(&config, &shutdown_handler).await?;
+    let mut hawk_actor =
+        init_hawk_actor(&config, &iris_store, &graph_store, &shutdown_handler).await?;
 
     if let Some(url) = config.get_anon_stats_db_url() {
         let schema = config.get_anon_stats_db_schema();
@@ -157,15 +160,6 @@ pub async fn server_main(config: Config) -> Result<()> {
                 "Anon stats persistence enabled but no anon stats database configured; skipping DB writes"
             );
     }
-
-    load_database(
-        &config,
-        &iris_store,
-        &graph_store,
-        &shutdown_handler,
-        &mut hawk_actor,
-    )
-    .await?;
 
     background_tasks.check_tasks();
 
@@ -428,12 +422,8 @@ async fn sync_sqs_queues(
     Ok(())
 }
 
-/// Initialize main Hawk actor process for handling query batches using HNSW
-/// approximate k-nearest neighbors graph search.
-async fn init_hawk_actor(
-    config: &Config,
-    shutdown_handler: &Arc<ShutdownHandler>,
-) -> Result<HawkActor> {
+/// Build `HawkArgs` from server config.
+fn build_hawk_args(config: &Config) -> Result<(HawkArgs, Vec<String>, Vec<String>)> {
     let server_coord_config = config.server_coordination.clone().unwrap();
 
     let node_inbound_addresses: Vec<String> = server_coord_config
@@ -470,89 +460,90 @@ async fn init_hawk_actor(
         numa: config.hawk_numa,
     };
 
-    tracing::info!(
-       "Initializing HawkActor with args: party_index: {}, inbound addresses: {:?}, outbound addresses: {:?}",
-        hawk_args.party_index,
-        node_inbound_addresses,
-        node_outbound_addresses
-    );
-
-    HawkActor::from_cli(
-        &hawk_args,
-        shutdown_handler.get_network_cancellation_token(),
-    )
-    .await
+    Ok((hawk_args, node_inbound_addresses, node_outbound_addresses))
 }
 
-/// Loads iris code shares & HNSW graph from Postgres and/or S3.
-async fn load_database(
+/// Initialize the Hawk actor: build the iris-loading initializer per config,
+/// run the iris and graph loads in parallel, then construct the actor with
+/// the populated workers and graph in place. After this returns, the actor
+/// is ready to serve queries — no separate `load_database` step.
+async fn init_hawk_actor(
     config: &Config,
     iris_store: &Store,
     graph_store: &GraphPg<Aby3Store<HawkOps>>,
     shutdown_handler: &Arc<ShutdownHandler>,
-    hawk_actor: &mut HawkActor,
-) -> Result<()> {
-    // ANCHOR: Load the database
-    tracing::info!("⚓️ ANCHOR: Load the database");
-    let (mut iris_loader, graph_loader) = hawk_actor.as_iris_loader().await;
-
-    // TODO: not needed?
-    if config.fake_db_size > 0 {
-        iris_loader.fake_db(config.fake_db_size);
-        iris_loader.wait_completion().await?;
-        return Ok(());
-    }
-
-    let parallelism = config
-        .cpu_database
-        .as_ref()
-        .ok_or(eyre!("Missing database config"))?
-        .load_parallelism;
+) -> Result<HawkActor> {
+    let (hawk_args, inbound, outbound) = build_hawk_args(config)?;
 
     tracing::info!(
-        "Initialize iris db: Loading from DB (parallelism: {})",
-        parallelism
+        "Initializing HawkActor with args: party_index: {}, inbound addresses: {:?}, outbound addresses: {:?}",
+        hawk_args.party_index,
+        inbound,
+        outbound,
     );
-    let download_shutdown_handler = Arc::clone(shutdown_handler);
+    tracing::info!("⚓️ ANCHOR: Load the database");
 
-    let store_len = iris_store.count_irises().await?;
-
-    let now = Instant::now();
-
-    let iris_load_future = async move {
-        load_iris_db(
-            &mut iris_loader,
-            iris_store,
-            store_len,
+    // Pick the iris-loading mode based on config. `fake_db_size > 0` is a
+    // benchmark / dev-loop knob that fills the store with sentinel irises
+    // and skips the graph load entirely; otherwise we run `load_iris_db`
+    // against the configured PG (and S3, when enabled).
+    let initializer: Box<dyn WorkerPoolInitializer> = if config.fake_db_size > 0 {
+        Box::new(LocalWorkerPoolInitializer::new_fake_db(
+            hawk_args.party_index,
+            HAWK_DISTANCE_MODE,
+            hawk_args.numa,
+            config.fake_db_size,
+        ))
+    } else {
+        let parallelism = config
+            .cpu_database
+            .as_ref()
+            .ok_or_else(|| eyre!("Missing database config"))?
+            .load_parallelism;
+        let store_len = iris_store.count_irises().await?;
+        tracing::info!(
+            "Initialize iris db: Loading from DB (parallelism: {})",
             parallelism,
-            None,
-            config,
-            download_shutdown_handler,
-        )
-        .await?;
-        iris_loader.wait_completion().await?;
-        eyre::Result::<()>::Ok(())
+        );
+        Box::new(LocalWorkerPoolInitializer::new_load_from_db(
+            hawk_args.party_index,
+            HAWK_DISTANCE_MODE,
+            hawk_args.numa,
+            DbLoadParams {
+                store: iris_store.clone(),
+                config: Arc::new(config.clone()),
+                max_serial_id: store_len,
+                parallelism,
+                s3_max_serial_id: None,
+                shutdown_handler: Arc::clone(shutdown_handler),
+            },
+        ))
     };
 
-    let graph_load_future = graph_loader.load_graph_store(
-        graph_store,
-        config.cpu_database.as_ref().unwrap().load_parallelism,
-    );
+    let now = Instant::now();
+    let ct = shutdown_handler.get_network_cancellation_token();
 
-    let (iris_result, graph_result) = tokio::join!(iris_load_future, graph_load_future);
-    iris_result.expect("Failed to load iris DB");
-    graph_result.expect("Failed to load graph DB");
+    if config.fake_db_size > 0 {
+        // Skip graph load — preserves the legacy `fake_db` shortcut.
+        return HawkActor::from_cli_with_initializer(&hawk_args, ct, initializer).await;
+    }
+
+    let graph_parallelism = config
+        .cpu_database
+        .as_ref()
+        .ok_or_else(|| eyre!("Missing database config"))?
+        .load_parallelism;
+
+    let (initialized, graph) = tokio::try_join!(
+        initializer.initialize(),
+        load_graphs_from_pg(graph_store, graph_parallelism),
+    )?;
     tracing::info!(
         "Loaded both iris and graph DBs into memory in {:?}",
         now.elapsed()
     );
 
-    // The registries are snapshotted from `iris_store` at HawkActor construction
-    // (i.e. empty), but `IrisLoader` populates `iris_store` after the fact.
-    // Rebuild the registries so sessions see the loaded VectorIds.
-    hawk_actor.refresh_registries().await;
-
-    Ok(())
+    HawkActor::from_initialized_workers(&hawk_args, ct, initialized, graph).await
 }
 
 /// Spawns thread responsible for communicating back results from batch query processing.


### PR DESCRIPTION
Stacked on top of #2098 (HawkActor decoupling) — uses the dyn-compatible `IrisWorkerPool` trait introduced there. Retarget to `main` once #2098 lands.

## Summary

Phase 2 PR 1 + PR 2 from the remote worker pool plan. Two pieces:

**\`iris-mpc-worker-protocol\` crate.** Wire types for the leader ↔ worker protocol. \`WorkerRequest\` / \`WorkerResponse\` enums map 1:1 to \`IrisWorkerPool\` trait methods, with semantics that aren't visible from the wire (idempotency rules, sharding convention, "first preprocessed / second raw" pairwise rule) documented at the variant and module levels. bincode + leading version byte; mismatched versions are rejected up front. \`IrisShare\` mirrors \`GaloisRingSharedIris\` field-for-field — wire-compatible bytes, but the crate stays independent of \`iris-mpc-cpu\`. \`WorkerResponse::ProtocolError\` is the variant-agnostic escape hatch for when the worker can't even decode the request.

**Strawman worker.** Library in \`iris-mpc-cpu::strawman_worker\` + thin bin in \`iris-mpc-bins\`. Wraps a \`LocalIrisWorkerPool\` with the ampc-actor-utils workpool worker protocol. Throwaway — deletes when the production worker binary lands. Until then it's the conformance baseline the production worker must match. Library exposes \`run_with_pool\` (arbitrary \`Arc<dyn IrisWorkerPool>\`) and \`run_local_with_store\` (pre-seeded store) for tests; bin uses \`run_local\` (empty store).

Smoke test in \`iris-mpc-cpu/tests/strawman_worker_smoke.rs\` proves end-to-end roundtrip over loopback: \`cache_queries\` + \`compute_dot_products\` both encode → wire → decode → dispatch → encode → wire → decode cleanly through a real \`LocalIrisWorkerPool\`.

## v1 scope (intentional)

- Single-shard. Sharding is leader-side and lands with \`RemoteIrisWorkerPool\` in the next PR.
- Plain TCP, no TLS. Adequate for loopback / dev clusters; production swaps in \`TlsConfig\`.
- In-memory only. No Postgres loading. Tests pre-seed via the store directly.
- No application-level readiness signal yet — TCP-up gates dispatch. Worker-author coordination will refine this.
- \`String\` errors over the wire. Typed enum can swap in later without breaking callers.

## Test plan

- [x] \`cargo build -p iris-mpc-worker-protocol\` clean
- [x] \`cargo test -p iris-mpc-worker-protocol\` (6/6 tests pass)
- [x] \`cargo test -p iris-mpc-cpu --test strawman_worker_smoke\` passes
- [x] \`cargo build -p iris-mpc-bins --bin strawman-worker\` clean
- [x] \`cargo fmt\` + \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [ ] Full CI on PR

## What's next

- PR 3 — \`RemoteIrisWorkerPool\` impl against \`LeaderHandle\`. Starts with N=1 (no sharding) using broadcast + scatter-gather to prove both patterns.
- PR 4 — Loopback conformance: run existing \`Aby3Store\` tests through \`RemoteIrisWorkerPool\` instead of \`LocalIrisWorkerPool\`. Should be free since \`Aby3Store::workers\` is already \`Arc<dyn IrisWorkerPool>\` after #2098.
- PR 5 — N>1 sharding (\`hash(VectorId) % N\` routing on the leader).

## Coordination items for the worker-binary author

The \`iris-mpc-worker-protocol\` crate is the contract surface. They'd consume:

- \`WorkerRequest\` / \`WorkerResponse\` enums.
- \`PROTOCOL_VERSION\` byte and codec helpers.
- \`QueryId\`, \`QuerySpec\`, \`IrisShare\`, \`CENTER_ROTATION\`.

Open questions worth their input before PR 3:

- Sharding hash function (currently TBD; will be \`hash(VectorId) % N\` but exact hash needs agreement).
- Application-level readiness round-trip (TCP-up isn't enough; we need a "shard hydrated" signal).
- Whether they want the wire crate to expand to share more types, or stay this minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)