### PR TITLE
chore: scale down the ampc-hnsw deployment on prod env

### DIFF
--- a/deploy/prod/common-values-ampc-hnsw.yaml
+++ b/deploy/prod/common-values-ampc-hnsw.yaml
@@ -1,7 +1,7 @@
 image: "ghcr.io/worldcoin/iris-mpc-cpu:v0.31.10@sha256:cf2f715c66748171940b448163f6b0e0ce7dedae783282b43b135fc2589f4f29"
 
 environment: prod
-replicaCount: 1
+replicaCount: 0
 
 strategy:
   type: Recreate


### PR DESCRIPTION
We want to scale down the deployment