### PR TITLE
[POP-3798] Optimized Neighborhood Encoding

### DIFF
--- a/iris-mpc-cpu/Cargo.toml
+++ b/iris-mpc-cpu/Cargo.toml
@@ -98,5 +98,9 @@ harness = false
 name = "dot"
 harness = false
 
+[[bench]]
+name = "encoded_neighborhood"
+harness = false
+
 [[example]]
 name = "hnsw-ex"

--- a/iris-mpc-cpu/benches/encoded_neighborhood.rs
+++ b/iris-mpc-cpu/benches/encoded_neighborhood.rs
@@ -1,0 +1,109 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use iris_mpc_cpu::hnsw::graph::encoded_neighborhood::EncodedNeighborhood;
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use std::collections::BTreeSet;
+
+fn sample_sorted_ids(seed: u64, k: usize, universe: u64) -> Vec<u32> {
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let mut set = BTreeSet::new();
+    while set.len() < k {
+        set.insert(rng.gen_range(0..universe) as u32);
+    }
+    set.into_iter().collect()
+}
+
+fn bench_encode_at_k450(c: &mut Criterion) {
+    let mut group = c.benchmark_group("encode/k=450");
+    group.throughput(Throughput::Elements(450));
+    let universes: &[(&str, u64)] = &[
+        ("n=1M", 1_000_000),
+        ("n=10M", 10_000_000),
+        ("n=100M", 100_000_000),
+        ("n=2^32", u32::MAX as u64),
+    ];
+    for &(label, universe) in universes {
+        let ids = sample_sorted_ids(0xA5A5_0000 ^ universe, 450, universe);
+        group.bench_with_input(BenchmarkId::from_parameter(label), &ids, |b, ids| {
+            b.iter(|| {
+                let encoded = EncodedNeighborhood::encode(black_box(ids)).expect("encode");
+                black_box(encoded);
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_decode_at_k450(c: &mut Criterion) {
+    let mut group = c.benchmark_group("decode/k=450");
+    group.throughput(Throughput::Elements(450));
+    let universes: &[(&str, u64)] = &[
+        ("n=1M", 1_000_000),
+        ("n=10M", 10_000_000),
+        ("n=100M", 100_000_000),
+        ("n=2^32", u32::MAX as u64),
+    ];
+    for &(label, universe) in universes {
+        let ids = sample_sorted_ids(0xA5A5_0000 ^ universe, 450, universe);
+        let encoded = EncodedNeighborhood::encode(&ids).expect("encode");
+        group.bench_with_input(
+            BenchmarkId::from_parameter(label),
+            &encoded,
+            |b, encoded| {
+                b.iter(|| {
+                    let decoded = encoded.decode().expect("decode");
+                    black_box(decoded);
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_scaling_at_n10m(c: &mut Criterion) {
+    let universe: u64 = 10_000_000;
+    let ks: &[usize] = &[10, 100, 450, 2000];
+
+    let mut enc_group = c.benchmark_group("scaling/n=10M/encode");
+    for &k in ks {
+        enc_group.throughput(Throughput::Elements(k as u64));
+        let ids = sample_sorted_ids(0xC0DE_0000 ^ k as u64, k, universe);
+        enc_group.bench_with_input(
+            BenchmarkId::from_parameter(format!("k={k}")),
+            &ids,
+            |b, ids| {
+                b.iter(|| {
+                    let encoded = EncodedNeighborhood::encode(black_box(ids)).expect("encode");
+                    black_box(encoded);
+                });
+            },
+        );
+    }
+    enc_group.finish();
+
+    let mut dec_group = c.benchmark_group("scaling/n=10M/decode");
+    for &k in ks {
+        dec_group.throughput(Throughput::Elements(k as u64));
+        let ids = sample_sorted_ids(0xC0DE_0000 ^ k as u64, k, universe);
+        let encoded = EncodedNeighborhood::encode(&ids).expect("encode");
+        dec_group.bench_with_input(
+            BenchmarkId::from_parameter(format!("k={k}")),
+            &encoded,
+            |b, e| {
+                b.iter(|| {
+                    let decoded = e.decode().expect("decode");
+                    black_box(decoded);
+                });
+            },
+        );
+    }
+    dec_group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_encode_at_k450,
+    bench_decode_at_k450,
+    bench_scaling_at_n10m
+);
+criterion_main!(benches);

--- a/iris-mpc-cpu/benches/encoded_neighborhood.rs
+++ b/iris-mpc-cpu/benches/encoded_neighborhood.rs
@@ -20,7 +20,7 @@ fn bench_encode_at_k450(c: &mut Criterion) {
         ("n=1M", 1_000_000),
         ("n=10M", 10_000_000),
         ("n=100M", 100_000_000),
-        ("n=2^32", u32::MAX as u64),
+        ("n=2^32-1", u32::MAX as u64),
     ];
     for &(label, universe) in universes {
         let ids = sample_sorted_ids(0xA5A5_0000 ^ universe, 450, universe);
@@ -41,7 +41,7 @@ fn bench_decode_at_k450(c: &mut Criterion) {
         ("n=1M", 1_000_000),
         ("n=10M", 10_000_000),
         ("n=100M", 100_000_000),
-        ("n=2^32", u32::MAX as u64),
+        ("n=2^32-1", u32::MAX as u64),
     ];
     for &(label, universe) in universes {
         let ids = sample_sorted_ids(0xA5A5_0000 ^ universe, 450, universe);

--- a/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
@@ -40,6 +40,11 @@ impl EncodedNeighborhood {
         if ids.len() > MAX_K {
             return Err(EncodeError::TooLarge(ids.len()));
         }
+        for i in 1..ids.len() {
+            if ids[i] <= ids[i - 1] {
+                return Err(EncodeError::NotSorted(i));
+            }
+        }
         let k = ids.len() as u16;
         let b = 0u8;
         let mut out = Vec::with_capacity(HEADER_LEN);
@@ -86,5 +91,27 @@ mod tests {
         let decoded = encoded.decode().expect("decode empty");
         assert!(decoded.is_empty());
         assert_eq!(encoded.as_bytes().len(), HEADER_LEN);
+    }
+
+    #[test]
+    fn rejects_unsorted() {
+        let err = EncodedNeighborhood::encode(&[5, 3]).unwrap_err();
+        assert!(matches!(err, EncodeError::NotSorted(1)), "got {:?}", err);
+    }
+
+    #[test]
+    fn rejects_duplicates() {
+        let err = EncodedNeighborhood::encode(&[5, 5]).unwrap_err();
+        assert!(matches!(err, EncodeError::NotSorted(1)), "got {:?}", err);
+    }
+
+    #[test]
+    fn rejects_too_large() {
+        let oversized: Vec<u32> = (0..(MAX_K as u32 + 1)).collect();
+        let err = EncodedNeighborhood::encode(&oversized).unwrap_err();
+        match err {
+            EncodeError::TooLarge(n) => assert_eq!(n, MAX_K + 1),
+            other => panic!("unexpected error: {other:?}"),
+        }
     }
 }

--- a/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
@@ -1,3 +1,50 @@
+//! Compact at-rest encoding for HNSW graph neighborhoods.
+//!
+//! A neighborhood is a sorted, strictly-increasing slice of `u32` IDs. We
+//! delta-encode it (`ids[0]` kept as an absolute value, then each later id as
+//! `ids[i] - ids[i-1] - 1`) and Rice-code the resulting `k` values into a
+//! packed bitstream. Decoding reverses this: read the header, Rice-decode `k`
+//! symbols, then prefix-sum them back into ids.
+//!
+//! # Wire format
+//!
+//! ```text
+//! +-------------+-----+-----------------------------+
+//! | k (u16 LE)  | b   | Rice-coded body, MSB-first  |
+//! +-------------+-----+-----------------------------+
+//!  bytes 0..2    2     3..
+//! ```
+//!
+//! Each Rice-coded value `v` is written as `q = v >> b` zero bits, a `1`
+//! terminator, then the low `b` bits of `v`. The Rice parameter `b` (which is
+//! a power-of-two Golomb divisor) is the same for every symbol in a blob and
+//! is chosen as described below. The body is zero-padded on the right to a
+//! whole number of bytes.
+//!
+//! # Choosing `b`
+//!
+//! For values drawn from a geometric distribution with mean `μ`, the
+//! bit-optimal Rice parameter is `b ≈ floor(log2(μ · ln 2))`. We approximate
+//! this as `floor(log2(μ))` (about half a bit too high on average — at most
+//! one extra bit per symbol), where `μ` is the exact mean of the `k` Rice-coded
+//! values: `(ids[k-1] - (k-1)) / k`. See `compute_b` for the implementation.
+//!
+//! # Example
+//!
+//! Encoding `[0, 5, 9]`:
+//!
+//! - Delta stream: `0` (= `ids[0]`), `4` (= 5-0-1), `3` (= 9-5-1).
+//! - `compute_b`: mean = `(9 - 2)/3 = 2`, so `b = floor(log2(2)) = 1`.
+//! - Per symbol, splitting `v` into quotient (unary) | terminator | low `b` bits:
+//!     - `0` → `1 | 0`              (2 bits)
+//!     - `4` → `00 | 1 | 0`         (4 bits)
+//!     - `3` → `0 | 1 | 1`          (3 bits)
+//! - Body bitstream `100010011` packs MSB-first (with 7 bits of zero padding)
+//!   into `[0x89, 0x80]`.
+//! - Full blob: `[0x03, 0x00, 0x01, 0x89, 0x80]` — 5 bytes for 3 ids.
+//!
+//! See `module_doc_example_bytes` for the test that pins these bytes.
+
 use thiserror::Error;
 
 /// Maximum supported neighborhood size. Limited by the 16-bit `k` field in the header.
@@ -275,6 +322,14 @@ fn rice_decode(reader: &mut BitReader<'_>, b: u8, gap_idx: usize) -> Result<u32,
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn module_doc_example_bytes() {
+        let encoded = EncodedNeighborhood::encode(&[0u32, 5, 9]).unwrap();
+        let actual: Vec<u8> = encoded.as_bytes().to_vec();
+        eprintln!("BYTES = {actual:02x?}");
+        assert_eq!(actual, vec![0x03, 0x00, 0x01, 0x89, 0x80]);
+    }
 
     #[test]
     fn rejects_empty() {

--- a/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
@@ -221,16 +221,25 @@ impl<'a> BitReader<'a> {
     }
 }
 
+/// Pick the Rice parameter `b` used by [`rice_encode`] / [`rice_decode`].
+///
+/// Rice coding is the power-of-two case of Golomb coding: a value `v` is split
+/// into `q = v >> b` (written in unary) and the low `b` bits (written raw), so
+/// each symbol costs `q + 1 + b` bits. For values drawn from a geometric
+/// distribution with mean `μ`, the bit-optimal choice is
+/// `b ≈ floor(log2(μ · ln 2))`, which we approximate here as `floor(log2(μ))`
+/// (about half a bit too high on average — at most one extra bit per symbol).
+///
+/// `μ` is the mean of the `k` values actually Rice-coded by [`encode`]: the
+/// absolute first id plus the `(k-1)` inter-element gaps `ids[i] - ids[i-1] - 1`,
+/// which sum to `ids[k-1] - (k-1)`.
 fn compute_b(ids: &[u32]) -> u8 {
     debug_assert!(!ids.is_empty());
     let k = ids.len() as u32;
-    // Average gap over all k gaps (including g[0] = ids[0]).
-    // Sum of gaps = ids[k-1] - (k - 1), so mean ≈ ids[k-1] / k.
-    // Using ids[k-1] / k (not the exact `(ids[k-1] - (k-1)) / k`) is fine: the
-    // overestimate is at most 1, which can't shift `b` by more than one bit.
-    let mean_gap = (ids[ids.len() - 1] / k).max(1);
-    let b = 31u8.saturating_sub(mean_gap.leading_zeros() as u8);
-    b.min(31)
+    // `ids[k-1] >= k-1` for any strictly-increasing u32 slice, so this never underflows.
+    let mean_gap = ((ids[ids.len() - 1] - (k - 1)) / k).max(1);
+    // floor(log2(mean_gap)) for mean_gap >= 1; result is always in [0, 31].
+    31u8.saturating_sub(mean_gap.leading_zeros() as u8)
 }
 
 fn rice_encode(writer: &mut BitWriter, value: u32, b: u8) {

--- a/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
@@ -331,6 +331,27 @@ mod tests {
         assert_eq!(decoded_or_panic(&encoded), vec![u32::MAX]);
     }
 
+    #[test]
+    fn round_trip_consecutive() {
+        let ids: Vec<u32> = (0..10).collect();
+        let encoded = EncodedNeighborhood::encode(&ids).expect("encode");
+        assert_eq!(encoded.decode().expect("decode"), ids);
+    }
+
+    #[test]
+    fn round_trip_handcrafted_small() {
+        let ids = vec![0u32, 1, 5, 100, 1000];
+        let encoded = EncodedNeighborhood::encode(&ids).expect("encode");
+        assert_eq!(encoded.decode().expect("decode"), ids);
+    }
+
+    #[test]
+    fn round_trip_widely_spaced() {
+        let ids = vec![0u32, 1_000, 1_000_000, 100_000_000, u32::MAX - 1];
+        let encoded = EncodedNeighborhood::encode(&ids).expect("encode");
+        assert_eq!(encoded.decode().expect("decode"), ids);
+    }
+
     fn decoded_or_panic(e: &EncodedNeighborhood) -> Vec<u32> {
         e.decode().expect("decode succeeded")
     }

--- a/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
@@ -14,6 +14,8 @@ pub struct EncodedNeighborhood {
 /// Errors returned by [`EncodedNeighborhood::encode`].
 #[derive(Debug, Error)]
 pub enum EncodeError {
+    #[error("input ids are empty")]
+    Empty,
     #[error("input ids not sorted strictly ascending at position {0}")]
     NotSorted(usize),
     #[error("neighborhood size {0} exceeds maximum {MAX_K}")]
@@ -38,6 +40,9 @@ pub enum DecodeError {
 impl EncodedNeighborhood {
     /// Encode a sorted-ascending, strictly-increasing slice of u32 IDs.
     pub fn encode(ids: &[u32]) -> Result<Self, EncodeError> {
+        if ids.is_empty() {
+            return Err(EncodeError::Empty);
+        }
         if ids.len() > MAX_K {
             return Err(EncodeError::TooLarge(ids.len()));
         }
@@ -48,15 +53,6 @@ impl EncodedNeighborhood {
         }
 
         let k = ids.len() as u16;
-        if ids.is_empty() {
-            let mut out = Vec::with_capacity(HEADER_LEN);
-            out.extend_from_slice(&k.to_le_bytes());
-            out.push(0);
-            return Ok(Self {
-                bytes: out.into_boxed_slice(),
-            });
-        }
-
         let b = compute_b(ids);
 
         let cap = HEADER_LEN + (ids.len() * (b as usize + 4)).div_ceil(8);
@@ -272,11 +268,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn empty_round_trip() {
-        let encoded = EncodedNeighborhood::encode(&[]).expect("encode empty");
-        let decoded = encoded.decode().expect("decode empty");
-        assert!(decoded.is_empty());
-        assert_eq!(encoded.as_bytes().len(), HEADER_LEN);
+    fn rejects_empty() {
+        let err = EncodedNeighborhood::encode(&[]).unwrap_err();
+        assert!(matches!(err, EncodeError::Empty), "got {:?}", err);
     }
 
     #[test]
@@ -433,7 +427,7 @@ mod tests {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
             // Vary k across a useful range, including small and near-MAX_K cases.
             let k = match seed % 4 {
-                0 => rng.gen_range(0..16),
+                0 => rng.gen_range(1..16),
                 1 => rng.gen_range(16..1024),
                 2 => rng.gen_range(1024..16_384),
                 _ => 65_535,

--- a/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
@@ -102,14 +102,15 @@ impl EncodedNeighborhood {
         let k = ids.len() as u16;
         let b = compute_b(ids);
 
-        // Per-symbol body cost is `b + 1 + q` bits with `E[q] ≈ 1` for an optimal `b`
-        // (geometric tail), so budgeting `b + 4` gives ~2 bits of slack per symbol.
-        // A reallocation needs `Σ q_i > 3k`, a `√(2k)`-sigma tail — negligible for
-        // any realistic `k`. Empirically (criterion bench across slack ∈ {2,3,4,6,8,16}
-        // and k ∈ {10, 450, 2000, 65535}), enlarging the slack does not change encode
+        // Body capacity (header lives in a separate Vec). Per-symbol body cost is
+        // `b + 1 + q` bits with `E[q] ≈ 1` for an optimal `b` (geometric tail), so
+        // budgeting `b + 4` gives ~2 bits of slack per symbol. A reallocation needs
+        // `Σ q_i > 3k`, a `√(2k)`-sigma tail — negligible for any realistic `k`.
+        // Empirically (criterion bench across slack ∈ {2,3,4,6,8,16} and k ∈
+        // {10, 450, 2000, 65535}), enlarging the slack does not change encode
         // timing within noise, so `+ 4` is not undersized.
-        let cap = HEADER_LEN + (ids.len() * (b as usize + 4)).div_ceil(8);
-        let mut writer = BitWriter::with_capacity(cap);
+        let body_cap = (ids.len() * (b as usize + 4)).div_ceil(8);
+        let mut writer = BitWriter::with_capacity(body_cap);
 
         let mut header = Vec::with_capacity(HEADER_LEN);
         header.extend_from_slice(&k.to_le_bytes());
@@ -262,15 +263,20 @@ impl<'a> BitReader<'a> {
         Some(out)
     }
 
-    fn read_unary(&mut self) -> Option<u32> {
-        let mut zeros: u32 = 0;
+    /// Read a unary-coded zero count terminated by a `1` bit. Returns `None`
+    /// on truncation (buffer exhausted before the terminator). Counts in `u64`
+    /// so that `read_bits` truncation is the only `None` case — even a fully
+    /// zero buffer of `isize::MAX` bytes can't overflow `u64`. Callers map a
+    /// returned count `> u32::MAX` to `QuotientOverflow` (see `rice_decode`).
+    fn read_unary(&mut self) -> Option<u64> {
+        let mut zeros: u64 = 0;
         loop {
             let bit = self.read_bits(1)?;
             if bit == 1 {
                 // `1` terminates the unary prefix; consumed but not part of the value.
                 return Some(zeros);
             }
-            zeros = zeros.checked_add(1)?;
+            zeros += 1;
         }
     }
 }
@@ -308,9 +314,10 @@ fn rice_encode(writer: &mut BitWriter, value: u32, b: u8) {
 
 fn rice_decode(reader: &mut BitReader<'_>, b: u8, gap_idx: usize) -> Result<u32, DecodeError> {
     debug_assert!(b <= 31, "rice parameter b must be 0..=31");
-    let q = reader
+    let q_raw = reader
         .read_unary()
         .ok_or(DecodeError::TruncatedBody(gap_idx))?;
+    let q = u32::try_from(q_raw).map_err(|_| DecodeError::QuotientOverflow(gap_idx))?;
     // `q << b` must fit in u32: the bit-width of `q` plus `b` cannot exceed 32.
     let bits_in_q = 32u8.saturating_sub(q.leading_zeros() as u8);
     if bits_in_q + b > 32 {

--- a/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
@@ -36,6 +36,7 @@ pub enum DecodeError {
 }
 
 impl EncodedNeighborhood {
+    /// Encode a sorted-ascending, strictly-increasing slice of u32 IDs.
     pub fn encode(ids: &[u32]) -> Result<Self, EncodeError> {
         if ids.len() > MAX_K {
             return Err(EncodeError::TooLarge(ids.len()));
@@ -79,14 +80,18 @@ impl EncodedNeighborhood {
         })
     }
 
+    /// Wrap an already-encoded byte blob (e.g. loaded from storage) without
+    /// validating its contents; validation happens on `decode`.
     pub fn from_bytes(bytes: Box<[u8]>) -> Self {
         Self { bytes }
     }
 
+    /// Return the underlying encoded bytes.
     pub fn as_bytes(&self) -> &[u8] {
         &self.bytes
     }
 
+    /// Decode back to a sorted-ascending `Vec<u32>` of neighbor IDs.
     pub fn decode(&self) -> Result<Vec<u32>, DecodeError> {
         if self.bytes.len() < HEADER_LEN {
             return Err(DecodeError::TruncatedHeader(self.bytes.len()));
@@ -129,15 +134,6 @@ struct BitWriter {
 }
 
 impl BitWriter {
-    #[allow(dead_code)]
-    fn new() -> Self {
-        Self {
-            bytes: Vec::new(),
-            buf: 0,
-            nbits: 0,
-        }
-    }
-
     fn with_capacity(cap_bytes: usize) -> Self {
         Self {
             bytes: Vec::with_capacity(cap_bytes),
@@ -252,6 +248,7 @@ fn rice_encode(writer: &mut BitWriter, value: u32, b: u8) {
 }
 
 fn rice_decode(reader: &mut BitReader<'_>, b: u8, gap_idx: usize) -> Result<u32, DecodeError> {
+    debug_assert!(b <= 31, "rice parameter b must be 0..=31");
     let q = reader
         .read_unary()
         .ok_or(DecodeError::TruncatedBody(gap_idx))?;
@@ -267,11 +264,6 @@ fn rice_decode(reader: &mut BitReader<'_>, b: u8, gap_idx: usize) -> Result<u32,
             .read_bits(b)
             .ok_or(DecodeError::TruncatedBody(gap_idx))?
     };
-    if b == 32 {
-        // Defense-in-depth: `compute_b` clamps to 31, but if a future change
-        // ever loosens that, keep the shift well-defined.
-        return Ok(r);
-    }
     Ok((q << b) | r)
 }
 

--- a/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
@@ -102,6 +102,12 @@ impl EncodedNeighborhood {
         let k = ids.len() as u16;
         let b = compute_b(ids);
 
+        // Per-symbol body cost is `b + 1 + q` bits with `E[q] ≈ 1` for an optimal `b`
+        // (geometric tail), so budgeting `b + 4` gives ~2 bits of slack per symbol.
+        // A reallocation needs `Σ q_i > 3k`, a `√(2k)`-sigma tail — negligible for
+        // any realistic `k`. Empirically (criterion bench across slack ∈ {2,3,4,6,8,16}
+        // and k ∈ {10, 450, 2000, 65535}), enlarging the slack does not change encode
+        // timing within noise, so `+ 4` is not undersized.
         let cap = HEADER_LEN + (ids.len() * (b as usize + 4)).div_ceil(8);
         let mut writer = BitWriter::with_capacity(cap);
 

--- a/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
@@ -11,6 +11,7 @@ pub struct EncodedNeighborhood {
     bytes: Box<[u8]>,
 }
 
+/// Errors returned by [`EncodedNeighborhood::encode`].
 #[derive(Debug, Error)]
 pub enum EncodeError {
     #[error("input ids not sorted strictly ascending at position {0}")]
@@ -19,6 +20,7 @@ pub enum EncodeError {
     TooLarge(usize),
 }
 
+/// Errors returned by [`EncodedNeighborhood::decode`].
 #[derive(Debug, Error)]
 pub enum DecodeError {
     #[error("encoded blob too short: header truncated, have {0} bytes")]
@@ -39,7 +41,7 @@ impl EncodedNeighborhood {
             return Err(EncodeError::TooLarge(ids.len()));
         }
         let k = ids.len() as u16;
-        let b: u8 = 0;
+        let b = 0u8;
         let mut out = Vec::with_capacity(HEADER_LEN);
         out.extend_from_slice(&k.to_le_bytes());
         out.push(b);
@@ -67,7 +69,7 @@ impl EncodedNeighborhood {
             return Err(DecodeError::InvalidParameter(b));
         }
         if k == 0 {
-            return Ok(Vec::new());
+            return Ok(vec![]);
         }
         // Body decoding lands in a later task.
         unimplemented!("body decode not implemented yet for k > 0")
@@ -82,7 +84,7 @@ mod tests {
     fn empty_round_trip() {
         let encoded = EncodedNeighborhood::encode(&[]).expect("encode empty");
         let decoded = encoded.decode().expect("decode empty");
-        assert_eq!(decoded, Vec::<u32>::new());
+        assert!(decoded.is_empty());
         assert_eq!(encoded.as_bytes().len(), HEADER_LEN);
     }
 }

--- a/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
@@ -367,43 +367,40 @@ mod tests {
     }
 
     #[test]
-    fn single_element_round_trip_zero() {
-        let encoded = EncodedNeighborhood::encode(&[0]).expect("encode");
-        let decoded = encoded.decode().expect("decode");
-        assert_eq!(decoded, vec![0u32]);
+    fn round_trip_single_zero() {
+        assert_round_trip(&[0]);
     }
 
     #[test]
-    fn single_element_round_trip_small() {
-        let encoded = EncodedNeighborhood::encode(&[42]).expect("encode");
-        assert_eq!(decoded_or_panic(&encoded), vec![42u32]);
+    fn round_trip_single_small() {
+        assert_round_trip(&[42]);
     }
 
     #[test]
-    fn single_element_round_trip_max() {
-        let encoded = EncodedNeighborhood::encode(&[u32::MAX]).expect("encode");
-        assert_eq!(decoded_or_panic(&encoded), vec![u32::MAX]);
+    fn round_trip_single_max() {
+        assert_round_trip(&[u32::MAX]);
     }
 
     #[test]
     fn round_trip_consecutive() {
-        let ids: Vec<u32> = (0..10).collect();
-        let encoded = EncodedNeighborhood::encode(&ids).expect("encode");
-        assert_eq!(encoded.decode().expect("decode"), ids);
+        assert_round_trip(&(0..10).collect::<Vec<_>>());
     }
 
     #[test]
     fn round_trip_handcrafted_small() {
-        let ids = vec![0u32, 1, 5, 100, 1000];
-        let encoded = EncodedNeighborhood::encode(&ids).expect("encode");
-        assert_eq!(encoded.decode().expect("decode"), ids);
+        assert_round_trip(&[0, 1, 5, 100, 1000]);
     }
 
     #[test]
     fn round_trip_widely_spaced() {
-        let ids = vec![0u32, 1_000, 1_000_000, 100_000_000, u32::MAX - 1];
-        let encoded = EncodedNeighborhood::encode(&ids).expect("encode");
-        assert_eq!(encoded.decode().expect("decode"), ids);
+        assert_round_trip(&[0, 1_000, 1_000_000, 100_000_000, u32::MAX - 1]);
+    }
+
+    #[test]
+    fn round_trip_big_first() {
+        // First id near u32::MAX, then small gaps. Stresses the absolute-first
+        // symbol (where Rice's quotient `q = ids[0] >> b` can be very large).
+        assert_round_trip(&[u32::MAX - 1000, u32::MAX - 500, u32::MAX - 100, u32::MAX]);
     }
 
     #[test]
@@ -419,16 +416,14 @@ mod tests {
                 ids[i] = ids[i - 1] + 1;
             }
         }
-        let encoded = EncodedNeighborhood::encode(&ids).expect("encode max_k");
-        assert_eq!(encoded.decode().expect("decode max_k"), ids);
+        assert_round_trip(&ids);
     }
 
     #[test]
     fn round_trip_high_universe() {
         // IDs clustered near u32::MAX.
         let ids: Vec<u32> = (0..450u32).map(|i| u32::MAX - 449 + i).collect();
-        let encoded = EncodedNeighborhood::encode(&ids).expect("encode high");
-        assert_eq!(encoded.decode().expect("decode high"), ids);
+        assert_round_trip(&ids);
     }
 
     #[test]
@@ -561,11 +556,12 @@ mod tests {
             );
 
             // Round-trip sanity check.
-            assert_eq!(encoded.decode().expect("decode"), ids);
+            assert_round_trip(&ids);
         }
     }
 
-    fn decoded_or_panic(e: &EncodedNeighborhood) -> Vec<u32> {
-        e.decode().expect("decode succeeded")
+    fn assert_round_trip(ids: &[u32]) {
+        let encoded = EncodedNeighborhood::encode(ids).expect("encode");
+        assert_eq!(encoded.decode().expect("decode"), ids);
     }
 }

--- a/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
@@ -45,12 +45,35 @@ impl EncodedNeighborhood {
                 return Err(EncodeError::NotSorted(i));
             }
         }
+
         let k = ids.len() as u16;
-        let b = 0u8;
-        let mut out = Vec::with_capacity(HEADER_LEN);
-        out.extend_from_slice(&k.to_le_bytes());
-        out.push(b);
-        // Body is empty for k=0; later tasks will append Rice-coded gaps here.
+        if ids.is_empty() {
+            let mut out = Vec::with_capacity(HEADER_LEN);
+            out.extend_from_slice(&k.to_le_bytes());
+            out.push(0);
+            return Ok(Self {
+                bytes: out.into_boxed_slice(),
+            });
+        }
+
+        let b = compute_b(ids);
+
+        let cap = HEADER_LEN + (ids.len() * (b as usize + 4)).div_ceil(8);
+        let mut writer = BitWriter::with_capacity(cap);
+
+        let mut header = Vec::with_capacity(HEADER_LEN);
+        header.extend_from_slice(&k.to_le_bytes());
+        header.push(b);
+
+        rice_encode(&mut writer, ids[0], b);
+        for i in 1..ids.len() {
+            let gap = ids[i] - ids[i - 1] - 1;
+            rice_encode(&mut writer, gap, b);
+        }
+
+        let body = writer.finish();
+        let mut out = header;
+        out.extend_from_slice(&body);
         Ok(Self {
             bytes: out.into_boxed_slice(),
         })
@@ -76,9 +99,181 @@ impl EncodedNeighborhood {
         if k == 0 {
             return Ok(vec![]);
         }
-        // Body decoding lands in a later task.
-        unimplemented!("body decode not implemented yet for k > 0")
+
+        let mut reader = BitReader::new(&self.bytes[HEADER_LEN..]);
+        let mut out = Vec::with_capacity(k);
+
+        let first = rice_decode(&mut reader, b, 0)?;
+        out.push(first);
+        let mut prev = first;
+        for i in 1..k {
+            let gap = rice_decode(&mut reader, b, i)?;
+            let next = prev
+                .checked_add(gap)
+                .and_then(|x| x.checked_add(1))
+                .ok_or(DecodeError::IdOverflow(i))?;
+            out.push(next);
+            prev = next;
+        }
+        Ok(out)
     }
+}
+
+/// MSB-first bit writer that flushes whole bytes to an internal `Vec<u8>`.
+struct BitWriter {
+    bytes: Vec<u8>,
+    /// Buffer holding up-to-7 not-yet-flushed bits in its most-significant positions.
+    buf: u8,
+    /// Number of valid bits in `buf` (0..8).
+    nbits: u8,
+}
+
+impl BitWriter {
+    #[allow(dead_code)]
+    fn new() -> Self {
+        Self {
+            bytes: Vec::new(),
+            buf: 0,
+            nbits: 0,
+        }
+    }
+
+    fn with_capacity(cap_bytes: usize) -> Self {
+        Self {
+            bytes: Vec::with_capacity(cap_bytes),
+            buf: 0,
+            nbits: 0,
+        }
+    }
+
+    /// Write the low `n` bits of `value` MSB-first. `n` must be 0..=32.
+    fn write_bits(&mut self, value: u32, n: u8) {
+        debug_assert!(n <= 32);
+        for i in (0..n).rev() {
+            let bit = ((value >> i) & 1) as u8;
+            self.buf = (self.buf << 1) | bit;
+            self.nbits += 1;
+            if self.nbits == 8 {
+                self.bytes.push(self.buf);
+                self.buf = 0;
+                self.nbits = 0;
+            }
+        }
+    }
+
+    fn write_one(&mut self) {
+        self.write_bits(1, 1);
+    }
+
+    fn write_zeros(&mut self, n: u32) {
+        // Write up to 32 bits at a time so very large quotients don't
+        // recursively explode through `write_bits`.
+        let mut remaining = n;
+        while remaining > 0 {
+            let chunk = remaining.min(32) as u8;
+            self.write_bits(0, chunk);
+            remaining -= chunk as u32;
+        }
+    }
+
+    fn finish(mut self) -> Vec<u8> {
+        if self.nbits > 0 {
+            let pad = 8 - self.nbits;
+            self.buf <<= pad;
+            self.bytes.push(self.buf);
+        }
+        self.bytes
+    }
+}
+
+/// MSB-first bit reader over a byte slice. Tracks position in bits.
+struct BitReader<'a> {
+    bytes: &'a [u8],
+    /// Bit offset from the start of `bytes` (MSB of byte 0 is bit 0).
+    pos: usize,
+}
+
+impl<'a> BitReader<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, pos: 0 }
+    }
+
+    fn total_bits(&self) -> usize {
+        self.bytes.len() * 8
+    }
+
+    fn read_bits(&mut self, n: u8) -> Option<u32> {
+        debug_assert!(n <= 32);
+        if self.pos + n as usize > self.total_bits() {
+            return None;
+        }
+        let mut out: u32 = 0;
+        for _ in 0..n {
+            let byte = self.bytes[self.pos / 8];
+            let bit = (byte >> (7 - (self.pos % 8))) & 1;
+            out = (out << 1) | bit as u32;
+            self.pos += 1;
+        }
+        Some(out)
+    }
+
+    fn read_unary(&mut self) -> Option<u32> {
+        let mut zeros: u32 = 0;
+        loop {
+            let bit = self.read_bits(1)?;
+            if bit == 1 {
+                return Some(zeros);
+            }
+            zeros = zeros.checked_add(1)?;
+        }
+    }
+}
+
+fn compute_b(ids: &[u32]) -> u8 {
+    debug_assert!(!ids.is_empty());
+    let mean_gap: u32 = if ids.len() == 1 {
+        ids[0].max(1)
+    } else {
+        // Strict-ascending guarantees `last >= first + (k-1)`, so the division yields >= 1.
+        let span = ids[ids.len() - 1] - ids[0];
+        let denom = (ids.len() as u32) - 1;
+        (span / denom).max(1)
+    };
+    // floor(log2(mean_gap)) for mean_gap >= 1.
+    let b = 31u8.saturating_sub(mean_gap.leading_zeros() as u8);
+    b.min(31)
+}
+
+fn rice_encode(writer: &mut BitWriter, value: u32, b: u8) {
+    let q = if b == 0 { value } else { value >> b };
+    writer.write_zeros(q);
+    writer.write_one();
+    if b > 0 {
+        let mask = (1u32 << b) - 1;
+        writer.write_bits(value & mask, b);
+    }
+}
+
+fn rice_decode(reader: &mut BitReader<'_>, b: u8, gap_idx: usize) -> Result<u32, DecodeError> {
+    let q = reader
+        .read_unary()
+        .ok_or(DecodeError::TruncatedBody(gap_idx))?;
+    if (q as u64) + (b as u64) > 32 {
+        return Err(DecodeError::QuotientOverflow(gap_idx));
+    }
+    let r = if b == 0 {
+        0
+    } else {
+        reader
+            .read_bits(b)
+            .ok_or(DecodeError::TruncatedBody(gap_idx))?
+    };
+    if b == 32 {
+        // Defense-in-depth: `compute_b` clamps to 31, but if a future change
+        // ever loosens that, keep the shift well-defined.
+        return Ok(r);
+    }
+    Ok((q << b) | r)
 }
 
 #[cfg(test)]
@@ -113,5 +308,28 @@ mod tests {
             EncodeError::TooLarge(n) => assert_eq!(n, MAX_K + 1),
             other => panic!("unexpected error: {other:?}"),
         }
+    }
+
+    #[test]
+    fn single_element_round_trip_zero() {
+        let encoded = EncodedNeighborhood::encode(&[0]).expect("encode");
+        let decoded = encoded.decode().expect("decode");
+        assert_eq!(decoded, vec![0u32]);
+    }
+
+    #[test]
+    fn single_element_round_trip_small() {
+        let encoded = EncodedNeighborhood::encode(&[42]).expect("encode");
+        assert_eq!(decoded_or_panic(&encoded), vec![42u32]);
+    }
+
+    #[test]
+    fn single_element_round_trip_max() {
+        let encoded = EncodedNeighborhood::encode(&[u32::MAX]).expect("encode");
+        assert_eq!(decoded_or_panic(&encoded), vec![u32::MAX]);
+    }
+
+    fn decoded_or_panic(e: &EncodedNeighborhood) -> Vec<u32> {
+        e.decode().expect("decode succeeded")
     }
 }

--- a/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
@@ -374,6 +374,64 @@ mod tests {
         assert_eq!(encoded.decode().expect("decode high"), ids);
     }
 
+    #[test]
+    fn decode_truncated_header() {
+        for len in 0..HEADER_LEN {
+            let bytes: Box<[u8]> = vec![0u8; len].into_boxed_slice();
+            let e = EncodedNeighborhood::from_bytes(bytes);
+            match e.decode() {
+                Err(DecodeError::TruncatedHeader(n)) => assert_eq!(n, len),
+                other => panic!("expected TruncatedHeader({len}), got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn decode_invalid_b() {
+        // k=0 so body is empty; b=32 is illegal.
+        let bytes: Box<[u8]> = vec![0u8, 0u8, 32u8].into_boxed_slice();
+        let e = EncodedNeighborhood::from_bytes(bytes);
+        match e.decode() {
+            Err(DecodeError::InvalidParameter(32)) => {}
+            other => panic!("expected InvalidParameter(32), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_truncated_body() {
+        let ids = vec![0u32, 100, 200, 300];
+        let encoded = EncodedNeighborhood::encode(&ids).expect("encode");
+        let full = encoded.as_bytes();
+        // Truncate every prefix that is longer than the header but shorter than the full body.
+        for cut in HEADER_LEN..full.len() {
+            let bytes: Box<[u8]> = full[..cut].to_vec().into_boxed_slice();
+            let e = EncodedNeighborhood::from_bytes(bytes);
+            match e.decode() {
+                Err(DecodeError::TruncatedBody(_))
+                | Err(DecodeError::QuotientOverflow(_))
+                | Err(DecodeError::IdOverflow(_))
+                | Err(DecodeError::TruncatedHeader(_)) => {}
+                Ok(decoded) => panic!("decoded a truncated blob ok: cut={cut}, got {decoded:?}"),
+                Err(other) => panic!("unexpected error at cut={cut}: {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn decode_garbage_does_not_panic() {
+        use rand::{Rng, SeedableRng};
+        use rand_chacha::ChaCha8Rng;
+
+        let mut rng = ChaCha8Rng::seed_from_u64(0xDEAD_BEEF);
+        for _ in 0..200 {
+            let len = rng.gen_range(0..64);
+            let bytes: Vec<u8> = (0..len).map(|_| rng.gen()).collect();
+            let e = EncodedNeighborhood::from_bytes(bytes.into_boxed_slice());
+            // We only require that decode does not panic. Either Ok or any DecodeError is acceptable.
+            let _ = e.decode();
+        }
+    }
+
     fn decoded_or_panic(e: &EncodedNeighborhood) -> Vec<u32> {
         e.decode().expect("decode succeeded")
     }

--- a/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
@@ -399,13 +399,6 @@ mod tests {
     }
 
     #[test]
-    fn round_trip_big_first() {
-        // First id near u32::MAX, then small gaps. Stresses the absolute-first
-        // symbol (where Rice's quotient `q = ids[0] >> b` can be very large).
-        assert_round_trip(&[u32::MAX - 1000, u32::MAX - 500, u32::MAX - 100, u32::MAX]);
-    }
-
-    #[test]
     fn round_trip_max_k() {
         // Sample a strictly-increasing sequence at MAX_K length.
         // Evenly spaced across u32 to exercise a typical mean_gap.

--- a/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
@@ -61,8 +61,6 @@ pub struct EncodedNeighborhood {
 /// Errors returned by [`EncodedNeighborhood::encode`].
 #[derive(Debug, Error)]
 pub enum EncodeError {
-    #[error("input ids are empty")]
-    Empty,
     #[error("input ids not sorted strictly ascending at position {0}")]
     NotSorted(usize),
     #[error("neighborhood size {0} exceeds maximum {MAX_K}")]
@@ -87,9 +85,6 @@ pub enum DecodeError {
 impl EncodedNeighborhood {
     /// Encode a sorted-ascending, strictly-increasing slice of u32 IDs.
     pub fn encode(ids: &[u32]) -> Result<Self, EncodeError> {
-        if ids.is_empty() {
-            return Err(EncodeError::Empty);
-        }
         if ids.len() > MAX_K {
             return Err(EncodeError::TooLarge(ids.len()));
         }
@@ -100,7 +95,17 @@ impl EncodedNeighborhood {
         }
 
         let k = ids.len() as u16;
-        let b = compute_b(ids);
+        let b = if ids.is_empty() { 0 } else { compute_b(ids) };
+
+        let mut header = Vec::with_capacity(HEADER_LEN);
+        header.extend_from_slice(&k.to_le_bytes());
+        header.push(b);
+
+        if ids.is_empty() {
+            return Ok(Self {
+                bytes: header.into_boxed_slice(),
+            });
+        }
 
         // Body capacity (header lives in a separate Vec). Per-symbol body cost is
         // `b + 1 + q` bits with `E[q] ≈ 1` for an optimal `b` (geometric tail), so
@@ -111,10 +116,6 @@ impl EncodedNeighborhood {
         // timing within noise, so `+ 4` is not undersized.
         let body_cap = (ids.len() * (b as usize + 4)).div_ceil(8);
         let mut writer = BitWriter::with_capacity(body_cap);
-
-        let mut header = Vec::with_capacity(HEADER_LEN);
-        header.extend_from_slice(&k.to_le_bytes());
-        header.push(b);
 
         rice_encode(&mut writer, ids[0], b);
         for i in 1..ids.len() {
@@ -352,8 +353,7 @@ fn rice_encode(writer: &mut BitWriter, value: u32, b: u8) {
     writer.write_zeros(q);
     writer.write_one();
     if b > 0 {
-        let mask = (1u32 << b) - 1;
-        writer.write_bits(value & mask, b);
+        writer.write_bits(value, b);
     }
 }
 
@@ -393,9 +393,10 @@ mod tests {
     }
 
     #[test]
-    fn rejects_empty() {
-        let err = EncodedNeighborhood::encode(&[]).unwrap_err();
-        assert!(matches!(err, EncodeError::Empty), "got {:?}", err);
+    fn round_trip_empty() {
+        let encoded = EncodedNeighborhood::encode(&[]).expect("encode");
+        assert_eq!(encoded.as_bytes(), &[0u8, 0u8, 0u8]);
+        assert_eq!(encoded.decode().expect("decode"), Vec::<u32>::new());
     }
 
     #[test]

--- a/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
@@ -258,7 +258,9 @@ fn rice_decode(reader: &mut BitReader<'_>, b: u8, gap_idx: usize) -> Result<u32,
     let q = reader
         .read_unary()
         .ok_or(DecodeError::TruncatedBody(gap_idx))?;
-    if (q as u64) + (b as u64) > 32 {
+    // `q << b` must fit in u32: the bit-width of `q` plus `b` cannot exceed 32.
+    let bits_in_q = 32u8.saturating_sub(q.leading_zeros() as u8);
+    if bits_in_q + b > 32 {
         return Err(DecodeError::QuotientOverflow(gap_idx));
     }
     let r = if b == 0 {

--- a/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
@@ -267,6 +267,7 @@ impl<'a> BitReader<'a> {
         loop {
             let bit = self.read_bits(1)?;
             if bit == 1 {
+                // `1` terminates the unary prefix; consumed but not part of the value.
                 return Some(zeros);
             }
             zeros = zeros.checked_add(1)?;

--- a/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
@@ -177,9 +177,12 @@ impl EncodedNeighborhood {
 /// MSB-first bit writer that flushes whole bytes to an internal `Vec<u8>`.
 struct BitWriter {
     bytes: Vec<u8>,
-    /// Buffer holding up-to-7 not-yet-flushed bits in its most-significant positions.
-    buf: u8,
-    /// Number of valid bits in `buf` (0..8).
+    /// Pending bits, MSB-aligned in `buf`: the most-significant `nbits` bits
+    /// are valid, lower bits are zero. Sized as `u64` so a single `write_bits`
+    /// call (up to 32 new bits, with up to 7 already buffered) always fits
+    /// without needing to split the write.
+    buf: u64,
+    /// Number of valid bits in `buf`. Always in 0..8 between calls.
     nbits: u8,
 }
 
@@ -195,15 +198,18 @@ impl BitWriter {
     /// Write the low `n` bits of `value` MSB-first. `n` must be 0..=32.
     fn write_bits(&mut self, value: u32, n: u8) {
         debug_assert!(n <= 32);
-        for i in (0..n).rev() {
-            let bit = ((value >> i) & 1) as u8;
-            self.buf = (self.buf << 1) | bit;
-            self.nbits += 1;
-            if self.nbits == 8 {
-                self.bytes.push(self.buf);
-                self.buf = 0;
-                self.nbits = 0;
-            }
+        // Insert the new bits into `buf` in one shot, then flush whole bytes.
+        // Pre-condition: `nbits` is in 0..8, `n` <= 32, so `nbits + n` <= 39
+        // and the shift `64 - nbits - n` is always in 25..=63.
+        if n > 0 {
+            let v = (value as u64) & ((1u64 << n) - 1);
+            self.buf |= v << (64 - self.nbits - n);
+            self.nbits += n;
+        }
+        while self.nbits >= 8 {
+            self.bytes.push((self.buf >> 56) as u8);
+            self.buf <<= 8;
+            self.nbits -= 8;
         }
     }
 
@@ -224,59 +230,98 @@ impl BitWriter {
 
     fn finish(mut self) -> Vec<u8> {
         if self.nbits > 0 {
-            let pad = 8 - self.nbits;
-            self.buf <<= pad;
-            self.bytes.push(self.buf);
+            // Bits are MSB-aligned in `buf` and unused low bits are already
+            // zero, so the top byte is the correctly zero-padded final byte.
+            self.bytes.push((self.buf >> 56) as u8);
         }
         self.bytes
     }
 }
 
-/// MSB-first bit reader over a byte slice. Tracks position in bits.
+/// MSB-first bit reader over a byte slice. Maintains a `u64` accumulator that
+/// is refilled from the source slice 8 bits at a time, so individual reads
+/// only touch memory when the accumulator runs low.
 struct BitReader<'a> {
     bytes: &'a [u8],
-    /// Bit offset from the start of `bytes` (MSB of byte 0 is bit 0).
-    pos: usize,
+    /// Pending bits, MSB-aligned: the most-significant `nvalid` bits are
+    /// valid, lower bits are zero.
+    buf: u64,
+    /// Number of valid bits in `buf`. Always in `0..=64`.
+    nvalid: u8,
+    /// Index of the next byte in `bytes` to load into `buf`.
+    next_byte: usize,
 }
 
 impl<'a> BitReader<'a> {
     fn new(bytes: &'a [u8]) -> Self {
-        Self { bytes, pos: 0 }
+        Self {
+            bytes,
+            buf: 0,
+            nvalid: 0,
+            next_byte: 0,
+        }
     }
 
-    fn total_bits(&self) -> usize {
-        self.bytes.len() * 8
+    /// Top up `buf` from the source slice 8 bits at a time. Stops when there
+    /// is no room for another whole byte (`nvalid > 56`) or the slice is
+    /// exhausted.
+    #[inline]
+    fn refill(&mut self) {
+        while self.nvalid <= 56 && self.next_byte < self.bytes.len() {
+            self.buf |= (self.bytes[self.next_byte] as u64) << (56 - self.nvalid);
+            self.nvalid += 8;
+            self.next_byte += 1;
+        }
     }
 
     fn read_bits(&mut self, n: u8) -> Option<u32> {
         debug_assert!(n <= 32);
-        if self.pos + n as usize > self.total_bits() {
-            return None;
+        if n == 0 {
+            return Some(0);
         }
-        let mut out: u32 = 0;
-        for _ in 0..n {
-            let byte = self.bytes[self.pos / 8];
-            let bit = (byte >> (7 - (self.pos % 8))) & 1;
-            out = (out << 1) | bit as u32;
-            self.pos += 1;
+        if self.nvalid < n {
+            self.refill();
+            if self.nvalid < n {
+                return None;
+            }
         }
+        // Take the top n bits, shift them to the LSB, then drop them from buf.
+        let out = (self.buf >> (64 - n)) as u32;
+        self.buf <<= n;
+        self.nvalid -= n;
         Some(out)
     }
 
     /// Read a unary-coded zero count terminated by a `1` bit. Returns `None`
     /// on truncation (buffer exhausted before the terminator). Counts in `u64`
-    /// so that `read_bits` truncation is the only `None` case — even a fully
-    /// zero buffer of `isize::MAX` bytes can't overflow `u64`. Callers map a
-    /// returned count `> u32::MAX` to `QuotientOverflow` (see `rice_decode`).
+    /// so that even a fully zero buffer of `isize::MAX` bytes can't overflow.
+    /// Callers map a returned count `> u32::MAX` to `QuotientOverflow` (see
+    /// `rice_decode`).
     fn read_unary(&mut self) -> Option<u64> {
         let mut zeros: u64 = 0;
         loop {
-            let bit = self.read_bits(1)?;
-            if bit == 1 {
-                // `1` terminates the unary prefix; consumed but not part of the value.
+            if self.nvalid == 0 {
+                self.refill();
+                if self.nvalid == 0 {
+                    return None;
+                }
+            }
+            let lz = self.buf.leading_zeros() as u64;
+            if lz < self.nvalid as u64 {
+                // Terminator landed inside the valid window: `lz` zero bits
+                // followed by the `1`. Consume both.
+                zeros += lz;
+                let consumed = (lz + 1) as u32;
+                // `consumed` can be 64 (terminator was the last valid bit),
+                // which a plain `<<` can't express on `u64`; saturate to 0.
+                self.buf = self.buf.checked_shl(consumed).unwrap_or(0);
+                self.nvalid -= consumed as u8;
                 return Some(zeros);
             }
-            zeros += 1;
+            // All `nvalid` bits in the window are zero; absorb and refill.
+            zeros += self.nvalid as u64;
+            self.buf = 0;
+            self.nvalid = 0;
         }
     }
 }

--- a/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
@@ -466,6 +466,48 @@ mod tests {
         }
     }
 
+    #[test]
+    fn encoded_size_matches_model() {
+        use rand::{Rng, SeedableRng};
+        use rand_chacha::ChaCha8Rng;
+
+        let k: usize = 450;
+        let cases: &[(u32, u8)] = &[
+            (1_000_000, 11),   // log2(1M/450) ~= 11
+            (10_000_000, 14),  // log2(10M/450) ~= 14
+            (100_000_000, 17), // log2(100M/450) ~= 17
+            (u32::MAX, 23),    // log2(2^32/450) ~= 23
+        ];
+
+        for &(universe, expected_b) in cases {
+            let mut rng = ChaCha8Rng::seed_from_u64(0xCAFE_F00D ^ universe as u64);
+            let mut set = std::collections::BTreeSet::new();
+            while set.len() < k {
+                set.insert(rng.gen_range(0..universe));
+            }
+            let ids: Vec<u32> = set.into_iter().collect();
+
+            let encoded = EncodedNeighborhood::encode(&ids).expect("encode");
+            let actual_b = encoded.as_bytes()[2];
+            assert!(
+                actual_b.abs_diff(expected_b) <= 1,
+                "universe={universe}: expected_b={expected_b}, got {actual_b}",
+            );
+
+            let model_bytes = (k * (actual_b as usize + 2)).div_ceil(8) + HEADER_LEN;
+            let actual_bytes = encoded.as_bytes().len();
+            let lower = (model_bytes as f64 * 0.90) as usize;
+            let upper = (model_bytes as f64 * 1.10) as usize;
+            assert!(
+                (lower..=upper).contains(&actual_bytes),
+                "universe={universe}: actual={actual_bytes}, model={model_bytes}, b={actual_b}",
+            );
+
+            // Round-trip sanity check.
+            assert_eq!(encoded.decode().expect("decode"), ids);
+        }
+    }
+
     fn decoded_or_panic(e: &EncodedNeighborhood) -> Vec<u32> {
         e.decode().expect("decode succeeded")
     }

--- a/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
@@ -1,0 +1,88 @@
+use thiserror::Error;
+
+/// Maximum supported neighborhood size. Limited by the 16-bit `k` field in the header.
+pub const MAX_K: usize = u16::MAX as usize;
+
+const HEADER_LEN: usize = 3;
+
+/// Compact at-rest form of a graph neighborhood: Rice-coded gap-encoded bytes.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EncodedNeighborhood {
+    bytes: Box<[u8]>,
+}
+
+#[derive(Debug, Error)]
+pub enum EncodeError {
+    #[error("input ids not sorted strictly ascending at position {0}")]
+    NotSorted(usize),
+    #[error("neighborhood size {0} exceeds maximum {MAX_K}")]
+    TooLarge(usize),
+}
+
+#[derive(Debug, Error)]
+pub enum DecodeError {
+    #[error("encoded blob too short: header truncated, have {0} bytes")]
+    TruncatedHeader(usize),
+    #[error("encoded blob too short: body needs more bits at gap {0}")]
+    TruncatedBody(usize),
+    #[error("invalid rice parameter b={0} (must be 0..=31)")]
+    InvalidParameter(u8),
+    #[error("malformed bitstream: quotient overflow at gap {0}")]
+    QuotientOverflow(usize),
+    #[error("decoded id overflow at gap {0}")]
+    IdOverflow(usize),
+}
+
+impl EncodedNeighborhood {
+    pub fn encode(ids: &[u32]) -> Result<Self, EncodeError> {
+        if ids.len() > MAX_K {
+            return Err(EncodeError::TooLarge(ids.len()));
+        }
+        let k = ids.len() as u16;
+        let b: u8 = 0;
+        let mut out = Vec::with_capacity(HEADER_LEN);
+        out.extend_from_slice(&k.to_le_bytes());
+        out.push(b);
+        // Body is empty for k=0; later tasks will append Rice-coded gaps here.
+        Ok(Self {
+            bytes: out.into_boxed_slice(),
+        })
+    }
+
+    pub fn from_bytes(bytes: Box<[u8]>) -> Self {
+        Self { bytes }
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    pub fn decode(&self) -> Result<Vec<u32>, DecodeError> {
+        if self.bytes.len() < HEADER_LEN {
+            return Err(DecodeError::TruncatedHeader(self.bytes.len()));
+        }
+        let k = u16::from_le_bytes([self.bytes[0], self.bytes[1]]) as usize;
+        let b = self.bytes[2];
+        if b > 31 {
+            return Err(DecodeError::InvalidParameter(b));
+        }
+        if k == 0 {
+            return Ok(Vec::new());
+        }
+        // Body decoding lands in a later task.
+        unimplemented!("body decode not implemented yet for k > 0")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_round_trip() {
+        let encoded = EncodedNeighborhood::encode(&[]).expect("encode empty");
+        let decoded = encoded.decode().expect("decode empty");
+        assert_eq!(decoded, Vec::<u32>::new());
+        assert_eq!(encoded.as_bytes().len(), HEADER_LEN);
+    }
+}

--- a/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
@@ -231,15 +231,12 @@ impl<'a> BitReader<'a> {
 
 fn compute_b(ids: &[u32]) -> u8 {
     debug_assert!(!ids.is_empty());
-    let mean_gap: u32 = if ids.len() == 1 {
-        ids[0].max(1)
-    } else {
-        // Strict-ascending guarantees `last >= first + (k-1)`, so the division yields >= 1.
-        let span = ids[ids.len() - 1] - ids[0];
-        let denom = (ids.len() as u32) - 1;
-        (span / denom).max(1)
-    };
-    // floor(log2(mean_gap)) for mean_gap >= 1.
+    let k = ids.len() as u32;
+    // Average gap over all k gaps (including g[0] = ids[0]).
+    // Sum of gaps = ids[k-1] - (k - 1), so mean ≈ ids[k-1] / k.
+    // Using ids[k-1] / k (not the exact `(ids[k-1] - (k-1)) / k`) is fine: the
+    // overestimate is at most 1, which can't shift `b` by more than one bit.
+    let mean_gap = (ids[ids.len() - 1] / k).max(1);
     let b = 31u8.saturating_sub(mean_gap.leading_zeros() as u8);
     b.min(31)
 }
@@ -350,6 +347,31 @@ mod tests {
         let ids = vec![0u32, 1_000, 1_000_000, 100_000_000, u32::MAX - 1];
         let encoded = EncodedNeighborhood::encode(&ids).expect("encode");
         assert_eq!(encoded.decode().expect("decode"), ids);
+    }
+
+    #[test]
+    fn round_trip_max_k() {
+        // Sample a strictly-increasing sequence at MAX_K length.
+        // Evenly spaced across u32 to exercise a typical mean_gap.
+        let k = MAX_K;
+        let step = (u32::MAX as u64 / k as u64) as u32;
+        let mut ids: Vec<u32> = (0..k).map(|i| (i as u32).saturating_mul(step)).collect();
+        // Ensure strict monotonicity (saturating multiply can collide near u32::MAX).
+        for i in 1..ids.len() {
+            if ids[i] <= ids[i - 1] {
+                ids[i] = ids[i - 1] + 1;
+            }
+        }
+        let encoded = EncodedNeighborhood::encode(&ids).expect("encode max_k");
+        assert_eq!(encoded.decode().expect("decode max_k"), ids);
+    }
+
+    #[test]
+    fn round_trip_high_universe() {
+        // IDs clustered near u32::MAX.
+        let ids: Vec<u32> = (0..450u32).map(|i| u32::MAX - 449 + i).collect();
+        let encoded = EncodedNeighborhood::encode(&ids).expect("encode high");
+        assert_eq!(encoded.decode().expect("decode high"), ids);
     }
 
     fn decoded_or_panic(e: &EncodedNeighborhood) -> Vec<u32> {

--- a/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
@@ -432,6 +432,40 @@ mod tests {
         }
     }
 
+    #[test]
+    fn random_round_trip_many_seeds() {
+        use rand::{Rng, SeedableRng};
+        use rand_chacha::ChaCha8Rng;
+
+        for seed in 0..32u64 {
+            let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            // Vary k across a useful range, including small and near-MAX_K cases.
+            let k = match seed % 4 {
+                0 => rng.gen_range(0..16),
+                1 => rng.gen_range(16..1024),
+                2 => rng.gen_range(1024..16_384),
+                _ => 65_535,
+            };
+            // Vary the universe to exercise different `b` values.
+            let universe: u32 = match seed % 3 {
+                0 => 1_000_000,
+                1 => 100_000_000,
+                _ => u32::MAX,
+            };
+
+            // Sample k unique values, sort, deduplicate.
+            let mut set = std::collections::BTreeSet::new();
+            while set.len() < k {
+                set.insert(rng.gen_range(0..universe));
+            }
+            let ids: Vec<u32> = set.into_iter().collect();
+
+            let encoded = EncodedNeighborhood::encode(&ids).expect("encode");
+            let decoded = encoded.decode().expect("decode");
+            assert_eq!(decoded, ids, "seed={seed} k={k} universe={universe}");
+        }
+    }
+
     fn decoded_or_panic(e: &EncodedNeighborhood) -> Vec<u32> {
         e.decode().expect("decode succeeded")
     }

--- a/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
@@ -329,6 +329,8 @@ fn rice_decode(reader: &mut BitReader<'_>, b: u8, gap_idx: usize) -> Result<u32,
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rand::{Rng, SeedableRng};
+    use rand_chacha::ChaCha8Rng;
 
     #[test]
     fn module_doc_example_bytes() {
@@ -471,9 +473,6 @@ mod tests {
 
     #[test]
     fn decode_garbage_does_not_panic() {
-        use rand::{Rng, SeedableRng};
-        use rand_chacha::ChaCha8Rng;
-
         let mut rng = ChaCha8Rng::seed_from_u64(0xDEAD_BEEF);
         for _ in 0..200 {
             let len = rng.gen_range(0..64);
@@ -486,9 +485,6 @@ mod tests {
 
     #[test]
     fn random_round_trip_many_seeds() {
-        use rand::{Rng, SeedableRng};
-        use rand_chacha::ChaCha8Rng;
-
         for seed in 0..32u64 {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
             // Vary k across a useful range, including small and near-MAX_K cases.
@@ -520,9 +516,6 @@ mod tests {
 
     #[test]
     fn encoded_size_matches_model() {
-        use rand::{Rng, SeedableRng};
-        use rand_chacha::ChaCha8Rng;
-
         let k: usize = 450;
         let cases: &[(u32, u8)] = &[
             (1_000_000, 11),   // log2(1M/450) ~= 11

--- a/iris-mpc-cpu/src/hnsw/graph/mod.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/mod.rs
@@ -1,3 +1,4 @@
+pub mod encoded_neighborhood;
 pub mod graph_diff;
 pub mod graph_store;
 pub mod layered_graph;


### PR DESCRIPTION
## Summary
- New module `iris_mpc_cpu::hnsw::graph::encoded_neighborhood::EncodedNeighborhood`: a compact at-rest format for sorted, strictly-increasing `Vec<u32>` neighborhood IDs.
- Wire layout is a 3-byte header (`k: u16 LE`, `b: u8`) followed by an MSB-first Rice-coded body. IDs are gap-encoded (`ids[0]` absolute, then `ids[i] - ids[i-1] - 1`) and Rice/Golomb-coded with a power-of-two divisor `2^b`.
- The Rice parameter `b` is chosen per neighborhood as `floor(log2(μ))` over the exact mean of the encoded values — about half a bit too high vs. the bit-optimal `floor(log2(μ·ln 2))`, but cheap to compute and good for any neighborhood size.
- Includes a criterion benchmark suite, round-trip / malformed neighborhood / fuzz tests, and an analytical-size sanity check.

## Wire format

```
+-------------+-----+-----------------------------+
| k (u16 LE)  | b   | Rice-coded body, MSB-first  |
+-------------+-----+-----------------------------+
 bytes 0..2    2     3..
```

Each Rice-coded value `v` is `q = v >> b` zero bits, a `1` terminator (self-delimiting), then the low `b` bits of `v`. Body is right-padded to whole bytes. Module docs include a worked example pinning the bytes of `[0, 5, 9]`.

## Benchmarks

M1 Pro, criterion default sample/warmup, single-thread.

**Encode/decode at k=450 across universes** (≈ HNSW M=64 neighborhoods at varying database sizes):

| Universe | encode  | decode  | encode thrpt | decode thrpt |
|----------|---------|---------|--------------|--------------|
| n=1M     | 6.27 µs | 8.37 µs | 71.8 Melem/s | 53.8 Melem/s |
| n=10M    | 7.36 µs | 9.82 µs | 61.2 Melem/s | 45.8 Melem/s |
| n=100M   | 8.58 µs | 11.49 µs| 52.4 Melem/s | 39.2 Melem/s |
| n=2³²    | 11.01 µs| 14.60 µs| 40.9 Melem/s | 30.8 Melem/s |

**Scaling at n=10M across k** (per-element cost amortizes once k ≳ 100):

| k     | encode  | decode  | encode thrpt | decode thrpt |
|-------|---------|---------|--------------|--------------|
| 10    | 302 ns  | 272 ns  | 33.0 Melem/s | 36.8 Melem/s |
| 100   | 1.78 µs | 2.24 µs | 56.1 Melem/s | 44.7 Melem/s |
| 450   | 7.31 µs | 10.72 µs| 61.5 Melem/s | 42.0 Melem/s |
| 2000  | 33.03 µs| 42.52 µs| 60.6 Melem/s | 47.0 Melem/s |

**Cap-slack sensitivity** (separate one-off run; not in the committed bench suite): encode timing was flat within ~0.7 % across `slack ∈ {2, 3, 4, 6, 8, 16}` for k ∈ {10, 450, 2000, 65535}. The `+ 4` slack in `BitWriter::with_capacity` is empirically safe — the body Vec doesn't reallocate. Reasoning is documented above the cap line.

**Encoded size vs. analytical model.** `encoded_size_matches_model` asserts the produced byte length is within ±10 % of the `(k·(b+2) + 24) / 8` model across `(universe, expected_b) ∈ {(1M, 11), (10M, 14), (100M, 17), (2³², 23)}` at k=450.

## Test plan
- [x] `cargo test -p iris-mpc-cpu --lib hnsw::graph::encoded_neighborhood` — 20 tests pass (round-trip across single-element / consecutive / handcrafted / widely-spaced / max-k / high-universe / random seeds; encode error paths; malformed-blob decode paths; garbage-input fuzz; size-vs-model).
- [x] `cargo bench -p iris-mpc-cpu --bench encoded_neighborhood` — runs cleanly (numbers above).

## Follow up
- Add conversion from the current `VectorId` to `u32`.
- Wire the encoder into the `GraphPg` write path and the decoder into the read path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)