### PR TITLE
Adjust ordering of deletion request application to HNSW graphs

### DIFF
--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -767,15 +767,12 @@ impl HawkActor {
             // so that downstream result derivation (merged_results / inserted_id)
             // still sees the correct serial IDs.
             let mut next_serial_id = self.registry[LEFT].read().await.next_id;
-            return Ok(plans
-                .into_iter()
-                .zip(insertion_ids.iter())
-                .zip(replace_ids.iter())
-                .map(|((plan, id), replace_id)| {
+            return Ok(izip!(plans, insertion_ids.iter(), replace_ids.iter())
+                .map(|(plan, insertion_id, replace_id)| {
                     let mut mutations = Vec::new();
 
                     if let Some(plan) = plan {
-                        let inserted_vector = if let Some(id) = id {
+                        let inserted_vector = if let Some(id) = insertion_id {
                             *id
                         } else {
                             let vid = VectorId::from_serial_id(next_serial_id);
@@ -1966,10 +1963,7 @@ impl HawkHandle {
 
         // Build replace_ids covering both reauth/identity-update targets (which
         // pair with an InsertPlan in the same slot) and pure deletions (which
-        // have None as their InsertPlan). Slot order matches requests_order so
-        // graph mutations are applied in arrival order. update_ids[i] already
-        // corresponds to requests_order[i] (both are built by parallel iteration
-        // over requests_order above).
+        // have None as their InsertPlan).
         let replace_ids = requests_order
             .iter()
             .enumerate()
@@ -2017,8 +2011,6 @@ impl HawkHandle {
             );
 
             // Collect the HNSW insertion plans for all mutating decisions.
-            // Deletion slots are always None here; their RemoveNode is produced by
-            // the insert pipeline via the replace_ids argument.
             let insert_plans = requests_order
                 .iter()
                 .map(|req_index| match req_index {

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -750,7 +750,11 @@ impl HawkActor {
         sessions: &[HawkSession],
         plans: VecRequests<Option<HawkInsertPlan>>,
         update_ids: &VecRequests<Option<VectorId>>,
+        replace_ids: &VecRequests<Option<VectorId>>,
     ) -> Result<VecRequests<Option<ConnectPlan>>> {
+        assert_eq!(plans.len(), replace_ids.len());
+        assert_eq!(plans.len(), update_ids.len());
+
         // Plans are to be inserted at the next version of non-None entries in `update_ids`
         let insertion_ids = update_ids
             .iter()
@@ -766,10 +770,11 @@ impl HawkActor {
             return Ok(plans
                 .into_iter()
                 .zip(insertion_ids.iter())
-                .map(|(plan, id)| {
-                    plan.map(|plan| {
-                        let mut mutations = Vec::new();
+                .zip(replace_ids.iter())
+                .map(|((plan, id), replace_id)| {
+                    let mut mutations = Vec::new();
 
+                    if let Some(plan) = plan {
                         let inserted_vector = if let Some(id) = id {
                             *id
                         } else {
@@ -777,16 +782,22 @@ impl HawkActor {
                             next_serial_id += 1;
                             vid
                         };
-                        if let Some(replace_id) = &plan.plan.replace_id {
-                            mutations.push(GraphMutation::RemoveNode { id: *replace_id });
-                        }
                         mutations.push(GraphMutation::AddNode {
                             id: inserted_vector,
                             height: plan.plan.links.len(),
                             update_ep: UpdateEntryPoint::False,
                         });
-                        GroupedMutations(mutations)
-                    })
+                    }
+
+                    if let Some(rid) = replace_id {
+                        mutations.push(GraphMutation::RemoveNode { id: *rid });
+                    }
+
+                    if mutations.is_empty() {
+                        None
+                    } else {
+                        Some(GroupedMutations(mutations))
+                    }
                 })
                 .collect_vec());
         }
@@ -805,6 +816,7 @@ impl HawkActor {
             &self.searcher,
             plans,
             &insertion_ids,
+            replace_ids,
         )
         .await
     }
@@ -1949,8 +1961,25 @@ impl HawkHandle {
 
         tracing::info!("Updated decisions (reset + reauth): {:?}", update_ids);
 
-        // Get deleted vector IDs for RemoveNode mutations
+        // Get deleted vector IDs for RemoveNode mutations.
         let deleted_ids = request.deletion_ids(&*hawk_actor.registry[LEFT].read().await);
+
+        // Build replace_ids covering both reauth/identity-update targets (which
+        // pair with an InsertPlan in the same slot) and pure deletions (which
+        // have None as their InsertPlan). Slot order matches requests_order so
+        // graph mutations are applied in arrival order. update_ids[i] already
+        // corresponds to requests_order[i] (both are built by parallel iteration
+        // over requests_order above).
+        let replace_ids = requests_order
+            .iter()
+            .enumerate()
+            .map(|(i, req_index)| match req_index {
+                RequestIndex::UniqueReauthResetCheck(_) | RequestIndex::IdentityUpdate(_) => {
+                    update_ids[i]
+                }
+                RequestIndex::Deletion(j) => Some(deleted_ids[*j]),
+            })
+            .collect_vec();
 
         // Store plans for both sides using BothEyes structure
         let mut plans_both_sides: Vec<BothEyes<Option<ConnectPlan>>> =
@@ -1987,8 +2016,10 @@ impl HawkHandle {
                 unique_insertions_persistence_skipped.len()
             );
 
-            // Collect the HNSW insertion plans for all mutating decisions
-            let mut insert_plans = requests_order
+            // Collect the HNSW insertion plans for all mutating decisions.
+            // Deletion slots are always None here; their RemoveNode is produced by
+            // the insert pipeline via the replace_ids argument.
+            let insert_plans = requests_order
                 .iter()
                 .map(|req_index| match req_index {
                     RequestIndex::UniqueReauthResetCheck(i) => match decisions[*i] {
@@ -2007,50 +2038,13 @@ impl HawkHandle {
                             .then(|| search_results[*i].center().clone()),
                     },
                     RequestIndex::IdentityUpdate(i) => Some(reset_results[*i].center().clone()),
-                    // Deletions will be handled separately below
                     RequestIndex::Deletion(_) => None,
                 })
                 .collect_vec();
 
-            // Set replace_id on plans for reauth updates and identity updates
-            for (idx, req_index) in requests_order.iter().enumerate() {
-                if let Some(plan) = &mut insert_plans[idx] {
-                    match req_index {
-                        RequestIndex::UniqueReauthResetCheck(i) => {
-                            if matches!(decisions[*i], ReauthUpdate(_)) {
-                                if let Some(update_id) = update_ids[idx] {
-                                    plan.plan.replace_id = Some(update_id);
-                                }
-                            }
-                        }
-                        RequestIndex::IdentityUpdate(_) => {
-                            if let Some(update_id) = update_ids[idx] {
-                                plan.plan.replace_id = Some(update_id);
-                            }
-                        }
-                        RequestIndex::Deletion(_) => {}
-                    }
-                }
-            }
-
-            let mut plans = hawk_actor
-                .insert(sessions, insert_plans, &update_ids)
+            let plans = hawk_actor
+                .insert(sessions, insert_plans, &update_ids, &replace_ids)
                 .await?;
-
-            // Apply deletion mutations directly to the in-memory graph
-            for (idx, req_index) in requests_order.iter().enumerate() {
-                if let RequestIndex::Deletion(i) = req_index {
-                    let vector_id = deleted_ids[*i];
-                    let removal_mutations = vec![GraphMutation::RemoveNode { id: vector_id }];
-
-                    // Store the removal plan for persistence
-                    plans[idx] = Some(GroupedMutations(removal_mutations.clone()));
-
-                    // Apply deletion mutation to the in-memory graph immediately
-                    let mut graph = hawk_actor.graph_store[*side as usize].write().await;
-                    graph.insert_apply(removal_mutations);
-                }
-            }
 
             // Store plans for this side
             for (plan, both_sides) in izip!(plans, &mut plans_both_sides) {

--- a/iris-mpc-cpu/src/execution/hawk_main/insert.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/insert.rs
@@ -47,10 +47,10 @@ impl<V: VectorStore> Clone for InsertPlanV<V> {
 /// Insert a collection `plans` of `InsertPlanV` structs into the graph and vector store,
 /// adjusting the insertion plans as needed to repair any conflict from parallel searches.
 ///
-/// The `ids` argument consists of `Option<VectorId>`s which are `Some(id)` if the associated
-/// plan is to be inserted with a specific identifier (e.g. for updates or for insertions
-/// which need to parallel an existing iris code database), and `None` if the associated plan
-/// is to be inserted at the next available serial ID, with version 0.
+/// The `insert_ids` argument consists of `Option<VectorId>`s which are `Some(id)` if the
+/// associated plan is to be inserted with a specific identifier (e.g. for updates or for
+/// insertions which need to parallel an existing iris code database), and `None` if the
+/// associated plan is to be inserted at the next available serial ID, with version 0.
 ///
 /// The `replace_ids` argument consists of `Option<VectorId>`s which are `Some(id)` if the
 /// associated slot should additionally emit a `RemoveNode(id)` mutation (e.g. for reauth or
@@ -62,7 +62,7 @@ pub async fn insert<V: VectorStoreMut>(
     graph: &mut GraphMem<<V as VectorStore>::VectorRef>,
     searcher: &HnswSearcher,
     plans: VecRequests<Option<InsertPlanV<V>>>,
-    ids: &VecRequests<Option<V::VectorRef>>,
+    insert_ids: &VecRequests<Option<V::VectorRef>>,
     replace_ids: &VecRequests<Option<V::VectorRef>>,
 ) -> Result<VecRequests<Option<ConnectPlanV<V>>>> {
     tracing::debug!("Inserting {} InsertPlans into store", plans.len());
@@ -74,7 +74,7 @@ pub async fn insert<V: VectorStoreMut>(
     );
     assert_eq!(
         plans.len(),
-        ids.len(),
+        insert_ids.len(),
         "plans and ids must be the same length"
     );
 
@@ -90,8 +90,8 @@ pub async fn insert<V: VectorStoreMut>(
     // for deletion-only slots).
     let mut mutations: Vec<Option<GroupedMutations<V::VectorRef>>> = vec![None; insert_plans.len()];
 
-    for (idx, ((plan, update_id), replace_id)) in
-        izip!(insert_plans, ids).zip(replace_ids.iter()).enumerate()
+    for (idx, (plan, update_id, replace_id)) in
+        izip!(insert_plans, insert_ids, replace_ids).enumerate()
     {
         let mut request_mutations: Vec<GraphMutation<V::VectorRef>> = vec![];
 

--- a/iris-mpc-cpu/src/execution/hawk_main/insert.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/insert.rs
@@ -51,6 +51,12 @@ impl<V: VectorStore> Clone for InsertPlanV<V> {
 /// plan is to be inserted with a specific identifier (e.g. for updates or for insertions
 /// which need to parallel an existing iris code database), and `None` if the associated plan
 /// is to be inserted at the next available serial ID, with version 0.
+///
+/// The `replace_ids` argument consists of `Option<VectorId>`s which are `Some(id)` if the
+/// associated slot should additionally emit a `RemoveNode(id)` mutation (e.g. for reauth or
+/// identity-update replacements, or for pure deletions). A pure-deletion slot has
+/// `plans[i] = None` and `replace_ids[i] = Some(id)`. A slot with both `plans[i] = None` and
+/// `replace_ids[i] = None` produces `None` in the output (no mutations for that slot).
 pub async fn insert<V: VectorStoreMut>(
     store: &mut V,
     graph: &mut GraphMem<<V as VectorStore>::VectorRef>,
@@ -740,9 +746,21 @@ mod tests {
         let slot0 = grouped[0].as_ref().expect("slot 0 should be Some");
         let mutations: &Vec<_> = &slot0.0;
 
-        // First non-edge mutation should be the AddNode, somewhere later we must
-        // see RemoveNode(old). AddEdges and any bilateral updates may appear in
-        // between.
+        let add_count = mutations
+            .iter()
+            .filter(|m| matches!(m, GraphMutation::AddNode { .. }))
+            .count();
+        assert_eq!(add_count, 1, "slot should contain exactly one AddNode");
+
+        let remove_old_count = mutations
+            .iter()
+            .filter(|m| matches!(m, GraphMutation::RemoveNode { id } if *id == old))
+            .count();
+        assert_eq!(
+            remove_old_count, 1,
+            "slot should contain exactly one RemoveNode(old)"
+        );
+
         let add_pos = mutations
             .iter()
             .position(|m| matches!(m, GraphMutation::AddNode { .. }))

--- a/iris-mpc-cpu/src/execution/hawk_main/insert.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/insert.rs
@@ -683,14 +683,21 @@ mod tests {
             None,
             None,
         ];
-        let ids: VecRequests<Option<<PlaintextStore as VectorStore>::VectorRef>> =
+        let insert_ids: VecRequests<Option<<PlaintextStore as VectorStore>::VectorRef>> =
             vec![None, None, None];
         let replace_ids: VecRequests<Option<<PlaintextStore as VectorStore>::VectorRef>> =
             vec![None, Some(a), Some(b)];
 
-        let grouped = insert(&mut store, &mut graph, &searcher, plans, &ids, &replace_ids)
-            .await
-            .expect("insert should succeed");
+        let grouped = insert(
+            &mut store,
+            &mut graph,
+            &searcher,
+            plans,
+            &insert_ids,
+            &replace_ids,
+        )
+        .await
+        .expect("insert should succeed");
 
         assert_eq!(grouped.len(), 3, "one output per slot");
 
@@ -735,13 +742,21 @@ mod tests {
         let plans = vec![Some(dummy_insert_plan(UpdateEntryPoint::SetUnique {
             layer: 0,
         }))];
-        let ids: VecRequests<Option<<PlaintextStore as VectorStore>::VectorRef>> = vec![None];
+        let insert_ids: VecRequests<Option<<PlaintextStore as VectorStore>::VectorRef>> =
+            vec![None];
         let replace_ids: VecRequests<Option<<PlaintextStore as VectorStore>::VectorRef>> =
             vec![Some(old)];
 
-        let grouped = insert(&mut store, &mut graph, &searcher, plans, &ids, &replace_ids)
-            .await
-            .expect("insert should succeed");
+        let grouped = insert(
+            &mut store,
+            &mut graph,
+            &searcher,
+            plans,
+            &insert_ids,
+            &replace_ids,
+        )
+        .await
+        .expect("insert should succeed");
 
         let slot0 = grouped[0].as_ref().expect("slot 0 should be Some");
         let mutations: &Vec<_> = &slot0.0;
@@ -783,13 +798,21 @@ mod tests {
         let searcher = HnswSearcher::new_with_test_parameters();
 
         let plans: VecRequests<Option<InsertPlanV<PlaintextStore>>> = vec![None];
-        let ids: VecRequests<Option<<PlaintextStore as VectorStore>::VectorRef>> = vec![None];
+        let insert_ids: VecRequests<Option<<PlaintextStore as VectorStore>::VectorRef>> =
+            vec![None];
         let replace_ids: VecRequests<Option<<PlaintextStore as VectorStore>::VectorRef>> =
             vec![None];
 
-        let grouped = insert(&mut store, &mut graph, &searcher, plans, &ids, &replace_ids)
-            .await
-            .expect("insert should succeed");
+        let grouped = insert(
+            &mut store,
+            &mut graph,
+            &searcher,
+            plans,
+            &insert_ids,
+            &replace_ids,
+        )
+        .await
+        .expect("insert should succeed");
 
         assert!(grouped[0].is_none(), "fully-empty slot should yield None");
     }

--- a/iris-mpc-cpu/src/execution/hawk_main/insert.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/insert.rs
@@ -75,7 +75,7 @@ pub async fn insert<V: VectorStoreMut>(
     assert_eq!(
         plans.len(),
         insert_ids.len(),
-        "plans and ids must be the same length"
+        "plans and insert_ids must be the same length"
     );
 
     let insert_plans = join_plans(plans, &searcher.layer_mode);

--- a/iris-mpc-cpu/src/execution/hawk_main/insert.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/insert.rs
@@ -30,7 +30,6 @@ pub struct InsertPlanV<V: VectorStore> {
     pub query: V::QueryRef,
     pub links: Vec<Vec<V::VectorRef>>,
     pub update_ep: UpdateEntryPoint,
-    pub replace_id: Option<V::VectorRef>,
 }
 
 // Manual implementation of Clone for InsertPlanV, since derive(Clone) does not
@@ -41,7 +40,6 @@ impl<V: VectorStore> Clone for InsertPlanV<V> {
             query: self.query.clone(),
             links: self.links.clone(),
             update_ep: self.update_ep.clone(),
-            replace_id: self.replace_id.clone(),
         }
     }
 }
@@ -59,8 +57,20 @@ pub async fn insert<V: VectorStoreMut>(
     searcher: &HnswSearcher,
     plans: VecRequests<Option<InsertPlanV<V>>>,
     ids: &VecRequests<Option<V::VectorRef>>,
+    replace_ids: &VecRequests<Option<V::VectorRef>>,
 ) -> Result<VecRequests<Option<ConnectPlanV<V>>>> {
     tracing::debug!("Inserting {} InsertPlans into store", plans.len());
+
+    assert_eq!(
+        plans.len(),
+        replace_ids.len(),
+        "plans and replace_ids must be the same length"
+    );
+    assert_eq!(
+        plans.len(),
+        ids.len(),
+        "plans and ids must be the same length"
+    );
 
     let insert_plans = join_plans(plans, &searcher.layer_mode);
     validate_ep_updates(&insert_plans, &searcher.layer_mode)?;
@@ -68,17 +78,21 @@ pub async fn insert<V: VectorStoreMut>(
     let mut inserted_ids = vec![];
     let m = searcher.params.get_M(0);
 
-    // Build one Option<GroupedMutations> per batch slot.  None slots pass through
+    // Build one Option<GroupedMutations> per batch slot. None slots pass through
     // insert_prepare_batch unchanged; Some slots carry per-request mutations
-    // (optional RemoveNode + InsertNode).
+    // (optional AddNode + AddEdges + optional RemoveNode, OR a pure RemoveNode
+    // for deletion-only slots).
     let mut mutations: Vec<Option<GroupedMutations<V::VectorRef>>> = vec![None; insert_plans.len()];
 
-    for (idx, (plan, update_id)) in izip!(insert_plans, ids).enumerate() {
+    for (idx, ((plan, update_id), replace_id)) in
+        izip!(insert_plans, ids).zip(replace_ids.iter()).enumerate()
+    {
+        let mut request_mutations: Vec<GraphMutation<V::VectorRef>> = vec![];
+
         if let Some(InsertPlanV {
             query,
             mut links,
             update_ep,
-            replace_id,
         }) = plan
         {
             // Extend links in bottom layer with items from batch, only when the
@@ -96,7 +110,6 @@ pub async fn insert<V: VectorStoreMut>(
                 Some(id) => store.insert_at(id, &query).await?,
             };
 
-            let mut request_mutations: Vec<GraphMutation<V::VectorRef>> = vec![];
             request_mutations.push(GraphMutation::AddNode {
                 id: inserted.clone(),
                 height: links.len(),
@@ -110,12 +123,16 @@ pub async fn insert<V: VectorStoreMut>(
                     edge_type: EdgeType::All,
                 });
             }
-            if let Some(rid) = replace_id {
-                request_mutations.push(GraphMutation::RemoveNode { id: rid.clone() });
-            }
 
-            mutations[idx] = Some(GroupedMutations(request_mutations));
             inserted_ids.push(inserted);
+        }
+
+        if let Some(rid) = replace_id {
+            request_mutations.push(GraphMutation::RemoveNode { id: rid.clone() });
+        }
+
+        if !request_mutations.is_empty() {
+            mutations[idx] = Some(GroupedMutations(request_mutations));
         }
     }
 
@@ -262,7 +279,6 @@ mod tests {
             query: Arc::new(IrisCode::default()),
             links: vec![Vec::new(); ins_layer],
             update_ep: ep_update,
-            replace_id: None,
         }
     }
 
@@ -636,5 +652,127 @@ mod tests {
             true,
             &linear_scan_layer_mode,
         );
+    }
+
+    /// Pure deletion is encoded as plans[i] = None, replace_ids[i] = Some(id).
+    /// The returned grouped_mutations should preserve slot order, with the deletion
+    /// slot emitting exactly one RemoveNode for the requested id.
+    #[tokio::test]
+    async fn test_insert_with_pure_deletion_preserves_slot_order() {
+        let mut store = PlaintextStore::default();
+        let mut graph: GraphMem<<PlaintextStore as VectorStore>::VectorRef> = GraphMem::new();
+        let searcher = HnswSearcher::new_with_test_parameters();
+
+        // Seed the store/graph with two existing vectors A and B so we have something
+        // to delete.
+        let a = store.insert(&Arc::new(IrisCode::default())).await;
+        let b = store.insert(&Arc::new(IrisCode::default())).await;
+        // Note: nodes A and B are deliberately not connected by edges — this test
+        // only exercises that the pipeline emits the right mutations in the right
+        // slots, not the bilateral-edge logic which is tested elsewhere.
+
+        // Batch: [insert C, delete A, delete B]
+        let plans = vec![
+            Some(dummy_insert_plan(UpdateEntryPoint::SetUnique { layer: 0 })),
+            None,
+            None,
+        ];
+        let ids: VecRequests<Option<<PlaintextStore as VectorStore>::VectorRef>> =
+            vec![None, None, None];
+        let replace_ids: VecRequests<Option<<PlaintextStore as VectorStore>::VectorRef>> =
+            vec![None, Some(a), Some(b)];
+
+        let grouped = insert(&mut store, &mut graph, &searcher, plans, &ids, &replace_ids)
+            .await
+            .expect("insert should succeed");
+
+        assert_eq!(grouped.len(), 3, "one output per slot");
+
+        // Slot 0 contains an AddNode (the insert of C).
+        let slot0 = grouped[0].as_ref().expect("slot 0 should be Some");
+        assert!(
+            slot0
+                .0
+                .iter()
+                .any(|m| matches!(m, GraphMutation::AddNode { .. })),
+            "slot 0 should contain AddNode"
+        );
+
+        // Slot 1 contains exactly one mutation, RemoveNode(a).
+        let slot1 = grouped[1].as_ref().expect("slot 1 should be Some");
+        assert_eq!(slot1.0.len(), 1, "deletion slot has one mutation");
+        match &slot1.0[0] {
+            GraphMutation::RemoveNode { id } => assert_eq!(*id, a),
+            other => panic!("expected RemoveNode(a) in slot 1, got {:?}", other),
+        }
+
+        // Slot 2 contains exactly one mutation, RemoveNode(b).
+        let slot2 = grouped[2].as_ref().expect("slot 2 should be Some");
+        assert_eq!(slot2.0.len(), 1, "deletion slot has one mutation");
+        match &slot2.0[0] {
+            GraphMutation::RemoveNode { id } => assert_eq!(*id, b),
+            other => panic!("expected RemoveNode(b) in slot 2, got {:?}", other),
+        }
+    }
+
+    /// Reauth-style replacement is encoded as both plans[i] = Some(plan) AND
+    /// replace_ids[i] = Some(old_id). The slot's group should contain an AddNode
+    /// for the new vector followed by a RemoveNode for the old one.
+    #[tokio::test]
+    async fn test_insert_with_combined_replace_emits_addnode_then_removenode() {
+        let mut store = PlaintextStore::default();
+        let mut graph: GraphMem<<PlaintextStore as VectorStore>::VectorRef> = GraphMem::new();
+        let searcher = HnswSearcher::new_with_test_parameters();
+
+        let old = store.insert(&Arc::new(IrisCode::default())).await;
+
+        let plans = vec![Some(dummy_insert_plan(UpdateEntryPoint::SetUnique {
+            layer: 0,
+        }))];
+        let ids: VecRequests<Option<<PlaintextStore as VectorStore>::VectorRef>> = vec![None];
+        let replace_ids: VecRequests<Option<<PlaintextStore as VectorStore>::VectorRef>> =
+            vec![Some(old)];
+
+        let grouped = insert(&mut store, &mut graph, &searcher, plans, &ids, &replace_ids)
+            .await
+            .expect("insert should succeed");
+
+        let slot0 = grouped[0].as_ref().expect("slot 0 should be Some");
+        let mutations: &Vec<_> = &slot0.0;
+
+        // First non-edge mutation should be the AddNode, somewhere later we must
+        // see RemoveNode(old). AddEdges and any bilateral updates may appear in
+        // between.
+        let add_pos = mutations
+            .iter()
+            .position(|m| matches!(m, GraphMutation::AddNode { .. }))
+            .expect("must contain AddNode");
+        let remove_pos = mutations
+            .iter()
+            .position(|m| matches!(m, GraphMutation::RemoveNode { id } if *id == old))
+            .expect("must contain RemoveNode(old)");
+        assert!(
+            add_pos < remove_pos,
+            "AddNode should precede the matching RemoveNode in the slot's group"
+        );
+    }
+
+    /// A None slot in both plans and replace_ids passes through as None.
+    #[tokio::test]
+    async fn test_insert_with_none_slot_yields_none() {
+        let mut store = PlaintextStore::default();
+        let mut graph: GraphMem<<PlaintextStore as VectorStore>::VectorRef> = GraphMem::new();
+        let searcher = HnswSearcher::new_with_test_parameters();
+
+        let plans: VecRequests<Option<InsertPlanV<PlaintextStore>>> = vec![None];
+        let ids: VecRequests<Option<<PlaintextStore as VectorStore>::VectorRef>> = vec![None];
+        let replace_ids: VecRequests<Option<<PlaintextStore as VectorStore>::VectorRef>> =
+            vec![None];
+
+        let grouped = insert(&mut store, &mut graph, &searcher, plans, &ids, &replace_ids)
+            .await
+            .expect("insert should succeed");
+
+        assert!(grouped[0].is_none(), "fully-empty slot should yield None");
     }
 }

--- a/iris-mpc-cpu/src/execution/hawk_main/matching.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/matching.rs
@@ -835,7 +835,6 @@ mod tests {
                     query: Aby3Query::new(QueryId::new()),
                     links: links_unstructured,
                     update_ep: UpdateEntryPoint::False,
-                    replace_id: None,
                 },
             };
             VecRotations::from(vec![

--- a/iris-mpc-cpu/src/execution/hawk_main/search.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/search.rs
@@ -389,7 +389,6 @@ async fn per_insert_query<N: Neighborhood<Aby3Store<HawkOps>>>(
             query,
             links: links_unstructured,
             update_ep,
-            replace_id: None,
         },
         classified,
     })
@@ -432,7 +431,6 @@ async fn per_search_query(
             query,
             links: links_unstructured,
             update_ep: UpdateEntryPoint::False,
-            replace_id: None,
         },
         classified,
     })
@@ -473,7 +471,6 @@ pub async fn search_single_query_no_match_count<H: std::hash::Hash>(
         query,
         links: links_unstructured,
         update_ep,
-        replace_id: None,
     })
 }
 

--- a/iris-mpc-cpu/src/genesis/hawk_handle.rs
+++ b/iris-mpc-cpu/src/genesis/hawk_handle.rs
@@ -204,12 +204,14 @@ impl Handle {
                                     let mut store = insert_session.aby3_store.write().await;
                                     let mut graph = insert_session.graph_store.write().await;
 
+                                    let replace_ids = vec![None; plans.len()];
                                     let plans = insert(
                                         &mut *store,
                                         &mut *graph,
                                         &searcher,
                                         plans,
                                         &batch_ids,
+                                        &replace_ids,
                                     )
                                     .await?;
                                     metrics::histogram!("genesis_insert_duration")
@@ -310,8 +312,16 @@ impl Handle {
                                     let mut store = session.aby3_store.write().await;
                                     let mut graph = session.graph_store.write().await;
 
-                                    let connect_plan =
-                                        insert(&mut *store, &mut *graph, &searcher, plans, &ids).await?;
+                                    let replace_ids = vec![None; plans.len()];
+                                    let connect_plan = insert(
+                                        &mut *store,
+                                        &mut *graph,
+                                        &searcher,
+                                        plans,
+                                        &ids,
+                                        &replace_ids,
+                                    )
+                                    .await?;
 
                                     // Evict the cached query now that search + insert are done.
                                     // Use the workers reference from the already-held write guard:

--- a/iris-mpc-cpu/src/genesis/plaintext.rs
+++ b/iris-mpc-cpu/src/genesis/plaintext.rs
@@ -263,7 +263,6 @@ pub async fn run_plaintext_genesis(mut state: GenesisState) -> Result<GenesisSta
                         query,
                         links: links_unstructured,
                         update_ep,
-                        replace_id: None,
                     };
 
                     insert::insert(
@@ -272,6 +271,7 @@ pub async fn run_plaintext_genesis(mut state: GenesisState) -> Result<GenesisSta
                         &searcher,
                         vec![Some(insert_plan)],
                         &vec![Some(vector_id)],
+                        &vec![None],
                     )
                     .await?;
                 }
@@ -368,7 +368,6 @@ pub async fn run_plaintext_genesis(mut state: GenesisState) -> Result<GenesisSta
                     query,
                     links: links_unstructured,
                     update_ep,
-                    replace_id: None,
                 };
 
                 results.push(Some(insert_plan));
@@ -381,7 +380,8 @@ pub async fn run_plaintext_genesis(mut state: GenesisState) -> Result<GenesisSta
             &mut state.dst_db.graphs,
             [left_insert_plans, right_insert_plans]
         ) {
-            insert::insert(store, graph, &searcher, plans, &ids).await?;
+            let replace_ids = vec![None; plans.len()];
+            insert::insert(store, graph, &searcher, plans, &ids, &replace_ids).await?;
         }
 
         // 3. Copy all irises to destination db

--- a/iris-mpc-cpu/src/hawkers/build_plaintext.rs
+++ b/iris-mpc-cpu/src/hawkers/build_plaintext.rs
@@ -68,7 +68,6 @@ pub async fn plaintext_parallel_batch_insert<D: DistanceOps>(
                     query,
                     links: links_unstructured,
                     update_ep,
-                    replace_id: None,
                 };
                 Ok((vector_id, insert_plan))
             });
@@ -90,7 +89,16 @@ pub async fn plaintext_parallel_batch_insert<D: DistanceOps>(
 
         // Unwrap Arc while inserting, then wrap again for the next batch
         let mut graph_temp = Arc::try_unwrap(graph).unwrap();
-        insert::insert(&mut store, &mut graph_temp, searcher, plans, &ids).await?;
+        let replace_ids = vec![None; plans.len()];
+        insert::insert(
+            &mut store,
+            &mut graph_temp,
+            searcher,
+            plans,
+            &ids,
+            &replace_ids,
+        )
+        .await?;
         graph = Arc::new(graph_temp);
 
         if inserted_count.saturating_sub(reported_count) >= REPORTING_INTERVAL {


### PR DESCRIPTION
Previously, deletions would be applied to graph data after all other graph updates were applied.  Since WAL entries are organized according to their index within a batch, this means that deletion mutations were applied in a different order to the in-memory graph than they would be upon replay from the WAL.  This PR restructures the functioning of `HawkHandle::handle_mutations` to bring deletion processing inside of the main `insert::insert` functionality.