### PR TITLE
[POP-3781] fix: make SQS-modification persistence flow fail-safe

### DIFF
--- a/iris-mpc-common/src/helpers/smpc_request.rs
+++ b/iris-mpc-common/src/helpers/smpc_request.rs
@@ -162,6 +162,9 @@ pub enum ReceiveRequestError {
     #[error("Failed to delete request from SQS: {0}")]
     FailedToDeleteFromSQS(#[from] Box<SdkError<DeleteMessageError>>),
 
+    #[error("Failed to mark request as deleted: {0}")]
+    FailedToMarkRequestAsDeleted(Report),
+
     #[error("Failed to persist request modification in the database: {0}")]
     FailedToPersistModification(#[from] Report),
 

--- a/iris-mpc/src/services/processors/batch.rs
+++ b/iris-mpc/src/services/processors/batch.rs
@@ -426,17 +426,36 @@ impl<'a> BatchProcessor<'a> {
             .string_value()
             .ok_or(ReceiveRequestError::NoMessageTypeAttribute)?;
 
-        self.delete_message(&sqs_message).await?;
-
+        // SQS delete-after-persist (POP-3781). The message is only
+        // deleted once processing has returned Ok — i.e. the modification
+        // row is durably persisted. If the process crashes (or returns
+        // Err) between receiving and persisting, `?` propagates without
+        // acking, SQS visibility timeout expires, and the message is
+        // redelivered. The previous delete-before-process ordering lost
+        // messages on crashes in that window.
+        //
+        // `DeleteMessage` itself uses strict `?` propagation. If the ack
+        // fails after persistence has succeeded, the Err tears down
+        // receive_batch_stream (batch.rs:116 — any Err from receive_batch
+        // breaks the spawn loop), which causes the node to restart. On
+        // restart, modifications_sync GCs any orphan IN_PROGRESS rows
+        // (no peer has them COMPLETED), and the redelivered SQS message
+        // is re-ingested cleanly. Without strict propagation, the orphan
+        // IN_PROGRESS row would persist (modifications_sync only runs at
+        // startup) and visibility-timeout redelivery would produce a
+        // second COMPLETED row plus a duplicate SNS result. Strict `?`
+        // is the trigger for the cleanup path, not just error escalation.
         #[cfg(feature = "explicit-sns-batching")]
         if request_type == BATCH_MESSAGE_TYPE {
             self.process_batch_message(&message, batch_metadata).await?;
+            self.delete_message(&sqs_message).await?;
             self.msg_counter += 1;
             return Ok(());
         }
 
         self.process_message_(&message, request_type, batch_metadata)
             .await?;
+        self.delete_message(&sqs_message).await?;
         self.msg_counter += 1;
         Ok(())
     }
@@ -1184,10 +1203,16 @@ impl<'a> BatchProcessor<'a> {
         &self,
         sqs_message: &aws_sdk_sqs::types::Message,
     ) -> Result<(), ReceiveRequestError> {
+        let receipt_handle = sqs_message.receipt_handle.as_deref().ok_or_else(|| {
+            ReceiveRequestError::FailedToMarkRequestAsDeleted(eyre::eyre!(
+                "SQS message missing receipt handle: {:?}",
+                sqs_message.message_id
+            ))
+        })?;
         self.client
             .delete_message()
             .queue_url(&self.config.requests_queue_url)
-            .receipt_handle(sqs_message.receipt_handle.as_ref().unwrap())
+            .receipt_handle(receipt_handle)
             .send()
             .await
             .map_err(ReceiveRequestError::from)?;

--- a/iris-mpc/src/services/processors/modifications_sync.rs
+++ b/iris-mpc/src/services/processors/modifications_sync.rs
@@ -86,16 +86,18 @@ pub async fn sync_modifications(
             | RESET_UPDATE_MESSAGE_TYPE
             | RECOVERY_UPDATE_MESSAGE_TYPE
             | UNIQUENESS_MESSAGE_TYPE => {
+                let s3_url = modification.s3_url.clone().ok_or_else(|| {
+                    eyre!("Persisted modification missing s3_url: {:?}", modification)
+                })?;
                 let (left_shares, right_shares) = get_iris_shares_parse_task(
                     config.party_id,
                     shares_encryption_key_pair.clone(),
                     Arc::clone(&semaphore),
                     aws_clients.s3_client.clone(),
                     config.shares_bucket_name.clone(),
-                    modification.clone().s3_url.unwrap(),
+                    s3_url,
                 )?
-                .await?
-                .unwrap();
+                .await??;
                 (
                     left_shares.code,
                     left_shares.mask,
@@ -104,7 +106,7 @@ pub async fn sync_modifications(
                 )
             }
             _ => {
-                panic!("Unknown modification type: {:?}", modification);
+                return Err(eyre!("Unknown modification type: {:?}", modification));
             }
         };
 


### PR DESCRIPTION
## Summary

Move `delete_message` in `BatchProcessor::process_message` from **before** the per-type processing branch to **after** it returns `Ok`, plus two small adjacent hardenings on the same persistence flow.

## The bug ([POP-3781](https://linear.app/worldcoin/issue/POP-3781))

Today, `process_message` deletes the SQS message immediately after parsing its message-type attribute, before dispatching to the inner processing branch. If the process crashes — or returns `Err` — between that ack and the modification being durably written to the DB, the message is **lost**: SQS will not redeliver it, and the DB never received it.

## What's in this PR

1. **Delete-after-persist ordering** in `BatchProcessor::process_message` — both the SNS-batching path (`#[cfg(feature = "explicit-sns-batching")]`) and the normal path now ack only after `process_batch_message?` / `process_message_?` returns `Ok`. The core fix.

2. **`delete_message` helper hardening** — `sqs_message.receipt_handle.as_ref().unwrap()` → `ok_or_else(...)` returning a new `ReceiveRequestError::FailedToMarkRequestAsDeleted(Report)` variant. The unwrap was effectively safe (SQS receive always populates `receipt_handle`), but this function is now invoked at a more critical moment, so converting the panic into a typed error is warranted hygiene.

3. **`modifications_sync.rs` hygiene** (peer-modification-sync apply path) — same conceptual concern (don't take the node down on bad input):
   - `modification.clone().s3_url.unwrap()` → `.s3_url.clone().ok_or_else(|| eyre!(...))`
   - `.await?.unwrap()` on the awaited JoinHandle → `.await??` (propagates the inner `Report` instead of panicking)
   - `panic!("Unknown modification type")` → `Err(eyre!(...))` typed return
   - No behavior change on the happy path; on the unhappy path, peer-sync now returns `Err` to its caller instead of taking the node down.

## Why strict `?` propagation on `DeleteMessage`

If the SQS `DeleteMessage` call fails after `process_message_` has already returned `Ok`, the error propagates rather than being swallowed. The cascade tear-down of `receive_batch_stream` (`batch.rs:116` — any `Err` from `receive_batch` breaks the spawn loop) triggers a node restart, at which point `modifications_sync` cleans up any orphan `IN_PROGRESS` rows that didn't complete their batch. The redelivered SQS message is then re-ingested cleanly. Net: zero duplicate rows, one SNS result emitted.

Swallowing the ack error (best-effort `if let Err` wrap) would *not* be safer here — `modifications_sync` only runs on startup, so the orphan `IN_PROGRESS` row would persist in the running node, and the redelivered message would create a second row that also completes, producing duplicate `COMPLETED` rows and duplicate SNS results.

## Behavior diff (`process_message`)

| Scenario | Before | After |
|---|---|---|
| Happy path (Ok) | ack before processing, then process | process, then ack |
| Inner returns `Err` (DB failure mid-write) | **message lost** (acked, then bailed) | message redelivered (not acked, error propagates) |
| Disabled recovery / reset check | acked, then `process_identity_match_check_request` sends SNS error response and returns Ok | unchanged — disabled path still returns Ok, ack happens at tail |
| Invalid message type (`_` match arm) | acked, then logged-and-Ok | unchanged — `Ok(())` returned, ack happens at tail |
| Process crashes between receive and persist | message lost | message redelivered |
| Transient `DeleteMessage` failure after successful persist | n/a (ack was first) | `Err` propagates → stream tear-down → restart-cleanup of orphan IN_PROGRESS row → redelivery → single fresh processing |

## Provenance

Items 1, 2, and 3 are cherry-picked equivalents of changes in #2007 (continuous-rerand branch, @philsippl), translated to current `main`'s shape — PR 2007's pre-image had a single inline `match request_type`, while `main` has since been refactored into `process_message` → `process_message_` / `process_batch_message` (via #2054), so this is not a clean cherry-pick.

The rest of #2007 (rerand.rs, s3_coordination.rs, epoch.rs, continuous_rerand.rs, new migrations, deploy values, spec doc, e2e tests) remains parked on `ps/cont-rerand`.

## Test plan

Local against `main` (`origin/main` at `16872f075`), Rust 1.95.0 — matches CI:

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings --no-deps` — clean
- `cargo check -p iris-mpc` — clean
- `cargo check -p iris-mpc --features explicit-sns-batching` — clean

CI will run the same lints + unit tests + integration tests.

## Risk

Low — 3 files, +38 / -7. Behavior changes are strict improvements: "errors no longer eat messages" (item 1), "bad peer-sync input no longer panics the node" (item 3). The cascade tear-down on transient `DeleteMessage` failure is intentional — it's what triggers the cleanup path that prevents duplicate state.
