### PR TITLE
[POP-3753] add explicit synchronization to genesis

### DIFF
--- a/iris-mpc-cpu/src/execution/hawk_main/state_check.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/state_check.rs
@@ -188,7 +188,7 @@ impl IrisDiffSearch {
 
 impl HawkSession {
     /// Returns true if there is a mismatch in shutdown states between nodes.
-    pub async fn sync_peers(
+    pub async fn sync_state(
         shutdown_flag: bool,
         sync_status: Arc<AtomicU8>,
         sessions: &BothEyes<Vec<HawkSession>>,

--- a/iris-mpc-cpu/src/genesis/hawk_handle.rs
+++ b/iris-mpc-cpu/src/genesis/hawk_handle.rs
@@ -72,7 +72,14 @@ impl Handle {
             }) = rx.recv().await
             {
                 let job_result = Self::handle_job(&mut actor, &sessions, request).await;
-                let health = do_health_check(&mut actor, &mut sessions, job_result.is_err()).await;
+                let health = if matches!(
+                    job_result,
+                    Ok((_, JobResult::SyncPeers)) | Ok((_, JobResult::SyncState { .. }))
+                ) {
+                    Ok(())
+                } else {
+                    do_health_check(&mut actor, &mut sessions, job_result.is_err()).await
+                };
                 let stop = health.is_err();
                 let _ = return_channel.send(health.and(job_result));
                 if stop {
@@ -353,18 +360,25 @@ impl Handle {
                     JobResult::new_modification_result(modification.id, left_vector, done_tx),
                 ))
             }
-            JobRequest::Sync {
+            JobRequest::SyncState {
                 shutdown,
                 sync_status,
             } => {
                 let _ = done_tx;
                 let mismatched = tokio::time::timeout(
                     SYNC_PEERS_TIMEOUT,
-                    HawkSession::sync_peers(shutdown, sync_status, sessions),
+                    HawkSession::sync_state(shutdown, sync_status, sessions),
                 )
                 .await
-                .map_err(|_| eyre!("sync_peers timed out after {SYNC_PEERS_TIMEOUT:?}"))??;
-                Ok((done_rx, JobResult::Sync { mismatched }))
+                .map_err(|_| eyre!("sync_state timed out after {SYNC_PEERS_TIMEOUT:?}"))??;
+                Ok((done_rx, JobResult::SyncState { mismatched }))
+            }
+            JobRequest::SyncPeers => {
+                let _ = done_tx;
+                tokio::time::timeout(SYNC_PEERS_TIMEOUT, actor.sync_peers())
+                    .await
+                    .map_err(|_| eyre!("sync_peers timeout after {SYNC_PEERS_TIMEOUT:?}"))??;
+                Ok((done_rx, JobResult::SyncPeers))
             }
         }
     }
@@ -414,7 +428,7 @@ impl Handle {
     ///
     /// Used to periodically synchronize db persistence threads of MPC nodes in
     /// genesis protocol.
-    pub async fn sync_peers(
+    pub async fn sync_state(
         &mut self,
         shutdown: bool,
         sync_done: Option<oneshot::Receiver<()>>,
@@ -433,14 +447,23 @@ impl Handle {
         }
 
         let r = self
-            .submit_request(JobRequest::Sync {
+            .submit_request(JobRequest::SyncState {
                 shutdown,
                 sync_status: status,
             })
             .await;
         let (_, r) = r.await?;
         match r {
-            JobResult::Sync { mismatched } => Ok(mismatched),
+            JobResult::SyncState { mismatched } => Ok(mismatched),
+            _ => bail!("invalid job result"),
+        }
+    }
+
+    pub async fn sync_peers(&mut self) -> Result<()> {
+        let r = self.submit_request(JobRequest::SyncPeers).await;
+        let (_, r) = r.await?;
+        match r {
+            JobResult::SyncPeers => Ok(()),
             _ => bail!("invalid job result"),
         }
     }

--- a/iris-mpc-cpu/src/genesis/hawk_handle.rs
+++ b/iris-mpc-cpu/src/genesis/hawk_handle.rs
@@ -72,6 +72,8 @@ impl Handle {
             }) = rx.recv().await
             {
                 let job_result = Self::handle_job(&mut actor, &sessions, request).await;
+                // SyncPeers and SyncState do not modify the inner state. As long as they didn't fail
+                // it is safe to skip the health check
                 let health = if matches!(
                     job_result,
                     Ok((_, JobResult::SyncPeers)) | Ok((_, JobResult::SyncState { .. }))

--- a/iris-mpc-cpu/src/genesis/hawk_job.rs
+++ b/iris-mpc-cpu/src/genesis/hawk_job.rs
@@ -180,7 +180,7 @@ impl fmt::Display for JobResult {
             } => {
                 write!(
                     f,
-                    "batch-id={}, batch-size={}, range=({:?}..{:?})",
+                    "JobResult::BatchIndexation: batch-id={}, batch-size={}, range=({:?}..{:?})",
                     batch_id,
                     vector_ids.len(),
                     first_serial_id,
@@ -190,20 +190,24 @@ impl fmt::Display for JobResult {
             JobResult::Modification {
                 modification_id, ..
             } => {
-                write!(f, "modification-id={}", modification_id)
+                write!(
+                    f,
+                    "JobResult::Modification: modification-id={}",
+                    modification_id
+                )
             }
             JobResult::SyncState { mismatched } => {
-                write!(f, "mismatched={}", mismatched)
+                write!(f, "JobResult::SyncState: mismatched={}", mismatched)
             }
             JobResult::SyncPeers => {
-                write!(f, "")
+                write!(f, "JobResult::SyncPeers")
             }
             JobResult::S3Checkpoint {
                 checkpoint_state, ..
             } => {
                 write!(
                     f,
-                    "iris-id={}, modification-id={}",
+                    "JobResult::S3Checkpoint: iris-id={}, modification-id={}",
                     checkpoint_state.last_indexed_iris_id,
                     checkpoint_state.last_indexed_modification_id
                 )

--- a/iris-mpc-cpu/src/genesis/hawk_job.rs
+++ b/iris-mpc-cpu/src/genesis/hawk_job.rs
@@ -58,11 +58,12 @@ pub enum JobRequest {
         modification: Modification,
     },
     /// Acts as a code barrier for inter-node synchronization.
-    Sync {
+    SyncState {
         /// Whether this node has been signaled to shut down.
         shutdown: bool,
         sync_status: Arc<AtomicU8>,
     },
+    SyncPeers,
 }
 
 /// Constructor.
@@ -114,11 +115,12 @@ pub enum JobResult {
         checkpoint_state: GraphCheckpointState,
         done_tx: sync::oneshot::Sender<()>,
     },
-    Sync {
+    SyncState {
         /// Whether the shutdown states of different nodes' Sync jobs
         /// were mismatched.
         mismatched: bool,
     },
+    SyncPeers,
 }
 
 /// Constructor.
@@ -190,8 +192,11 @@ impl fmt::Display for JobResult {
             } => {
                 write!(f, "modification-id={}", modification_id)
             }
-            JobResult::Sync { mismatched } => {
+            JobResult::SyncState { mismatched } => {
                 write!(f, "mismatched={}", mismatched)
+            }
+            JobResult::SyncPeers => {
+                write!(f, "")
             }
             JobResult::S3Checkpoint {
                 checkpoint_state, ..

--- a/iris-mpc-upgrade-hawk/src/genesis/graph_checkpoint.rs
+++ b/iris-mpc-upgrade-hawk/src/genesis/graph_checkpoint.rs
@@ -53,7 +53,7 @@ pub async fn upload_and_sync_genesis_checkpoint(
     let (tx, done_rx) = oneshot::channel();
     let result = JobResult::new_s3_checkpoint(checkpoint_state, tx);
     tx_results.send(result).await?;
-    hawk_handle.sync_peers(false, Some(done_rx)).await?;
+    hawk_handle.sync_state(false, Some(done_rx)).await?;
     Ok(())
 }
 

--- a/iris-mpc-upgrade-hawk/src/genesis/mod.rs
+++ b/iris-mpc-upgrade-hawk/src/genesis/mod.rs
@@ -642,7 +642,7 @@ async fn exec_delta(
             let is_sync_batch = idx % (PERSIST_DELAY - 1) == 0 || idx == end;
             if is_sync_batch {
                 let wait_start = Instant::now();
-                hawk_handle.sync_peers(false, Some(done_rx)).await?;
+                hawk_handle.sync_state(false, Some(done_rx)).await?;
                 metrics::histogram!("genesis_persist_wait_duration")
                     .record(wait_start.elapsed().as_secs_f64());
             }
@@ -795,7 +795,7 @@ async fn exec_indexation(
         {
             // Coordinator: escape on shutdown.
             let shutdown = shutdown_handler.is_shutting_down();
-            let mismatch = hawk_handle.sync_peers(shutdown, None).await?;
+            let mismatch = hawk_handle.sync_state(shutdown, None).await?;
             if shutdown || mismatch {
                 tracing::warn!("Shutting down has been triggered");
                 break;
@@ -826,7 +826,7 @@ async fn exec_indexation(
                 if let Some(prev_done_rx) = persist_ch.take() {
                     let wait_start = Instant::now();
                     // Wait for other nodes to finish equivalent persistence.
-                    hawk_handle.sync_peers(false, Some(prev_done_rx)).await?;
+                    hawk_handle.sync_state(false, Some(prev_done_rx)).await?;
                     metrics::histogram!("genesis_persist_wait_duration")
                         .record(wait_start.elapsed().as_secs_f64());
                 }
@@ -901,11 +901,12 @@ async fn exec_indexation(
                     last_indexed_id
                 );
             } else if let Some(rx) = persist_ch.take() {
-                hawk_handle.sync_peers(false, Some(rx)).await?;
+                hawk_handle.sync_state(false, Some(rx)).await?;
             }
             metrics::histogram!("genesis_persist_wait_duration")
                 .record(wait_start.elapsed().as_secs_f64());
 
+            hawk_handle.sync_peers().await?;
             tracing::info!("All batches have been processed, shutting down...");
 
             Ok(())
@@ -1453,7 +1454,7 @@ async fn get_results_thread(
                     save_checkpoint_state(graph_tx, &checkpoint_state).await?;
                     let _ = done_tx.send(());
                 },
-                JobResult::Sync { .. } => unreachable!(),
+                JobResult::SyncState { .. } | JobResult::SyncPeers => unreachable!(),
             }
         }
 


### PR DESCRIPTION
This is still needed at the end of `exec_indexation`, at least for the integration tests. Otherwise one of the 3 MPC parties could do `sync_state()` (previously called `sync_peers`), exit, and then have the other parties try to do `health_check` + `sync_state()` and have their networking stack fail because one of the parties already quit. 

This was needed to make tests pass after fully implementing the WAL.