### PR TITLE
[POP-3786] Add jemalloc profiling canary

### DIFF
--- a/.github/workflows/temp-branch-build-and-push.yaml
+++ b/.github/workflows/temp-branch-build-and-push.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - "dev"
-      - "pop-3544-gpu-shutdown-guardrail"
+      - "carlomazzaferro/pop-3786-investigate-host-memory-leak-in-iris-mpc"
 
 concurrency:
   group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
@@ -62,5 +62,6 @@ jobs:
           platforms: linux/amd64
           build-args: |
             ARCHITECTURE=x86_64
+            CARGO_FEATURES=jemalloc
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2948,6 +2948,8 @@ dependencies = [
  "sha2",
  "sodiumoxide",
  "sqlx",
+ "tikv-jemalloc-ctl",
+ "tikv-jemallocator",
  "tokio",
  "tokio-util",
  "toml",
@@ -5818,6 +5820,37 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,10 @@ RUN cargo install cargo-build-deps \
     && cargo install cargo-edit --version 0.13.6 --locked
 
 FROM --platform=linux/amd64 build-image as build-app
+ARG CARGO_FEATURES=""
 WORKDIR /src/gpu-iris-mpc
 COPY . .
-RUN cargo build -p iris-mpc-bins --release --target x86_64-unknown-linux-gnu --bin nccl --bin iris-mpc-gpu --bin client --bin key-manager --bin reshare-server --bin reshare-client
+RUN cargo build -p iris-mpc-bins --release --target x86_64-unknown-linux-gnu ${CARGO_FEATURES:+--features ${CARGO_FEATURES}} --bin nccl --bin iris-mpc-gpu --bin client --bin key-manager --bin reshare-server --bin reshare-client
 
 FROM --platform=linux/amd64 public.ecr.aws/deep-learning-containers/base:12.8.0-gpu-py312-cu128-ubuntu22.04-ec2-v1.17
 ENV DEBIAN_FRONTEND=noninteractive

--- a/iris-mpc-bins/Cargo.toml
+++ b/iris-mpc-bins/Cargo.toml
@@ -16,6 +16,7 @@ helpers = [
 ]
 phase_trace = ["iris-mpc-cpu/phase_trace"]
 networking_metrics = ["iris-mpc-cpu/networking_metrics"]
+jemalloc = ["dep:tikv-jemallocator", "dep:tikv-jemalloc-ctl"]
 
 [dependencies]
 aes-prng = { git = "https://github.com/tf-encrypted/aes-prng.git", branch = "dragos/display" }
@@ -52,6 +53,8 @@ sodiumoxide = "0.2.7"
 sqlx.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
+tikv-jemallocator = { version = "0.6", optional = true, features = ["profiling"] }
+tikv-jemalloc-ctl = { version = "0.6", optional = true }
 toml.workspace = true
 ampc-actor-utils.workspace = true
 ampc-anon-stats.workspace = true

--- a/iris-mpc-bins/bin/iris-mpc/server.rs
+++ b/iris-mpc-bins/bin/iris-mpc/server.rs
@@ -1,6 +1,10 @@
 #![allow(clippy::needless_range_loop, unused)]
 #![recursion_limit = "256"]
 
+#[cfg(feature = "jemalloc")]
+#[global_allocator]
+static GLOBAL_ALLOCATOR: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 use ampc_anon_stats::store::postgres::AccessMode as AnonStatsAccessMode;
 use ampc_anon_stats::store::postgres::PostgresClient as AnonStatsPgClient;
 use ampc_anon_stats::AnonStatsStore;
@@ -12,6 +16,7 @@ use ampc_server_utils::{
     init_heartbeat_task, set_node_ready, shutdown_handler::ShutdownHandler,
     start_coordination_server, wait_for_others_ready, wait_for_others_unready, TaskMonitor,
 };
+#[cfg(feature = "jemalloc")]
 use aws_sdk_s3::Client as S3Client;
 use aws_sdk_secretsmanager::Client as SecretsManagerClient;
 use aws_sdk_sns::{types::MessageAttributeValue, Client as SNSClient};
@@ -31,6 +36,8 @@ use iris_mpc::services::processors::result_message::{
 };
 use iris_mpc_common::config::CommonConfig;
 use iris_mpc_common::galois_engine::degree4::GaloisShares;
+#[cfg(feature = "jemalloc")]
+use iris_mpc_common::helpers::sqs_s3_helper::upload_file_to_s3;
 use iris_mpc_common::helpers::sync::ModificationKey::{RequestId, RequestSerialId};
 use iris_mpc_common::job::{GaloisSharesBothSides, RequestIndex};
 use iris_mpc_common::postgres::{AccessMode, PostgresClient};
@@ -71,11 +78,13 @@ use iris_mpc_store::{
 use itertools::{cloned, izip, Itertools};
 use metrics_exporter_statsd::StatsdBuilder;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "jemalloc")]
+use std::ffi::CString;
 use std::process::exit;
 use std::{
     collections::HashMap,
     fmt::Debug,
-    mem, panic,
+    fs, mem, panic,
     sync::{
         atomic::{AtomicU64, Ordering},
         Arc, Mutex,
@@ -106,6 +115,132 @@ fn decode_iris_message_shares(
 
 fn trim_mask(mask: GaloisRingIrisCodeShare) -> GaloisRingTrimmedMaskCodeShare {
     mask.into()
+}
+
+fn emit_process_memory_metrics() {
+    let Ok(status) = fs::read_to_string("/proc/self/status") else {
+        return;
+    };
+
+    for line in status.lines() {
+        let Some((key, value)) = line.split_once(':') else {
+            continue;
+        };
+
+        match key {
+            "VmRSS" => record_status_kib_gauge("process_memory_rss_bytes", value),
+            "VmHWM" => record_status_kib_gauge("process_memory_peak_rss_bytes", value),
+            "VmSize" => record_status_kib_gauge("process_memory_virtual_bytes", value),
+            "VmData" => record_status_kib_gauge("process_memory_data_bytes", value),
+            "VmSwap" => record_status_kib_gauge("process_memory_swap_bytes", value),
+            "Threads" => record_status_count_gauge("process_threads", value),
+            _ => {}
+        }
+    }
+}
+
+fn record_status_kib_gauge(metric: &'static str, value: &str) {
+    if let Some(kib) = value
+        .split_whitespace()
+        .next()
+        .and_then(|v| v.parse::<u64>().ok())
+    {
+        metrics::gauge!(metric).set((kib * 1024) as f64);
+    }
+}
+
+fn record_status_count_gauge(metric: &'static str, value: &str) {
+    if let Ok(count) = value.trim().parse::<u64>() {
+        metrics::gauge!(metric).set(count as f64);
+    }
+}
+
+#[cfg(feature = "jemalloc")]
+fn spawn_jemalloc_profile_dump_task(
+    s3_client: S3Client,
+    bucket: String,
+    prefix: String,
+    party_id: usize,
+    run_id: String,
+) {
+    let interval_secs = std::env::var("JEMALLOC_PROFILE_DUMP_INTERVAL_SECS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(60 * 60);
+
+    if interval_secs == 0 {
+        tracing::info!("jemalloc periodic heap profile dumping disabled");
+        return;
+    }
+
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(Duration::from_secs(interval_secs)).await;
+            dump_and_upload_jemalloc_profile(
+                s3_client.clone(),
+                &bucket,
+                &prefix,
+                party_id,
+                &run_id,
+            )
+            .await;
+        }
+    });
+}
+
+#[cfg(feature = "jemalloc")]
+async fn dump_and_upload_jemalloc_profile(
+    s3_client: S3Client,
+    bucket: &str,
+    prefix: &str,
+    party_id: usize,
+    run_id: &str,
+) {
+    let ts = chrono::Utc::now().format("%Y-%m-%dT%H-%M-%SZ");
+    let file_path = format!("/tmp/iris-mpc-gpu-jeprof-party{}-{}.heap", party_id, ts);
+
+    match dump_jemalloc_profile(&file_path) {
+        Ok(()) => tracing::info!(%file_path, "dumped jemalloc heap profile"),
+        Err(err) => {
+            tracing::warn!(?err, %file_path, "failed to dump jemalloc heap profile");
+            return;
+        }
+    }
+
+    let contents = match fs::read(&file_path) {
+        Ok(contents) => contents,
+        Err(err) => {
+            tracing::warn!(?err, %file_path, "failed to read jemalloc heap profile");
+            return;
+        }
+    };
+
+    let key = format!(
+        "{}/{}/party{}/jemalloc/{}.heap",
+        prefix, run_id, party_id, ts
+    );
+
+    match upload_file_to_s3(bucket, &key, s3_client, &contents).await {
+        Ok(_) => tracing::info!(bucket, key, "uploaded jemalloc heap profile to s3"),
+        Err(err) => tracing::warn!(
+            ?err,
+            bucket,
+            key,
+            "failed to upload jemalloc heap profile to s3"
+        ),
+    }
+
+    if let Err(err) = fs::remove_file(&file_path) {
+        tracing::warn!(?err, %file_path, "failed to remove local jemalloc heap profile");
+    }
+}
+
+#[cfg(feature = "jemalloc")]
+fn dump_jemalloc_profile(file_path: &str) -> Result<(), tikv_jemalloc_ctl::Error> {
+    let file_path =
+        CString::new(file_path).expect("jemalloc profile path cannot contain NUL bytes");
+
+    unsafe { tikv_jemalloc_ctl::raw::write(b"prof.dump\0", file_path.as_ptr()) }
 }
 
 #[tokio::main]
@@ -164,6 +299,20 @@ async fn server_main(config: Config) -> Result<()> {
 
     tracing::info!("Initialising AWS services");
     let aws_clients = AwsClients::new(&config.clone()).await?;
+
+    #[cfg(feature = "jemalloc")]
+    spawn_jemalloc_profile_dump_task(
+        aws_clients.s3_client.clone(),
+        std::env::var("JEMALLOC_PROFILE_S3_BUCKET")
+            .unwrap_or_else(|_| format!("wf-smpcv2-{}-sns-buffer", config.environment)),
+        std::env::var("JEMALLOC_PROFILE_S3_PREFIX").unwrap_or_else(|_| "gpu/jemalloc".to_string()),
+        config.party_id,
+        config
+            .pprof_run_id
+            .clone()
+            .unwrap_or_else(|| chrono::Utc::now().format("run-%Y%m%dT%H%M%SZ").to_string()),
+    );
+
     let next_sns_seq_number_future = get_next_sns_seq_num(
         &aws_clients.sqs_client,
         &config.requests_queue_url,
@@ -1097,6 +1246,8 @@ async fn server_main(config: Config) -> Result<()> {
             let result = timeout(processing_timeout, result_future.await)
                 .await
                 .map_err(|e| eyre!("ServerActor processing timeout: {:?}", e))??;
+
+            emit_process_memory_metrics();
 
             tx.send(result).await?;
 


### PR DESCRIPTION
## Summary

Adds a GPU-service jemalloc canary path for POP-3786 without changing the default allocator:

- adds optional `iris-mpc-bins/jemalloc` feature using `tikv-jemallocator` with profiling enabled
- adds Docker `CARGO_FEATURES` build arg so canary images can be built with `--build-arg CARGO_FEATURES=jemalloc`
- emits process-level memory gauges from `/proc/self/status` after each processed GPU batch
- when built with `jemalloc`, periodically dumps jemalloc heap profiles and uploads them to an S3 bucket the GPU `iris-mpc` pod identity can write to

The default non-jemalloc build path remains unchanged.

## Writable S3 path used

The HNSW pprof bucket is not writable by the GPU `iris-mpc` role.

Infra check:

- GPU pod identity role: `smpc-setup/iam-iris-mpc.tf`
- write policy: `iris_mpc_sns_buffer_s3_write_policy`
- granted bucket ARN var: `var.vpc_account_sns_buffer_bucket_arn`
- stage invocations set it to `arn:aws:s3:::wf-smpcv2-stage-sns-buffer`

Therefore the GPU heap profiles default to:

```text
wf-smpcv2-<environment>-sns-buffer
```

For stage this is:

```text
wf-smpcv2-stage-sns-buffer
```

Override is still possible via `JEMALLOC_PROFILE_S3_BUCKET`.

## How to get inspectable output

Build the GPU image with jemalloc enabled:

```bash
docker build \
  --build-arg CARGO_FEATURES=jemalloc \
  -t <gpu-canary-image> \
  .
```

Run one staging/prod party with:

```bash
MALLOC_CONF=prof:true,prof_active:true,lg_prof_sample:19
JEMALLOC_PROFILE_DUMP_INTERVAL_SECS=3600
JEMALLOC_PROFILE_S3_BUCKET=wf-smpcv2-stage-sns-buffer
JEMALLOC_PROFILE_S3_PREFIX=gpu/jemalloc
SMPC__PPROF_RUN_ID=pop-3786-<env>-<party>-<date>
```

Notes:

- `JEMALLOC_PROFILE_DUMP_INTERVAL_SECS=3600` dumps hourly; reduce to `300` for a short staging smoke test.
- `JEMALLOC_PROFILE_S3_BUCKET` defaults to `wf-smpcv2-${environment}-sns-buffer` if omitted.
- `JEMALLOC_PROFILE_S3_PREFIX` defaults to `gpu/jemalloc` if omitted.
- Files are written briefly under `/tmp`, read back, uploaded to S3, then removed. No SSH access is required.

Uploaded heap profile S3 key shape:

```text
s3://<bucket>/<prefix>/<run_id>/party<party_id>/jemalloc/<timestamp>.heap
```

Example:

```text
s3://wf-smpcv2-stage-sns-buffer/gpu/jemalloc/pop-3786-stage-party0-20260504/party0/jemalloc/2026-05-04T16-00-00Z.heap
```

Download profiles locally:

```bash
aws s3 sync \
  s3://<bucket>/<prefix>/<run_id>/party<party_id>/jemalloc/ \
  ./pop-3786-jeprof-party<party_id>/
```

Compare early vs late profiles:

```bash
jeprof --text /path/to/iris-mpc-gpu early.heap > early.txt
jeprof --text /path/to/iris-mpc-gpu late.heap > late.txt
jeprof --base early.heap --text /path/to/iris-mpc-gpu late.heap > diff.txt
jeprof --base early.heap --pdf /path/to/iris-mpc-gpu late.heap > diff.pdf
```

Expected signal:

- If Rust-side allocator retention/fragmentation is material, late or diff profiles should show growing allocation sites over a few hours under traffic.
- If S3 profiles stay flat while pod RSS keeps growing, prioritize non-Rust allocator/cache suspects: libfabric/EFA MR cache, aws-ofi-nccl bounce buffers, CUDA/NCCL host-side pools.

## Metrics added

Emitted after every processed GPU batch:

- `process_memory_rss_bytes`
- `process_memory_peak_rss_bytes`
- `process_memory_virtual_bytes`
- `process_memory_data_bytes`
- `process_memory_swap_bytes`
- `process_threads`

These let us compare process RSS against pod/container memory in Datadog.

## Validation

```bash
cargo fmt
cargo check -p iris-mpc-bins --bin iris-mpc-gpu --features jemalloc
cargo check -p iris-mpc-bins --bin iris-mpc-gpu
cargo clippy -p iris-mpc-bins --bin iris-mpc-gpu --features jemalloc -- -D warnings
cargo clippy -p iris-mpc-bins --bin iris-mpc-gpu -- -D warnings
```

All passed locally.
