### PR TITLE
[POP-3877] Add converters for GraphV4

### DIFF
--- a/iris-mpc-bins/bin/iris-mpc-cpu/graph_utils.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/graph_utils.rs
@@ -15,7 +15,7 @@ use iris_mpc_cpu::{
     utils::serialization::graph::{
         check_valid_graph_formats, check_valid_graph_pair_formats, read_graph,
         read_graph_from_file, read_graph_pair, read_graph_pair_from_file, write_graph_pair_to_file,
-        write_graph_to_file, GraphFormat, GRAPH_FORMAT_CURRENT,
+        write_graph_to_file, GraphFormat,
     },
 };
 
@@ -246,7 +246,7 @@ fn upgrade_format(
 
         println!(
             "Writing graph pair to file using current stable graph format {}: {}",
-            GRAPH_FORMAT_CURRENT,
+            GraphFormat::Current.version(),
             path_string(&dst_file)
         );
         write_graph_pair_to_file(dst_file, graph_pair)
@@ -265,7 +265,7 @@ fn upgrade_format(
 
         println!(
             "Writing graph to file using current stable graph format {}: {}",
-            GRAPH_FORMAT_CURRENT,
+            GraphFormat::Current.version(),
             path_string(&dst_file)
         );
         write_graph_to_file(dst_file, graph)
@@ -369,7 +369,7 @@ fn graph_statistics(src_file: PathBuf, src_format: GraphFormat) -> Result<()> {
     println!("=== Graph Statistics ===");
 
     if matches!(src_format, GraphFormat::Current) {
-        println!("File format: {}", GRAPH_FORMAT_CURRENT);
+        println!("File format: {}", GraphFormat::Current.version());
     } else {
         println!("File format: {}", src_format);
     }

--- a/iris-mpc-bins/bin/iris-mpc-cpu/graph_utils.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/graph_utils.rs
@@ -246,7 +246,7 @@ fn upgrade_format(
 
         println!(
             "Writing graph pair to file using current stable graph format {}: {}",
-            GraphFormat::Current.version(),
+            GraphFormat::Current,
             path_string(&dst_file)
         );
         write_graph_pair_to_file(dst_file, graph_pair)
@@ -265,7 +265,7 @@ fn upgrade_format(
 
         println!(
             "Writing graph to file using current stable graph format {}: {}",
-            GraphFormat::Current.version(),
+            GraphFormat::Current,
             path_string(&dst_file)
         );
         write_graph_to_file(dst_file, graph)
@@ -369,7 +369,7 @@ fn graph_statistics(src_file: PathBuf, src_format: GraphFormat) -> Result<()> {
     println!("=== Graph Statistics ===");
 
     if matches!(src_format, GraphFormat::Current) {
-        println!("File format: {}", GraphFormat::Current.version());
+        println!("File format: {}", GraphFormat::Current);
     } else {
         println!("File format: {}", src_format);
     }

--- a/iris-mpc-cpu/src/graph_checkpoint/s3_client/mod.rs
+++ b/iris-mpc-cpu/src/graph_checkpoint/s3_client/mod.rs
@@ -175,6 +175,9 @@ pub async fn download_graph_checkpoint(
     state: &GraphCheckpointState,
 ) -> Result<BothEyes<GraphMem<IrisVectorId>>> {
     let format = GraphFormat::try_from(state.graph_version)?;
+    if format == GraphFormat::Raw {
+        bail!("Unexpected graph checkpoint format: Raw");
+    }
     let binary_graph = download_and_hash(s3_client, bucket, state).await?;
 
     // todo: deserialize in a way that does not require holding 2 graphs in memory at once.

--- a/iris-mpc-cpu/src/graph_checkpoint/s3_client/mod.rs
+++ b/iris-mpc-cpu/src/graph_checkpoint/s3_client/mod.rs
@@ -1,7 +1,7 @@
 mod multipart;
 mod streaming;
 mod streaming_download;
-use std::{fmt::Display, io::Cursor, str::FromStr, time::Instant};
+use std::{io::Cursor, time::Instant};
 
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::Client as S3Client;
@@ -16,14 +16,13 @@ use crate::{
             graph_store::{self, GraphPg},
             layered_graph::GraphMem,
         },
-        vector_store::Ref,
         VectorStore,
     },
-    utils::serialization::graph::GraphFormat,
+    utils::serialization::graph::{read_graph_pair, GraphFormat},
 };
 
 use crate::graph_checkpoint::data::*;
-use iris_mpc_common::IrisSerialId;
+use iris_mpc_common::{IrisSerialId, IrisVectorId};
 pub use multipart::*;
 pub use streaming::*;
 pub use streaming_download::*;
@@ -170,21 +169,18 @@ async fn _upload_graph_checkpoint(
     Ok(checkpoint)
 }
 
-pub async fn download_graph_checkpoint<T: Ref + Display + FromStr + Ord>(
+pub async fn download_graph_checkpoint(
     s3_client: &S3Client,
     bucket: &str,
     state: &GraphCheckpointState,
-) -> Result<BothEyes<GraphMem<T>>> {
-    if state.graph_version != GraphFormat::Current.version() {
-        bail!("unexpected graph version: {}", state.graph_version);
-    }
-
+) -> Result<BothEyes<GraphMem<IrisVectorId>>> {
+    let format = GraphFormat::try_from(state.graph_version)?;
     let binary_graph = download_and_hash(s3_client, bucket, state).await?;
 
     // todo: deserialize in a way that does not require holding 2 graphs in memory at once.
     // currently binary_graph and graphs make two graphs in RAM at once
     let mut cursor = Cursor::new(&binary_graph);
-    let graphs: BothEyes<GraphMem<_>> = bincode::deserialize_from(&mut cursor)?;
+    let graphs = read_graph_pair(&mut cursor, format)?;
     Ok(graphs)
 }
 

--- a/iris-mpc-cpu/src/utils/serialization/graph.rs
+++ b/iris-mpc-cpu/src/utils/serialization/graph.rs
@@ -29,6 +29,13 @@ pub enum GraphFormat {
     Current,
 
     /// Stable graph serialization format Version 4.
+    ///
+    /// - Binary format
+    /// - Multiple entry-points
+    /// - VectorId = (SerialId, VersionId)
+    /// - Contains layer checksums
+    /// - Edges store VectorIds only
+    /// - Sequence number for timestamping graph mutations <-- DIFF with V3
     V4,
 
     /// Stable graph serialization format Version 3.

--- a/iris-mpc-cpu/src/utils/serialization/graph.rs
+++ b/iris-mpc-cpu/src/utils/serialization/graph.rs
@@ -17,6 +17,7 @@ use crate::{
         graph_v1::{self, read_graph_v1, GraphV1},
         graph_v2::{self, read_graph_v2, GraphV2},
         graph_v3::{self, read_graph_v3, GraphV3},
+        graph_v4::{self, read_graph_v4, GraphV4},
     },
 };
 
@@ -26,6 +27,9 @@ use crate::{
 pub enum GraphFormat {
     /// Designated current stable format for `GraphMem` serialization.
     Current,
+
+    /// Stable graph serialization format Version 4.
+    V4,
 
     /// Stable graph serialization format Version 3.
     ///
@@ -75,7 +79,8 @@ impl GraphFormat {
     /// Current and V3 both map to 3.
     pub fn version(&self) -> i32 {
         match self {
-            GraphFormat::Current | GraphFormat::V3 => 3,
+            GraphFormat::Current | GraphFormat::V4 => 4,
+            GraphFormat::V3 => 3,
             GraphFormat::V2 => 2,
             GraphFormat::V1 => 1,
             GraphFormat::V0 => 0,
@@ -88,7 +93,8 @@ impl GraphFormat {
 }
 
 /// Array of all concrete graph formats
-pub const ALL_CONCRETE_GRAPH_FORMATS: [GraphFormat; 5] = [
+pub const ALL_CONCRETE_GRAPH_FORMATS: [GraphFormat; 6] = [
+    GraphFormat::V4,
     GraphFormat::V3,
     GraphFormat::V2,
     GraphFormat::V1,
@@ -96,13 +102,11 @@ pub const ALL_CONCRETE_GRAPH_FORMATS: [GraphFormat; 5] = [
     GraphFormat::Raw,
 ];
 
-/// Current standard serialization format
-pub const GRAPH_FORMAT_CURRENT: GraphFormat = GraphFormat::V3;
-
 impl Display for GraphFormat {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = match self {
             GraphFormat::Current => "Current",
+            GraphFormat::V4 => "V4",
             GraphFormat::V3 => "V3",
             GraphFormat::V2 => "V2",
             GraphFormat::V1 => "V1",
@@ -122,6 +126,7 @@ impl TryFrom<i32> for GraphFormat {
             1 => Ok(GraphFormat::V1),
             2 => Ok(GraphFormat::V2),
             3 => Ok(GraphFormat::V3),
+            4 => Ok(GraphFormat::V4),
             -1 => Ok(GraphFormat::Raw),
             _ => Err(eyre::eyre!("unsupported graph format version: {}", value)),
         }
@@ -129,21 +134,21 @@ impl TryFrom<i32> for GraphFormat {
 }
 
 /// Designated method for reading a `GraphMem`. Currently goes through the
-/// `GraphV3` serialization type.
+/// `GraphV4` serialization type.
 pub fn read_graph_current<R: std::io::Read>(
     reader: &mut R,
 ) -> eyre::Result<GraphMem<IrisVectorId>> {
-    let data = bincode::deserialize_from::<_, GraphV3>(reader)?.into();
+    let data = bincode::deserialize_from::<_, GraphV4>(reader)?.into();
     Ok(data)
 }
 
 /// Designated method for writing a `GraphMem`. Currently goes through the
-/// `GraphV3` serialization type.
+/// `GraphV4` serialization type.
 pub fn write_graph_current<W: std::io::Write>(
     writer: &mut W,
     data: GraphMem<IrisVectorId>,
 ) -> Result<()> {
-    bincode::serialize_into::<_, GraphV3>(writer, &(data.into()))?;
+    bincode::serialize_into::<_, GraphV4>(writer, &(data.into()))?;
     Ok(())
 }
 
@@ -177,6 +182,10 @@ pub fn read_graph<R: std::io::Read>(
 ) -> Result<GraphMem<IrisVectorId>> {
     match format {
         GraphFormat::Current => read_graph_current(reader),
+        GraphFormat::V4 => {
+            let graph = read_graph_v4(reader)?;
+            Ok(graph.into())
+        }
         GraphFormat::V3 => {
             let graph = read_graph_v3(reader)?;
             Ok(graph.into())
@@ -242,7 +251,7 @@ pub fn check_valid_graph_formats(data: &[u8]) -> Vec<GraphFormat> {
 }
 
 /// Write a `GraphMem` to file using the `GraphFormat::Current` serialization
-/// format, currently `GraphV3`.
+/// format, currently `GraphV4`.
 pub fn write_graph_to_file<P: AsRef<Path>>(path: P, data: GraphMem<IrisVectorId>) -> Result<()> {
     let file = File::create(path)?;
     let mut writer = BufWriter::new(file);
@@ -258,22 +267,22 @@ fn read_pair<R: std::io::Read, G: for<'a> Deserialize<'a>>(reader: &mut R) -> Re
 }
 
 /// Designated method for reading a pair of `GraphMem` structs. Currently goes
-/// through the `GraphV3` serialization type.
+/// through the `GraphV4` serialization type.
 pub fn read_graph_pair_current<R: std::io::Read>(
     reader: &mut R,
 ) -> Result<[GraphMem<IrisVectorId>; 2]> {
-    let data = read_pair::<_, GraphV3>(reader)?.map(|graph| graph.into());
+    let data = read_pair::<_, GraphV4>(reader)?.map(|graph| graph.into());
     Ok(data)
 }
 
 /// Designated method for writing a pair of `GraphMem` structs. Currently goes
-/// through the `GraphV3` serialization type.
+/// through the `GraphV4` serialization type.
 pub fn write_graph_pair_current<W: std::io::Write>(
     writer: &mut W,
     data: [GraphMem<IrisVectorId>; 2],
 ) -> Result<()> {
     let data = data.map(|graph| graph.into());
-    bincode::serialize_into::<_, [GraphV3; 2]>(writer, &data)?;
+    bincode::serialize_into::<_, [GraphV4; 2]>(writer, &data)?;
     Ok(())
 }
 
@@ -309,6 +318,10 @@ pub fn read_graph_pair<R: std::io::Read>(
 ) -> Result<[GraphMem<IrisVectorId>; 2]> {
     match format {
         GraphFormat::Current => read_graph_pair_current(reader),
+        GraphFormat::V4 => {
+            let graphs = read_pair::<_, GraphV4>(reader)?;
+            Ok(graphs.map(|graph| graph.into()))
+        }
         GraphFormat::V3 => {
             let graphs = read_pair::<_, GraphV3>(reader)?;
             Ok(graphs.map(|graph| graph.into()))
@@ -378,7 +391,7 @@ pub fn check_valid_graph_pair_formats(data: &[u8]) -> Vec<GraphFormat> {
 }
 
 /// Write a pair of `GraphMem` structs to file using the `GraphFormat::Current`
-/// graph serialization format, currently `GraphV3`.
+/// graph serialization format, currently `GraphV4`.
 pub fn write_graph_pair_to_file<P: AsRef<Path>>(
     path: P,
     data: [GraphMem<IrisVectorId>; 2],
@@ -607,6 +620,92 @@ impl From<GraphMem<IrisVectorId>> for graph_v3::GraphV3 {
         graph_v3::GraphV3 {
             entry_point: value.entry_points.into_iter().map(|ep| ep.into()).collect(),
             layers: value.layers.into_iter().map(|layer| layer.into()).collect(),
+        }
+    }
+}
+
+/* --------------- Conversion GraphV4 -> GraphMem ------------------- */
+
+impl From<graph_v4::VectorId> for IrisVectorId {
+    fn from(value: graph_v4::VectorId) -> Self {
+        IrisVectorId::new(value.id, value.version)
+    }
+}
+
+impl From<graph_v4::EntryPoint> for layered_graph::EntryPoint<IrisVectorId> {
+    fn from(value: graph_v4::EntryPoint) -> Self {
+        layered_graph::EntryPoint {
+            point: value.point.into(),
+            layer: value.layer,
+        }
+    }
+}
+
+impl From<graph_v4::Layer> for Layer<IrisVectorId> {
+    fn from(value: graph_v4::Layer) -> Self {
+        let mut layer = Layer::new();
+        for (v, nb) in value.links.into_iter() {
+            layer.set_links(v.into(), nb.0.into_iter().map(|x| x.into()).collect());
+        }
+        layer
+    }
+}
+
+impl From<graph_v4::GraphV4> for GraphMem<IrisVectorId> {
+    fn from(value: graph_v4::GraphV4) -> Self {
+        GraphMem {
+            entry_points: value.entry_points.into_iter().map(|e| e.into()).collect(),
+            layers: value.layers.into_iter().map(|layer| layer.into()).collect(),
+            last_update_seq_no: value.last_update_seq_no,
+        }
+    }
+}
+
+/* --------------- Conversion GraphMem -> GraphV4 ------------------- */
+
+impl From<IrisVectorId> for graph_v4::VectorId {
+    fn from(value: IrisVectorId) -> Self {
+        graph_v4::VectorId {
+            id: value.serial_id(),
+            version: value.version_id(),
+        }
+    }
+}
+
+impl From<layered_graph::EntryPoint<IrisVectorId>> for graph_v4::EntryPoint {
+    fn from(value: layered_graph::EntryPoint<IrisVectorId>) -> Self {
+        graph_v4::EntryPoint {
+            point: value.point.into(),
+            layer: value.layer,
+        }
+    }
+}
+
+impl From<Layer<IrisVectorId>> for graph_v4::Layer {
+    fn from(value: Layer<IrisVectorId>) -> Self {
+        let set_hash = value.checksum();
+        graph_v4::Layer {
+            links: value
+                .links
+                .into_iter()
+                .map(|(v, nb)| {
+                    (
+                        v.into(),
+                        graph_v4::EdgeIds(nb.into_iter().map(|x| x.into()).collect()),
+                    )
+                })
+                .collect(),
+            set_hash,
+        }
+    }
+}
+
+impl From<GraphMem<IrisVectorId>> for graph_v4::GraphV4 {
+    fn from(value: GraphMem<IrisVectorId>) -> Self {
+        graph_v4::GraphV4 {
+            entry_points: value.entry_points.into_iter().map(|ep| ep.into()).collect(),
+            layers: value.layers.into_iter().map(|layer| layer.into()).collect(),
+            last_update_seq_no: value.last_update_seq_no,
         }
     }
 }

--- a/iris-mpc-cpu/src/utils/serialization/graph.rs
+++ b/iris-mpc-cpu/src/utils/serialization/graph.rs
@@ -76,7 +76,6 @@ pub enum GraphFormat {
 
 impl GraphFormat {
     /// Convert GraphFormat to its corresponding i32 value for storage.
-    /// Current and V3 both map to 3.
     pub fn version(&self) -> i32 {
         match self {
             GraphFormat::Current | GraphFormat::V4 => 4,

--- a/iris-mpc-cpu/src/utils/serialization/graph.rs
+++ b/iris-mpc-cpu/src/utils/serialization/graph.rs
@@ -581,55 +581,6 @@ impl From<graph_v3::GraphV3> for GraphMem<IrisVectorId> {
     }
 }
 
-/* --------------- Conversion GraphMem -> GraphV3 ------------------- */
-
-impl From<IrisVectorId> for graph_v3::VectorId {
-    fn from(value: IrisVectorId) -> Self {
-        graph_v3::VectorId {
-            id: value.serial_id(),
-            version: value.version_id(),
-        }
-    }
-}
-
-impl From<layered_graph::EntryPoint<IrisVectorId>> for graph_v3::EntryPoint {
-    fn from(value: layered_graph::EntryPoint<IrisVectorId>) -> Self {
-        graph_v3::EntryPoint {
-            point: value.point.into(),
-            layer: value.layer,
-        }
-    }
-}
-
-impl From<Layer<IrisVectorId>> for graph_v3::Layer {
-    fn from(value: Layer<IrisVectorId>) -> Self {
-        graph_v3::Layer {
-            links: value
-                .links
-                .into_iter()
-                .map(|(v, nb)| {
-                    (
-                        v.into(),
-                        graph_v3::EdgeIds(nb.into_iter().map(|x| x.into()).collect()),
-                    )
-                })
-                .collect(),
-            // This is ignored when deserializing
-            // But it needs to exist
-            set_hash: 0,
-        }
-    }
-}
-
-impl From<GraphMem<IrisVectorId>> for graph_v3::GraphV3 {
-    fn from(value: GraphMem<IrisVectorId>) -> Self {
-        graph_v3::GraphV3 {
-            entry_point: value.entry_points.into_iter().map(|ep| ep.into()).collect(),
-            layers: value.layers.into_iter().map(|layer| layer.into()).collect(),
-        }
-    }
-}
-
 /* --------------- Conversion GraphV4 -> GraphMem ------------------- */
 
 impl From<graph_v4::VectorId> for IrisVectorId {

--- a/iris-mpc-cpu/src/utils/serialization/types/graph_v4.rs
+++ b/iris-mpc-cpu/src/utils/serialization/types/graph_v4.rs
@@ -1,0 +1,50 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// An in-memory implementation of an HNSW hierarchical graph.
+///
+/// This type is a serialization-focused adapter, provided for long-term
+/// compatibility and portability of serialized data.
+#[derive(Default, PartialEq, Eq, Debug, Serialize, Deserialize)]
+pub struct GraphV4 {
+    pub entry_points: Vec<EntryPoint>,
+    pub layers: Vec<Layer>,
+    pub last_update_seq_no: u64,
+}
+
+/// Type associated with the `GraphV4` serialization type.
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EntryPoint {
+    pub point: VectorId,
+    pub layer: usize,
+}
+
+/// Type associated with the `GraphV4` serialization type.
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Layer {
+    pub links: HashMap<VectorId, EdgeIds>,
+    pub set_hash: u64,
+}
+
+/// Type associated with the `GraphV4` serialization type.
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EdgeIds(pub Vec<VectorId>);
+
+/// Type associated with the `GraphV4` serialization type.
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+pub struct VectorId {
+    pub id: u32,
+    pub version: i16,
+}
+
+/* ------------------------------- I/O ------------------------------ */
+
+pub fn read_graph_v4<R: std::io::Read>(reader: &mut R) -> eyre::Result<GraphV4> {
+    let data = bincode::deserialize_from(reader)?;
+    Ok(data)
+}
+
+pub fn write_graph_v4<W: std::io::Write>(writer: &mut W, data: &GraphV4) -> eyre::Result<()> {
+    bincode::serialize_into(writer, data)?;
+    Ok(())
+}

--- a/iris-mpc-cpu/src/utils/serialization/types/graph_v4.rs
+++ b/iris-mpc-cpu/src/utils/serialization/types/graph_v4.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 ///
 /// This type is a serialization-focused adapter, provided for long-term
 /// compatibility and portability of serialized data.
-#[derive(Default, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GraphV4 {
     pub entry_points: Vec<EntryPoint>,
     pub layers: Vec<Layer>,

--- a/iris-mpc-cpu/src/utils/serialization/types/mod.rs
+++ b/iris-mpc-cpu/src/utils/serialization/types/mod.rs
@@ -9,4 +9,5 @@ pub mod graph_v0;
 pub mod graph_v1;
 pub mod graph_v2;
 pub mod graph_v3;
+pub mod graph_v4;
 pub mod iris_base64;


### PR DESCRIPTION
GraphMem has been updated and the conversion functions now need to account for the extra `seq_no` field. 

Also the `download_graph_checkpoint` function now uses the `read_graph_pair` function to process checkpoints which are older than `GraphFormat::Current`. 