### PR TITLE
Refactor GraphMutation for uniform edge ops and two-phase apply

### DIFF
--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -789,7 +789,7 @@ impl HawkActor {
                         if let Some(replace_id) = &plan.plan.replace_id {
                             mutations.push(GraphMutation::RemoveNode { id: *replace_id });
                         }
-                        mutations.push(GraphMutation::InsertNode {
+                        mutations.push(GraphMutation::AddNode {
                             id: inserted_vector,
                             layers: vec![],
                             update_ep: UpdateEntryPoint::False,
@@ -1485,7 +1485,7 @@ impl HawkResult {
                     .or(mutation.plans[RIGHT].as_ref())
                     .and_then(|plan| {
                         plan.0.iter().find_map(|m| match m {
-                            GraphMutation::InsertNode { id, .. } => Some(*id),
+                            GraphMutation::AddNode { id, .. } => Some(*id),
                             _ => None,
                         })
                     })
@@ -2618,7 +2618,7 @@ mod hawk_mutation_tests {
     use iris_mpc_common::helpers::sync::ModificationKey;
 
     fn create_test_connect_plan(vector_id: VectorId) -> ConnectPlan {
-        GroupedMutations(vec![GraphMutation::InsertNode {
+        GroupedMutations(vec![GraphMutation::AddNode {
             id: vector_id,
             layers: vec![(0, vec![vector_id])],
             update_ep: UpdateEntryPoint::False,

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -791,7 +791,7 @@ impl HawkActor {
                         }
                         mutations.push(GraphMutation::AddNode {
                             id: inserted_vector,
-                            layers: vec![],
+                            max_graph_layer: plan.plan.links.len().saturating_sub(1),
                             update_ep: UpdateEntryPoint::False,
                         });
                         GroupedMutations(mutations)
@@ -2614,15 +2614,23 @@ mod tests {
 #[cfg(test)]
 mod hawk_mutation_tests {
     use super::*;
-    use crate::hnsw::graph::UpdateEntryPoint;
+    use crate::hnsw::graph::{mutation::EdgeDirection, UpdateEntryPoint};
     use iris_mpc_common::helpers::sync::ModificationKey;
 
     fn create_test_connect_plan(vector_id: VectorId) -> ConnectPlan {
-        GroupedMutations(vec![GraphMutation::AddNode {
-            id: vector_id,
-            layers: vec![(0, vec![vector_id])],
-            update_ep: UpdateEntryPoint::False,
-        }])
+        GroupedMutations(vec![
+            GraphMutation::AddNode {
+                id: vector_id,
+                max_graph_layer: 0,
+                update_ep: UpdateEntryPoint::False,
+            },
+            GraphMutation::AddEdges {
+                id: vector_id,
+                layer: 0,
+                to_add: vec![vector_id],
+                direction: EdgeDirection::Outgoing,
+            },
+        ])
     }
 
     #[test]

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -1413,7 +1413,7 @@ impl HawkRequest {
                     let query = Aby3Query::new(query_id);
                     VecRotationSupport::new_center_only(query)
                 })
-                .collect_vec()
+                .collect()
         });
         (
             IdentityUpdateRequests {

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -2614,7 +2614,7 @@ mod tests {
 #[cfg(test)]
 mod hawk_mutation_tests {
     use super::*;
-    use crate::hnsw::graph::{mutation::EdgeDirection, UpdateEntryPoint};
+    use crate::hnsw::graph::{mutation::EdgeType, UpdateEntryPoint};
     use iris_mpc_common::helpers::sync::ModificationKey;
 
     fn create_test_connect_plan(vector_id: VectorId) -> ConnectPlan {
@@ -2625,10 +2625,10 @@ mod hawk_mutation_tests {
                 update_ep: UpdateEntryPoint::False,
             },
             GraphMutation::AddEdges {
-                id: vector_id,
+                base: vector_id,
                 layer: 0,
-                to_add: vec![vector_id],
-                direction: EdgeDirection::Outgoing,
+                neighbors: vec![vector_id],
+                edge_type: EdgeType::Base,
             },
         ])
     }

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -791,7 +791,7 @@ impl HawkActor {
                         }
                         mutations.push(GraphMutation::AddNode {
                             id: inserted_vector,
-                            max_graph_layer: plan.plan.links.len().saturating_sub(1),
+                            height: plan.plan.links.len(),
                             update_ep: UpdateEntryPoint::False,
                         });
                         GroupedMutations(mutations)
@@ -2621,7 +2621,7 @@ mod hawk_mutation_tests {
         GroupedMutations(vec![
             GraphMutation::AddNode {
                 id: vector_id,
-                max_graph_layer: 0,
+                height: 1,
                 update_ep: UpdateEntryPoint::False,
             },
             GraphMutation::AddEdges {

--- a/iris-mpc-cpu/src/execution/hawk_main/insert.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/insert.rs
@@ -1,5 +1,5 @@
 use crate::hnsw::{
-    graph::{GraphMutation, GroupedMutations, UpdateEntryPoint},
+    graph::{mutation::EdgeDirection, GraphMutation, GroupedMutations, UpdateEntryPoint},
     searcher::{ConnectPlanV, LayerMode},
     vector_store::VectorStoreMut,
     GraphMem, HnswSearcher, VectorStore,
@@ -103,10 +103,14 @@ pub async fn insert<V: VectorStoreMut>(
                 layers: links.iter().cloned().enumerate().collect(),
                 update_ep,
             });
-            request_mutations.push(GraphMutation::AddEdges {
-                id: inserted.clone(),
-                layers: links.into_iter().enumerate().collect(),
-            });
+            for (layer_idx, layer_links) in links.into_iter().enumerate() {
+                request_mutations.push(GraphMutation::AddEdges {
+                    id: inserted.clone(),
+                    layer: layer_idx,
+                    to_add: layer_links,
+                    direction: EdgeDirection::Bidirectional,
+                });
+            }
             if let Some(rid) = replace_id {
                 request_mutations.push(GraphMutation::RemoveNode { id: rid.clone() });
             }

--- a/iris-mpc-cpu/src/execution/hawk_main/insert.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/insert.rs
@@ -99,7 +99,7 @@ pub async fn insert<V: VectorStoreMut>(
             let mut request_mutations: Vec<GraphMutation<V::VectorRef>> = vec![];
             request_mutations.push(GraphMutation::AddNode {
                 id: inserted.clone(),
-                max_graph_layer: links.len().saturating_sub(1),
+                height: links.len(),
                 update_ep,
             });
             for (layer_idx, layer_links) in links.into_iter().enumerate() {

--- a/iris-mpc-cpu/src/execution/hawk_main/insert.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/insert.rs
@@ -97,13 +97,13 @@ pub async fn insert<V: VectorStoreMut>(
             };
 
             let mut request_mutations: Vec<GraphMutation<V::VectorRef>> = vec![];
-            request_mutations.push(GraphMutation::InsertNode {
+            request_mutations.push(GraphMutation::AddNode {
                 id: inserted.clone(),
                 // Convert links (Vec<Vec<VectorRef>>) to layers (Vec<(usize, Vec<VectorRef>)>)
                 layers: links.iter().cloned().enumerate().collect(),
                 update_ep,
             });
-            request_mutations.push(GraphMutation::AddNeighbors {
+            request_mutations.push(GraphMutation::AddEdges {
                 id: inserted.clone(),
                 layers: links.into_iter().enumerate().collect(),
             });

--- a/iris-mpc-cpu/src/execution/hawk_main/insert.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/insert.rs
@@ -1,5 +1,5 @@
 use crate::hnsw::{
-    graph::{mutation::EdgeDirection, GraphMutation, GroupedMutations, UpdateEntryPoint},
+    graph::{mutation::EdgeType, GraphMutation, GroupedMutations, UpdateEntryPoint},
     searcher::{ConnectPlanV, LayerMode},
     vector_store::VectorStoreMut,
     GraphMem, HnswSearcher, VectorStore,
@@ -104,10 +104,10 @@ pub async fn insert<V: VectorStoreMut>(
             });
             for (layer_idx, layer_links) in links.into_iter().enumerate() {
                 request_mutations.push(GraphMutation::AddEdges {
-                    id: inserted.clone(),
+                    base: inserted.clone(),
                     layer: layer_idx,
-                    to_add: layer_links,
-                    direction: EdgeDirection::Bidirectional,
+                    neighbors: layer_links,
+                    edge_type: EdgeType::All,
                 });
             }
             if let Some(rid) = replace_id {

--- a/iris-mpc-cpu/src/execution/hawk_main/insert.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/insert.rs
@@ -99,8 +99,7 @@ pub async fn insert<V: VectorStoreMut>(
             let mut request_mutations: Vec<GraphMutation<V::VectorRef>> = vec![];
             request_mutations.push(GraphMutation::AddNode {
                 id: inserted.clone(),
-                // Convert links (Vec<Vec<VectorRef>>) to layers (Vec<(usize, Vec<VectorRef>)>)
-                layers: links.iter().cloned().enumerate().collect(),
+                max_graph_layer: links.len().saturating_sub(1),
                 update_ep,
             });
             for (layer_idx, layer_links) in links.into_iter().enumerate() {

--- a/iris-mpc-cpu/src/execution/hawk_main/state_check.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/state_check.rs
@@ -38,7 +38,7 @@ impl SetHash {
         self.accumulator = self.accumulator.wrapping_add(Self::hash(value));
     }
 
-    /// Inverse of [`add_unordered`]. Subtracts the value's hash from the
+    /// Inverse of [`Self::add_unordered`]. Subtracts the value's hash from the
     /// accumulator using wrapping subtraction, so a balanced add+remove
     /// pair returns the accumulator to its prior state exactly.
     pub fn remove(&mut self, value: impl Hash) {
@@ -59,7 +59,7 @@ impl SetHash {
         self.fold_unordered_set(key, items, u64::wrapping_add);
     }
 
-    /// Inverse of [`add_unordered_set`]: removes a `(key, set-of-items)`
+    /// Inverse of [`Self::add_unordered_set`]: removes a `(key, set-of-items)`
     /// pair previously added, using wrapping subtraction. Must be called
     /// with the same `(key, items)` content that was added, otherwise the
     /// accumulator drifts.

--- a/iris-mpc-cpu/src/execution/hawk_main/test_utils.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/test_utils.rs
@@ -102,12 +102,12 @@ pub async fn init_graph(actor: &mut HawkActor) -> Result<()> {
                 UpdateEntryPoint::False
             };
             let mutations = vec![
-                GraphMutation::InsertNode {
+                GraphMutation::AddNode {
                     id: id(i),
                     layers: vec![(0, edges(i))],
                     update_ep,
                 },
-                GraphMutation::AddNeighbors {
+                GraphMutation::AddEdges {
                     id: id(i),
                     layers: vec![(0, edges(i))],
                 },

--- a/iris-mpc-cpu/src/execution/hawk_main/test_utils.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/test_utils.rs
@@ -95,7 +95,7 @@ pub async fn init_graph(actor: &mut HawkActor) -> Result<()> {
         for i in 0..db_size {
             let update_ep = if i == 0 {
                 match layer_mode {
-                    LayerMode::Standard { .. } => UpdateEntryPoint::SetUnique { layer: 1 },
+                    LayerMode::Standard { .. } => UpdateEntryPoint::SetUnique { layer: 0 },
                     LayerMode::LinearScan { .. } => UpdateEntryPoint::False,
                 }
             } else {

--- a/iris-mpc-cpu/src/execution/hawk_main/test_utils.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/test_utils.rs
@@ -104,7 +104,7 @@ pub async fn init_graph(actor: &mut HawkActor) -> Result<()> {
             let mutations = vec![
                 GraphMutation::AddNode {
                     id: id(i),
-                    max_graph_layer: 0,
+                    height: 1,
                     update_ep,
                 },
                 GraphMutation::AddEdges {

--- a/iris-mpc-cpu/src/execution/hawk_main/test_utils.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/test_utils.rs
@@ -16,7 +16,7 @@ use tokio_util::sync::CancellationToken;
 use crate::{
     execution::local::get_free_local_addresses,
     hnsw::{
-        graph::{GraphMutation, UpdateEntryPoint},
+        graph::{mutation::EdgeDirection, GraphMutation, UpdateEntryPoint},
         searcher::LayerMode,
     },
     protocol::shared_iris::GaloisRingSharedIris,
@@ -109,7 +109,9 @@ pub async fn init_graph(actor: &mut HawkActor) -> Result<()> {
                 },
                 GraphMutation::AddEdges {
                     id: id(i),
-                    layers: vec![(0, edges(i))],
+                    layer: 0,
+                    to_add: edges(i),
+                    direction: EdgeDirection::Bidirectional,
                 },
             ];
             graph.insert_apply(mutations);

--- a/iris-mpc-cpu/src/execution/hawk_main/test_utils.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/test_utils.rs
@@ -16,7 +16,7 @@ use tokio_util::sync::CancellationToken;
 use crate::{
     execution::local::get_free_local_addresses,
     hnsw::{
-        graph::{mutation::EdgeDirection, GraphMutation, UpdateEntryPoint},
+        graph::{mutation::EdgeType, GraphMutation, UpdateEntryPoint},
         searcher::LayerMode,
     },
     protocol::shared_iris::GaloisRingSharedIris,
@@ -108,10 +108,10 @@ pub async fn init_graph(actor: &mut HawkActor) -> Result<()> {
                     update_ep,
                 },
                 GraphMutation::AddEdges {
-                    id: id(i),
+                    base: id(i),
                     layer: 0,
-                    to_add: edges(i),
-                    direction: EdgeDirection::Bidirectional,
+                    neighbors: edges(i),
+                    edge_type: EdgeType::All,
                 },
             ];
             graph.insert_apply(mutations);

--- a/iris-mpc-cpu/src/execution/hawk_main/test_utils.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/test_utils.rs
@@ -95,7 +95,7 @@ pub async fn init_graph(actor: &mut HawkActor) -> Result<()> {
         for i in 0..db_size {
             let update_ep = if i == 0 {
                 match layer_mode {
-                    LayerMode::Standard { .. } => UpdateEntryPoint::SetUnique { layer: 0 },
+                    LayerMode::Standard { .. } => UpdateEntryPoint::SetUnique { layer: 1 },
                     LayerMode::LinearScan { .. } => UpdateEntryPoint::False,
                 }
             } else {
@@ -104,7 +104,7 @@ pub async fn init_graph(actor: &mut HawkActor) -> Result<()> {
             let mutations = vec![
                 GraphMutation::AddNode {
                     id: id(i),
-                    layers: vec![(0, edges(i))],
+                    max_graph_layer: 0,
                     update_ep,
                 },
                 GraphMutation::AddEdges {

--- a/iris-mpc-cpu/src/hawkers/ideal_knn_engines.rs
+++ b/iris-mpc-cpu/src/hawkers/ideal_knn_engines.rs
@@ -42,7 +42,7 @@ impl<V> KNNResult<V> {
     }
 }
 
-/// Reads a Vec<KNNResult<u32>> from a file, skipping the first line (header).
+/// Reads a `Vec<KNNResult<u32>>` from a file, skipping the first line (header).
 pub fn read_knn_results_from_file(path: PathBuf) -> std::io::Result<Vec<KNNResult<u32>>> {
     let file = File::open(path)?;
     let mut lines = BufReader::new(file).lines();

--- a/iris-mpc-cpu/src/hnsw/graph/graph_store.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/graph_store.rs
@@ -24,7 +24,7 @@ pub struct GraphCheckpointRow {
 #[derive(sqlx::FromRow, Debug, Clone, PartialEq, Eq)]
 pub struct GraphMutationRow {
     pub modification_id: i64,
-    /// Bincode-serialized BothEyes<Vec<GraphMutation<VectorId>>> (mutations for both eyes)
+    /// Bincode-serialized `BothEyes<Vec<GraphMutation<VectorId>>>` (mutations for both eyes)
     pub serialized_mutations: Vec<u8>,
 }
 

--- a/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
@@ -185,7 +185,7 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
                     // Remove from entry points if present
                     self.entry_points.retain(|ep| &ep.point != id);
                 }
-                GraphMutation::InsertNode {
+                GraphMutation::AddNode {
                     id,
                     layers,
                     update_ep,
@@ -220,7 +220,7 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
                         self.layers[layer_idx].insert_node(id.clone(), neighbors);
                     }
                 }
-                GraphMutation::AddNeighbors { id, layers } => {
+                GraphMutation::AddEdges { id, layers } => {
                     for (layer_idx, neighborhoods) in layers {
                         if self.layers.len() < layer_idx + 1 {
                             self.layers.resize(layer_idx + 1, Layer::new());
@@ -228,7 +228,7 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
                         self.layers[layer_idx].add_neighbor(id.clone(), neighborhoods);
                     }
                 }
-                GraphMutation::RemoveNeighbors {
+                GraphMutation::RemoveEdges {
                     ref id,
                     layer,
                     to_remove,

--- a/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
@@ -242,7 +242,7 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
                                     base
                                 );
                             } else {
-                                layer_mut.add_outgoing_edges(&base, to_add);
+                                layer_mut.link_neighbors_to_node(&base, to_add);
                             }
                         }
                         EdgeType::Neighbors => {
@@ -254,7 +254,7 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
                                     );
                                 }
                             }
-                            layer_mut.add_incoming_edges(&base, to_add);
+                            layer_mut.link_node_to_neighbors(&base, to_add);
                         }
                         EdgeType::All => {
                             if layer_mut.get_links(&base).is_none() {
@@ -263,7 +263,7 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
                                     base
                                 );
                             } else {
-                                layer_mut.add_outgoing_edges(&base, to_add.clone());
+                                layer_mut.link_neighbors_to_node(&base, to_add.clone());
                             }
                             for target in &to_add {
                                 if layer_mut.get_links(target).is_none() {
@@ -273,7 +273,7 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
                                     );
                                 }
                             }
-                            layer_mut.add_incoming_edges(&base, to_add);
+                            layer_mut.link_node_to_neighbors(&base, to_add);
                         }
                     }
                 }
@@ -299,7 +299,7 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
                                     base
                                 );
                             } else {
-                                layer_mut.remove_outgoing_edges(&base, to_remove);
+                                layer_mut.unlink_neighbors_from_node(&base, to_remove);
                             }
                         }
                         EdgeType::Neighbors => {
@@ -311,7 +311,7 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
                                     );
                                 }
                             }
-                            layer_mut.remove_incoming_edges(&base, to_remove);
+                            layer_mut.unlink_node_from_neighbors(&base, to_remove);
                         }
                         EdgeType::All => {
                             if layer_mut.get_links(&base).is_none() {
@@ -320,7 +320,7 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
                                     base
                                 );
                             } else {
-                                layer_mut.remove_outgoing_edges(&base, to_remove.clone());
+                                layer_mut.unlink_neighbors_from_node(&base, to_remove.clone());
                             }
                             for target in &to_remove {
                                 if layer_mut.get_links(target).is_none() {
@@ -330,7 +330,7 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
                                     );
                                 }
                             }
-                            layer_mut.remove_incoming_edges(&base, to_remove);
+                            layer_mut.unlink_node_from_neighbors(&base, to_remove);
                         }
                     }
                 }
@@ -596,13 +596,13 @@ impl<V: Ref + Display + FromStr + Ord> Layer<V> {
     /// this layer are silently skipped (callers that need to log the missing
     /// case should check `get_links(target)` first). Idempotent: if `id` is
     /// already present in a target's list, that target is left unchanged.
-    pub fn add_incoming_edges(&mut self, id: &V, to_add: Vec<V>) {
-        for target in &to_add {
+    pub fn link_node_to_neighbors(&mut self, node: &V, neighbors: Vec<V>) {
+        for target in &neighbors {
             if let Some(target_links) = self.links.get_mut(target) {
-                if let Err(pos) = target_links.binary_search(id) {
+                if let Err(pos) = target_links.binary_search(node) {
                     self.set_hash
                         .remove_unordered_set(target, target_links.iter());
-                    target_links.insert(pos, id.clone());
+                    target_links.insert(pos, node.clone());
                     self.set_hash.add_unordered_set(target, target_links.iter());
                 }
             }
@@ -613,17 +613,17 @@ impl<V: Ref + Display + FromStr + Ord> Layer<V> {
     /// No-op if `id` is not present in this layer (callers that need to log
     /// the missing case should check `get_links(id)` first). Idempotent:
     /// existing entries are not duplicated.
-    pub fn add_outgoing_edges(&mut self, id: &V, to_add: Vec<V>) {
-        let Some(node_links) = self.links.get_mut(id) else {
+    pub fn link_neighbors_to_node(&mut self, node: &V, neighbors: Vec<V>) {
+        let Some(node_links) = self.links.get_mut(node) else {
             return;
         };
-        self.set_hash.remove_unordered_set(id, node_links.iter());
-        for nb in to_add {
+        self.set_hash.remove_unordered_set(node, node_links.iter());
+        for nb in neighbors {
             if let Err(pos) = node_links.binary_search(&nb) {
                 node_links.insert(pos, nb);
             }
         }
-        self.set_hash.add_unordered_set(id, node_links.iter());
+        self.set_hash.add_unordered_set(node, node_links.iter());
     }
 
     /// Remove a node from the graph and clean up all backlinks from its neighbors.
@@ -652,12 +652,12 @@ impl<V: Ref + Display + FromStr + Ord> Layer<V> {
     /// Remove `id` from each target's neighbor list, where `target` ranges over
     /// `to_remove`. Targets that don't exist in this layer are silently skipped
     /// (the caller's apply path is responsible for any logging).
-    pub fn remove_incoming_edges(&mut self, id: &V, to_remove: Vec<V>) {
-        for target in &to_remove {
+    pub fn unlink_node_from_neighbors(&mut self, node: &V, neighbors: Vec<V>) {
+        for target in &neighbors {
             if let Some(target_links) = self.links.get_mut(target) {
                 self.set_hash
                     .remove_unordered_set(target, target_links.iter());
-                target_links.retain(|x| x != id);
+                target_links.retain(|x| x != node);
                 self.set_hash.add_unordered_set(target, target_links.iter());
             }
         }
@@ -667,13 +667,13 @@ impl<V: Ref + Display + FromStr + Ord> Layer<V> {
     /// if `id` is not present in this layer (callers that need to log the
     /// missing case should check `get_links(id)` first). The removal is
     /// unidirectional: the targets' own link lists are not modified.
-    pub fn remove_outgoing_edges(&mut self, id: &V, to_remove: Vec<V>) {
-        let Some(node_links) = self.links.get_mut(id) else {
+    pub fn unlink_neighbors_from_node(&mut self, node: &V, neighbors: Vec<V>) {
+        let Some(node_links) = self.links.get_mut(node) else {
             return;
         };
-        self.set_hash.remove_unordered_set(id, node_links.iter());
-        node_links.retain(|x| !to_remove.contains(x));
-        self.set_hash.add_unordered_set(id, node_links.iter());
+        self.set_hash.remove_unordered_set(node, node_links.iter());
+        node_links.retain(|x| !neighbors.contains(x));
+        self.set_hash.add_unordered_set(node, node_links.iter());
     }
 
     pub fn set_links(&mut self, from: V, links: Vec<V>) {

--- a/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
@@ -254,7 +254,7 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
                                     );
                                 }
                             }
-                            layer_mut.add_neighbor(id.clone(), to_add);
+                            layer_mut.add_incoming_edges(&id, to_add);
                         }
                         EdgeDirection::Bidirectional => {
                             if layer_mut.get_links(&id).is_none() {
@@ -273,7 +273,7 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
                                     );
                                 }
                             }
-                            layer_mut.add_neighbor(id, to_add);
+                            layer_mut.add_incoming_edges(&id, to_add);
                         }
                     }
                 }
@@ -299,7 +299,7 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
                                     id
                                 );
                             } else {
-                                layer_mut.remove_neighbors(&id, to_remove);
+                                layer_mut.remove_outgoing_edges(&id, to_remove);
                             }
                         }
                         EdgeDirection::Incoming => {
@@ -320,7 +320,7 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
                                     id
                                 );
                             } else {
-                                layer_mut.remove_neighbors(&id, to_remove.clone());
+                                layer_mut.remove_outgoing_edges(&id, to_remove.clone());
                             }
                             for target in &to_remove {
                                 if layer_mut.get_links(target).is_none() {
@@ -591,18 +591,19 @@ impl<V: Ref + Display + FromStr + Ord> Layer<V> {
         self.set_links(id.clone(), neighbors.clone());
     }
 
-    // invariant: neighbor_links is kept sorted; relies on the planner sorting before set_links
-    pub fn add_neighbor(&mut self, id: V, neighborhoods: Vec<V>) {
-        for nbhd in &neighborhoods {
-            if let Some(neighbor_links) = self.links.get_mut(nbhd) {
-                match neighbor_links.binary_search(&id) {
-                    Err(i) => {
-                        self.set_hash
-                            .remove_unordered_set(nbhd, neighbor_links.iter());
-                        neighbor_links.insert(i, id.clone());
-                        self.set_hash.add_unordered_set(nbhd, neighbor_links.iter());
-                    }
-                    Ok(_) => continue, // link already exists
+    /// Insert `id` as an incoming edge into each target's neighbor list,
+    /// keeping each list sorted and deduplicated. Targets that don't exist in
+    /// this layer are silently skipped (callers that need to log the missing
+    /// case should check `get_links(target)` first). Idempotent: if `id` is
+    /// already present in a target's list, that target is left unchanged.
+    pub fn add_incoming_edges(&mut self, id: &V, to_add: Vec<V>) {
+        for target in &to_add {
+            if let Some(target_links) = self.links.get_mut(target) {
+                if let Err(pos) = target_links.binary_search(id) {
+                    self.set_hash
+                        .remove_unordered_set(target, target_links.iter());
+                    target_links.insert(pos, id.clone());
+                    self.set_hash.add_unordered_set(target, target_links.iter());
                 }
             }
         }
@@ -662,16 +663,19 @@ impl<V: Ref + Display + FromStr + Ord> Layer<V> {
         }
     }
 
-    pub fn remove_neighbors(&mut self, id: &V, neighbors_to_remove: Vec<V>) {
-        if let Some(node_links) = self.links.get_mut(id) {
-            self.set_hash.remove_unordered_set(id, node_links.iter());
-            for neighbor in &neighbors_to_remove {
-                // this is a uni-directional pruning. it is incorrect to prune the neighbors links
-                // when doing compaction.
-                node_links.retain(|x| x != neighbor);
-            }
-            self.set_hash.add_unordered_set(id, node_links.iter());
-        }
+    /// Remove each entry in `to_remove` from `id`'s own neighbor list. No-op
+    /// if `id` is not present in this layer (callers that need to log the
+    /// missing case should check `get_links(id)` first). The removal is
+    /// unidirectional: the targets' own link lists are not modified. This is
+    /// the compaction contract — callers (and any WAL replay) must not infer
+    /// bidirectional pruning from this operation.
+    pub fn remove_outgoing_edges(&mut self, id: &V, to_remove: Vec<V>) {
+        let Some(node_links) = self.links.get_mut(id) else {
+            return;
+        };
+        self.set_hash.remove_unordered_set(id, node_links.iter());
+        node_links.retain(|x| !to_remove.contains(x));
+        self.set_hash.add_unordered_set(id, node_links.iter());
     }
 
     pub fn set_links(&mut self, from: V, links: Vec<V>) {

--- a/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
@@ -7,7 +7,7 @@ use crate::{
     execution::hawk_main::state_check::SetHash,
     hawkers::ideal_knn_engines::{read_knn_results_from_file, Engine, EngineChoice, KNNResult},
     hnsw::{
-        graph::{mutation::EdgeDirection, GraphMutation, UpdateEntryPoint},
+        graph::{mutation::EdgeType, GraphMutation, UpdateEntryPoint},
         searcher::LayerMode,
         vector_store::Ref,
         HnswSearcher,
@@ -225,112 +225,112 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
             match mutation {
                 GraphMutation::AddNode { .. } | GraphMutation::RemoveNode { .. } => {}
                 GraphMutation::AddEdges {
-                    id,
+                    base,
                     layer,
-                    to_add,
-                    direction,
+                    neighbors: to_add,
+                    edge_type,
                 } => {
                     if self.layers.len() < layer + 1 {
                         self.layers.resize(layer + 1, Layer::new());
                     }
                     let layer_mut = &mut self.layers[layer];
-                    match direction {
-                        EdgeDirection::Outgoing => {
-                            if layer_mut.get_links(&id).is_none() {
+                    match edge_type {
+                        EdgeType::Base => {
+                            if layer_mut.get_links(&base).is_none() {
                                 warn!(
-                                    "AddEdges(Outgoing): id={:?} missing at layer {layer}; skipping",
-                                    id
+                                    "AddEdges(Base): base={:?} missing at layer {layer}; skipping",
+                                    base
                                 );
                             } else {
-                                layer_mut.add_outgoing_edges(&id, to_add);
+                                layer_mut.add_outgoing_edges(&base, to_add);
                             }
                         }
-                        EdgeDirection::Incoming => {
+                        EdgeType::Neighbors => {
                             for target in &to_add {
                                 if layer_mut.get_links(target).is_none() {
                                     warn!(
-                                        "AddEdges(Incoming): target={:?} missing at layer {layer} (id={:?}); add_neighbor will no-op for this target",
-                                        target, id
+                                        "AddEdges(Neighbors): target={:?} missing at layer {layer} (base={:?}); add_neighbor will no-op for this target",
+                                        target, base
                                     );
                                 }
                             }
-                            layer_mut.add_incoming_edges(&id, to_add);
+                            layer_mut.add_incoming_edges(&base, to_add);
                         }
-                        EdgeDirection::Bidirectional => {
-                            if layer_mut.get_links(&id).is_none() {
+                        EdgeType::All => {
+                            if layer_mut.get_links(&base).is_none() {
                                 warn!(
-                                    "AddEdges(Bidirectional): id={:?} missing at layer {layer}; skipping outgoing half",
-                                    id
+                                    "AddEdges(All): base={:?} missing at layer {layer}; skipping outgoing half",
+                                    base
                                 );
                             } else {
-                                layer_mut.add_outgoing_edges(&id, to_add.clone());
+                                layer_mut.add_outgoing_edges(&base, to_add.clone());
                             }
                             for target in &to_add {
                                 if layer_mut.get_links(target).is_none() {
                                     warn!(
-                                        "AddEdges(Bidirectional): target={:?} missing at layer {layer} (id={:?}); add_neighbor will no-op for this target",
-                                        target, id
+                                        "AddEdges(All): target={:?} missing at layer {layer} (base={:?}); add_neighbor will no-op for this target",
+                                        target, base
                                     );
                                 }
                             }
-                            layer_mut.add_incoming_edges(&id, to_add);
+                            layer_mut.add_incoming_edges(&base, to_add);
                         }
                     }
                 }
                 GraphMutation::RemoveEdges {
-                    id,
+                    base,
                     layer,
-                    to_remove,
-                    direction,
+                    neighbors: to_remove,
+                    edge_type,
                 } => {
                     if self.layers.len() < layer + 1 {
                         warn!(
-                            "RemoveEdges: layer {layer} does not exist (id={:?}); skipping",
-                            id
+                            "RemoveEdges: layer {layer} does not exist (base={:?}); skipping",
+                            base
                         );
                         continue;
                     }
                     let layer_mut = &mut self.layers[layer];
-                    match direction {
-                        EdgeDirection::Outgoing => {
-                            if layer_mut.get_links(&id).is_none() {
+                    match edge_type {
+                        EdgeType::Base => {
+                            if layer_mut.get_links(&base).is_none() {
                                 warn!(
-                                    "RemoveEdges(Outgoing): id={:?} missing at layer {layer}; skipping",
-                                    id
+                                    "RemoveEdges(Base): base={:?} missing at layer {layer}; skipping",
+                                    base
                                 );
                             } else {
-                                layer_mut.remove_outgoing_edges(&id, to_remove);
+                                layer_mut.remove_outgoing_edges(&base, to_remove);
                             }
                         }
-                        EdgeDirection::Incoming => {
+                        EdgeType::Neighbors => {
                             for target in &to_remove {
                                 if layer_mut.get_links(target).is_none() {
                                     warn!(
-                                        "RemoveEdges(Incoming): target={:?} missing at layer {layer} (id={:?}); remove_incoming_edges will no-op for this target",
-                                        target, id
+                                        "RemoveEdges(Neighbors): target={:?} missing at layer {layer} (base={:?}); remove_incoming_edges will no-op for this target",
+                                        target, base
                                     );
                                 }
                             }
-                            layer_mut.remove_incoming_edges(&id, to_remove);
+                            layer_mut.remove_incoming_edges(&base, to_remove);
                         }
-                        EdgeDirection::Bidirectional => {
-                            if layer_mut.get_links(&id).is_none() {
+                        EdgeType::All => {
+                            if layer_mut.get_links(&base).is_none() {
                                 warn!(
-                                    "RemoveEdges(Bidirectional): id={:?} missing at layer {layer}; skipping outgoing half",
-                                    id
+                                    "RemoveEdges(All): base={:?} missing at layer {layer}; skipping outgoing half",
+                                    base
                                 );
                             } else {
-                                layer_mut.remove_outgoing_edges(&id, to_remove.clone());
+                                layer_mut.remove_outgoing_edges(&base, to_remove.clone());
                             }
                             for target in &to_remove {
                                 if layer_mut.get_links(target).is_none() {
                                     warn!(
-                                        "RemoveEdges(Bidirectional): target={:?} missing at layer {layer} (id={:?}); remove_incoming_edges will no-op for this target",
-                                        target, id
+                                        "RemoveEdges(All): target={:?} missing at layer {layer} (base={:?}); remove_incoming_edges will no-op for this target",
+                                        target, base
                                     );
                                 }
                             }
-                            layer_mut.remove_incoming_edges(&id, to_remove);
+                            layer_mut.remove_incoming_edges(&base, to_remove);
                         }
                     }
                 }
@@ -666,9 +666,7 @@ impl<V: Ref + Display + FromStr + Ord> Layer<V> {
     /// Remove each entry in `to_remove` from `id`'s own neighbor list. No-op
     /// if `id` is not present in this layer (callers that need to log the
     /// missing case should check `get_links(id)` first). The removal is
-    /// unidirectional: the targets' own link lists are not modified. This is
-    /// the compaction contract — callers (and any WAL replay) must not infer
-    /// bidirectional pruning from this operation.
+    /// unidirectional: the targets' own link lists are not modified.
     pub fn remove_outgoing_edges(&mut self, id: &V, to_remove: Vec<V>) {
         let Some(node_links) = self.links.get_mut(id) else {
             return;
@@ -993,7 +991,7 @@ mod tests {
         Ok(())
     }
 
-    use crate::hnsw::graph::mutation::{EdgeDirection, GraphMutation, UpdateEntryPoint};
+    use crate::hnsw::graph::mutation::{EdgeType, GraphMutation, UpdateEntryPoint};
 
     #[test]
     fn add_edges_outgoing_writes_only_to_id_list() {
@@ -1020,10 +1018,10 @@ mod tests {
             },
         ]);
         graph.insert_apply(vec![GraphMutation::AddEdges {
-            id: a,
+            base: a,
             layer: 0,
-            to_add: vec![b, c],
-            direction: EdgeDirection::Outgoing,
+            neighbors: vec![b, c],
+            edge_type: EdgeType::Base,
         }]);
         assert_eq!(graph.layers[0].get_links(&a).unwrap(), &[b, c]);
         assert_eq!(
@@ -1060,10 +1058,10 @@ mod tests {
             },
         ]);
         graph.insert_apply(vec![GraphMutation::AddEdges {
-            id: a,
+            base: a,
             layer: 0,
-            to_add: vec![b, c],
-            direction: EdgeDirection::Incoming,
+            neighbors: vec![b, c],
+            edge_type: EdgeType::Neighbors,
         }]);
         assert_eq!(
             graph.layers[0].get_links(&a).unwrap(),
@@ -1097,10 +1095,10 @@ mod tests {
             },
         ]);
         graph.insert_apply(vec![GraphMutation::AddEdges {
-            id: a,
+            base: a,
             layer: 0,
-            to_add: vec![b, c],
-            direction: EdgeDirection::Bidirectional,
+            neighbors: vec![b, c],
+            edge_type: EdgeType::All,
         }]);
         assert_eq!(graph.layers[0].get_links(&a).unwrap(), &[b, c]);
         assert_eq!(graph.layers[0].get_links(&b).unwrap(), &[a]);
@@ -1120,10 +1118,10 @@ mod tests {
                 update_ep: UpdateEntryPoint::SetUnique { layer: 1 },
             },
             GraphMutation::AddEdges {
-                id: a,
+                base: a,
                 layer: 0,
-                to_add: vec![b, c],
-                direction: EdgeDirection::Outgoing,
+                neighbors: vec![b, c],
+                edge_type: EdgeType::Base,
             },
             GraphMutation::AddNode {
                 id: b,
@@ -1131,10 +1129,10 @@ mod tests {
                 update_ep: UpdateEntryPoint::False,
             },
             GraphMutation::AddEdges {
-                id: b,
+                base: b,
                 layer: 0,
-                to_add: vec![a],
-                direction: EdgeDirection::Outgoing,
+                neighbors: vec![a],
+                edge_type: EdgeType::Base,
             },
             GraphMutation::AddNode {
                 id: c,
@@ -1142,17 +1140,17 @@ mod tests {
                 update_ep: UpdateEntryPoint::False,
             },
             GraphMutation::AddEdges {
-                id: c,
+                base: c,
                 layer: 0,
-                to_add: vec![a],
-                direction: EdgeDirection::Outgoing,
+                neighbors: vec![a],
+                edge_type: EdgeType::Base,
             },
         ]);
         graph.insert_apply(vec![GraphMutation::RemoveEdges {
-            id: a,
+            base: a,
             layer: 0,
-            to_remove: vec![b],
-            direction: EdgeDirection::Outgoing,
+            neighbors: vec![b],
+            edge_type: EdgeType::Base,
         }]);
         assert_eq!(graph.layers[0].get_links(&a).unwrap(), &[c]);
         // Bidirectional cleanup is not implied — b's list still contains a.
@@ -1169,10 +1167,10 @@ mod tests {
         graph.insert_apply(vec![
             // Listed first: an edge op that references a node not yet created.
             GraphMutation::AddEdges {
-                id: a,
+                base: a,
                 layer: 0,
-                to_add: vec![b],
-                direction: EdgeDirection::Outgoing,
+                neighbors: vec![b],
+                edge_type: EdgeType::Base,
             },
             // Listed second: the node creation.
             GraphMutation::AddNode {

--- a/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
@@ -187,7 +187,7 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
                 }
                 GraphMutation::AddNode {
                     id,
-                    max_graph_layer,
+                    height,
                     update_ep,
                 } => {
                     match update_ep {
@@ -209,10 +209,10 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
                         UpdateEntryPoint::False => {}
                     }
 
-                    if self.layers.len() < *max_graph_layer + 1 {
-                        self.layers.resize(*max_graph_layer + 1, Layer::new());
+                    if self.layers.len() < *height {
+                        self.layers.resize(*height, Layer::new());
                     }
-                    for layer_idx in 0..=*max_graph_layer {
+                    for layer_idx in 0..*height {
                         self.layers[layer_idx].insert_node(id.clone(), Vec::new());
                     }
                 }
@@ -1005,17 +1005,17 @@ mod tests {
         graph.insert_apply(vec![
             GraphMutation::AddNode {
                 id: a,
-                max_graph_layer: 0,
+                height: 1,
                 update_ep: UpdateEntryPoint::SetUnique { layer: 1 },
             },
             GraphMutation::AddNode {
                 id: b,
-                max_graph_layer: 0,
+                height: 1,
                 update_ep: UpdateEntryPoint::False,
             },
             GraphMutation::AddNode {
                 id: c,
-                max_graph_layer: 0,
+                height: 1,
                 update_ep: UpdateEntryPoint::False,
             },
         ]);
@@ -1045,17 +1045,17 @@ mod tests {
         graph.insert_apply(vec![
             GraphMutation::AddNode {
                 id: a,
-                max_graph_layer: 0,
+                height: 1,
                 update_ep: UpdateEntryPoint::SetUnique { layer: 1 },
             },
             GraphMutation::AddNode {
                 id: b,
-                max_graph_layer: 0,
+                height: 1,
                 update_ep: UpdateEntryPoint::False,
             },
             GraphMutation::AddNode {
                 id: c,
-                max_graph_layer: 0,
+                height: 1,
                 update_ep: UpdateEntryPoint::False,
             },
         ]);
@@ -1082,17 +1082,17 @@ mod tests {
         graph.insert_apply(vec![
             GraphMutation::AddNode {
                 id: a,
-                max_graph_layer: 0,
+                height: 1,
                 update_ep: UpdateEntryPoint::SetUnique { layer: 1 },
             },
             GraphMutation::AddNode {
                 id: b,
-                max_graph_layer: 0,
+                height: 1,
                 update_ep: UpdateEntryPoint::False,
             },
             GraphMutation::AddNode {
                 id: c,
-                max_graph_layer: 0,
+                height: 1,
                 update_ep: UpdateEntryPoint::False,
             },
         ]);
@@ -1116,7 +1116,7 @@ mod tests {
         graph.insert_apply(vec![
             GraphMutation::AddNode {
                 id: a,
-                max_graph_layer: 0,
+                height: 1,
                 update_ep: UpdateEntryPoint::SetUnique { layer: 1 },
             },
             GraphMutation::AddEdges {
@@ -1127,7 +1127,7 @@ mod tests {
             },
             GraphMutation::AddNode {
                 id: b,
-                max_graph_layer: 0,
+                height: 1,
                 update_ep: UpdateEntryPoint::False,
             },
             GraphMutation::AddEdges {
@@ -1138,7 +1138,7 @@ mod tests {
             },
             GraphMutation::AddNode {
                 id: c,
-                max_graph_layer: 0,
+                height: 1,
                 update_ep: UpdateEntryPoint::False,
             },
             GraphMutation::AddEdges {
@@ -1177,12 +1177,12 @@ mod tests {
             // Listed second: the node creation.
             GraphMutation::AddNode {
                 id: a,
-                max_graph_layer: 0,
+                height: 1,
                 update_ep: UpdateEntryPoint::SetUnique { layer: 0 },
             },
             GraphMutation::AddNode {
                 id: b,
-                max_graph_layer: 0,
+                height: 1,
                 update_ep: UpdateEntryPoint::False,
             },
         ]);

--- a/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
@@ -275,7 +275,7 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
                     }
                 }
                 GraphMutation::RemoveEdges {
-                    ref id,
+                    id,
                     layer,
                     to_remove,
                     direction,
@@ -290,13 +290,13 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
                     let layer_mut = &mut self.layers[layer];
                     match direction {
                         EdgeDirection::Outgoing => {
-                            if layer_mut.get_links(id).is_none() {
+                            if layer_mut.get_links(&id).is_none() {
                                 warn!(
                                     "RemoveEdges(Outgoing): id={:?} missing at layer {layer}; skipping",
                                     id
                                 );
                             } else {
-                                layer_mut.remove_neighbors(id, to_remove);
+                                layer_mut.remove_neighbors(&id, to_remove);
                             }
                         }
                         EdgeDirection::Incoming => {
@@ -308,16 +308,16 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
                                     );
                                 }
                             }
-                            layer_mut.remove_incoming_edges(id, to_remove);
+                            layer_mut.remove_incoming_edges(&id, to_remove);
                         }
                         EdgeDirection::Bidirectional => {
-                            if layer_mut.get_links(id).is_none() {
+                            if layer_mut.get_links(&id).is_none() {
                                 warn!(
                                     "RemoveEdges(Bidirectional): id={:?} missing at layer {layer}; skipping outgoing half",
                                     id
                                 );
                             } else {
-                                layer_mut.remove_neighbors(id, to_remove.clone());
+                                layer_mut.remove_neighbors(&id, to_remove.clone());
                             }
                             for target in &to_remove {
                                 if layer_mut.get_links(target).is_none() {
@@ -327,7 +327,7 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
                                     );
                                 }
                             }
-                            layer_mut.remove_incoming_edges(id, to_remove);
+                            layer_mut.remove_incoming_edges(&id, to_remove);
                         }
                     }
                 }

--- a/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
@@ -213,7 +213,7 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
                         self.layers.resize(*height, Layer::new());
                     }
                     for layer_idx in 0..*height {
-                        self.layers[layer_idx].insert_node(id.clone(), Vec::new());
+                        self.layers[layer_idx].insert_node(id, Vec::new());
                     }
                 }
                 GraphMutation::AddEdges { .. } | GraphMutation::RemoveEdges { .. } => {}
@@ -587,7 +587,7 @@ impl<V: Ref + Display + FromStr + Ord> Layer<V> {
         self.set_hash.checksum()
     }
 
-    pub fn insert_node(&mut self, id: V, neighbors: Vec<V>) {
+    pub fn insert_node(&mut self, id: &V, neighbors: Vec<V>) {
         self.set_links(id.clone(), neighbors.clone());
     }
 

--- a/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
@@ -246,7 +246,7 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
                             for target in &to_add {
                                 if layer_mut.get_links(target).is_none() {
                                     warn!(
-                                        "AddEdges(Incoming): target={:?} missing at layer {layer} (id={:?}); skipping",
+                                        "AddEdges(Incoming): target={:?} missing at layer {layer} (id={:?}); add_neighbor will no-op for this target",
                                         target, id
                                     );
                                 }
@@ -265,7 +265,7 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
                             for target in &to_add {
                                 if layer_mut.get_links(target).is_none() {
                                     warn!(
-                                        "AddEdges(Bidirectional): target={:?} missing at layer {layer} (id={:?}); skipping incoming half for this target",
+                                        "AddEdges(Bidirectional): target={:?} missing at layer {layer} (id={:?}); add_neighbor will no-op for this target",
                                         target, id
                                     );
                                 }
@@ -556,8 +556,9 @@ impl<V: Ref + Display + FromStr + Ord> Layer<V> {
     }
 
     /// Add `to_add` into `id`'s own neighbor list, sorted and deduplicated.
-    /// No-op if `id` is not present in this layer. Idempotent: existing
-    /// entries are not duplicated.
+    /// No-op if `id` is not present in this layer (callers that need to log
+    /// the missing case should check `get_links(id)` first). Idempotent:
+    /// existing entries are not duplicated.
     pub fn add_outgoing_edges(&mut self, id: &V, to_add: Vec<V>) {
         let Some(node_links) = self.links.get_mut(id) else {
             return;

--- a/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
@@ -278,8 +278,58 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
                     ref id,
                     layer,
                     to_remove,
+                    direction,
                 } => {
-                    self.layers[layer].remove_neighbors(id, to_remove);
+                    if self.layers.len() < layer + 1 {
+                        warn!(
+                            "RemoveEdges: layer {layer} does not exist (id={:?}); skipping",
+                            id
+                        );
+                        continue;
+                    }
+                    let layer_mut = &mut self.layers[layer];
+                    match direction {
+                        EdgeDirection::Outgoing => {
+                            if layer_mut.get_links(id).is_none() {
+                                warn!(
+                                    "RemoveEdges(Outgoing): id={:?} missing at layer {layer}; skipping",
+                                    id
+                                );
+                            } else {
+                                layer_mut.remove_neighbors(id, to_remove);
+                            }
+                        }
+                        EdgeDirection::Incoming => {
+                            for target in &to_remove {
+                                if layer_mut.get_links(target).is_none() {
+                                    warn!(
+                                        "RemoveEdges(Incoming): target={:?} missing at layer {layer} (id={:?}); remove_incoming_edges will no-op for this target",
+                                        target, id
+                                    );
+                                }
+                            }
+                            layer_mut.remove_incoming_edges(id, to_remove);
+                        }
+                        EdgeDirection::Bidirectional => {
+                            if layer_mut.get_links(id).is_none() {
+                                warn!(
+                                    "RemoveEdges(Bidirectional): id={:?} missing at layer {layer}; skipping outgoing half",
+                                    id
+                                );
+                            } else {
+                                layer_mut.remove_neighbors(id, to_remove.clone());
+                            }
+                            for target in &to_remove {
+                                if layer_mut.get_links(target).is_none() {
+                                    warn!(
+                                        "RemoveEdges(Bidirectional): target={:?} missing at layer {layer} (id={:?}); remove_incoming_edges will no-op for this target",
+                                        target, id
+                                    );
+                                }
+                            }
+                            layer_mut.remove_incoming_edges(id, to_remove);
+                        }
+                    }
                 }
             }
         }
@@ -591,6 +641,20 @@ impl<V: Ref + Display + FromStr + Ord> Layer<V> {
                     self.set_hash
                         .add_unordered_set(&neighbor, neighbor_links.iter());
                 }
+            }
+        }
+    }
+
+    /// Remove `id` from each target's neighbor list, where `target` ranges over
+    /// `to_remove`. Targets that don't exist in this layer are silently skipped
+    /// (the caller's apply path is responsible for any logging).
+    pub fn remove_incoming_edges(&mut self, id: &V, to_remove: Vec<V>) {
+        for target in &to_remove {
+            if let Some(target_links) = self.links.get_mut(target) {
+                self.set_hash
+                    .remove_unordered_set(target, target_links.iter());
+                target_links.retain(|x| x != id);
+                self.set_hash.add_unordered_set(target, target_links.iter());
             }
         }
     }

--- a/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
@@ -188,13 +188,12 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
                 }
                 GraphMutation::AddNode {
                     id,
-                    layers,
+                    max_graph_layer,
                     update_ep,
                 } => {
-                    // Handle entry point update
+                    // Handle entry point update.
                     match update_ep {
                         UpdateEntryPoint::SetUnique { layer } => {
-                            // Ensure we have enough layers
                             if self.layers.len() < layer + 1 {
                                 self.layers.resize(layer + 1, Layer::new());
                             }
@@ -212,13 +211,13 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
                         UpdateEntryPoint::False => {}
                     }
 
-                    // Insert node into each specified layer
-                    for (layer_idx, neighbors) in layers {
-                        // Ensure we have enough layers
-                        if self.layers.len() < layer_idx + 1 {
-                            self.layers.resize(layer_idx + 1, Layer::new());
-                        }
-                        self.layers[layer_idx].insert_node(id.clone(), neighbors);
+                    // Ensure layers exist up to max_graph_layer and insert an empty entry
+                    // for this id in each.
+                    if self.layers.len() < max_graph_layer + 1 {
+                        self.layers.resize(max_graph_layer + 1, Layer::new());
+                    }
+                    for layer_idx in 0..=max_graph_layer {
+                        self.layers[layer_idx].insert_node(id.clone(), Vec::new());
                     }
                 }
                 GraphMutation::AddEdges {
@@ -998,17 +997,17 @@ mod tests {
         graph.insert_apply(vec![
             GraphMutation::AddNode {
                 id: a,
-                layers: vec![(0, vec![])],
-                update_ep: UpdateEntryPoint::SetUnique { layer: 0 },
+                max_graph_layer: 0,
+                update_ep: UpdateEntryPoint::SetUnique { layer: 1 },
             },
             GraphMutation::AddNode {
                 id: b,
-                layers: vec![(0, vec![])],
+                max_graph_layer: 0,
                 update_ep: UpdateEntryPoint::False,
             },
             GraphMutation::AddNode {
                 id: c,
-                layers: vec![(0, vec![])],
+                max_graph_layer: 0,
                 update_ep: UpdateEntryPoint::False,
             },
         ]);
@@ -1038,17 +1037,17 @@ mod tests {
         graph.insert_apply(vec![
             GraphMutation::AddNode {
                 id: a,
-                layers: vec![(0, vec![])],
-                update_ep: UpdateEntryPoint::SetUnique { layer: 0 },
+                max_graph_layer: 0,
+                update_ep: UpdateEntryPoint::SetUnique { layer: 1 },
             },
             GraphMutation::AddNode {
                 id: b,
-                layers: vec![(0, vec![])],
+                max_graph_layer: 0,
                 update_ep: UpdateEntryPoint::False,
             },
             GraphMutation::AddNode {
                 id: c,
-                layers: vec![(0, vec![])],
+                max_graph_layer: 0,
                 update_ep: UpdateEntryPoint::False,
             },
         ]);
@@ -1075,17 +1074,17 @@ mod tests {
         graph.insert_apply(vec![
             GraphMutation::AddNode {
                 id: a,
-                layers: vec![(0, vec![])],
-                update_ep: UpdateEntryPoint::SetUnique { layer: 0 },
+                max_graph_layer: 0,
+                update_ep: UpdateEntryPoint::SetUnique { layer: 1 },
             },
             GraphMutation::AddNode {
                 id: b,
-                layers: vec![(0, vec![])],
+                max_graph_layer: 0,
                 update_ep: UpdateEntryPoint::False,
             },
             GraphMutation::AddNode {
                 id: c,
-                layers: vec![(0, vec![])],
+                max_graph_layer: 0,
                 update_ep: UpdateEntryPoint::False,
             },
         ]);
@@ -1109,18 +1108,36 @@ mod tests {
         graph.insert_apply(vec![
             GraphMutation::AddNode {
                 id: a,
-                layers: vec![(0, vec![b, c])],
-                update_ep: UpdateEntryPoint::SetUnique { layer: 0 },
+                max_graph_layer: 0,
+                update_ep: UpdateEntryPoint::SetUnique { layer: 1 },
+            },
+            GraphMutation::AddEdges {
+                id: a,
+                layer: 0,
+                to_add: vec![b, c],
+                direction: EdgeDirection::Outgoing,
             },
             GraphMutation::AddNode {
                 id: b,
-                layers: vec![(0, vec![a])],
+                max_graph_layer: 0,
                 update_ep: UpdateEntryPoint::False,
+            },
+            GraphMutation::AddEdges {
+                id: b,
+                layer: 0,
+                to_add: vec![a],
+                direction: EdgeDirection::Outgoing,
             },
             GraphMutation::AddNode {
                 id: c,
-                layers: vec![(0, vec![a])],
+                max_graph_layer: 0,
                 update_ep: UpdateEntryPoint::False,
+            },
+            GraphMutation::AddEdges {
+                id: c,
+                layer: 0,
+                to_add: vec![a],
+                direction: EdgeDirection::Outgoing,
             },
         ]);
         graph.insert_apply(vec![GraphMutation::RemoveEdges {

--- a/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
@@ -7,7 +7,7 @@ use crate::{
     execution::hawk_main::state_check::SetHash,
     hawkers::ideal_knn_engines::{read_knn_results_from_file, Engine, EngineChoice, KNNResult},
     hnsw::{
-        graph::{GraphMutation, UpdateEntryPoint},
+        graph::{mutation::EdgeDirection, GraphMutation, UpdateEntryPoint},
         searcher::LayerMode,
         vector_store::Ref,
         HnswSearcher,
@@ -31,6 +31,7 @@ use std::{
     sync::Arc,
 };
 use tokio::sync::RwLock;
+use tracing::warn;
 
 /// Representation of the entry point of HNSW search in a layered graph.
 /// This is a vector reference along with the layer of the graph at which
@@ -220,12 +221,57 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
                         self.layers[layer_idx].insert_node(id.clone(), neighbors);
                     }
                 }
-                GraphMutation::AddEdges { id, layers } => {
-                    for (layer_idx, neighborhoods) in layers {
-                        if self.layers.len() < layer_idx + 1 {
-                            self.layers.resize(layer_idx + 1, Layer::new());
+                GraphMutation::AddEdges {
+                    id,
+                    layer,
+                    to_add,
+                    direction,
+                } => {
+                    if self.layers.len() < layer + 1 {
+                        self.layers.resize(layer + 1, Layer::new());
+                    }
+                    let layer_mut = &mut self.layers[layer];
+                    match direction {
+                        EdgeDirection::Outgoing => {
+                            if layer_mut.get_links(&id).is_none() {
+                                warn!(
+                                    "AddEdges(Outgoing): id={:?} missing at layer {layer}; skipping",
+                                    id
+                                );
+                            } else {
+                                layer_mut.add_outgoing_edges(&id, to_add);
+                            }
                         }
-                        self.layers[layer_idx].add_neighbor(id.clone(), neighborhoods);
+                        EdgeDirection::Incoming => {
+                            for target in &to_add {
+                                if layer_mut.get_links(target).is_none() {
+                                    warn!(
+                                        "AddEdges(Incoming): target={:?} missing at layer {layer} (id={:?}); skipping",
+                                        target, id
+                                    );
+                                }
+                            }
+                            layer_mut.add_neighbor(id.clone(), to_add);
+                        }
+                        EdgeDirection::Bidirectional => {
+                            if layer_mut.get_links(&id).is_none() {
+                                warn!(
+                                    "AddEdges(Bidirectional): id={:?} missing at layer {layer}; skipping outgoing half",
+                                    id
+                                );
+                            } else {
+                                layer_mut.add_outgoing_edges(&id, to_add.clone());
+                            }
+                            for target in &to_add {
+                                if layer_mut.get_links(target).is_none() {
+                                    warn!(
+                                        "AddEdges(Bidirectional): target={:?} missing at layer {layer} (id={:?}); skipping incoming half for this target",
+                                        target, id
+                                    );
+                                }
+                            }
+                            layer_mut.add_neighbor(id, to_add);
+                        }
                     }
                 }
                 GraphMutation::RemoveEdges {
@@ -507,6 +553,22 @@ impl<V: Ref + Display + FromStr + Ord> Layer<V> {
                 }
             }
         }
+    }
+
+    /// Add `to_add` into `id`'s own neighbor list, sorted and deduplicated.
+    /// No-op if `id` is not present in this layer. Idempotent: existing
+    /// entries are not duplicated.
+    pub fn add_outgoing_edges(&mut self, id: &V, to_add: Vec<V>) {
+        let Some(node_links) = self.links.get_mut(id) else {
+            return;
+        };
+        self.set_hash.remove_unordered_set(id, node_links.iter());
+        for nb in to_add {
+            if let Err(pos) = node_links.binary_search(&nb) {
+                node_links.insert(pos, nb);
+            }
+        }
+        self.set_hash.add_unordered_set(id, node_links.iter());
     }
 
     /// Remove a node from the graph and clean up all backlinks from its neighbors.

--- a/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
@@ -176,14 +176,13 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
     /// This updates the graph's entry points set and connects the new vector to its
     /// neighbors as specified in the mutations.
     pub fn insert_apply(&mut self, plan: Vec<GraphMutation<V>>) {
-        for mutation in plan {
+        // Pass 1: apply node-level mutations.
+        for mutation in plan.iter() {
             match mutation {
-                GraphMutation::RemoveNode { ref id } => {
-                    // Remove node from all layers where it exists
+                GraphMutation::RemoveNode { id } => {
                     for layer in &mut self.layers {
                         layer.remove_node(id);
                     }
-                    // Remove from entry points if present
                     self.entry_points.retain(|ep| &ep.point != id);
                 }
                 GraphMutation::AddNode {
@@ -191,35 +190,40 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
                     max_graph_layer,
                     update_ep,
                 } => {
-                    // Handle entry point update.
                     match update_ep {
                         UpdateEntryPoint::SetUnique { layer } => {
-                            if self.layers.len() < layer + 1 {
-                                self.layers.resize(layer + 1, Layer::new());
+                            if self.layers.len() < *layer + 1 {
+                                self.layers.resize(*layer + 1, Layer::new());
                             }
                             self.entry_points = vec![EntryPoint {
                                 point: id.clone(),
-                                layer,
+                                layer: *layer,
                             }];
                         }
                         UpdateEntryPoint::Append { layer } => {
                             self.entry_points.push(EntryPoint {
                                 point: id.clone(),
-                                layer,
+                                layer: *layer,
                             });
                         }
                         UpdateEntryPoint::False => {}
                     }
 
-                    // Ensure layers exist up to max_graph_layer and insert an empty entry
-                    // for this id in each.
-                    if self.layers.len() < max_graph_layer + 1 {
-                        self.layers.resize(max_graph_layer + 1, Layer::new());
+                    if self.layers.len() < *max_graph_layer + 1 {
+                        self.layers.resize(*max_graph_layer + 1, Layer::new());
                     }
-                    for layer_idx in 0..=max_graph_layer {
+                    for layer_idx in 0..=*max_graph_layer {
                         self.layers[layer_idx].insert_node(id.clone(), Vec::new());
                     }
                 }
+                GraphMutation::AddEdges { .. } | GraphMutation::RemoveEdges { .. } => {}
+            }
+        }
+
+        // Pass 2: apply edge-level mutations.
+        for mutation in plan.into_iter() {
+            match mutation {
+                GraphMutation::AddNode { .. } | GraphMutation::RemoveNode { .. } => {}
                 GraphMutation::AddEdges {
                     id,
                     layer,
@@ -1149,5 +1153,37 @@ mod tests {
         assert_eq!(graph.layers[0].get_links(&a).unwrap(), &[c]);
         // Bidirectional cleanup is not implied — b's list still contains a.
         assert_eq!(graph.layers[0].get_links(&b).unwrap(), &[a]);
+    }
+
+    #[test]
+    fn two_phase_apply_edges_before_node_in_vec_still_works() {
+        // Pass 1 should apply AddNode before pass 2 applies AddEdges, regardless
+        // of their order in the input Vec.
+        let mut graph = GraphMem::<IrisVectorId>::new();
+        let a = IrisVectorId::from_serial_id(1);
+        let b = IrisVectorId::from_serial_id(2);
+        graph.insert_apply(vec![
+            // Listed first: an edge op that references a node not yet created.
+            GraphMutation::AddEdges {
+                id: a,
+                layer: 0,
+                to_add: vec![b],
+                direction: EdgeDirection::Outgoing,
+            },
+            // Listed second: the node creation.
+            GraphMutation::AddNode {
+                id: a,
+                max_graph_layer: 0,
+                update_ep: UpdateEntryPoint::SetUnique { layer: 0 },
+            },
+            GraphMutation::AddNode {
+                id: b,
+                max_graph_layer: 0,
+                update_ep: UpdateEntryPoint::False,
+            },
+        ]);
+        // Pass-1 created the nodes, then pass-2 applied the edge — so a should
+        // now have b in its outgoing list.
+        assert_eq!(graph.layers[0].get_links(&a).unwrap(), &[b]);
     }
 }

--- a/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
@@ -985,4 +985,152 @@ mod tests {
 
         Ok(())
     }
+
+    use crate::hnsw::graph::mutation::{EdgeDirection, GraphMutation, UpdateEntryPoint};
+
+    #[test]
+    fn add_edges_outgoing_writes_only_to_id_list() {
+        let mut graph = GraphMem::<IrisVectorId>::new();
+        let a = IrisVectorId::from_serial_id(1);
+        let b = IrisVectorId::from_serial_id(2);
+        let c = IrisVectorId::from_serial_id(3);
+        // Seed: a, b, c all exist at layer 0 with no edges.
+        graph.insert_apply(vec![
+            GraphMutation::AddNode {
+                id: a,
+                layers: vec![(0, vec![])],
+                update_ep: UpdateEntryPoint::SetUnique { layer: 0 },
+            },
+            GraphMutation::AddNode {
+                id: b,
+                layers: vec![(0, vec![])],
+                update_ep: UpdateEntryPoint::False,
+            },
+            GraphMutation::AddNode {
+                id: c,
+                layers: vec![(0, vec![])],
+                update_ep: UpdateEntryPoint::False,
+            },
+        ]);
+        graph.insert_apply(vec![GraphMutation::AddEdges {
+            id: a,
+            layer: 0,
+            to_add: vec![b, c],
+            direction: EdgeDirection::Outgoing,
+        }]);
+        assert_eq!(graph.layers[0].get_links(&a).unwrap(), &[b, c]);
+        assert_eq!(
+            graph.layers[0].get_links(&b).unwrap(),
+            &[] as &[IrisVectorId]
+        );
+        assert_eq!(
+            graph.layers[0].get_links(&c).unwrap(),
+            &[] as &[IrisVectorId]
+        );
+    }
+
+    #[test]
+    fn add_edges_incoming_writes_only_to_target_lists() {
+        let mut graph = GraphMem::<IrisVectorId>::new();
+        let a = IrisVectorId::from_serial_id(1);
+        let b = IrisVectorId::from_serial_id(2);
+        let c = IrisVectorId::from_serial_id(3);
+        graph.insert_apply(vec![
+            GraphMutation::AddNode {
+                id: a,
+                layers: vec![(0, vec![])],
+                update_ep: UpdateEntryPoint::SetUnique { layer: 0 },
+            },
+            GraphMutation::AddNode {
+                id: b,
+                layers: vec![(0, vec![])],
+                update_ep: UpdateEntryPoint::False,
+            },
+            GraphMutation::AddNode {
+                id: c,
+                layers: vec![(0, vec![])],
+                update_ep: UpdateEntryPoint::False,
+            },
+        ]);
+        graph.insert_apply(vec![GraphMutation::AddEdges {
+            id: a,
+            layer: 0,
+            to_add: vec![b, c],
+            direction: EdgeDirection::Incoming,
+        }]);
+        assert_eq!(
+            graph.layers[0].get_links(&a).unwrap(),
+            &[] as &[IrisVectorId]
+        );
+        assert_eq!(graph.layers[0].get_links(&b).unwrap(), &[a]);
+        assert_eq!(graph.layers[0].get_links(&c).unwrap(), &[a]);
+    }
+
+    #[test]
+    fn add_edges_bidirectional_writes_both_sides() {
+        let mut graph = GraphMem::<IrisVectorId>::new();
+        let a = IrisVectorId::from_serial_id(1);
+        let b = IrisVectorId::from_serial_id(2);
+        let c = IrisVectorId::from_serial_id(3);
+        graph.insert_apply(vec![
+            GraphMutation::AddNode {
+                id: a,
+                layers: vec![(0, vec![])],
+                update_ep: UpdateEntryPoint::SetUnique { layer: 0 },
+            },
+            GraphMutation::AddNode {
+                id: b,
+                layers: vec![(0, vec![])],
+                update_ep: UpdateEntryPoint::False,
+            },
+            GraphMutation::AddNode {
+                id: c,
+                layers: vec![(0, vec![])],
+                update_ep: UpdateEntryPoint::False,
+            },
+        ]);
+        graph.insert_apply(vec![GraphMutation::AddEdges {
+            id: a,
+            layer: 0,
+            to_add: vec![b, c],
+            direction: EdgeDirection::Bidirectional,
+        }]);
+        assert_eq!(graph.layers[0].get_links(&a).unwrap(), &[b, c]);
+        assert_eq!(graph.layers[0].get_links(&b).unwrap(), &[a]);
+        assert_eq!(graph.layers[0].get_links(&c).unwrap(), &[a]);
+    }
+
+    #[test]
+    fn remove_edges_outgoing_only_modifies_id_list() {
+        let mut graph = GraphMem::<IrisVectorId>::new();
+        let a = IrisVectorId::from_serial_id(1);
+        let b = IrisVectorId::from_serial_id(2);
+        let c = IrisVectorId::from_serial_id(3);
+        graph.insert_apply(vec![
+            GraphMutation::AddNode {
+                id: a,
+                layers: vec![(0, vec![b, c])],
+                update_ep: UpdateEntryPoint::SetUnique { layer: 0 },
+            },
+            GraphMutation::AddNode {
+                id: b,
+                layers: vec![(0, vec![a])],
+                update_ep: UpdateEntryPoint::False,
+            },
+            GraphMutation::AddNode {
+                id: c,
+                layers: vec![(0, vec![a])],
+                update_ep: UpdateEntryPoint::False,
+            },
+        ]);
+        graph.insert_apply(vec![GraphMutation::RemoveEdges {
+            id: a,
+            layer: 0,
+            to_remove: vec![b],
+            direction: EdgeDirection::Outgoing,
+        }]);
+        assert_eq!(graph.layers[0].get_links(&a).unwrap(), &[c]);
+        // Bidirectional cleanup is not implied — b's list still contains a.
+        assert_eq!(graph.layers[0].get_links(&b).unwrap(), &[a]);
+    }
 }

--- a/iris-mpc-cpu/src/hnsw/graph/mutation.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/mutation.rs
@@ -23,9 +23,10 @@ pub enum GraphMutation<Vector: Ord> {
         id: Vector,
     },
     AddEdges {
-        // list of layer, neighbors
-        layers: Vec<(usize, Vec<Vector>)>,
         id: Vector,
+        layer: usize,
+        to_add: Vec<Vector>,
+        direction: EdgeDirection,
     },
     RemoveEdges {
         to_remove: Vec<Vector>,
@@ -47,9 +48,17 @@ impl<V: std::fmt::Debug + Ord> std::fmt::Debug for GraphMutation<V> {
                 .field("update_ep", update_ep)
                 .field("id", id)
                 .finish(),
-            Self::AddEdges { id, layers: _ } => {
-                f.debug_struct("AddNeighbor").field("id", id).finish()
-            }
+            Self::AddEdges {
+                id,
+                layer,
+                direction,
+                ..
+            } => f
+                .debug_struct("AddEdges")
+                .field("id", id)
+                .field("layer", layer)
+                .field("direction", direction)
+                .finish(),
             Self::RemoveEdges { .. } => f.debug_struct("RemoveInvalidNeighbors").finish(),
         }
     }

--- a/iris-mpc-cpu/src/hnsw/graph/mutation.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/mutation.rs
@@ -55,6 +55,19 @@ impl<V: std::fmt::Debug + Ord> std::fmt::Debug for GraphMutation<V> {
     }
 }
 
+/// Direction in which edge mutations are applied between `id` and the
+/// vectors listed in `to_add` / `to_remove`.
+///
+/// - `Outgoing`: writes to `id`'s own neighbor list (forward edges from `id`).
+/// - `Incoming`: writes `id` into each target's neighbor list (back-edges into `id`).
+/// - `Bidirectional`: both of the above, applied together.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EdgeDirection {
+    Outgoing,
+    Incoming,
+    Bidirectional,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum UpdateEntryPoint {
     /// Do not update entry points based on inserted vector.

--- a/iris-mpc-cpu/src/hnsw/graph/mutation.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/mutation.rs
@@ -136,7 +136,7 @@ mod tests {
         let mut layer = Layer::new();
         layer.insert_node(10i32, vec![]);
         layer.insert_node(20i32, vec![]);
-        layer.add_neighbor(5, vec![10, 20]);
+        layer.add_incoming_edges(&5, vec![10, 20]);
         assert_eq!(layer.get_links(&10), Some([5].as_slice()));
         assert_eq!(layer.get_links(&20), Some([5].as_slice()));
     }
@@ -147,8 +147,8 @@ mod tests {
     fn add_neighbors_is_idempotent() {
         let mut layer = Layer::new();
         layer.insert_node(10i32, vec![]);
-        layer.add_neighbor(5, vec![10]);
-        layer.add_neighbor(5, vec![10]);
+        layer.add_incoming_edges(&5, vec![10]);
+        layer.add_incoming_edges(&5, vec![10]);
         assert_eq!(layer.get_links(&10), Some([5].as_slice()));
     }
 
@@ -159,9 +159,9 @@ mod tests {
     fn add_neighbors_maintains_sorted_order() {
         let mut layer = Layer::new();
         layer.insert_node(10i32, vec![]);
-        layer.add_neighbor(7, vec![10]);
-        layer.add_neighbor(3, vec![10]);
-        layer.add_neighbor(5, vec![10]);
+        layer.add_incoming_edges(&7, vec![10]);
+        layer.add_incoming_edges(&3, vec![10]);
+        layer.add_incoming_edges(&5, vec![10]);
         assert_eq!(layer.get_links(&10), Some([3, 5, 7].as_slice()));
     }
 
@@ -170,7 +170,7 @@ mod tests {
     #[test]
     fn add_neighbors_skips_nonexistent_nodes() {
         let mut layer = Layer::new();
-        layer.add_neighbor(1i32, vec![99]); // node 99 was never inserted
+        layer.add_incoming_edges(&1i32, vec![99]); // node 99 was never inserted
         assert!(layer.get_links(&99).is_none());
     }
 
@@ -181,7 +181,7 @@ mod tests {
     fn remove_neighbors_removes_specified_only() {
         let mut layer = Layer::new();
         layer.insert_node(1i32, vec![2, 3, 4, 5]);
-        layer.remove_neighbors(&1, vec![2, 4]);
+        layer.remove_outgoing_edges(&1, vec![2, 4]);
         assert_eq!(layer.get_links(&1), Some([3, 5].as_slice()));
     }
 
@@ -193,7 +193,7 @@ mod tests {
         let mut layer = Layer::new();
         layer.insert_node(1i32, vec![2, 3]);
         layer.insert_node(2i32, vec![1, 3]);
-        layer.remove_neighbors(&1, vec![2]);
+        layer.remove_outgoing_edges(&1, vec![2]);
         assert_eq!(layer.get_links(&1), Some([3].as_slice()));
         assert_eq!(layer.get_links(&2), Some([1, 3].as_slice()));
     }
@@ -202,7 +202,7 @@ mod tests {
     #[test]
     fn remove_neighbors_on_nonexistent_node_is_noop() {
         let mut layer = Layer::new();
-        layer.remove_neighbors(&99i32, vec![1, 2]); // should not panic
+        layer.remove_outgoing_edges(&99i32, vec![1, 2]); // should not panic
     }
 
     // ── WAL replay sequences ──────────────────────────────────────────────────
@@ -221,7 +221,7 @@ mod tests {
         // New node 40 inserted with forward links to 10 and 20
         layer.insert_node(40, vec![10, 20]);
         // Backlinks: 10 and 20 each gain 40 as a neighbor
-        layer.add_neighbor(40, vec![10, 20]);
+        layer.add_incoming_edges(&40, vec![10, 20]);
 
         assert_eq!(layer.get_links(&40), Some([10, 20].as_slice()));
         assert_eq!(layer.get_links(&10).unwrap(), &[20, 30, 40]);
@@ -242,9 +242,9 @@ mod tests {
         // Insert node 4 with forward links [1, 2]
         layer.insert_node(4, vec![1, 2]);
         // Backlinks into 1 and 2
-        layer.add_neighbor(4, vec![1, 2]);
+        layer.add_incoming_edges(&4, vec![1, 2]);
         // Compaction: node 2 now exceeds link limit, prune neighbor 3
-        layer.remove_neighbors(&2, vec![3]);
+        layer.remove_outgoing_edges(&2, vec![3]);
 
         assert_eq!(layer.get_links(&4), Some([1, 2].as_slice()));
         assert_eq!(layer.get_links(&1).unwrap(), &[2, 3, 4]);

--- a/iris-mpc-cpu/src/hnsw/graph/mutation.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/mutation.rs
@@ -16,10 +16,7 @@ pub enum GraphMutation<Vector: Ord> {
     AddNode {
         id: Vector,
         /// Number of real graph layers this node is included in. The node will
-        /// be present in layers `0..height`, i.e. layer indices `0..=height-1`.
-        /// `height == 0` represents a node that is not inserted into any graph
-        /// layer (used as a marker on code paths that record an insertion
-        /// without mutating the in-memory graph).
+        /// be present in layers `0..height`.
         height: usize,
         update_ep: UpdateEntryPoint,
     },
@@ -115,7 +112,7 @@ mod tests {
     #[test]
     fn insert_node_sets_exact_links() {
         let mut layer = Layer::new();
-        layer.insert_node(1i32, vec![2, 3, 4]);
+        layer.insert_node(&1i32, vec![2, 3, 4]);
         assert_eq!(layer.get_links(&1), Some([2, 3, 4].as_slice()));
     }
 
@@ -123,8 +120,8 @@ mod tests {
     #[test]
     fn insert_node_replaces_existing_links() {
         let mut layer = Layer::new();
-        layer.insert_node(1i32, vec![2, 3]);
-        layer.insert_node(1i32, vec![4, 5]);
+        layer.insert_node(&1i32, vec![2, 3]);
+        layer.insert_node(&1i32, vec![4, 5]);
         assert_eq!(layer.get_links(&1), Some([4, 5].as_slice()));
     }
 
@@ -134,8 +131,8 @@ mod tests {
     #[test]
     fn add_neighbors_inserts_id_into_existing_nodes() {
         let mut layer = Layer::new();
-        layer.insert_node(10i32, vec![]);
-        layer.insert_node(20i32, vec![]);
+        layer.insert_node(&10i32, vec![]);
+        layer.insert_node(&20i32, vec![]);
         layer.add_incoming_edges(&5, vec![10, 20]);
         assert_eq!(layer.get_links(&10), Some([5].as_slice()));
         assert_eq!(layer.get_links(&20), Some([5].as_slice()));
@@ -146,7 +143,7 @@ mod tests {
     #[test]
     fn add_neighbors_is_idempotent() {
         let mut layer = Layer::new();
-        layer.insert_node(10i32, vec![]);
+        layer.insert_node(&10i32, vec![]);
         layer.add_incoming_edges(&5, vec![10]);
         layer.add_incoming_edges(&5, vec![10]);
         assert_eq!(layer.get_links(&10), Some([5].as_slice()));
@@ -158,7 +155,7 @@ mod tests {
     #[test]
     fn add_neighbors_maintains_sorted_order() {
         let mut layer = Layer::new();
-        layer.insert_node(10i32, vec![]);
+        layer.insert_node(&10i32, vec![]);
         layer.add_incoming_edges(&7, vec![10]);
         layer.add_incoming_edges(&3, vec![10]);
         layer.add_incoming_edges(&5, vec![10]);
@@ -180,7 +177,7 @@ mod tests {
     #[test]
     fn remove_neighbors_removes_specified_only() {
         let mut layer = Layer::new();
-        layer.insert_node(1i32, vec![2, 3, 4, 5]);
+        layer.insert_node(&1i32, vec![2, 3, 4, 5]);
         layer.remove_outgoing_edges(&1, vec![2, 4]);
         assert_eq!(layer.get_links(&1), Some([3, 5].as_slice()));
     }
@@ -191,8 +188,8 @@ mod tests {
     #[test]
     fn remove_neighbors_is_unidirectional() {
         let mut layer = Layer::new();
-        layer.insert_node(1i32, vec![2, 3]);
-        layer.insert_node(2i32, vec![1, 3]);
+        layer.insert_node(&1i32, vec![2, 3]);
+        layer.insert_node(&2i32, vec![1, 3]);
         layer.remove_outgoing_edges(&1, vec![2]);
         assert_eq!(layer.get_links(&1), Some([3].as_slice()));
         assert_eq!(layer.get_links(&2), Some([1, 3].as_slice()));
@@ -214,12 +211,12 @@ mod tests {
     #[test]
     fn wal_replay_insert_then_backlinks() {
         let mut layer = Layer::new();
-        layer.insert_node(10i32, vec![20, 30]);
-        layer.insert_node(20i32, vec![10, 30]);
-        layer.insert_node(30i32, vec![10, 20]);
+        layer.insert_node(&10i32, vec![20, 30]);
+        layer.insert_node(&20i32, vec![10, 30]);
+        layer.insert_node(&30i32, vec![10, 20]);
 
         // New node 40 inserted with forward links to 10 and 20
-        layer.insert_node(40, vec![10, 20]);
+        layer.insert_node(&40, vec![10, 20]);
         // Backlinks: 10 and 20 each gain 40 as a neighbor
         layer.add_incoming_edges(&40, vec![10, 20]);
 
@@ -235,12 +232,12 @@ mod tests {
     #[test]
     fn wal_replay_insert_backlinks_then_compact() {
         let mut layer = Layer::new();
-        layer.insert_node(1i32, vec![2, 3]);
-        layer.insert_node(2i32, vec![1, 3]);
-        layer.insert_node(3i32, vec![1, 2]);
+        layer.insert_node(&1i32, vec![2, 3]);
+        layer.insert_node(&2i32, vec![1, 3]);
+        layer.insert_node(&3i32, vec![1, 2]);
 
         // Insert node 4 with forward links [1, 2]
-        layer.insert_node(4, vec![1, 2]);
+        layer.insert_node(&4, vec![1, 2]);
         // Backlinks into 1 and 2
         layer.add_incoming_edges(&4, vec![1, 2]);
         // Compaction: node 2 now exceeds link limit, prune neighbor 3

--- a/iris-mpc-cpu/src/hnsw/graph/mutation.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/mutation.rs
@@ -29,9 +29,10 @@ pub enum GraphMutation<Vector: Ord> {
         direction: EdgeDirection,
     },
     RemoveEdges {
-        to_remove: Vec<Vector>,
-        layer: usize,
         id: Vector,
+        layer: usize,
+        to_remove: Vec<Vector>,
+        direction: EdgeDirection,
     },
 }
 
@@ -59,7 +60,17 @@ impl<V: std::fmt::Debug + Ord> std::fmt::Debug for GraphMutation<V> {
                 .field("layer", layer)
                 .field("direction", direction)
                 .finish(),
-            Self::RemoveEdges { .. } => f.debug_struct("RemoveInvalidNeighbors").finish(),
+            Self::RemoveEdges {
+                id,
+                layer,
+                direction,
+                ..
+            } => f
+                .debug_struct("RemoveEdges")
+                .field("id", id)
+                .field("layer", layer)
+                .field("direction", direction)
+                .finish(),
         }
     }
 }

--- a/iris-mpc-cpu/src/hnsw/graph/mutation.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/mutation.rs
@@ -14,10 +14,14 @@ pub struct GroupedMutations<V: Ord>(pub Vec<GraphMutation<V>>);
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum GraphMutation<Vector: Ord> {
     AddNode {
-        // List of layer, neighbors.
-        layers: Vec<(usize, Vec<Vector>)>,
-        update_ep: UpdateEntryPoint,
         id: Vector,
+        /// The top real graph layer this node lives in. The node will be present
+        /// in layers `0..=max_graph_layer`. When `update_ep` is
+        /// `SetUnique { layer: L }` or `Append { layer: L }`, the apply path
+        /// requires `max_graph_layer == L - 1` (the entry-point layer is a virtual
+        /// layer one above the top real graph layer in this codebase's structure).
+        max_graph_layer: usize,
+        update_ep: UpdateEntryPoint,
     },
     RemoveNode {
         id: Vector,
@@ -41,13 +45,14 @@ impl<V: std::fmt::Debug + Ord> std::fmt::Debug for GraphMutation<V> {
         match self {
             Self::RemoveNode { id } => f.debug_struct("RemoveNode").field("id", id).finish(),
             Self::AddNode {
-                layers: _,
-                update_ep,
                 id,
+                max_graph_layer,
+                update_ep,
             } => f
-                .debug_struct("InsertNode")
-                .field("update_ep", update_ep)
+                .debug_struct("AddNode")
                 .field("id", id)
+                .field("max_graph_layer", max_graph_layer)
+                .field("update_ep", update_ep)
                 .finish(),
             Self::AddEdges {
                 id,

--- a/iris-mpc-cpu/src/hnsw/graph/mutation.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/mutation.rs
@@ -15,12 +15,12 @@ pub struct GroupedMutations<V: Ord>(pub Vec<GraphMutation<V>>);
 pub enum GraphMutation<Vector: Ord> {
     AddNode {
         id: Vector,
-        /// The top real graph layer this node lives in. The node will be present
-        /// in layers `0..=max_graph_layer`. When `update_ep` is
-        /// `SetUnique { layer: L }` or `Append { layer: L }`, the apply path
-        /// requires `max_graph_layer == L - 1` (the entry-point layer is a virtual
-        /// layer one above the top real graph layer in this codebase's structure).
-        max_graph_layer: usize,
+        /// Number of real graph layers this node is included in. The node will
+        /// be present in layers `0..height`, i.e. layer indices `0..=height-1`.
+        /// `height == 0` represents a node that is not inserted into any graph
+        /// layer (used as a marker on code paths that record an insertion
+        /// without mutating the in-memory graph).
+        height: usize,
         update_ep: UpdateEntryPoint,
     },
     RemoveNode {
@@ -46,12 +46,12 @@ impl<V: std::fmt::Debug + Ord> std::fmt::Debug for GraphMutation<V> {
             Self::RemoveNode { id } => f.debug_struct("RemoveNode").field("id", id).finish(),
             Self::AddNode {
                 id,
-                max_graph_layer,
+                height,
                 update_ep,
             } => f
                 .debug_struct("AddNode")
                 .field("id", id)
-                .field("max_graph_layer", max_graph_layer)
+                .field("height", height)
                 .field("update_ep", update_ep)
                 .finish(),
             Self::AddEdges {

--- a/iris-mpc-cpu/src/hnsw/graph/mutation.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/mutation.rs
@@ -24,16 +24,16 @@ pub enum GraphMutation<Vector: Ord> {
         id: Vector,
     },
     AddEdges {
-        id: Vector,
+        base: Vector,
+        neighbors: Vec<Vector>,
         layer: usize,
-        to_add: Vec<Vector>,
-        direction: EdgeDirection,
+        edge_type: EdgeType,
     },
     RemoveEdges {
-        id: Vector,
+        base: Vector,
+        neighbors: Vec<Vector>,
         layer: usize,
-        to_remove: Vec<Vector>,
-        direction: EdgeDirection,
+        edge_type: EdgeType,
     },
 }
 
@@ -52,42 +52,49 @@ impl<V: std::fmt::Debug + Ord> std::fmt::Debug for GraphMutation<V> {
                 .field("update_ep", update_ep)
                 .finish(),
             Self::AddEdges {
-                id,
+                base,
                 layer,
-                direction,
+                edge_type,
                 ..
             } => f
                 .debug_struct("AddEdges")
-                .field("id", id)
+                .field("base", base)
                 .field("layer", layer)
-                .field("direction", direction)
+                .field("edge_type", edge_type)
                 .finish(),
             Self::RemoveEdges {
-                id,
+                base,
                 layer,
-                direction,
+                edge_type,
                 ..
             } => f
                 .debug_struct("RemoveEdges")
-                .field("id", id)
+                .field("base", base)
                 .field("layer", layer)
-                .field("direction", direction)
+                .field("edge_type", edge_type)
                 .finish(),
         }
     }
 }
 
-/// Direction in which edge mutations are applied between `id` and the
-/// vectors listed in `to_add` / `to_remove`.
+/// Type of edges between `base` and the nodes listed in `neighbors` affected by
+/// edge mutations.
 ///
-/// - `Outgoing`: writes to `id`'s own neighbor list (forward edges from `id`).
-/// - `Incoming`: writes `id` into each target's neighbor list (back-edges into `id`).
-/// - `Bidirectional`: both of the above, applied together.
+/// - `Base`: affects nodes listed in `neighbors` found in `base`'s neighbor
+///   list (forward edges from `base`).
+/// - `Neighbors`: affects instances of `base` in each neighbor node's neighbor
+///   list (back-edges into `base`).
+/// - `All`: affects both of the above types of edges (symmetric edges).
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum EdgeDirection {
-    Outgoing,
-    Incoming,
-    Bidirectional,
+pub enum EdgeType {
+    /// Affects forward edges from the base node
+    Base,
+
+    /// Affects back edges into the base node
+    Neighbors,
+
+    /// Affects both forward edges from and back edges into the base node
+    All,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/iris-mpc-cpu/src/hnsw/graph/mutation.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/mutation.rs
@@ -140,7 +140,7 @@ mod tests {
         let mut layer = Layer::new();
         layer.insert_node(&10i32, vec![]);
         layer.insert_node(&20i32, vec![]);
-        layer.add_incoming_edges(&5, vec![10, 20]);
+        layer.link_node_to_neighbors(&5, vec![10, 20]);
         assert_eq!(layer.get_links(&10), Some([5].as_slice()));
         assert_eq!(layer.get_links(&20), Some([5].as_slice()));
     }
@@ -151,8 +151,8 @@ mod tests {
     fn add_neighbors_is_idempotent() {
         let mut layer = Layer::new();
         layer.insert_node(&10i32, vec![]);
-        layer.add_incoming_edges(&5, vec![10]);
-        layer.add_incoming_edges(&5, vec![10]);
+        layer.link_node_to_neighbors(&5, vec![10]);
+        layer.link_node_to_neighbors(&5, vec![10]);
         assert_eq!(layer.get_links(&10), Some([5].as_slice()));
     }
 
@@ -163,9 +163,9 @@ mod tests {
     fn add_neighbors_maintains_sorted_order() {
         let mut layer = Layer::new();
         layer.insert_node(&10i32, vec![]);
-        layer.add_incoming_edges(&7, vec![10]);
-        layer.add_incoming_edges(&3, vec![10]);
-        layer.add_incoming_edges(&5, vec![10]);
+        layer.link_node_to_neighbors(&7, vec![10]);
+        layer.link_node_to_neighbors(&3, vec![10]);
+        layer.link_node_to_neighbors(&5, vec![10]);
         assert_eq!(layer.get_links(&10), Some([3, 5, 7].as_slice()));
     }
 
@@ -174,7 +174,7 @@ mod tests {
     #[test]
     fn add_neighbors_skips_nonexistent_nodes() {
         let mut layer = Layer::new();
-        layer.add_incoming_edges(&1i32, vec![99]); // node 99 was never inserted
+        layer.link_node_to_neighbors(&1i32, vec![99]); // node 99 was never inserted
         assert!(layer.get_links(&99).is_none());
     }
 
@@ -185,7 +185,7 @@ mod tests {
     fn remove_neighbors_removes_specified_only() {
         let mut layer = Layer::new();
         layer.insert_node(&1i32, vec![2, 3, 4, 5]);
-        layer.remove_outgoing_edges(&1, vec![2, 4]);
+        layer.unlink_neighbors_from_node(&1, vec![2, 4]);
         assert_eq!(layer.get_links(&1), Some([3, 5].as_slice()));
     }
 
@@ -197,7 +197,7 @@ mod tests {
         let mut layer = Layer::new();
         layer.insert_node(&1i32, vec![2, 3]);
         layer.insert_node(&2i32, vec![1, 3]);
-        layer.remove_outgoing_edges(&1, vec![2]);
+        layer.unlink_neighbors_from_node(&1, vec![2]);
         assert_eq!(layer.get_links(&1), Some([3].as_slice()));
         assert_eq!(layer.get_links(&2), Some([1, 3].as_slice()));
     }
@@ -206,7 +206,7 @@ mod tests {
     #[test]
     fn remove_neighbors_on_nonexistent_node_is_noop() {
         let mut layer = Layer::new();
-        layer.remove_outgoing_edges(&99i32, vec![1, 2]); // should not panic
+        layer.unlink_neighbors_from_node(&99i32, vec![1, 2]); // should not panic
     }
 
     // ── WAL replay sequences ──────────────────────────────────────────────────
@@ -225,7 +225,7 @@ mod tests {
         // New node 40 inserted with forward links to 10 and 20
         layer.insert_node(&40, vec![10, 20]);
         // Backlinks: 10 and 20 each gain 40 as a neighbor
-        layer.add_incoming_edges(&40, vec![10, 20]);
+        layer.link_node_to_neighbors(&40, vec![10, 20]);
 
         assert_eq!(layer.get_links(&40), Some([10, 20].as_slice()));
         assert_eq!(layer.get_links(&10).unwrap(), &[20, 30, 40]);
@@ -246,9 +246,9 @@ mod tests {
         // Insert node 4 with forward links [1, 2]
         layer.insert_node(&4, vec![1, 2]);
         // Backlinks into 1 and 2
-        layer.add_incoming_edges(&4, vec![1, 2]);
+        layer.link_node_to_neighbors(&4, vec![1, 2]);
         // Compaction: node 2 now exceeds link limit, prune neighbor 3
-        layer.remove_outgoing_edges(&2, vec![3]);
+        layer.unlink_neighbors_from_node(&2, vec![3]);
 
         assert_eq!(layer.get_links(&4), Some([1, 2].as_slice()));
         assert_eq!(layer.get_links(&1).unwrap(), &[2, 3, 4]);

--- a/iris-mpc-cpu/src/hnsw/graph/mutation.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/mutation.rs
@@ -13,21 +13,21 @@ pub struct GroupedMutations<V: Ord>(pub Vec<GraphMutation<V>>);
 /// Represents a diff to apply to an existing graph.
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum GraphMutation<Vector: Ord> {
-    RemoveNode {
-        id: Vector,
-    },
-    InsertNode {
+    AddNode {
         // List of layer, neighbors.
         layers: Vec<(usize, Vec<Vector>)>,
         update_ep: UpdateEntryPoint,
         id: Vector,
     },
-    AddNeighbors {
+    RemoveNode {
+        id: Vector,
+    },
+    AddEdges {
         // list of layer, neighbors
         layers: Vec<(usize, Vec<Vector>)>,
         id: Vector,
     },
-    RemoveNeighbors {
+    RemoveEdges {
         to_remove: Vec<Vector>,
         layer: usize,
         id: Vector,
@@ -38,7 +38,7 @@ impl<V: std::fmt::Debug + Ord> std::fmt::Debug for GraphMutation<V> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::RemoveNode { id } => f.debug_struct("RemoveNode").field("id", id).finish(),
-            Self::InsertNode {
+            Self::AddNode {
                 layers: _,
                 update_ep,
                 id,
@@ -47,10 +47,10 @@ impl<V: std::fmt::Debug + Ord> std::fmt::Debug for GraphMutation<V> {
                 .field("update_ep", update_ep)
                 .field("id", id)
                 .finish(),
-            Self::AddNeighbors { id, layers: _ } => {
+            Self::AddEdges { id, layers: _ } => {
                 f.debug_struct("AddNeighbor").field("id", id).finish()
             }
-            Self::RemoveNeighbors { .. } => f.debug_struct("RemoveInvalidNeighbors").finish(),
+            Self::RemoveEdges { .. } => f.debug_struct("RemoveInvalidNeighbors").finish(),
         }
     }
 }

--- a/iris-mpc-cpu/src/hnsw/graph/test_utils.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/test_utils.rs
@@ -18,8 +18,9 @@ use crate::{
                 node_equiv::ensure_node_equivalence,
                 run_diff,
             },
+            mutation::EdgeType,
             neighborhood::Neighborhood,
-            GraphMutation,
+            GraphMutation, UpdateEntryPoint,
         },
         vector_store::{VectorStore, VectorStoreMut},
         SortedNeighborhood,
@@ -375,7 +376,7 @@ impl DbContext {
         let ep_mutation = GraphMutation::AddNode {
             id: vectors[0],
             height: 1,
-            update_ep: crate::hnsw::graph::mutation::UpdateEntryPoint::SetUnique { layer: 0 },
+            update_ep: UpdateEntryPoint::SetUnique { layer: 0 },
         };
         left_graph.insert_apply(vec![ep_mutation]);
 
@@ -392,13 +393,13 @@ impl DbContext {
                 GraphMutation::AddNode {
                     id: vectors[i],
                     height: 1,
-                    update_ep: crate::hnsw::graph::mutation::UpdateEntryPoint::False,
+                    update_ep: UpdateEntryPoint::False,
                 },
                 GraphMutation::AddEdges {
-                    id: vectors[i],
+                    base: vectors[i],
                     layer: 0,
-                    to_add: neighbors,
-                    direction: crate::hnsw::graph::mutation::EdgeDirection::Outgoing,
+                    neighbors,
+                    edge_type: EdgeType::Base,
                 },
             ];
             left_graph.insert_apply(mutations);

--- a/iris-mpc-cpu/src/hnsw/graph/test_utils.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/test_utils.rs
@@ -374,8 +374,8 @@ impl DbContext {
         // Set entry point via InsertNode with SetUnique
         let ep_mutation = GraphMutation::AddNode {
             id: vectors[0],
-            layers: vec![(0, vec![])],
-            update_ep: crate::hnsw::graph::mutation::UpdateEntryPoint::SetUnique { layer: 0 },
+            max_graph_layer: 0,
+            update_ep: crate::hnsw::graph::mutation::UpdateEntryPoint::SetUnique { layer: 1 },
         };
         left_graph.insert_apply(vec![ep_mutation]);
 
@@ -388,12 +388,20 @@ impl DbContext {
                     .await?;
             }
             let neighbors = links.edge_ids();
-            let mutation = GraphMutation::AddNode {
-                id: vectors[i],
-                layers: vec![(0, neighbors)],
-                update_ep: crate::hnsw::graph::mutation::UpdateEntryPoint::False,
-            };
-            left_graph.insert_apply(vec![mutation]);
+            let mutations = vec![
+                GraphMutation::AddNode {
+                    id: vectors[i],
+                    max_graph_layer: 0,
+                    update_ep: crate::hnsw::graph::mutation::UpdateEntryPoint::False,
+                },
+                GraphMutation::AddEdges {
+                    id: vectors[i],
+                    layer: 0,
+                    to_add: neighbors,
+                    direction: crate::hnsw::graph::mutation::EdgeDirection::Outgoing,
+                },
+            ];
+            left_graph.insert_apply(mutations);
         }
 
         // Use same graph for both eyes (this is test data)

--- a/iris-mpc-cpu/src/hnsw/graph/test_utils.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/test_utils.rs
@@ -375,7 +375,7 @@ impl DbContext {
         let ep_mutation = GraphMutation::AddNode {
             id: vectors[0],
             max_graph_layer: 0,
-            update_ep: crate::hnsw::graph::mutation::UpdateEntryPoint::SetUnique { layer: 1 },
+            update_ep: crate::hnsw::graph::mutation::UpdateEntryPoint::SetUnique { layer: 0 },
         };
         left_graph.insert_apply(vec![ep_mutation]);
 

--- a/iris-mpc-cpu/src/hnsw/graph/test_utils.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/test_utils.rs
@@ -372,7 +372,7 @@ impl DbContext {
         let mut left_graph = GraphMem::<PlaintextVectorRef>::new();
 
         // Set entry point via InsertNode with SetUnique
-        let ep_mutation = GraphMutation::InsertNode {
+        let ep_mutation = GraphMutation::AddNode {
             id: vectors[0],
             layers: vec![(0, vec![])],
             update_ep: crate::hnsw::graph::mutation::UpdateEntryPoint::SetUnique { layer: 0 },
@@ -388,7 +388,7 @@ impl DbContext {
                     .await?;
             }
             let neighbors = links.edge_ids();
-            let mutation = GraphMutation::InsertNode {
+            let mutation = GraphMutation::AddNode {
                 id: vectors[i],
                 layers: vec![(0, neighbors)],
                 update_ep: crate::hnsw::graph::mutation::UpdateEntryPoint::False,

--- a/iris-mpc-cpu/src/hnsw/graph/test_utils.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/test_utils.rs
@@ -374,7 +374,7 @@ impl DbContext {
         // Set entry point via InsertNode with SetUnique
         let ep_mutation = GraphMutation::AddNode {
             id: vectors[0],
-            max_graph_layer: 0,
+            height: 1,
             update_ep: crate::hnsw::graph::mutation::UpdateEntryPoint::SetUnique { layer: 0 },
         };
         left_graph.insert_apply(vec![ep_mutation]);
@@ -391,7 +391,7 @@ impl DbContext {
             let mutations = vec![
                 GraphMutation::AddNode {
                     id: vectors[i],
-                    max_graph_layer: 0,
+                    height: 1,
                     update_ep: crate::hnsw::graph::mutation::UpdateEntryPoint::False,
                 },
                 GraphMutation::AddEdges {

--- a/iris-mpc-cpu/src/hnsw/metrics/network_tree/formatter.rs
+++ b/iris-mpc-cpu/src/hnsw/metrics/network_tree/formatter.rs
@@ -22,7 +22,7 @@ const MIN_NAME_WIDTH: usize = 20;
 /// `tracing_forest`.
 ///
 /// Implements the `tracing_forest::Formatter` trait: each time a tracing span
-/// tree is completed, `fmt()` converts it into a [`NetworkTree`] (deduplicating
+/// tree is completed, `fmt()` converts it into a `NetworkTree` (deduplicating
 /// repeated children) and accumulates per-function byte/message counters into an
 /// internal [`StatsTreeNode`] forest.
 ///
@@ -89,7 +89,7 @@ const MIN_NAME_WIDTH: usize = 20;
 ///
 /// Both tables can be sorted by total bytes (default) or total messages via
 /// [`SortBy`].  When `tracing_output` is enabled, `fmt()` additionally returns
-/// a per-call tree string (the [`NetworkTree`] rendering with `x N` call
+/// a per-call tree string (the `NetworkTree` rendering with `x N` call
 /// counts and per-call byte budgets); otherwise it returns an empty string for
 /// efficiency.
 pub struct NetworkFormatter {

--- a/iris-mpc-cpu/src/hnsw/searcher.rs
+++ b/iris-mpc-cpu/src/hnsw/searcher.rs
@@ -10,7 +10,7 @@ use super::{
 };
 use crate::hnsw::{
     graph::{
-        mutation::{EdgeDirection, GroupedMutations},
+        mutation::{EdgeType, GroupedMutations},
         neighborhood::Neighborhood,
         GraphMutation, UpdateEntryPoint,
     },
@@ -1557,10 +1557,10 @@ impl HnswSearcher {
         }];
         for (layer_idx, layer_links) in layers.into_iter() {
             group_mutations.push(GraphMutation::AddEdges {
-                id: inserted_vector.clone(),
+                base: inserted_vector.clone(),
                 layer: layer_idx,
-                to_add: layer_links,
-                direction: EdgeDirection::Bidirectional,
+                neighbors: layer_links,
+                edge_type: EdgeType::All,
             });
         }
         let mutations = vec![Some(GroupedMutations(group_mutations))];
@@ -1618,21 +1618,18 @@ impl HnswSearcher {
             };
 
             // Build the link vectors from this group's AddEdges entries that target
-            // this id with Outgoing or Bidirectional direction. Sort each layer's list.
+            // this id with Base or All edge type. Sort each layer's list.
             let mut links: Vec<Vec<V::VectorRef>> = vec![Vec::new(); height];
             for mutation in group.0.iter_mut() {
                 if let GraphMutation::AddEdges {
-                    id: edge_id,
+                    base: edge_id,
                     layer,
-                    to_add,
-                    direction,
+                    neighbors: to_add,
+                    edge_type,
                 } = mutation
                 {
-                    let touches_id_outgoing = *edge_id == id
-                        && matches!(
-                            direction,
-                            EdgeDirection::Outgoing | EdgeDirection::Bidirectional
-                        );
+                    let touches_id_outgoing =
+                        *edge_id == id && matches!(edge_type, EdgeType::Base | EdgeType::All);
                     if touches_id_outgoing && *layer < height {
                         to_add.sort();
                         links[*layer] = to_add.clone();
@@ -1764,10 +1761,10 @@ impl HnswSearcher {
                         .unwrap_or(last_some_idx);
                     if let Some(Some(group)) = mutations.get_mut(group_idx) {
                         group.0.push(GraphMutation::RemoveEdges {
-                            id: id.clone(),
+                            base: id.clone(),
                             layer: *layer,
-                            to_remove,
-                            direction: EdgeDirection::Outgoing,
+                            neighbors: to_remove,
+                            edge_type: EdgeType::Base,
                         });
                     }
                 }
@@ -1785,10 +1782,10 @@ impl HnswSearcher {
                     .unwrap_or(last_some_idx);
                 if let Some(Some(group)) = mutations.get_mut(group_idx) {
                     group.0.push(GraphMutation::RemoveEdges {
-                        id,
+                        base: id,
                         layer,
-                        to_remove,
-                        direction: EdgeDirection::Outgoing,
+                        neighbors: to_remove,
+                        edge_type: EdgeType::Base,
                     });
                 }
             }
@@ -2084,10 +2081,10 @@ mod tests {
                     update_ep,
                 },
                 GraphMutation::AddEdges {
-                    id: vector_id,
+                    base: vector_id,
                     layer: 0,
-                    to_add: nbs,
-                    direction: EdgeDirection::Outgoing,
+                    neighbors: nbs,
+                    edge_type: EdgeType::Base,
                 },
             ];
 
@@ -2104,10 +2101,10 @@ mod tests {
                 update_ep: UpdateEntryPoint::False,
             },
             GraphMutation::AddEdges {
-                id: next_id,
+                base: next_id,
                 layer: 0,
-                to_add: ids[0..5].to_vec(),
-                direction: EdgeDirection::Outgoing,
+                neighbors: ids[0..5].to_vec(),
+                edge_type: EdgeType::Base,
             },
         ]))];
 
@@ -2120,7 +2117,7 @@ mod tests {
         assert_eq!(grouped_plans.len(), 1);
         let group = grouped_plans[0].as_ref().unwrap();
 
-        // 1 AddNode + 1 AddEdges(Outgoing) + 6 RemoveEdges (compaction for next_id
+        // 1 AddNode + 1 AddEdges(Base) + 6 RemoveEdges (compaction for next_id
         // itself and each of the 5 pre-existing nodes whose neighborhood overflowed).
         assert_eq!(group.0.len(), 8);
 
@@ -2139,13 +2136,13 @@ mod tests {
             .iter()
             .filter_map(|m| {
                 if let GraphMutation::RemoveEdges {
-                    id,
+                    base,
                     layer,
-                    to_remove,
-                    direction: _,
+                    neighbors,
+                    edge_type: _,
                 } = m
                 {
-                    Some((id, layer, to_remove))
+                    Some((base, layer, neighbors))
                 } else {
                     None
                 }

--- a/iris-mpc-cpu/src/hnsw/searcher.rs
+++ b/iris-mpc-cpu/src/hnsw/searcher.rs
@@ -1549,9 +1549,10 @@ impl HnswSearcher {
     ) -> Result<ConnectPlanV<V>> {
         let layers: Vec<(usize, Vec<V::VectorRef>)> = links.into_iter().enumerate().collect();
 
+        let max_graph_layer = layers.iter().map(|(l, _)| *l).max().unwrap_or(0);
         let mut group_mutations: Vec<GraphMutation<V::VectorRef>> = vec![GraphMutation::AddNode {
             id: inserted_vector.clone(),
-            layers: layers.clone(),
+            max_graph_layer,
             update_ep,
         }];
         for (layer_idx, layer_links) in layers.into_iter() {
@@ -1602,25 +1603,45 @@ impl HnswSearcher {
 
         for (group_idx, opt_group) in mutations.iter_mut().enumerate() {
             let Some(group) = opt_group else { continue };
-            for mutation in group.0.iter_mut() {
-                let GraphMutation::AddNode {
-                    id,
-                    layers,
-                    update_ep,
-                } = mutation
-                else {
-                    continue;
-                };
 
-                let max_layer = layers.iter().map(|(l, _)| *l).max().unwrap_or(0);
-                let mut links = vec![Vec::new(); max_layer + 1];
-                for (layer, neighbors) in layers.iter_mut() {
-                    neighbors.sort();
-                    links[*layer] = neighbors.clone();
+            // Find the AddNode in this group (assume at most one — matches current usage).
+            let add_node = group.0.iter().find_map(|m| match m {
+                GraphMutation::AddNode {
+                    id,
+                    max_graph_layer,
+                    update_ep,
+                } => Some((id.clone(), *max_graph_layer, update_ep.clone())),
+                _ => None,
+            });
+            let Some((id, max_graph_layer, update_ep)) = add_node else {
+                continue;
+            };
+
+            // Build the link vectors from this group's AddEdges entries that target
+            // this id with Outgoing or Bidirectional direction. Sort each layer's list.
+            let mut links: Vec<Vec<V::VectorRef>> = vec![Vec::new(); max_graph_layer + 1];
+            for mutation in group.0.iter_mut() {
+                if let GraphMutation::AddEdges {
+                    id: edge_id,
+                    layer,
+                    to_add,
+                    direction,
+                } = mutation
+                {
+                    let touches_id_outgoing = *edge_id == id
+                        && matches!(
+                            direction,
+                            EdgeDirection::Outgoing | EdgeDirection::Bidirectional
+                        );
+                    if touches_id_outgoing && *layer <= max_graph_layer {
+                        to_add.sort();
+                        links[*layer] = to_add.clone();
+                    }
                 }
-                update_to_group.push(group_idx);
-                updates.push((id.clone(), links, update_ep.clone()));
             }
+
+            update_to_group.push(group_idx);
+            updates.push((id, links, update_ep));
         }
 
         if updates.is_empty() {
@@ -2050,17 +2071,25 @@ mod tests {
 
             // Set entry point for first item
             let update_ep = if i == 0 {
-                UpdateEntryPoint::SetUnique { layer: 0 }
+                UpdateEntryPoint::SetUnique { layer: 1 }
             } else {
                 UpdateEntryPoint::False
             };
 
             // Create mutations for this vector at layer 0
-            let mutations = vec![GraphMutation::AddNode {
-                id: vector_id,
-                layers: vec![(0, nbs)],
-                update_ep,
-            }];
+            let mutations = vec![
+                GraphMutation::AddNode {
+                    id: vector_id,
+                    max_graph_layer: 0,
+                    update_ep,
+                },
+                GraphMutation::AddEdges {
+                    id: vector_id,
+                    layer: 0,
+                    to_add: nbs,
+                    direction: EdgeDirection::Outgoing,
+                },
+            ];
 
             // Apply the mutations to the graph
             graph_store.insert_apply(mutations);
@@ -2068,11 +2097,19 @@ mod tests {
 
         // Create an update for inserting vector id 6
         let next_id = ids[5];
-        let mutations = vec![Some(GroupedMutations(vec![GraphMutation::AddNode {
-            id: next_id,
-            layers: vec![(0, ids[0..5].to_vec())],
-            update_ep: UpdateEntryPoint::False,
-        }]))];
+        let mutations = vec![Some(GroupedMutations(vec![
+            GraphMutation::AddNode {
+                id: next_id,
+                max_graph_layer: 0,
+                update_ep: UpdateEntryPoint::False,
+            },
+            GraphMutation::AddEdges {
+                id: next_id,
+                layer: 0,
+                to_add: ids[0..5].to_vec(),
+                direction: EdgeDirection::Outgoing,
+            },
+        ]))];
 
         // Prepare the batch insertion
         let grouped_plans = searcher
@@ -2083,11 +2120,9 @@ mod tests {
         assert_eq!(grouped_plans.len(), 1);
         let group = grouped_plans[0].as_ref().unwrap();
 
-        // Expected: 1 InsertNode for next_id + 6 RemoveNeighbors (one for next_id
-        // itself whose 5-neighbor list exceeds M_limit=4, and one per each of the
-        // 5 pre-existing nodes whose backlink-extended neighborhood of 5 also
-        // exceeds M_limit=4).
-        assert_eq!(group.0.len(), 7);
+        // 1 AddNode + 1 AddEdges(Outgoing) + 6 RemoveEdges (compaction for next_id
+        // itself and each of the 5 pre-existing nodes whose neighborhood overflowed).
+        assert_eq!(group.0.len(), 8);
 
         // Verify the first mutation is an InsertNode with the correct shape.
         let plan = &group.0[0];

--- a/iris-mpc-cpu/src/hnsw/searcher.rs
+++ b/iris-mpc-cpu/src/hnsw/searcher.rs
@@ -10,7 +10,9 @@ use super::{
 };
 use crate::hnsw::{
     graph::{
-        mutation::GroupedMutations, neighborhood::Neighborhood, GraphMutation, UpdateEntryPoint,
+        mutation::{EdgeDirection, GroupedMutations},
+        neighborhood::Neighborhood,
+        GraphMutation, UpdateEntryPoint,
     },
     metrics::ops_counter::Operation,
     VectorStore,
@@ -1545,20 +1547,22 @@ impl HnswSearcher {
         links: Vec<Vec<V::VectorRef>>,
         update_ep: UpdateEntryPoint,
     ) -> Result<ConnectPlanV<V>> {
-        // Convert links to layers format
         let layers: Vec<(usize, Vec<V::VectorRef>)> = links.into_iter().enumerate().collect();
 
-        let mutations = vec![Some(GroupedMutations(vec![
-            GraphMutation::AddNode {
+        let mut group_mutations: Vec<GraphMutation<V::VectorRef>> = vec![GraphMutation::AddNode {
+            id: inserted_vector.clone(),
+            layers: layers.clone(),
+            update_ep,
+        }];
+        for (layer_idx, layer_links) in layers.into_iter() {
+            group_mutations.push(GraphMutation::AddEdges {
                 id: inserted_vector.clone(),
-                layers: layers.clone(),
-                update_ep,
-            },
-            GraphMutation::AddEdges {
-                id: inserted_vector,
-                layers,
-            },
-        ]))];
+                layer: layer_idx,
+                to_add: layer_links,
+                direction: EdgeDirection::Bidirectional,
+            });
+        }
+        let mutations = vec![Some(GroupedMutations(group_mutations))];
         let mut grouped = self.insert_prepare_batch(store, graph, mutations).await?;
         grouped
             .pop()

--- a/iris-mpc-cpu/src/hnsw/searcher.rs
+++ b/iris-mpc-cpu/src/hnsw/searcher.rs
@@ -1746,6 +1746,7 @@ impl HnswSearcher {
                             id: id.clone(),
                             layer: *layer,
                             to_remove,
+                            direction: EdgeDirection::Outgoing,
                         });
                     }
                 }
@@ -1766,6 +1767,7 @@ impl HnswSearcher {
                         id,
                         layer,
                         to_remove,
+                        direction: EdgeDirection::Outgoing,
                     });
                 }
             }
@@ -2105,6 +2107,7 @@ mod tests {
                     id,
                     layer,
                     to_remove,
+                    direction: _,
                 } = m
                 {
                     Some((id, layer, to_remove))

--- a/iris-mpc-cpu/src/hnsw/searcher.rs
+++ b/iris-mpc-cpu/src/hnsw/searcher.rs
@@ -1549,12 +1549,12 @@ impl HnswSearcher {
         let layers: Vec<(usize, Vec<V::VectorRef>)> = links.into_iter().enumerate().collect();
 
         let mutations = vec![Some(GroupedMutations(vec![
-            GraphMutation::InsertNode {
+            GraphMutation::AddNode {
                 id: inserted_vector.clone(),
                 layers: layers.clone(),
                 update_ep,
             },
-            GraphMutation::AddNeighbors {
+            GraphMutation::AddEdges {
                 id: inserted_vector,
                 layers,
             },
@@ -1599,7 +1599,7 @@ impl HnswSearcher {
         for (group_idx, opt_group) in mutations.iter_mut().enumerate() {
             let Some(group) = opt_group else { continue };
             for mutation in group.0.iter_mut() {
-                let GraphMutation::InsertNode {
+                let GraphMutation::AddNode {
                     id,
                     layers,
                     update_ep,
@@ -1738,7 +1738,7 @@ impl HnswSearcher {
                         .or_else(|| nbhd_last_group.get(&(id.clone(), *layer)).copied())
                         .unwrap_or(last_some_idx);
                     if let Some(Some(group)) = mutations.get_mut(group_idx) {
-                        group.0.push(GraphMutation::RemoveNeighbors {
+                        group.0.push(GraphMutation::RemoveEdges {
                             id: id.clone(),
                             layer: *layer,
                             to_remove,
@@ -1758,7 +1758,7 @@ impl HnswSearcher {
                     .or_else(|| nbhd_last_group.get(&(id.clone(), layer)).copied())
                     .unwrap_or(last_some_idx);
                 if let Some(Some(group)) = mutations.get_mut(group_idx) {
-                    group.0.push(GraphMutation::RemoveNeighbors {
+                    group.0.push(GraphMutation::RemoveEdges {
                         id,
                         layer,
                         to_remove,
@@ -2050,7 +2050,7 @@ mod tests {
             };
 
             // Create mutations for this vector at layer 0
-            let mutations = vec![GraphMutation::InsertNode {
+            let mutations = vec![GraphMutation::AddNode {
                 id: vector_id,
                 layers: vec![(0, nbs)],
                 update_ep,
@@ -2062,7 +2062,7 @@ mod tests {
 
         // Create an update for inserting vector id 6
         let next_id = ids[5];
-        let mutations = vec![Some(GroupedMutations(vec![GraphMutation::InsertNode {
+        let mutations = vec![Some(GroupedMutations(vec![GraphMutation::AddNode {
             id: next_id,
             layers: vec![(0, ids[0..5].to_vec())],
             update_ep: UpdateEntryPoint::False,
@@ -2085,7 +2085,7 @@ mod tests {
 
         // Verify the first mutation is an InsertNode with the correct shape.
         let plan = &group.0[0];
-        if let GraphMutation::InsertNode { id, update_ep, .. } = plan {
+        if let GraphMutation::AddNode { id, update_ep, .. } = plan {
             assert_eq!(*id, next_id);
             assert_eq!(*update_ep, UpdateEntryPoint::False);
         } else {
@@ -2097,7 +2097,7 @@ mod tests {
             .0
             .iter()
             .filter_map(|m| {
-                if let GraphMutation::RemoveNeighbors {
+                if let GraphMutation::RemoveEdges {
                     id,
                     layer,
                     to_remove,

--- a/iris-mpc-cpu/src/hnsw/searcher.rs
+++ b/iris-mpc-cpu/src/hnsw/searcher.rs
@@ -1549,10 +1549,10 @@ impl HnswSearcher {
     ) -> Result<ConnectPlanV<V>> {
         let layers: Vec<(usize, Vec<V::VectorRef>)> = links.into_iter().enumerate().collect();
 
-        let max_graph_layer = layers.iter().map(|(l, _)| *l).max().unwrap_or(0);
+        let height = layers.len();
         let mut group_mutations: Vec<GraphMutation<V::VectorRef>> = vec![GraphMutation::AddNode {
             id: inserted_vector.clone(),
-            max_graph_layer,
+            height,
             update_ep,
         }];
         for (layer_idx, layer_links) in layers.into_iter() {
@@ -1608,18 +1608,18 @@ impl HnswSearcher {
             let add_node = group.0.iter().find_map(|m| match m {
                 GraphMutation::AddNode {
                     id,
-                    max_graph_layer,
+                    height,
                     update_ep,
-                } => Some((id.clone(), *max_graph_layer, update_ep.clone())),
+                } => Some((id.clone(), *height, update_ep.clone())),
                 _ => None,
             });
-            let Some((id, max_graph_layer, update_ep)) = add_node else {
+            let Some((id, height, update_ep)) = add_node else {
                 continue;
             };
 
             // Build the link vectors from this group's AddEdges entries that target
             // this id with Outgoing or Bidirectional direction. Sort each layer's list.
-            let mut links: Vec<Vec<V::VectorRef>> = vec![Vec::new(); max_graph_layer + 1];
+            let mut links: Vec<Vec<V::VectorRef>> = vec![Vec::new(); height];
             for mutation in group.0.iter_mut() {
                 if let GraphMutation::AddEdges {
                     id: edge_id,
@@ -1633,7 +1633,7 @@ impl HnswSearcher {
                             direction,
                             EdgeDirection::Outgoing | EdgeDirection::Bidirectional
                         );
-                    if touches_id_outgoing && *layer <= max_graph_layer {
+                    if touches_id_outgoing && *layer < height {
                         to_add.sort();
                         links[*layer] = to_add.clone();
                     }
@@ -2080,7 +2080,7 @@ mod tests {
             let mutations = vec![
                 GraphMutation::AddNode {
                     id: vector_id,
-                    max_graph_layer: 0,
+                    height: 1,
                     update_ep,
                 },
                 GraphMutation::AddEdges {
@@ -2100,7 +2100,7 @@ mod tests {
         let mutations = vec![Some(GroupedMutations(vec![
             GraphMutation::AddNode {
                 id: next_id,
-                max_graph_layer: 0,
+                height: 1,
                 update_ep: UpdateEntryPoint::False,
             },
             GraphMutation::AddEdges {

--- a/iris-mpc-cpu/src/hnsw/sorting/min_k_batcher.rs
+++ b/iris-mpc-cpu/src/hnsw/sorting/min_k_batcher.rs
@@ -2,7 +2,7 @@
 //! the smallest K values (in arbitrary order).
 //!
 //! Based on the following paper:
-//! - (<https://eprint.iacr.org/2023/852.pdf>) [1]
+//! - <https://eprint.iacr.org/2023/852.pdf>
 
 use cached::proc_macro::cached;
 use eyre::{bail, OptionExt, Result};

--- a/iris-mpc-cpu/src/protocol/ops.rs
+++ b/iris-mpc-cpu/src/protocol/ops.rs
@@ -120,7 +120,7 @@ where
 }
 
 /// Row-major prerotated query for L1 cache efficiency.
-/// Layout: [row0_rot0..rot30][row1_rot0..rot30]...
+/// Layout: `[row0_rot0..rot30][row1_rot0..rot30]...`
 pub struct PrerotatedQueryRowMajor {
     /// code: 16 rows × 31 rotations × 800 elements = 396,800 u16s (~793KB)
     code_data: Vec<u16>,


### PR DESCRIPTION
## Summary

Restructures the `GraphMutation` enum so node-level and edge-level operations are cleanly separated, edge ops are uniform with an explicit direction, and `GraphMem::insert_apply` is two-pass.

**Structural changes (in `iris-mpc-cpu/src/hnsw/graph/mutation.rs`):**
- New `EdgeDirection` enum with `Outgoing` / `Incoming` / `Bidirectional` variants. `Bidirectional` is stored as a single op (semantic intent), not split into primitives.
- `AddEdges` and `RemoveEdges` are now single-layer with an explicit `direction: EdgeDirection`. Both have mirrored shapes (`{ id, layer, to_add | to_remove, direction }`).
- `AddNode` reshaped from `{ id, layers: Vec<(usize, Vec<V>)>, update_ep }` to `{ id, max_graph_layer: usize, update_ep }` — purely node-level, no forward neighborhood data. Forward links move into `AddEdges` ops emitted alongside `AddNode` in the same group.

**Apply path (in `iris-mpc-cpu/src/hnsw/graph/layered_graph.rs`):**
- `GraphMem::insert_apply` is now two-pass — `AddNode` / `RemoveNode` first, then `AddEdges` / `RemoveEdges`. This eliminates a class of ordering bugs (an edge op listed before its node op in the input Vec now applies correctly).
- Direction dispatch in the edge arms with `warn!` paths for missing referents.
- Four `Layer` edge primitives are now uniform in signature (`(&mut self, id: &V, to_add|to_remove: Vec<V>)`) and style: `add_outgoing_edges`, `add_incoming_edges`, `remove_outgoing_edges`, `remove_incoming_edges`.

**Searcher (in `iris-mpc-cpu/src/hnsw/searcher.rs`):**
- `insert_prepare_batch` reads new-node neighborhoods from `AddEdges` ops in the same group (Outgoing or Bidirectional) instead of from `AddNode.layers`.
- All call sites of the old enum shape across `hawk_main.rs`, `insert.rs`, and the test_utils helpers migrated.

**`GroupedMutations` stays a dumb `Vec` wrapper** — no construction-time validation added. Deferred to the future modification-id design per the linked planning doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)