### PR TITLE
scale to smaller instance

### DIFF
--- a/deploy/dev/common-values-ampc-hnsw.yaml
+++ b/deploy/dev/common-values-ampc-hnsw.yaml
@@ -55,11 +55,11 @@ startupProbe:
 
 resources:
   limits:
-    cpu: 188
-    memory: 2720Gi
+    cpu: 28
+    memory: 450Gi
   requests:
-    cpu: 188
-    memory: 2720Gi
+    cpu: 28
+    memory: 450Gi
 
 imagePullSecrets:
   - name: github-secret
@@ -70,7 +70,7 @@ podAnnotations:
 nodeSelector:
   kubernetes.io/arch: arm64
   karpenter.sh/capacity-type: on-demand
-  node.kubernetes.io/instance-type: "x8g.48xlarge"
+  node.kubernetes.io/instance-type: "x8g.8xlarge"
 
 podSecurityContext:
   runAsUser: 65534


### PR DESCRIPTION
  - instance-type: x8g.48xlarge → x8g.8xlarge
  - cpu: 188 → 28 (32 vCPU − 4 reserved)
  - memory: 2720Gi → 450Gi (~88% of 512 GiB)