### PR TITLE
fix: honor skip_persistence for reauth updates

### DIFF
--- a/.github/workflows/temp-branch-build-and-push-hawk-arm64.yaml
+++ b/.github/workflows/temp-branch-build-and-push-hawk-arm64.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - "dev"
       - "feat/recovery-update"
+      - "pop-3712-reauth-skip-persistence-alias"
 
     paths-ignore:
       - "deploy/**"

--- a/.github/workflows/temp-branch-build-and-push-hawk.yaml
+++ b/.github/workflows/temp-branch-build-and-push-hawk.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "dev"
+      - "pop-3712-reauth-skip-persistence-alias"
     paths-ignore:
       - "deploy/**"
 

--- a/.github/workflows/temp-branch-build-and-push.yaml
+++ b/.github/workflows/temp-branch-build-and-push.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - "dev"
       - "pop-3544-gpu-shutdown-guardrail"
+      - "pop-3712-reauth-skip-persistence-alias"
 
 concurrency:
   group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"

--- a/deploy/stage/common-values-ampc-hnsw.yaml
+++ b/deploy/stage/common-values-ampc-hnsw.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc-cpu:dc0d24635bc49bdb812f784ba04d0dafcfa962bf"
+image: "ghcr.io/worldcoin/iris-mpc-cpu:fe3bb8ea5a97ccc653c2781b74881917cec39543-arm64"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/common-values-ampc-hnsw.yaml
+++ b/deploy/stage/common-values-ampc-hnsw.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc-cpu:fe3bb8ea5a97ccc653c2781b74881917cec39543-arm64"
+image: "ghcr.io/worldcoin/iris-mpc-cpu:c1a65e9b8636ee35c60b63cf64a578c4b98e6aa5-arm64"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/common-values-ampc-hnsw.yaml
+++ b/deploy/stage/common-values-ampc-hnsw.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc-cpu:v0.31.5@sha256:9c69b755ec49a73d3d7bd684203137d29833a5f183d647356f5d2eec64148045"
+image: "ghcr.io/worldcoin/iris-mpc-cpu:dc0d24635bc49bdb812f784ba04d0dafcfa962bf"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:05be653e8be89160a4e2b86e282fd2901e6143d7"
+image: "ghcr.io/worldcoin/iris-mpc:dc0d24635bc49bdb812f784ba04d0dafcfa962bf"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:v0.31.8@sha256:0eeee5ba03d9f7e4f954a1e99df8ff92b97352830f5d3cc34fcbe75ee0efbf6f"
+image: "ghcr.io/worldcoin/iris-mpc:05be653e8be89160a4e2b86e282fd2901e6143d7"
 
 environment: stage
 replicaCount: 1

--- a/iris-mpc-bins/bin/iris-mpc/server.rs
+++ b/iris-mpc-bins/bin/iris-mpc/server.rs
@@ -655,10 +655,11 @@ async fn server_main(config: Config) -> Result<()> {
                     );
                     let result_string = serde_json::to_string(&result_event)
                         .expect("failed to serialize reauth result");
+                    let persisted = success && !skip_persistence.get(i).copied().unwrap_or(false);
                     modifications
                         .get_mut(&RequestSerialId(serial_id))
                         .unwrap()
-                        .mark_completed(success, &result_string, None, None);
+                        .mark_completed(persisted, &result_string, None, None);
                     result_string
                 })
                 .collect::<Vec<String>>();

--- a/iris-mpc-common/src/helpers/smpc_request.rs
+++ b/iris-mpc-common/src/helpers/smpc_request.rs
@@ -136,6 +136,7 @@ pub struct ReAuthRequest {
     pub reauth_id: String,
     pub s3_key: String,
     pub serial_id: u32,
+    #[serde(alias = "skipPersistence")]
     pub skip_persistence: Option<bool>,
     pub use_or_rule: bool,
 }

--- a/iris-mpc-common/src/helpers/smpc_request.rs
+++ b/iris-mpc-common/src/helpers/smpc_request.rs
@@ -136,7 +136,6 @@ pub struct ReAuthRequest {
     pub reauth_id: String,
     pub s3_key: String,
     pub serial_id: u32,
-    #[serde(alias = "skipPersistence")]
     pub skip_persistence: Option<bool>,
     pub use_or_rule: bool,
 }

--- a/iris-mpc-common/tests/smpc_request.rs
+++ b/iris-mpc-common/tests/smpc_request.rs
@@ -7,7 +7,7 @@ mod tests {
         sha256::sha256_as_hex_string,
         smpc_request::{
             decrypt_iris_share, get_iris_data_by_party_id, validate_iris_share, IrisCodeSharesJSON,
-            UniquenessRequest,
+            ReAuthRequest, UniquenessRequest,
         },
     };
     use serde_json::json;
@@ -41,6 +41,20 @@ mod tests {
             left_mask_code_shares: STANDARD.encode("left_iris_mask_mock"),
             right_mask_code_shares: STANDARD.encode("right_iris_mask_mock"),
         }
+    }
+
+    #[test]
+    fn test_reauth_request_accepts_camel_case_skip_persistence() {
+        let request: ReAuthRequest = serde_json::from_value(json!({
+            "reauth_id": "test-reauth-id",
+            "s3_key": "test-s3-key",
+            "serial_id": 42,
+            "skipPersistence": true,
+            "use_or_rule": false,
+        }))
+        .unwrap();
+
+        assert_eq!(request.skip_persistence, Some(true));
     }
 
     #[tokio::test]

--- a/iris-mpc-common/tests/smpc_request.rs
+++ b/iris-mpc-common/tests/smpc_request.rs
@@ -44,12 +44,12 @@ mod tests {
     }
 
     #[test]
-    fn test_reauth_request_accepts_camel_case_skip_persistence() {
+    fn test_reauth_request_accepts_snake_case_skip_persistence() {
         let request: ReAuthRequest = serde_json::from_value(json!({
             "reauth_id": "test-reauth-id",
             "s3_key": "test-s3-key",
             "serial_id": 42,
-            "skipPersistence": true,
+            "skip_persistence": true,
             "use_or_rule": false,
         }))
         .unwrap();

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -2156,10 +2156,18 @@ impl HawkHandle {
                             let request_id = &request.batch.request_ids[i];
                             Some(ModificationKey::RequestId(request_id.clone()))
                         }
-                        ReauthUpdate(vector_id) => {
+                        ReauthUpdate(vector_id)
+                            if !request
+                                .batch
+                                .skip_persistence
+                                .get(i)
+                                .copied()
+                                .unwrap_or(false) =>
+                        {
                             Some(ModificationKey::RequestSerialId(vector_id.serial_id()))
                         }
                         UniqueInsertSkipped | NoMutation => None,
+                        ReauthUpdate(_) => None,
                     }
                 }
                 RequestIndex::IdentityUpdate(i) => {

--- a/iris-mpc/src/services/processors/job.rs
+++ b/iris-mpc/src/services/processors/job.rs
@@ -13,6 +13,7 @@ use iris_mpc_common::helpers::smpc_response::{
     UniquenessResult,
 };
 
+use iris_mpc_common::helpers::sync::ModificationKey;
 use iris_mpc_common::helpers::sync::ModificationKey::{RequestId, RequestSerialId};
 use iris_mpc_common::iris_db::get_dummy_shares_for_deletion;
 use iris_mpc_common::job::ServerJobResult;
@@ -193,11 +194,16 @@ pub async fn process_job_result(
                 .wrap_err("failed to serialize reauth result")?;
 
             let modification_key = RequestSerialId(serial_id);
-            let graph_mutation = hawk_mutation.get_serialized_mutation_by_key(&modification_key);
+            let (persisted, graph_mutation) = reauth_modification_persistence(
+                success,
+                skip_persistence.get(i).copied().unwrap_or(false),
+                &modification_key,
+                &hawk_mutation,
+            );
             modifications
                 .get_mut(&modification_key)
                 .unwrap()
-                .mark_completed(success, &result_string, None, graph_mutation);
+                .mark_completed(persisted, &result_string, None, graph_mutation);
 
             Ok(result_string)
         })
@@ -550,4 +556,74 @@ async fn persist(
     }
 
     Ok(())
+}
+
+fn reauth_modification_persistence(
+    success: bool,
+    skip_persistence: bool,
+    modification_key: &ModificationKey,
+    hawk_mutation: &HawkMutation,
+) -> (bool, Option<Vec<u8>>) {
+    let persisted = success && !skip_persistence;
+    let graph_mutation = if persisted {
+        hawk_mutation.get_serialized_mutation_by_key(modification_key)
+    } else {
+        None
+    };
+
+    (persisted, graph_mutation)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use iris_mpc_cpu::execution::hawk_main::SingleHawkMutation;
+
+    #[test]
+    fn successful_reauth_with_skip_persistence_is_not_persisted() {
+        let modification_key = RequestSerialId(7);
+        let hawk_mutation = HawkMutation(vec![SingleHawkMutation {
+            plans: [None, None],
+            modification_key: Some(modification_key.clone()),
+            request_index: None,
+        }]);
+
+        let (persisted, graph_mutation) =
+            reauth_modification_persistence(true, true, &modification_key, &hawk_mutation);
+
+        assert!(!persisted);
+        assert!(graph_mutation.is_none());
+    }
+
+    #[test]
+    fn successful_reauth_without_skip_persistence_keeps_graph_mutation() {
+        let modification_key = RequestSerialId(7);
+        let hawk_mutation = HawkMutation(vec![SingleHawkMutation {
+            plans: [None, None],
+            modification_key: Some(modification_key.clone()),
+            request_index: None,
+        }]);
+
+        let (persisted, graph_mutation) =
+            reauth_modification_persistence(true, false, &modification_key, &hawk_mutation);
+
+        assert!(persisted);
+        assert!(graph_mutation.is_some());
+    }
+
+    #[test]
+    fn failed_reauth_is_not_persisted() {
+        let modification_key = RequestSerialId(7);
+        let hawk_mutation = HawkMutation(vec![SingleHawkMutation {
+            plans: [None, None],
+            modification_key: Some(modification_key.clone()),
+            request_index: None,
+        }]);
+
+        let (persisted, graph_mutation) =
+            reauth_modification_persistence(false, false, &modification_key, &hawk_mutation);
+
+        assert!(!persisted);
+        assert!(graph_mutation.is_none());
+    }
 }


### PR DESCRIPTION
## Summary
- Honor reauth `skip_persistence` when completing modification records, so successful skipped reauths are marked non-persisted.
- Avoid attaching graph mutation payloads to reauth modifications when `skip_persistence` is set.
- Keep the request schema snake_case and add a regression guard that reauth payloads parse `skip_persistence` as emitted by signup-service.

## Root cause
The producer already sends `skip_persistence` in snake_case. The flag was parsed and passed into the batch correctly, and the direct Postgres `update_iris` path already checked it.

The missing path was the modification record used for sync/roll-forward: successful reauths were marked `persisted = true` unconditionally and could carry a graph mutation payload. That made skipped reauths look persisted to modification sync even though the reauth update itself was supposed to be non-persistent.

## Test Plan
- `cargo fmt`
- `cargo test -p iris-mpc-common test_reauth_request_accepts_snake_case_skip_persistence`
- `cargo test -p iris-mpc reauth_`
- `cargo test -p iris-mpc-cpu hawk_mutation_tests`
- `git diff --check`

## E2E Stage Verification

Tested end-to-end on `smpcv2-{0,1,2}-stage` against `signup-service-app` in `orb-stage-v2-eu-central-1`:

1. **Enrollment** — ran `simulate-signup --zkp-secret pop3712-enroll`. Commitment `0x26d7f6d0e55ec1a4591d456bca334ef64c553ef63a30d7df65ee49bc5854fd13` was enrolled without `skip_persistence` so a `serial_id` was written to `mpcv2.results` normally (`modifications.persisted = true`).

2. **Wired the test identity** — set `INTEGRATION_TEST_ID_COMMITMENT` in signup-service-app to the enrolled commitment, so the next reauth for that identity would have `IsTest = true` → `SkipPersistence = true` in the SNS message to iris-mpc.

3. **Reauth** — ran `simulate-reauth --zkp-secret pop3712-enroll`. iris-mpc received the request with `skip_persistence = true`.

4. **DB check** — queried `SMPC_stage_{0,1,2}.modifications` directly via socat port-forwards:

   | Party | id  | serial_id | request_type | status    | persisted |
   |-------|-----|-----------|--------------|-----------|-----------|
   | 0     | 507 | 479       | reauth       | COMPLETED | **f**     |
   | 1     | 507 | 479       | reauth       | COMPLETED | **f**     |
   | 2     | 507 | 479       | reauth       | COMPLETED | **f**     |

   Prior reauthes in the same table (`id=503`, `id=499`) have `persisted = true`, confirming the field is only `false` when `skip_persistence` is explicitly set.

Fixes POP-3712