### PR TITLE
bump ampc common to use modified http endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 [[package]]
 name = "ampc-actor-utils"
 version = "0.1.0"
-source = "git+https://github.com/worldcoin/ampc-common.git?rev=56588b880303fbc19cbacef83a00cb83c5f248d9#56588b880303fbc19cbacef83a00cb83c5f248d9"
+source = "git+https://github.com/worldcoin/ampc-common.git?rev=d5a211f306f2793c0eb63cd272556e45b7f3eb52#d5a211f306f2793c0eb63cd272556e45b7f3eb52"
 dependencies = [
  "aes-prng",
  "ampc-secret-sharing",
@@ -111,7 +111,7 @@ dependencies = [
 [[package]]
 name = "ampc-anon-stats"
 version = "0.1.0"
-source = "git+https://github.com/worldcoin/ampc-common.git?rev=56588b880303fbc19cbacef83a00cb83c5f248d9#56588b880303fbc19cbacef83a00cb83c5f248d9"
+source = "git+https://github.com/worldcoin/ampc-common.git?rev=d5a211f306f2793c0eb63cd272556e45b7f3eb52#d5a211f306f2793c0eb63cd272556e45b7f3eb52"
 dependencies = [
  "ampc-actor-utils",
  "ampc-secret-sharing",
@@ -137,7 +137,7 @@ dependencies = [
 [[package]]
 name = "ampc-secret-sharing"
 version = "0.1.0"
-source = "git+https://github.com/worldcoin/ampc-common.git?rev=56588b880303fbc19cbacef83a00cb83c5f248d9#56588b880303fbc19cbacef83a00cb83c5f248d9"
+source = "git+https://github.com/worldcoin/ampc-common.git?rev=d5a211f306f2793c0eb63cd272556e45b7f3eb52#d5a211f306f2793c0eb63cd272556e45b7f3eb52"
 dependencies = [
  "aes-prng",
  "bytemuck",
@@ -152,7 +152,7 @@ dependencies = [
 [[package]]
 name = "ampc-server-utils"
 version = "0.1.0"
-source = "git+https://github.com/worldcoin/ampc-common.git?rev=56588b880303fbc19cbacef83a00cb83c5f248d9#56588b880303fbc19cbacef83a00cb83c5f248d9"
+source = "git+https://github.com/worldcoin/ampc-common.git?rev=d5a211f306f2793c0eb63cd272556e45b7f3eb52#d5a211f306f2793c0eb63cd272556e45b7f3eb52"
 dependencies = [
  "aws-sdk-secretsmanager",
  "aws-sdk-sqs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,10 +83,10 @@ tokio-util = "0.7.15"
 toml = { version = "0.8.23", features = ["preserve_order"] }
 uuid = { version = "1", features = ["v4"] }
 iris-mpc-cpu = { path = "./iris-mpc-cpu" }
-ampc-anon-stats = { git = "https://github.com/worldcoin/ampc-common.git", rev = "56588b880303fbc19cbacef83a00cb83c5f248d9" }
-ampc-actor-utils = { git = "https://github.com/worldcoin/ampc-common.git", rev = "56588b880303fbc19cbacef83a00cb83c5f248d9" }
-ampc-secret-sharing = { git = "https://github.com/worldcoin/ampc-common.git", rev = "56588b880303fbc19cbacef83a00cb83c5f248d9" }
-ampc-server-utils = { git = "https://github.com/worldcoin/ampc-common.git", rev = "56588b880303fbc19cbacef83a00cb83c5f248d9" }
+ampc-anon-stats = { git = "https://github.com/worldcoin/ampc-common.git", rev = "d5a211f306f2793c0eb63cd272556e45b7f3eb52" }
+ampc-actor-utils = { git = "https://github.com/worldcoin/ampc-common.git", rev = "d5a211f306f2793c0eb63cd272556e45b7f3eb52" }
+ampc-secret-sharing = { git = "https://github.com/worldcoin/ampc-common.git", rev = "d5a211f306f2793c0eb63cd272556e45b7f3eb52" }
+ampc-server-utils = { git = "https://github.com/worldcoin/ampc-common.git", rev = "d5a211f306f2793c0eb63cd272556e45b7f3eb52" }
 
 # Abort on panics rather than unwinding.
 # This improves performance and makes panic propagation more reliable.

--- a/iris-mpc-bins/bin/iris-mpc-cpu/communication_stats.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/communication_stats.rs
@@ -147,7 +147,7 @@ impl NetworkHandle for CountingNetworkHandle {
     }
 
     async fn sync_peers(&mut self) -> Result<()> {
-        self.inner.sync_peers().await
+        self.inner.control_channel().await?.sync().await
     }
 }
 

--- a/iris-mpc-bins/bin/iris-mpc-cpu/communication_stats.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/communication_stats.rs
@@ -39,7 +39,10 @@ use std::{
     collections::HashMap, error::Error, fmt::Write as _, path::PathBuf, sync::Arc, time::Duration,
 };
 
-use ampc_actor_utils::execution::{player::Identity, session::NetworkSession};
+use ampc_actor_utils::{
+    execution::{player::Identity, session::NetworkSession},
+    network::mpc::handle::control_channel::ControlChannel,
+};
 use async_trait::async_trait;
 use clap::Parser;
 use eyre::Result;
@@ -146,8 +149,8 @@ impl NetworkHandle for CountingNetworkHandle {
         self.inner.make_sessions().await
     }
 
-    async fn sync_peers(&mut self) -> Result<()> {
-        self.inner.control_channel().await?.sync().await
+    async fn control_channel(&mut self) -> Result<Box<dyn ControlChannel>> {
+        self.inner.control_channel().await
     }
 }
 
@@ -186,7 +189,7 @@ impl NetworkHandle for DummyNetHandle {
     )> {
         unreachable!("DummyNetHandle should never be called")
     }
-    async fn sync_peers(&mut self) -> Result<()> {
+    async fn control_channel(&mut self) -> Result<Box<dyn ControlChannel>> {
         unreachable!("DummyNetHandle should never be called")
     }
 }

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -708,7 +708,7 @@ impl HawkActor {
     }
 
     pub async fn sync_peers(&mut self) -> Result<()> {
-        self.networking.sync_peers().await
+        self.networking.control_channel().await?.sync().await
     }
 
     fn create_session(

--- a/iris-mpc-cpu/src/graph_checkpoint/mod.rs
+++ b/iris-mpc-cpu/src/graph_checkpoint/mod.rs
@@ -95,11 +95,10 @@ pub async fn get_others_graph_hashes(
 ) -> Result<Vec<GraphCheckpointHashes>> {
     tracing::info!("⚓️ ANCHOR: Syncing latest graph checkpoints");
 
-    let connected_and_ready =
-        try_get_endpoint_other_nodes(config, GRAPH_CHECKPOINT_ENDPOINT).await?;
+    let responses = try_get_endpoint_other_nodes(config, GRAPH_CHECKPOINT_ENDPOINT).await?;
 
-    let mut graph_checkpoints = Vec::with_capacity(connected_and_ready.len());
-    for (status_code, body) in connected_and_ready.into_iter() {
+    let mut graph_checkpoints = Vec::with_capacity(responses.len());
+    for (status_code, body) in responses.into_iter() {
         if !status_code.is_success() {
             bail!("failed to get graph checkpoint: {:?}", status_code);
         }

--- a/iris-mpc-cpu/src/graph_checkpoint/mod.rs
+++ b/iris-mpc-cpu/src/graph_checkpoint/mod.rs
@@ -5,7 +5,7 @@ use ampc_server_utils::{try_get_endpoint_other_nodes, ServerCoordinationConfig};
 pub use data::*;
 pub use s3_client::*;
 
-use eyre::{bail, Result};
+use eyre::{bail, Context, Result};
 
 use crate::{
     execution::hawk_main::HawkOps, hawkers::aby3::aby3_store::Aby3Store,
@@ -98,12 +98,15 @@ pub async fn get_others_graph_hashes(
     let connected_and_ready =
         try_get_endpoint_other_nodes(config, GRAPH_CHECKPOINT_ENDPOINT).await?;
 
-    let response_texts_futs: Vec<_> = connected_and_ready
-        .into_iter()
-        .map(|resp| resp.json())
-        .collect();
-    let graph_checkpoints: Vec<GraphCheckpointHashes> =
-        futures::future::try_join_all(response_texts_futs).await?;
+    let mut graph_checkpoints = Vec::with_capacity(connected_and_ready.len());
+    for (status_code, body) in connected_and_ready.into_iter() {
+        if !status_code.is_success() {
+            bail!("failed to get graph checkpoint: {:?}", status_code);
+        }
+        let cp = serde_json::from_slice(&body)
+            .wrap_err("Failed to deserialize graph checkpoint hashes")?;
+        graph_checkpoints.push(cp);
+    }
 
     Ok(graph_checkpoints)
 }

--- a/iris-mpc-upgrade-hawk/src/genesis/mod.rs
+++ b/iris-mpc-upgrade-hawk/src/genesis/mod.rs
@@ -416,7 +416,7 @@ async fn exec_setup(
     // Networking only: sync_peers + rollback must run before the iris
     // load decides `max_serial_id`.
     let (hawk_args, mut hawk_networking) = build_hawk_networking(config, &shutdown_handler).await?;
-    hawk_networking.sync_peers().await?;
+    hawk_networking.control_channel().await?.sync().await?;
 
     if let Some(cp) = graph_checkpoint.as_ref() {
         maybe_rollback_iris_db(


### PR DESCRIPTION
the modified http endpoint is in ampc-common. this would help potentially diagnose an issue with staging. 

ampc-common also modified the NetworkHandle trait, requiring an update to `sync_peers()`. 

the modified http endpoint requires the checkpoint sync code to be updated too. the response body is now returned. 