### PR TITLE
[POP-3799] improve logging

### DIFF
--- a/iris-mpc-common/src/test.rs
+++ b/iris-mpc-common/src/test.rs
@@ -29,7 +29,6 @@ use std::{
     collections::{HashMap, HashSet},
     ops::Range,
 };
-use tracing::{info_span, Instrument};
 use uuid::Uuid;
 
 const THRESHOLD_ABSOLUTE: usize = IRIS_CODE_LENGTH * 345 / 1000; // 0.345 * 12800
@@ -1380,34 +1379,63 @@ impl TestCaseGenerator {
                 assert!(was_match);
             } else {
                 assert!(!was_match);
-                // idx == u32::MAX means no insertion happened (NON_MATCH_ID sentinel)
-                // This can happen for invalidated requests
-                if idx != u32::MAX {
-                    // Check if another party already processed this insertion
-                    if let std::collections::hash_map::Entry::Vacant(e) =
-                        self.inserted_responses.entry(idx)
-                    {
-                        // First party processing this insertion
-                        // Bounds check: new insertion idx must be >= initial_db_len
-                        if idx < initial_db_len {
-                            tracing::warn!("new insertion idx {} < initial_db_len {} (insertions should be after initial DB)",
-                                idx,
-                                initial_db_len
-                            );
-                        }
-                        let request = requests.get(req_id).unwrap().clone();
-                        e.insert(request);
-                    } else {
-                        // Already validated by party 0; just verify consistency
-                        let stored = self.inserted_responses.get(&idx).unwrap();
-                        let current = requests.get(req_id).unwrap();
-                        assert_eq!(
-                            stored.left.code, current.left.code,
-                            "inconsistent insertion data across parties for idx {}",
-                            idx
-                        );
-                    }
+                self.validate_and_store_insertion(idx, req_id, requests, initial_db_len);
+            }
+        }
+    }
+
+    /// Validates and stores a new insertion, or verifies consistency of an existing one.
+    /// Handles the case where multiple parties process the same insertion.
+    fn validate_and_store_insertion(
+        &mut self,
+        idx: u32,
+        req_id: &str,
+        requests: &HashMap<String, E2ETemplate>,
+        initial_db_len: u32,
+    ) {
+        // idx == u32::MAX means no insertion happened (NON_MATCH_ID sentinel)
+        // This can happen for invalidated requests
+        if idx != u32::MAX {
+            // Check if another party already processed this insertion
+            if let std::collections::hash_map::Entry::Vacant(e) = self.inserted_responses.entry(idx)
+            {
+                // First party processing this insertion
+                // Bounds check: new insertion idx must be >= initial_db_len
+                if idx < initial_db_len {
+                    tracing::warn!(
+                        idx,
+                        initial_db_len,
+                        "new insertion index is before initial database length (insertions should be after initial DB)"
+                    );
                 }
+                let request = requests.get(req_id).unwrap().clone();
+                e.insert(request);
+            } else {
+                // Already validated by another party; verify consistency
+                let stored = self.inserted_responses.get(&idx).unwrap();
+                let current = requests.get(req_id).unwrap();
+
+                // Compare full E2ETemplate: both eyes' code and mask
+                assert_eq!(
+                    stored.left.code, current.left.code,
+                    "inconsistent left code insertion data across parties for idx {}",
+                    idx
+                );
+                assert_eq!(
+                    stored.left.mask, current.left.mask,
+                    "inconsistent left mask insertion data across parties for idx {}",
+                    idx
+                );
+                assert_eq!(
+                    stored.right.code, current.right.code,
+                    "inconsistent right code insertion data across parties for idx {}",
+                    idx
+                );
+                assert_eq!(
+                    stored.right.mask, current.right.mask,
+                    "inconsistent right mask insertion data across parties for idx {}",
+                    idx
+                );
             }
         }
     }

--- a/iris-mpc-common/src/test.rs
+++ b/iris-mpc-common/src/test.rs
@@ -29,6 +29,7 @@ use std::{
     collections::{HashMap, HashSet},
     ops::Range,
 };
+use tracing::{info_span, Instrument};
 use uuid::Uuid;
 
 const THRESHOLD_ABSOLUTE: usize = IRIS_CODE_LENGTH * 345 / 1000; // 0.345 * 12800
@@ -1338,6 +1339,10 @@ impl TestCaseGenerator {
             return;
         }
 
+        // Compute bounds for idx validation
+        let initial_db_len = self.initial_db_state.initial_db_len() as u32;
+        let max_valid_idx = initial_db_len + self.inserted_responses.len() as u32;
+
         if let Some(expected_idx) = expected_idx {
             assert!(!full_face_mirror_attack_detected);
             assert!(
@@ -1349,6 +1354,15 @@ impl TestCaseGenerator {
                 assert_eq!(
                     expected_idx, idx,
                     "expected matched index to be as expected"
+                );
+                // Bounds check: matched idx must be within valid DB range
+                assert!(
+                    idx < max_valid_idx,
+                    "matched idx {} exceeds max valid idx {} (initial_db_len={}, insertions={})",
+                    idx,
+                    max_valid_idx,
+                    initial_db_len,
+                    self.inserted_responses.len()
                 );
             } else {
                 assert!(
@@ -1366,8 +1380,34 @@ impl TestCaseGenerator {
                 assert!(was_match);
             } else {
                 assert!(!was_match);
-                let request = requests.get(req_id).unwrap().clone();
-                self.inserted_responses.insert(idx, request);
+                // idx == u32::MAX means no insertion happened (NON_MATCH_ID sentinel)
+                // This can happen for invalidated requests
+                if idx != u32::MAX {
+                    // Check if another party already processed this insertion
+                    if let std::collections::hash_map::Entry::Vacant(e) =
+                        self.inserted_responses.entry(idx)
+                    {
+                        // First party processing this insertion
+                        // Bounds check: new insertion idx must be >= initial_db_len
+                        if idx < initial_db_len {
+                            tracing::warn!("new insertion idx {} < initial_db_len {} (insertions should be after initial DB)",
+                                idx,
+                                initial_db_len
+                            );
+                        }
+                        let request = requests.get(req_id).unwrap().clone();
+                        e.insert(request);
+                    } else {
+                        // Already validated by party 0; just verify consistency
+                        let stored = self.inserted_responses.get(&idx).unwrap();
+                        let current = requests.get(req_id).unwrap();
+                        assert_eq!(
+                            stored.left.code, current.left.code,
+                            "inconsistent insertion data across parties for idx {}",
+                            idx
+                        );
+                    }
+                }
             }
         }
     }

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -147,6 +147,7 @@ use tokio::{
     sync::{mpsc, oneshot, RwLock, RwLockWriteGuard},
 };
 use tokio_util::sync::CancellationToken;
+use tracing::{Instrument, Span};
 
 /// Distance type used by the HawkActor. Change to `NhdOps` for Normalized Hamming Distance.
 pub type HawkOps = FhdOps;
@@ -1807,12 +1808,14 @@ impl JobSubmissionHandle for HawkHandle {
         // Wait for the job to be sent for backpressure.
         let sent = self.job_queue.send(job).await;
 
+        let span = Span::current();
         async move {
             // In a second Future, wait for the result.
             sent?;
             let result = rx.await??;
             Ok(result.job_result())
         }
+        .instrument(span)
     }
 }
 
@@ -1825,6 +1828,9 @@ impl HawkHandle {
         // fresh inserts allocate VectorIds that collide with the load.
         // Verify before any session work begins, and again at the start of
         // every batch (see `handle_job`).
+        let parent_span = Span::current();
+        let parent_span2 = parent_span.clone();
+
         hawk_actor.assert_registry_consistency().await;
 
         let mut sessions = hawk_actor.new_session_groups().await?;
@@ -1841,11 +1847,12 @@ impl HawkHandle {
         tokio::spawn(async move {
             let mut batch_count: u32 = 0;
             while let Some(job) = rx.recv().await {
+                let parent_span3 = parent_span2.clone();
                 batch_count += 1;
                 // check if there was a networking error
                 let error_ct = hawk_actor.error_ct.clone();
                 let job_result = tokio::select! {
-                    r = Self::handle_job(&mut hawk_actor, &mut sessions, job.request, batch_count) => r,
+                    r = Self::handle_job(&mut hawk_actor, &mut sessions, job.request, batch_count).instrument(parent_span3)=> r,
                     _ = error_ct.cancelled() => Err(eyre!("networking error")),
                 };
 
@@ -1865,7 +1872,7 @@ impl HawkHandle {
             while let Some(job) = rx.recv().await {
                 let _ = job.return_channel.send(Err(eyre::eyre!("stopping")));
             }
-        });
+        }.instrument(parent_span));
 
         Ok(Self { job_queue: tx })
     }
@@ -1914,8 +1921,11 @@ impl HawkHandle {
                 // The "b" (raw) operand always uses Normal queries to get the
                 // same-eye iris, even when comparing in Mirror orientation.
                 let raw_queries = request.queries(Orientation::Normal);
+                let span = Span::current();
                 tokio::spawn(async move {
-                    intra_batch_is_match(&sessions_intra, &search_queries, &raw_queries).await
+                    intra_batch_is_match(&sessions_intra, &search_queries, &raw_queries)
+                        .instrument(span)
+                        .await
                 })
             };
 
@@ -1959,11 +1969,12 @@ impl HawkHandle {
         };
 
         // Search for both orientations
+        let span = Span::current();
         let (search_normal, search_mirror, match_result) = {
             let start = Instant::now();
             let ((search_normal, matches_normal), (search_mirror, matches_mirror)) = try_join!(
-                do_search(Orientation::Normal),
-                do_search(Orientation::Mirror),
+                do_search(Orientation::Normal).instrument(span.clone()),
+                do_search(Orientation::Mirror).instrument(span.clone()),
             )?;
             metrics::histogram!("all_search_duration").record(start.elapsed().as_secs_f64());
 
@@ -2009,6 +2020,7 @@ impl HawkHandle {
             identity_updates,
             &request,
         )
+        .instrument(span)
         .await?;
 
         // Evict cached queries now that the batch is fully processed.
@@ -2229,6 +2241,7 @@ mod tests {
     use rand::SeedableRng;
     use std::{ops::Not, time::Duration};
     use tokio::time::sleep;
+    use tracing::{info_span, Instrument};
     use tracing_test::traced_test;
 
     /// Regression guard for the load → registry wiring in `iris-mpc/src/server/mod.rs::load_database`.
@@ -2373,8 +2386,11 @@ mod tests {
         let addresses = get_free_local_addresses(N_PARTIES).await?;
 
         let handles = (0..N_PARTIES)
-            .map(|i| go(addresses.clone(), i))
-            .map(tokio::spawn)
+            .map(|i| {
+                let span = info_span!("mpc_node", idx = i);
+                let future = go(addresses.clone(), i);
+                tokio::spawn(async move { future.instrument(span).await })
+            })
             .collect::<JoinAll<_>>()
             .await
             .into_iter()
@@ -2427,12 +2443,20 @@ mod tests {
             );
         }
 
-        let all_results =
-            parallelize(izip!(&irises, handles.clone()).map(|(shares, mut handle)| {
+        let all_results = parallelize(izip!(0..handles.len(), &irises, handles.clone()).map(
+            |(idx, shares, mut handle)| {
+                let span = info_span!("mpc_node", idx = idx);
                 let batch = batch_of_party(&batch_0, shares);
-                async move { handle.submit_batch_query(batch).await.await }
-            }))
-            .await?;
+                async move {
+                    handle
+                        .submit_batch_query(batch)
+                        .instrument(span)
+                        .await
+                        .await
+                }
+            },
+        ))
+        .await?;
 
         let result = assert_all_equal(all_results);
 

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -1828,8 +1828,8 @@ impl HawkHandle {
         // fresh inserts allocate VectorIds that collide with the load.
         // Verify before any session work begins, and again at the start of
         // every batch (see `handle_job`).
-        let parent_span = Span::current();
-        let parent_span2 = parent_span.clone();
+        let request_handler_span = Span::current();
+        let job_handler_span = request_handler_span.clone();
 
         hawk_actor.assert_registry_consistency().await;
 
@@ -1847,12 +1847,12 @@ impl HawkHandle {
         tokio::spawn(async move {
             let mut batch_count: u32 = 0;
             while let Some(job) = rx.recv().await {
-                let parent_span3 = parent_span2.clone();
                 batch_count += 1;
                 // check if there was a networking error
                 let error_ct = hawk_actor.error_ct.clone();
+                let span = job_handler_span.clone();
                 let job_result = tokio::select! {
-                    r = Self::handle_job(&mut hawk_actor, &mut sessions, job.request, batch_count).instrument(parent_span3)=> r,
+                    r = Self::handle_job(&mut hawk_actor, &mut sessions, job.request, batch_count).instrument(span)=> r,
                     _ = error_ct.cancelled() => Err(eyre!("networking error")),
                 };
 
@@ -1872,7 +1872,7 @@ impl HawkHandle {
             while let Some(job) = rx.recv().await {
                 let _ = job.return_channel.send(Err(eyre::eyre!("stopping")));
             }
-        }.instrument(parent_span));
+        }.instrument(request_handler_span));
 
         Ok(Self { job_queue: tx })
     }
@@ -1921,11 +1921,8 @@ impl HawkHandle {
                 // The "b" (raw) operand always uses Normal queries to get the
                 // same-eye iris, even when comparing in Mirror orientation.
                 let raw_queries = request.queries(Orientation::Normal);
-                let span = Span::current();
-                tokio::spawn(async move {
-                    intra_batch_is_match(&sessions_intra, &search_queries, &raw_queries)
-                        .instrument(span)
-                        .await
+                scheduler::spawn_with_span(async move {
+                    Ok(intra_batch_is_match(&sessions_intra, &search_queries, &raw_queries).await)
                 })
             };
 
@@ -1962,7 +1959,7 @@ impl HawkHandle {
                     is_match_batch(search_queries, step1.missing_vector_ids(), sessions_search)
                         .await?;
 
-                step1.step2(&missing_is_match, intra_results.await??)
+                step1.step2(&missing_is_match, intra_results.await???)
             };
 
             Ok((search_results, match_result))
@@ -2389,7 +2386,7 @@ mod tests {
             .map(|i| {
                 let span = info_span!("mpc_node", idx = i);
                 let future = go(addresses.clone(), i);
-                tokio::spawn(async move { future.instrument(span).await })
+                tokio::spawn(future.instrument(span))
             })
             .collect::<JoinAll<_>>()
             .await

--- a/iris-mpc-cpu/src/execution/hawk_main/is_match_batch.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/is_match_batch.rs
@@ -10,7 +10,7 @@ use futures::future::JoinAll;
 use itertools::{izip, Itertools};
 use std::{collections::HashMap, sync::Arc, time::Instant};
 use tokio::task::JoinError;
-use tracing::instrument;
+use tracing::{instrument, Instrument, Span};
 
 #[instrument(level = "trace", target = "searcher::network", skip_all)]
 pub async fn is_match_batch(
@@ -68,9 +68,12 @@ async fn per_side(
     assert!(chunks.len() <= n_sessions);
 
     // Process the chunks in parallel (CPU and IO).
+    let parent_span = Span::current();
     let results = izip!(chunks, sessions)
-        .map(|(chunk, session)| per_session(chunk, session.clone()))
-        .map(tokio::spawn)
+        .map(|(chunk, session)| {
+            let span = parent_span.clone();
+            tokio::spawn(per_session(chunk, session.clone()).instrument(span))
+        })
         .collect::<JoinAll<_>>()
         .await;
 

--- a/iris-mpc-cpu/src/execution/hawk_main/is_match_batch.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/is_match_batch.rs
@@ -1,7 +1,7 @@
 use super::HawkOps;
 use super::{BothEyes, HawkSession, MapEdges, VecEdges, VecRequests, VectorId, LEFT, RIGHT};
 use crate::{
-    execution::hawk_main::VecRotations,
+    execution::hawk_main::{scheduler, VecRotations},
     hawkers::aby3::aby3_store::{Aby3Query, Aby3Store},
     hnsw::VectorStore,
 };
@@ -10,7 +10,7 @@ use futures::future::JoinAll;
 use itertools::{izip, Itertools};
 use std::{collections::HashMap, sync::Arc, time::Instant};
 use tokio::task::JoinError;
-use tracing::{instrument, Instrument, Span};
+use tracing::instrument;
 
 #[instrument(level = "trace", target = "searcher::network", skip_all)]
 pub async fn is_match_batch(
@@ -68,11 +68,9 @@ async fn per_side(
     assert!(chunks.len() <= n_sessions);
 
     // Process the chunks in parallel (CPU and IO).
-    let parent_span = Span::current();
     let results = izip!(chunks, sessions)
         .map(|(chunk, session)| {
-            let span = parent_span.clone();
-            tokio::spawn(per_session(chunk, session.clone()).instrument(span))
+            scheduler::spawn_task_with_span(per_session(chunk, session.clone()))
         })
         .collect::<JoinAll<_>>()
         .await;

--- a/iris-mpc-cpu/src/execution/hawk_main/scheduler.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/scheduler.rs
@@ -157,8 +157,12 @@ where
     F: Future<Output = Result<T>> + Send + 'static,
     F::Output: Send + 'static,
 {
+    let parent_span = Span::current();
     tasks
-        .map(tokio::spawn)
+        .map(|task| {
+            let span = parent_span.clone();
+            tokio::spawn(async move { task.instrument(span).await })
+        })
         .collect::<JoinAll<_>>()
         .await
         .into_iter()

--- a/iris-mpc-cpu/src/execution/hawk_main/scheduler.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/scheduler.rs
@@ -3,9 +3,33 @@ use eyre::{eyre, Result};
 use futures::future::JoinAll;
 use itertools::Itertools;
 use std::{collections::HashMap, future::Future};
-use tokio::{sync::mpsc::UnboundedReceiver, task::JoinError};
+use tokio::{sync::mpsc::UnboundedReceiver, task::JoinError, task::JoinHandle};
+use tracing::{Instrument, Span};
 
 const N_EYES: usize = 2;
+
+/// Helper to spawn a task with the current tracing span preserved.
+/// This ensures that child tasks inherit and maintain the parent span context.
+/// The future should return a Result type.
+pub fn spawn_with_span<F, T>(task: F) -> JoinHandle<Result<T>>
+where
+    F: Future<Output = Result<T>> + Send + 'static,
+    T: Send + 'static,
+{
+    let span = Span::current();
+    tokio::spawn(async move { task.instrument(span).await })
+}
+
+/// Helper to spawn a task with the current tracing span preserved, without Result wrapping.
+/// Useful for tasks that already return Result or other types directly.
+pub fn spawn_task_with_span<F>(task: F) -> JoinHandle<F::Output>
+where
+    F: Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    let span = Span::current();
+    tokio::spawn(task.instrument(span))
+}
 
 /// A schedule is a collections of batches to process in parallel.
 pub struct Schedule {
@@ -155,14 +179,10 @@ impl Schedule {
 pub async fn parallelize<F, T>(tasks: impl Iterator<Item = F>) -> Result<Vec<T>>
 where
     F: Future<Output = Result<T>> + Send + 'static,
-    F::Output: Send + 'static,
+    T: Send + 'static,
 {
-    let parent_span = Span::current();
     tasks
-        .map(|task| {
-            let span = parent_span.clone();
-            tokio::spawn(async move { task.instrument(span).await })
-        })
+        .map(spawn_with_span)
         .collect::<JoinAll<_>>()
         .await
         .into_iter()

--- a/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
@@ -1559,6 +1559,7 @@ mod tests {
                     &query,
                     layer,
                 )
+                .instrument(plaintext_span.clone())
                 .await?;
         }
 
@@ -1595,109 +1596,7 @@ mod tests {
 
         for (role, mpc_graph) in mpc_graphs.into_iter().enumerate() {
             let mpc_graph = mpc_graph.unwrap_or_else(|| panic!("party {role} did not finish"));
-
-            // Manual graph comparison
-            let num_layers_mpc = mpc_graph.layers.len();
-            let num_layers_pt = plaintext_graph.layers.len();
-            println!(
-                "[Role {}] Layers count - MPC: {}, Plaintext: {}",
-                role, num_layers_mpc, num_layers_pt
-            );
-            if num_layers_mpc != num_layers_pt {
-                panic!(
-                    "[Role {}] Layer count mismatch: {} vs {}",
-                    role, num_layers_mpc, num_layers_pt
-                );
-            }
-
-            // Compare each layer
-            for (layer_idx, (mpc_layer, pt_layer)) in mpc_graph
-                .layers
-                .iter()
-                .zip(plaintext_graph.layers.iter())
-                .enumerate()
-            {
-                // Check if layers contain the same elements
-                let mpc_keys: std::collections::BTreeSet<_> = mpc_layer.links.keys().collect();
-                let pt_keys: std::collections::BTreeSet<_> = pt_layer.links.keys().collect();
-
-                if mpc_keys != pt_keys {
-                    println!(
-                        "[Role {} Layer {}] Element mismatch detected",
-                        role, layer_idx
-                    );
-                    panic!("[Role {} Layer {}] Layer elements differ: MPC has {} elements, plaintext has {} elements",
-                           role, layer_idx, mpc_keys.len(), pt_keys.len());
-                }
-                println!(
-                    "[Role {} Layer {}] Elements match - {} nodes",
-                    role,
-                    layer_idx,
-                    mpc_keys.len()
-                );
-
-                // Compare ordering by checking neighbors for each node
-                for node_id in mpc_keys.iter() {
-                    let mpc_neighbors = mpc_layer
-                        .links
-                        .get(node_id)
-                        .map(|v| v.as_slice())
-                        .unwrap_or(&[]);
-                    let pt_neighbors = pt_layer
-                        .links
-                        .get(node_id)
-                        .map(|v| v.as_slice())
-                        .unwrap_or(&[]);
-
-                    if mpc_neighbors != pt_neighbors {
-                        println!(
-                            "[Role {} Layer {}] Ordering mismatch for node {}",
-                            role, layer_idx, node_id
-                        );
-                        println!(
-                            "[Role {} Layer {}] Node {} MPC neighbors: {:?}",
-                            role, layer_idx, node_id, mpc_neighbors
-                        );
-                        println!(
-                            "[Role {} Layer {}] Node {} Plaintext neighbors: {:?}",
-                            role, layer_idx, node_id, pt_neighbors
-                        );
-                        panic!("[Role {} Layer {}] Neighbor list differs for node {}: MPC has {} neighbors, plaintext has {} neighbors",
-                               role, layer_idx, node_id, mpc_neighbors.len(), pt_neighbors.len());
-                    }
-                }
-                println!(
-                    "[Role {} Layer {}] Ordering matches for all nodes",
-                    role, layer_idx
-                );
-
-                // Compare order-agnostic SetHash checksums. Note: we cannot
-                // use `format!("{:?}", layer)` here, because that prints the
-                // underlying `HashMap` in non-deterministic iteration order
-                // and would produce false-positive mismatches even when the
-                // two layers are bit-for-bit equivalent.
-                let mpc_hash = mpc_layer.checksum();
-                let pt_hash = pt_layer.checksum();
-                if mpc_hash != pt_hash {
-                    println!(
-                        "[Role {} Layer {}] Hash mismatch detected (MPC: {:#x}, Plaintext: {:#x})",
-                        role, layer_idx, mpc_hash, pt_hash
-                    );
-                    panic!("[Role {} Layer {}] Layer hashes differ", role, layer_idx);
-                }
-                println!(
-                    "[Role {} Layer {}] Hashes match ({:#x})",
-                    role, layer_idx, mpc_hash
-                );
-            }
-
-            // Compare entry points
-            if mpc_graph.entry_points != plaintext_graph.entry_points {
-                println!("[Role {}] Entry points mismatch", role);
-                panic!("[Role {}] Entry points differ", role);
-            }
-            println!("[Role {}] Entry points match", role);
-            println!("[Role {}] All graph comparisons passed", role);
+            verify_graph_consistency(role, &mpc_graph, &plaintext_graph)?;
         }
 
         // If either assert fails the parameters no longer exercise the
@@ -1705,6 +1604,114 @@ mod tests {
         assert_eq!(plaintext_graph.get_num_layers(), 2);
         assert!(plaintext_graph.entry_points.len() >= 2);
 
+        Ok(())
+    }
+
+    /// Verifies that an MPC graph matches the plaintext reference graph.
+    /// Logs detailed comparison information and panics on mismatches.
+    fn verify_graph_consistency(
+        role: usize,
+        mpc_graph: &GraphMem<VectorId>,
+        plaintext_graph: &GraphMem<VectorId>,
+    ) -> eyre::Result<()> {
+        use std::collections::BTreeSet;
+
+        // Check layer count
+        let num_layers_mpc = mpc_graph.layers.len();
+        let num_layers_pt = plaintext_graph.layers.len();
+        tracing::debug!(
+            role,
+            num_layers_mpc,
+            num_layers_pt,
+            "Comparing layer counts"
+        );
+
+        if num_layers_mpc != num_layers_pt {
+            panic!(
+                "[Role {}] Layer count mismatch: MPC={} vs plaintext={}",
+                role, num_layers_mpc, num_layers_pt
+            );
+        }
+
+        // Compare each layer
+        for (layer_idx, (mpc_layer, pt_layer)) in mpc_graph
+            .layers
+            .iter()
+            .zip(plaintext_graph.layers.iter())
+            .enumerate()
+        {
+            // Check if layers contain the same elements
+            let mpc_keys: BTreeSet<_> = mpc_layer.links.keys().collect();
+            let pt_keys: BTreeSet<_> = pt_layer.links.keys().collect();
+
+            if mpc_keys != pt_keys {
+                tracing::error!(
+                    role,
+                    layer_idx,
+                    mpc_count = mpc_keys.len(),
+                    pt_count = pt_keys.len(),
+                    "Layer elements differ"
+                );
+                panic!(
+                    "[Role {}] Layer {} elements mismatch: MPC={} nodes, plaintext={} nodes",
+                    role,
+                    layer_idx,
+                    mpc_keys.len(),
+                    pt_keys.len()
+                );
+            }
+            tracing::debug!(
+                role,
+                layer_idx,
+                node_count = mpc_keys.len(),
+                "Layer elements verified"
+            );
+
+            // Compare ordering by checking neighbors for each node
+            for node_id in mpc_keys.iter() {
+                let mpc_neighbors = mpc_layer
+                    .links
+                    .get(node_id)
+                    .map(|v| v.as_slice())
+                    .unwrap_or(&[]);
+                let pt_neighbors = pt_layer
+                    .links
+                    .get(node_id)
+                    .map(|v| v.as_slice())
+                    .unwrap_or(&[]);
+
+                if mpc_neighbors != pt_neighbors {
+                    tracing::error!(
+                        role,
+                        layer_idx,
+                        node_id = %node_id,
+                        mpc_neighbor_count = mpc_neighbors.len(),
+                        pt_neighbor_count = pt_neighbors.len(),
+                        "Node neighbor list differs"
+                    );
+                    panic!(
+                    "[Role {}] Layer {} node {} neighbor mismatch: MPC={} neighbors, plaintext={} neighbors",
+                    role,
+                    layer_idx,
+                    node_id,
+                    mpc_neighbors.len(),
+                    pt_neighbors.len()
+                );
+                }
+            }
+            tracing::debug!(
+                role,
+                layer_idx,
+                "Layer node orderings verified for all nodes"
+            );
+        }
+
+        // Compare entry points
+        if mpc_graph.entry_points != plaintext_graph.entry_points {
+            tracing::error!(role, "Entry points mismatch");
+            panic!("[Role {}] Entry points differ", role);
+        }
+        tracing::info!(role, "Graph consistency verified");
         Ok(())
     }
 }

--- a/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
@@ -784,6 +784,7 @@ mod tests {
     use itertools::{izip, Itertools};
     use rand::SeedableRng;
     use tokio::task::JoinSet;
+    use tracing::{info_span, Instrument};
     use tracing_test::traced_test;
 
     #[tokio::test(flavor = "multi_thread")]
@@ -1548,6 +1549,7 @@ mod tests {
 
         let mut plaintext_store = PlaintextStore::<FhdOps>::new();
         let mut plaintext_graph: GraphMem<VectorId> = GraphMem::new();
+        let plaintext_span = info_span!("plaintext_insert");
         for (iris, &layer) in cleartext_db.iter().zip(insertion_layers.iter()) {
             let query = Arc::new(iris.clone());
             searcher
@@ -1562,7 +1564,7 @@ mod tests {
 
         let stores = setup_local_store_aby3_players(NetworkType::Local).await?;
         let mut jobs = JoinSet::new();
-        for store in stores.into_iter() {
+        for (idx, store) in stores.into_iter().enumerate() {
             let role = get_owner_index(&store).await?;
             let irises: Vec<ArcIris> = shared_irises
                 .iter()
@@ -1571,12 +1573,14 @@ mod tests {
             let layers = insertion_layers.clone();
             let searcher = searcher.clone();
             jobs.spawn(async move {
+                let mpc_span = info_span!("mpc_insert", id = idx);
                 let mut store = store.lock().await;
                 let queries = cache_irises(&store.workers, irises).await?;
                 let mut graph: GraphMem<VectorId> = GraphMem::new();
                 for (query, &layer) in queries.iter().zip(layers.iter()) {
                     searcher
                         .insert::<_, SortedNeighborhood<_>>(&mut *store, &mut graph, query, layer)
+                        .instrument(mpc_span.clone())
                         .await?;
                 }
                 Ok::<(usize, GraphMem<VectorId>), eyre::Report>((role, graph))
@@ -1591,10 +1595,109 @@ mod tests {
 
         for (role, mpc_graph) in mpc_graphs.into_iter().enumerate() {
             let mpc_graph = mpc_graph.unwrap_or_else(|| panic!("party {role} did not finish"));
-            assert_eq!(
-                mpc_graph, plaintext_graph,
-                "MPC graph for party {role} differs from plaintext graph",
+
+            // Manual graph comparison
+            let num_layers_mpc = mpc_graph.layers.len();
+            let num_layers_pt = plaintext_graph.layers.len();
+            println!(
+                "[Role {}] Layers count - MPC: {}, Plaintext: {}",
+                role, num_layers_mpc, num_layers_pt
             );
+            if num_layers_mpc != num_layers_pt {
+                panic!(
+                    "[Role {}] Layer count mismatch: {} vs {}",
+                    role, num_layers_mpc, num_layers_pt
+                );
+            }
+
+            // Compare each layer
+            for (layer_idx, (mpc_layer, pt_layer)) in mpc_graph
+                .layers
+                .iter()
+                .zip(plaintext_graph.layers.iter())
+                .enumerate()
+            {
+                // Check if layers contain the same elements
+                let mpc_keys: std::collections::BTreeSet<_> = mpc_layer.links.keys().collect();
+                let pt_keys: std::collections::BTreeSet<_> = pt_layer.links.keys().collect();
+
+                if mpc_keys != pt_keys {
+                    println!(
+                        "[Role {} Layer {}] Element mismatch detected",
+                        role, layer_idx
+                    );
+                    panic!("[Role {} Layer {}] Layer elements differ: MPC has {} elements, plaintext has {} elements",
+                           role, layer_idx, mpc_keys.len(), pt_keys.len());
+                }
+                println!(
+                    "[Role {} Layer {}] Elements match - {} nodes",
+                    role,
+                    layer_idx,
+                    mpc_keys.len()
+                );
+
+                // Compare ordering by checking neighbors for each node
+                for node_id in mpc_keys.iter() {
+                    let mpc_neighbors = mpc_layer
+                        .links
+                        .get(node_id)
+                        .map(|v| v.as_slice())
+                        .unwrap_or(&[]);
+                    let pt_neighbors = pt_layer
+                        .links
+                        .get(node_id)
+                        .map(|v| v.as_slice())
+                        .unwrap_or(&[]);
+
+                    if mpc_neighbors != pt_neighbors {
+                        println!(
+                            "[Role {} Layer {}] Ordering mismatch for node {}",
+                            role, layer_idx, node_id
+                        );
+                        println!(
+                            "[Role {} Layer {}] Node {} MPC neighbors: {:?}",
+                            role, layer_idx, node_id, mpc_neighbors
+                        );
+                        println!(
+                            "[Role {} Layer {}] Node {} Plaintext neighbors: {:?}",
+                            role, layer_idx, node_id, pt_neighbors
+                        );
+                        panic!("[Role {} Layer {}] Neighbor list differs for node {}: MPC has {} neighbors, plaintext has {} neighbors",
+                               role, layer_idx, node_id, mpc_neighbors.len(), pt_neighbors.len());
+                    }
+                }
+                println!(
+                    "[Role {} Layer {}] Ordering matches for all nodes",
+                    role, layer_idx
+                );
+
+                // Compare order-agnostic SetHash checksums. Note: we cannot
+                // use `format!("{:?}", layer)` here, because that prints the
+                // underlying `HashMap` in non-deterministic iteration order
+                // and would produce false-positive mismatches even when the
+                // two layers are bit-for-bit equivalent.
+                let mpc_hash = mpc_layer.checksum();
+                let pt_hash = pt_layer.checksum();
+                if mpc_hash != pt_hash {
+                    println!(
+                        "[Role {} Layer {}] Hash mismatch detected (MPC: {:#x}, Plaintext: {:#x})",
+                        role, layer_idx, mpc_hash, pt_hash
+                    );
+                    panic!("[Role {} Layer {}] Layer hashes differ", role, layer_idx);
+                }
+                println!(
+                    "[Role {} Layer {}] Hashes match ({:#x})",
+                    role, layer_idx, mpc_hash
+                );
+            }
+
+            // Compare entry points
+            if mpc_graph.entry_points != plaintext_graph.entry_points {
+                println!("[Role {}] Entry points mismatch", role);
+                panic!("[Role {}] Entry points differ", role);
+            }
+            println!("[Role {}] Entry points match", role);
+            println!("[Role {}] All graph comparisons passed", role);
         }
 
         // If either assert fails the parameters no longer exercise the

--- a/iris-mpc-cpu/tests/e2e.rs
+++ b/iris-mpc-cpu/tests/e2e.rs
@@ -21,6 +21,7 @@ use iris_mpc_cpu::{
 use rand::{rngs::StdRng, SeedableRng};
 use std::{collections::HashMap, future::Future, sync::Arc, time::Duration};
 use tokio_util::sync::CancellationToken;
+use tracing::{info_span, Instrument};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use uuid::Uuid;
 
@@ -50,7 +51,7 @@ fn install_tracing() {
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
         )
-        .with(tracing_subscriber::fmt::layer())
+        .with(tracing_subscriber::fmt::layer().with_ansi(false))
         .try_init();
 }
 
@@ -86,6 +87,21 @@ async fn create_graph_from_plain_dbs(
     let right_graph = right_store
         .generate_graph(&mut rng, DB_SIZE, searcher)
         .await?;
+
+    let left_graph_max_id = left_graph
+        .layers
+        .iter()
+        .filter_map(|x| x.links.keys().max())
+        .max()
+        .map(|x| x.serial_id() as usize);
+    let right_graph_max_id = right_graph
+        .layers
+        .iter()
+        .filter_map(|x| x.links.keys().max())
+        .max()
+        .map(|x| x.serial_id() as usize);
+    assert_eq!(Some(DB_SIZE), left_graph_max_id);
+    assert_eq!(Some(DB_SIZE), right_graph_max_id);
 
     let left_mpc_graph: GraphMem<Aby3VectorRef> = left_graph;
     let right_mpc_graph: GraphMem<Aby3VectorRef> = right_graph;
@@ -125,6 +141,14 @@ async fn create_graph_from_plain_dbs(
         right_shared_irises.insert(vector_id, Arc::new(shares[player_index].clone()));
     }
 
+    tracing::info!(
+        "Creating iris stores: left_shared_irises.len()={}, right_shared_irises.len()={}, \
+         left max_serial_id={:?}, right max_serial_id={:?}",
+        left_shared_irises.len(),
+        right_shared_irises.len(),
+        left_shared_irises.keys().map(|v| v.serial_id()).max(),
+        right_shared_irises.keys().map(|v| v.serial_id()).max(),
+    );
     let left_iris_store = Aby3Store::<FhdOps>::new_storage(Some(left_shared_irises));
     let right_iris_store = Aby3Store::<FhdOps>::new_storage(Some(right_shared_irises));
 
@@ -139,6 +163,7 @@ async fn start_hawk_node(
     left_db: &IrisDB,
     right_db: &IrisDB,
 ) -> Result<HawkHandle> {
+    let span = info_span!("mpc_node", idx = args.party_index);
     tracing::info!("🦅 Starting Hawk node {}", args.party_index);
 
     // Bootstrap graph must match the actor's runtime searcher
@@ -152,12 +177,33 @@ async fn start_hawk_node(
     searcher.layer_distribution = LayerDistribution::new_geometric_from_M(HNSW_LAYER_DENSITY);
 
     let (graph, iris_store) =
-        create_graph_from_plain_dbs(args.party_index, left_db, right_db, &searcher).await?;
-    let hawk_actor =
-        HawkActor::from_cli_with_graph_and_store(args, CancellationToken::new(), graph, iris_store)
+        create_graph_from_plain_dbs(args.party_index, left_db, right_db, &searcher)
+            .instrument(span.clone())
             .await?;
 
-    let handle = HawkHandle::new(hawk_actor).await?;
+    // Verify iris_store has correct size before creating HawkActor
+    assert_eq!(
+        iris_store[0].db_size(),
+        DB_SIZE,
+        "Left iris_store size mismatch: expected {}, got {}",
+        DB_SIZE,
+        iris_store[0].db_size()
+    );
+    assert_eq!(
+        iris_store[1].db_size(),
+        DB_SIZE,
+        "Right iris_store size mismatch: expected {}, got {}",
+        DB_SIZE,
+        iris_store[1].db_size()
+    );
+
+    let mut hawk_actor =
+        HawkActor::from_cli_with_graph_and_store(args, CancellationToken::new(), graph, iris_store)
+            .instrument(span.clone())
+            .await?;
+
+    hawk_actor.refresh_registries().await;
+    let handle = HawkHandle::new(hawk_actor).instrument(span).await?;
 
     Ok(handle)
 }
@@ -235,6 +281,9 @@ async fn e2e_test_async() -> Result<()> {
     let test_db = generate_full_test_db(DB_SIZE, DB_RNG_SEED, false);
     let db_left = test_db.plain_dbs(0);
     let db_right = test_db.plain_dbs(1);
+
+    assert_eq!(DB_SIZE, db_left.len());
+    assert_eq!(DB_SIZE, db_right.len());
 
     let addresses = ["127.0.0.1:16000", "127.0.0.1:16100", "127.0.0.1:16200"]
         .into_iter()
@@ -519,9 +568,21 @@ async fn submit_variants_batch(
 
     let [b0, b1, b2] = batches;
     let (f0, f1, f2) = tokio::join!(
-        h0.submit_batch_query(b0),
-        h1.submit_batch_query(b1),
-        h2.submit_batch_query(b2),
+        {
+            let idx = 0;
+            let span = info_span!("mpc_node", idx = idx);
+            h0.submit_batch_query(b0).instrument(span)
+        },
+        {
+            let idx = 1;
+            let span = info_span!("mpc_node", idx = idx);
+            h1.submit_batch_query(b1).instrument(span)
+        },
+        {
+            let idx = 2;
+            let span = info_span!("mpc_node", idx = idx);
+            h2.submit_batch_query(b2).instrument(span)
+        }
     );
     let res0 = f0.await?;
     let res1 = f1.await?;


### PR DESCRIPTION
Within iris-mpc-cpu, propagate spans across spawned tasks. For unit tests which spawn multiple MPC parties, attach spans to identify which logs are emitted by which party. 