### PR TITLE
chore: Start HNSW in euc1-az1 with own db-export

### DIFF
--- a/deploy/prod/ampc-hnsw-0-prod/values-ampc-hnsw.yaml
+++ b/deploy/prod/ampc-hnsw-0-prod/values-ampc-hnsw.yaml
@@ -99,10 +99,10 @@ env:
     value: "true"
 
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
-    value: "iris-mpc-db-exporter-store-node-0-prod--eun1-az3--x-s3"
+    value: "ampc-hnsw-db-exporter-store-node-0-prod--eun1-az3--x-s3"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "genesis_base_even_odd_with_version_id_output_16k_rerandomized"
+    value: "hnsw_even_odd_with_version_id_output_16k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
     value: "64"

--- a/deploy/prod/ampc-hnsw-1-prod/values-ampc-hnsw.yaml
+++ b/deploy/prod/ampc-hnsw-1-prod/values-ampc-hnsw.yaml
@@ -99,10 +99,10 @@ env:
     value: "true"
 
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
-    value: "iris-mpc-db-exporter-store-node-1-prod--eun1-az3--x-s3"
+    value: "ampc-hnsw-db-exporter-store-node-1-prod--eun1-az3--x-s3"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "genesis_base_even_odd_with_version_id_output_16k_rerandomized"
+    value: "hnsw_even_odd_with_version_id_output_16k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
     value: "64"

--- a/deploy/prod/ampc-hnsw-2-prod/values-ampc-hnsw.yaml
+++ b/deploy/prod/ampc-hnsw-2-prod/values-ampc-hnsw.yaml
@@ -99,10 +99,10 @@ env:
     value: "true"
 
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
-    value: "iris-mpc-db-exporter-store-node-2-prod--eun1-az3--x-s3"
+    value: "ampc-hnsw-db-exporter-store-node-2-prod--eun1-az3--x-s3"
 
   - name: SMPC__DB_CHUNKS_FOLDER_NAME
-    value: "genesis_base_even_odd_with_version_id_output_16k_rerandomized"
+    value: "hnsw_even_odd_with_version_id_output_16k"
 
   - name: SMPC__LOAD_CHUNKS_PARALLELISM
     value: "64"

--- a/deploy/prod/common-values-ampc-hnsw-db-exporter.yaml
+++ b/deploy/prod/common-values-ampc-hnsw-db-exporter.yaml
@@ -1,7 +1,5 @@
 image: "ghcr.io/worldcoin/iris-mpc-database-exporter:v0.31.11@sha256:0dcd552aa455b6af8064529298eab4787bbfa0c539a5bcd01e009b408ec14149"
 
-replicaCount: 0
-
 environment: prod
 
 schedule: "30 14 * * *"

--- a/deploy/prod/common-values-ampc-hnsw.yaml
+++ b/deploy/prod/common-values-ampc-hnsw.yaml
@@ -1,7 +1,7 @@
 image: "ghcr.io/worldcoin/iris-mpc-cpu:v0.31.10@sha256:cf2f715c66748171940b448163f6b0e0ce7dedae783282b43b135fc2589f4f29"
 
 environment: prod
-replicaCount: 0
+replicaCount: 1
 
 strategy:
   type: Recreate
@@ -71,6 +71,7 @@ nodeSelector:
   kubernetes.io/arch: arm64
   karpenter.sh/capacity-type: on-demand
   node.kubernetes.io/instance-type: "x8g.48xlarge"
+  topology.k8s.aws/zone-id: "euc1-az1"
 
 podSecurityContext:
   runAsUser: 65534


### PR DESCRIPTION
- scale HNSW up,
- run in same AZ, the one where Aurora is operating,
- switch to dedicated export S3 buckets