### PR TITLE
[exhibit] S3 loader: fail-fast without try_stream! (fixes Ok(Err) swallow in #2153)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3121,7 +3121,6 @@ name = "iris-mpc-store"
 version = "0.1.0"
 dependencies = [
  "ampc-server-utils",
- "async-stream",
  "async-trait",
  "aws-config",
  "aws-sdk-s3",

--- a/iris-mpc-store/Cargo.toml
+++ b/iris-mpc-store/Cargo.toml
@@ -8,7 +8,6 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-async-stream.workspace = true
 aws-config.workspace = true
 aws-sdk-s3.workspace = true
 async-trait.workspace = true

--- a/iris-mpc-store/src/loader.rs
+++ b/iris-mpc-store/src/loader.rs
@@ -3,18 +3,16 @@ use crate::{
     fetch_and_parse_chunks, last_snapshot_timestamp, DbStoredIris, S3Store, S3StoredIris, Store,
 };
 use ampc_server_utils::shutdown_handler::ShutdownHandler;
-use async_stream::try_stream;
 use aws_config::Region;
 use eyre::bail;
 use futures::stream::BoxStream;
-use futures::{Stream, StreamExt};
+use futures::StreamExt;
 use iris_mpc_common::config::Config;
 use iris_mpc_common::helpers::inmemory_store::InMemoryStore;
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::sync::mpsc::{self, Receiver};
-use tokio::task::JoinHandle;
+use tokio::sync::mpsc;
 
 /// Helper function to load Aurora db records from the stream into memory
 #[allow(clippy::needless_lifetimes)]
@@ -114,7 +112,7 @@ pub async fn load_iris_db(
             min_last_modified_at
         );
 
-        let (tx, rx) = mpsc::channel::<S3StoredIris>(config.load_chunks_buffer_size);
+        let (tx, mut rx) = mpsc::channel::<S3StoredIris>(config.load_chunks_buffer_size);
         let import_runtime = tokio::runtime::Builder::new_multi_thread()
             .worker_threads(s3_load_parallelism)
             .thread_name("s3-importer")
@@ -145,54 +143,32 @@ pub async fn load_iris_db(
         }
         let _drop_guard = RuntimeShutdownGuard(Some(import_runtime));
 
-        // Stream that yields S3StoredIris items from the channel while monitoring
-        // fetch_handle for errors.  Once fetch_handle finishes successfully we
-        // switch to draining the channel directly; if it exits with a JoinError
-        // (i.e. a panic inside the spawned task) we surface that as a stream error.
-        fn get_s3_stream(
-            join_handle: JoinHandle<eyre::Result<()>>,
-            mut rx: Receiver<S3StoredIris>,
-        ) -> impl Stream<Item = Result<S3StoredIris, eyre::Report>> {
-            try_stream! {
-                let mut fetch_done = false;
-                let mut task_error: Option<eyre::Report> = None;
-                tokio::pin!(join_handle);
-                loop {
-                    tokio::select! {
-                        result = &mut join_handle, if !fetch_done => {
-                            fetch_done = true;
-                            if  let Err(e) = result {
-                                task_error = Some(eyre::eyre!("S3 fetch task yielded an error: {}", e));
-                            }
-                        }
-
-                        item = rx.recv() => {
-                            match item {
-                                Some(iris) => yield iris,
-                                None if fetch_done => break,
-                                None => {
-                                    if let Err(e) = join_handle.await {
-                                        task_error = Some(eyre::eyre!("S3 fetch task failed: {}", e));
-                                    }
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                }
-                if let Some(e) = task_error.take() {
-                    Err(e)?;
-                }
-            }
-        }
-        let s3_stream = get_s3_stream(fetch_handle, rx);
-        tokio::pin!(s3_stream);
-
+        // Consume parsed irises while watching the fetch task. `biased` polls the
+        // task before the channel, so a fetch failure aborts immediately instead of
+        // draining the backlog (and the in-flight retry-with-backoff subtasks).
         let mut time_waiting_for_stream = Duration::from_secs(0);
         let mut time_loading_into_memory = Duration::from_secs(0);
         let mut load_summary_ts = Instant::now();
-        while let Some(iris) = s3_stream.next().await {
-            let iris = iris?;
+        let mut fetch_done = false;
+        tokio::pin!(fetch_handle);
+        loop {
+            let iris = tokio::select! {
+                biased;
+                res = &mut fetch_handle, if !fetch_done => {
+                    fetch_done = true;
+                    match res {
+                        Ok(Ok(())) => continue,
+                        Ok(Err(e)) => return Err(e),
+                        Err(join_err) => {
+                            return Err(eyre::eyre!("S3 fetch task panicked: {}", join_err))
+                        }
+                    }
+                }
+                item = rx.recv() => match item {
+                    Some(iris) => iris,
+                    None => break,
+                },
+            };
             time_waiting_for_stream += load_summary_ts.elapsed();
             load_summary_ts = Instant::now();
             let serial_id = iris.serial_id();
@@ -246,6 +222,17 @@ pub async fn load_iris_db(
             all_serial_ids.remove(&(serial_id as i64));
             record_counter += 1;
         }
+
+        // Reached only by breaking on a closed channel. If the task's result wasn't
+        // observed in the loop, join it now to surface a late failure.
+        if !fetch_done {
+            match fetch_handle.await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => return Err(e),
+                Err(join_err) => return Err(eyre::eyre!("S3 fetch task failed: {}", join_err)),
+            }
+        }
+
         tracing::info!(
             "S3 Loading summary => Loaded {:?} items. Waited for stream: {:?}, Loaded into \
              memory: {:?}.",


### PR DESCRIPTION
> **Draft / exhibit, not for merge.** Counter-proposal stacked on top of #2153 (base = `sw/dont_block_runtime_with_graph_deserialization`), so this diff is purely the delta on top of that PR.

## What this shows

#2153 wraps the S3 fetch channel in a hand-rolled `Stream` (`get_s3_stream` + `try_stream!`, a `select!` over `&mut join_handle` and `rx.recv()`, two `tokio::pin!`s, a `fetch_done` flag and a `task_error` stash-and-reemit). This branch replaces it with an inline **biased `select!`** that fails fast, keeps the dedicated runtime + `RuntimeShutdownGuard` untouched, and **drops the `async-stream` dependency**.

```rust
let mut fetch_done = false;
tokio::pin!(fetch_handle);
loop {
    let iris = tokio::select! {
        biased;                                   // poll the task before the channel
        res = &mut fetch_handle, if !fetch_done => {
            fetch_done = true;
            match res {
                Ok(Ok(()))    => continue,        // success: drain the buffered backlog
                Ok(Err(e))    => return Err(e),   // fail fast
                Err(join_err) => return Err(eyre::eyre!("S3 fetch task panicked: {}", join_err)),
            }
        }
        item = rx.recv() => match item {
            Some(iris) => iris,
            None       => break,
        },
    };
    // ... existing per-iris processing ...
}
if !fetch_done {                                  // broke on closed channel; surface a late result
    match fetch_handle.await { /* same 3-arm match */ }
}
```

## Two independent problems in #2153, both fixed here

**1. Swallowed errors (correctness).** Both error checks in #2153 are `if let Err(e) = result`, where `result: Result<eyre::Result<()>, JoinError>`. That matches only the outer `JoinError` (panic/cancel); `Ok(Err(_))` — the *designed* failure path of `fetch_and_parse_chunks` (e.g. an S3 range read exhausting all retries) — falls through and is dropped. Since #2153 also removes the old `.expect(...)`, `Ok(Err(_))` is now the *common* failure mode, so the stated goal ("surface fetch errors") is unmet for the path that matters. The exhaustive `match` here propagates it.

**2. Drains instead of failing fast (behavior).** Independently of the bug, the error is stashed in `task_error` and only emitted *after* the loop, which breaks only once the channel closes. The channel doesn't close when the fetch task returns `Err` — `fetch_and_parse_chunks` clones `tx` into each download subtask and returns early via `?`, leaving the others **detached** and still retrying with exponential backoff. So #2153 (even with the swallow bug fixed) waits through the entire doomed backlog/backoff before aborting. The `biased; … return Err(e)` here aborts on the spot; the subsequent `return` drops `_drop_guard`, so `import_runtime.shutdown_background()` cancels the detached subtasks instead of letting them grind through retries.

|  | correct? | fail-fast? |
|---|---|---|
| #2153 as-is | ✗ swallows `Ok(Err)` | ✗ |
| #2153 + exhaustive match only | ✓ | ✗ (still drains — error deferred to loop end) |
| **this branch** | ✓ | ✓ |

Fixing the swallow bug and making it fail-fast are orthogonal: the first is the match arm, the second is `biased` + returning from the arm instead of stashing.

The `try_stream!`/`Stream` wrapper bought nothing here — #2153 detects task completion early and then does nothing with it (flips a flag and keeps draining). The only payoff of a `Stream` would be the *unrealized* unification of the S3 path with the Aurora `BoxStream` consumer, which isn't in #2153.

Compiles clean; `cargo clippy -p iris-mpc-store` clean.
