### PR TITLE
chore(POP-3895): Configure db-exporter in AMPC cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 
 .DS_Store
 vendor/
+
+iris-mpc-db-exporter/test/test_output

--- a/deploy/prod/ampc-hnsw-0-prod/values-ampc-hnsw-db-exporter.yaml
+++ b/deploy/prod/ampc-hnsw-0-prod/values-ampc-hnsw-db-exporter.yaml
@@ -12,6 +12,10 @@ env:
     value: eu-north-1
   - name: GIN_MODE
     value: release
+  - name: FORCE_OVERRIDE_SCHEMA_NAME
+    value: "true"
+  - name: OVERRIDDEN_SCHEMA_NAME
+    value: "SMPC_rerand_genesis_restored_v2_0"
   - name: EXPORT_S3_BUCKET_NAME
     value: "ampc-hnsw-db-exporter-store-node-0-prod--eun1-az3--x-s3"
   - name: NODE_ID

--- a/deploy/prod/ampc-hnsw-1-prod/values-ampc-hnsw-db-exporter.yaml
+++ b/deploy/prod/ampc-hnsw-1-prod/values-ampc-hnsw-db-exporter.yaml
@@ -12,6 +12,10 @@ env:
     value: eu-north-1
   - name: GIN_MODE
     value: release
+  - name: FORCE_OVERRIDE_SCHEMA_NAME
+    value: "true"
+  - name: OVERRIDDEN_SCHEMA_NAME
+    value: "SMPC_rerand_genesis_restored_v2_1"
   - name: EXPORT_S3_BUCKET_NAME
     value: "ampc-hnsw-db-exporter-store-node-1-prod--eun1-az3--x-s3"
   - name: NODE_ID

--- a/deploy/prod/ampc-hnsw-2-prod/values-ampc-hnsw-db-exporter.yaml
+++ b/deploy/prod/ampc-hnsw-2-prod/values-ampc-hnsw-db-exporter.yaml
@@ -12,6 +12,10 @@ env:
     value: eu-north-1
   - name: GIN_MODE
     value: release
+  - name: FORCE_OVERRIDE_SCHEMA_NAME
+    value: "true"
+  - name: OVERRIDDEN_SCHEMA_NAME
+    value: "SMPC_rerand_genesis_restored_v2_2"
   - name: EXPORT_S3_BUCKET_NAME
     value: "ampc-hnsw-db-exporter-store-node-2-prod--eun1-az3--x-s3"
   - name: NODE_ID

--- a/iris-mpc-db-exporter/.env.local
+++ b/iris-mpc-db-exporter/.env.local
@@ -1,2 +1,4 @@
 DATABASE_URL=postgres://dbuser:password@localhost:5432/db?sslmode=disable
 DD_TRACE_ENABLED=false
+FORCE_OVERRIDE_SCHEMA_NAME=true
+OVERRIDDEN_SCHEMA_NAME=another_schema

--- a/iris-mpc-db-exporter/docker-compose.yaml
+++ b/iris-mpc-db-exporter/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   db:
-    image: postgres:latest
+    image: postgres:15
     environment:
       POSTGRES_USER: dbuser
       POSTGRES_PASSWORD: password

--- a/iris-mpc-db-exporter/src/config/config.go
+++ b/iris-mpc-db-exporter/src/config/config.go
@@ -18,6 +18,8 @@ type Config struct {
 	NodeId                     int
 	Environment                string
 	SmpcSchemaName             string
+	ForceOverrideSchemaName    bool
+	OverriddenSchemaName       string
 	MaxItemsPerUploadPart      int
 	SingleCodeSize             int
 	SingleMaskSize             int
@@ -38,6 +40,8 @@ func Load() Config {
 		NodeId:                     loadIntVar("NODE_ID", 0),
 		Environment:                loadStringVar("ENV", "local"),
 		SmpcSchemaName:             loadStringVar("SMPC_SCHEMA_NAME", "SMPC"),
+		ForceOverrideSchemaName:    loadBoolVar("FORCE_OVERRIDE_SCHEMA_NAME", false),
+		OverriddenSchemaName:       loadStringVar("OVERRIDDEN_SCHEMA_NAME", ""),
 		MaxItemsPerUploadPart:      loadIntVar("MAX_ITEMS_PER_UPLOAD_PART", 200), // defines the number of items to be uploaded in a single part of the multipart upload
 		SingleCodeSize:             loadIntVar("SINGLE_CODE_SIZE", 25600),
 		SingleMaskSize:             loadIntVar("SINGLE_MASK_SIZE", 12800),

--- a/iris-mpc-db-exporter/src/iris/store.go
+++ b/iris-mpc-db-exporter/src/iris/store.go
@@ -38,12 +38,17 @@ type Store struct {
 }
 
 func NewStore(ctx context.Context, db *sql.DB, config config.Config) *Store {
-	schema := fmt.Sprintf(irisDbSchemaFormat, config.SmpcSchemaName, config.Environment, config.NodeId)
+	var schema string
+	if config.ForceOverrideSchemaName {
+		schema = config.OverriddenSchemaName
+	} else {
+		schema = fmt.Sprintf(irisDbSchemaFormat, config.SmpcSchemaName, config.Environment, config.NodeId)
+	}
 
 	// create schema if not exists - used for db populate in local environment
 	o11y.S(ctx).Infof("ENV: %s", config.Environment)
 	if config.Environment == "local" || config.Environment == "CI" {
-		o11y.S(ctx).Info("Creating schema if not exists in local environment")
+		o11y.S(ctx).Infof("Creating schema %s if not exists in local environment", schema)
 		createSchemaIfNotExistsCmd := fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS \"%s\";", schema)
 		_, err := db.Exec(createSchemaIfNotExistsCmd)
 		if err != nil {


### PR DESCRIPTION
## Summary
Configure `iris-mpc-db-exporter` for AMPC production clusters with support for explicit schema overrides.

## Changes
- Added support for overriding the target PostgreSQL schema via:
  - `FORCE_OVERRIDE_SCHEMA_NAME`
  - `OVERRIDDEN_SCHEMA_NAME`
- Added production configuration for:
  - `ampc-hnsw-0-prod`
  - `ampc-hnsw-1-prod`
  - `ampc-hnsw-2-prod`
- Configured each cluster to export from restored rerand genesis schemas:
  - `SMPC_rerand_genesis_restored_v2_0`
  - `SMPC_rerand_genesis_restored_v2_1`
  - `SMPC_rerand_genesis_restored_v2_2`
- Improved local development setup:
  - added schema override env vars to `.env.local`
  - downgraded local Postgres image from `postgres:latest` to `postgres:15` for compatibility with CI
- Added generated test output path to `.gitignore`

## Motivation
The exporter currently derives schema names dynamically from environment and node ID. For restored genesis datasets, the schema naming does not follow the standard convention, so explicit schema overrides are required to support exports from AMPC restored databases.
