### PR TITLE
chore: Delay ampc-hnsw exporter execution

### DIFF
--- a/deploy/prod/common-values-ampc-hnsw-db-exporter.yaml
+++ b/deploy/prod/common-values-ampc-hnsw-db-exporter.yaml
@@ -4,7 +4,7 @@ replicaCount: 0
 
 environment: prod
 
-schedule: "0 11 * * *"
+schedule: "0 12 * * *"
 
 # this is needed to prevent the job from restarting if it fails
 backoffLimit: 0


### PR DESCRIPTION
To allow sync protocol to finish before execution today.