### PR TITLE
[POP-3901] make load_iris_db cancellable

### DIFF
--- a/iris-mpc-store/Cargo.toml
+++ b/iris-mpc-store/Cargo.toml
@@ -25,7 +25,7 @@ ampc-server-utils.workspace = true
 
 [dev-dependencies]
 rand.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
 
 [features]
 db_dependent = []

--- a/iris-mpc-store/src/loader.rs
+++ b/iris-mpc-store/src/loader.rs
@@ -65,6 +65,7 @@ async fn load_db_records_from_aurora<'a>(
     Ok(())
 }
 
+/// Main iris loader method into memory. Load from either S3 + Aurora or only Aurora based on the config.
 pub async fn load_iris_db(
     actor: &mut impl InMemoryStore,
     store: &Store,
@@ -91,7 +92,7 @@ pub async fn load_iris_db(
         },
     }
 }
-/// Main iris loader method into memory. Load from either S3 + Aurora or only Aurora based on the config.
+
 async fn load_iris_db_internal(
     actor: &mut impl InMemoryStore,
     store: &Store,

--- a/iris-mpc-store/src/loader.rs
+++ b/iris-mpc-store/src/loader.rs
@@ -65,8 +65,34 @@ async fn load_db_records_from_aurora<'a>(
     Ok(())
 }
 
-/// Main iris loader method into memory. Load from either S3 + Aurora or only Aurora based on the config.
 pub async fn load_iris_db(
+    actor: &mut impl InMemoryStore,
+    store: &Store,
+    max_serial_id_to_load: usize,
+    store_load_parallelism: usize,
+    s3_max_serial_id_to_load: Option<usize>,
+    config: &Config,
+    download_shutdown_handler: Arc<ShutdownHandler>,
+) -> Result<()> {
+    let shutdown = download_shutdown_handler.clone();
+    tokio::select! {
+        r = load_iris_db_internal(
+            actor,
+            store,
+            max_serial_id_to_load,
+            store_load_parallelism,
+            s3_max_serial_id_to_load,
+            config,
+            download_shutdown_handler
+        ) => r,
+        _ = shutdown.wait_for_shutdown() => {
+            tracing::warn!("Shutdown requested by shutdown_handler.");
+            Err(eyre::eyre!("Shutdown requested"))
+        },
+    }
+}
+/// Main iris loader method into memory. Load from either S3 + Aurora or only Aurora based on the config.
+async fn load_iris_db_internal(
     actor: &mut impl InMemoryStore,
     store: &Store,
     max_serial_id_to_load: usize,
@@ -118,6 +144,7 @@ pub async fn load_iris_db(
             .thread_name("s3-importer")
             .enable_all()
             .build()?;
+        let shutdown = download_shutdown_handler.clone();
         let fetch_handle = import_runtime.spawn(async move {
             fetch_and_parse_chunks(
                 s3_arc,
@@ -128,11 +155,14 @@ pub async fn load_iris_db(
                 tx,
                 s3_load_max_retries,
                 s3_load_initial_backoff_ms,
+                shutdown,
             )
             .await
         });
         // Guard that calls shutdown_background() on drop so the runtime threads
         // are always released non-blockingly, even on early returns / errors.
+        // in the event that the shutdown handler causes this function to terminate before the RuntimeShutdownGuard
+        // is created, fetch_and_parse_chunks will terminate anyway because it also listens for the shutdown signal.
         struct RuntimeShutdownGuard(Option<tokio::runtime::Runtime>);
         impl Drop for RuntimeShutdownGuard {
             fn drop(&mut self) {
@@ -163,7 +193,7 @@ pub async fn load_iris_db(
                             return Err(eyre::eyre!("S3 fetch task panicked: {}", join_err))
                         }
                     }
-                }
+                },
                 item = rx.recv() => match item {
                     Some(iris) => iris,
                     None => break,
@@ -210,10 +240,6 @@ pub async fn load_iris_db(
                     elapsed,
                     record_counter as f64 / elapsed.as_secs_f64()
                 );
-                if download_shutdown_handler.is_shutting_down() {
-                    tracing::warn!("Shutdown requested by shutdown_handler.");
-                    return Err(eyre::eyre!("Shutdown requested"));
-                }
             }
 
             time_loading_into_memory += load_summary_ts.elapsed();

--- a/iris-mpc-store/src/s3_importer.rs
+++ b/iris-mpc-store/src/s3_importer.rs
@@ -593,6 +593,7 @@ mod tests {
             tx,
             1,
             0,
+            Arc::new(ShutdownHandler::new(1)),
         )
         .await;
         let mut count = 0;
@@ -638,6 +639,7 @@ mod tests {
             tx,
             1,
             0,
+            Arc::new(ShutdownHandler::new(1)),
         )
         .await;
 
@@ -695,6 +697,7 @@ mod tests {
             tx,
             5,
             100,
+            Arc::new(ShutdownHandler::new(1)),
         )
         .await;
 

--- a/iris-mpc-store/src/s3_importer.rs
+++ b/iris-mpc-store/src/s3_importer.rs
@@ -5,9 +5,10 @@ use aws_sdk_s3::config::StalledStreamProtectionConfig;
 use aws_sdk_s3::{config::Builder as S3ConfigBuilder, Client as S3Client};
 use aws_sdk_s3::{primitives::ByteStream, Client};
 use eyre::{bail, eyre, Result};
+use futures::{stream, StreamExt};
 use iris_mpc_common::{vector_id::VectorId, IRIS_CODE_LENGTH, MASK_CODE_LENGTH};
-use std::{collections::VecDeque, mem, sync::Arc, time::Duration};
-use tokio::{io::AsyncReadExt, sync::mpsc::Sender, task};
+use std::{mem, sync::Arc, time::Duration};
+use tokio::{io::AsyncReadExt, sync::mpsc::Sender};
 
 const SINGLE_ELEMENT_SIZE: usize = IRIS_CODE_LENGTH * mem::size_of::<u16>() * 2
     + MASK_CODE_LENGTH * mem::size_of::<u16>() * 2
@@ -305,10 +306,9 @@ pub async fn fetch_and_parse_chunks(
     } else {
         last_snapshot_details.chunk_size as usize
     };
-    let mut handles: VecDeque<task::JoinHandle<Result<(), eyre::Error>>> =
-        VecDeque::with_capacity(concurrency);
 
-    for chunk in (1..=effective_last_serial_id).step_by(range_size) {
+    let chunk_iterator = (1_i64..=effective_last_serial_id).step_by(range_size);
+    let stream = stream::iter(chunk_iterator).map(|chunk| {
         let chunk_id =
             (chunk / last_snapshot_details.chunk_size) * last_snapshot_details.chunk_size + 1;
         let prefix_name = prefix_name.clone();
@@ -316,83 +316,72 @@ pub async fn fetch_and_parse_chunks(
         let remaining_items = (effective_last_serial_id - chunk + 1) as usize;
         let requested_range_size = remaining_items.min(range_size);
 
-        // Wait if we've hit the concurrency limit
-        if handles.len() >= concurrency {
-            let handle = handles.pop_front().expect("No s3 import handles to pop");
-            handle.await??;
-        }
+        let store = Arc::clone(&store);
+        let tx = tx.clone();
+        let shutdown = Arc::clone(&shutdown_handler);
+        let key = format!("{}/{}.bin", prefix_name, chunk_id);
 
-        let shutdown = shutdown_handler.clone();
-        handles.push_back(task::spawn({
-            let store = Arc::clone(&store);
-            let tx = tx.clone();
-            async move {
-                let mut attempt = 0;
-                let mut backoff_ms = initial_backoff_ms;
-                let key = format!("{}/{}.bin", prefix_name, chunk_id);
-                let shutdown_fut = shutdown.wait_for_shutdown();
-                tokio::pin!(shutdown_fut);
-
-                // Retry reading the range with exponential backoff
-                loop {
-                    attempt += 1;
-                    let res = tokio::select! {
-                        r = read_range_in_chunk(
-                            Arc::clone(&store),
-                            &key,
-                            offset_within_chunk,
-                            requested_range_size,
-                            tx.clone(),
-                        ) => r,
-                        _ = &mut shutdown_fut => {
-                            return Err(eyre::eyre!("Shutdown requested"));
-                        },
-                    };
-                    match res {
-                        Ok(_) => {
-                            return Ok(());
-                        }
-                        Err(e) => {
-                            // If we've tried all attempts, bail
-                            if attempt >= max_retries {
-                                return Err(eyre::eyre!(
-                                    "Failed to read {} after {} retries: {:?}",
-                                    key,
-                                    attempt,
-                                    e
-                                ));
-                            }
-
-                            tracing::warn!(
-                                "Error reading {} (attempt {} of {}): {:?}; retrying in {} ms",
-                                key,
-                                attempt,
-                                max_retries,
-                                e,
-                                backoff_ms
-                            );
-
-                            tokio::select! {
-                                _ = tokio::time::sleep(Duration::from_millis(backoff_ms)) => {},
-                                _ = &mut shutdown_fut => {
-                                    return Err(eyre::eyre!("Shutdown requested"));
-                                }
-                            }
-                            backoff_ms *= 2; // exponential backoff
-                        }
-                    }
-                }
+        async move {
+            tokio::select! {
+                res = fetch_single_chunk(store, key, offset_within_chunk, requested_range_size, tx, max_retries, initial_backoff_ms) => res,
+                _ = shutdown.wait_for_shutdown() => Err(eyre::eyre!("Shutdown requested")),
             }
-        }));
+        }
+    });
+
+    let mut results = stream.buffer_unordered(concurrency);
+
+    while let Some(result) = results.next().await {
+        result?;
     }
 
-    tracing::info!("All s3 import tasks are spawned. Waiting for them to finish");
-    // Wait for remaining handles
-    for handle in handles {
-        handle.await??;
-    }
     tracing::info!("All s3 import tasks are finished.");
     Ok(())
+}
+
+async fn fetch_single_chunk(
+    store: Arc<impl ObjectStore>,
+    key: String,
+    offset: usize,
+    size: usize,
+    tx: Sender<S3StoredIris>,
+    max_retries: usize,
+    initial_backoff_ms: u64,
+) -> Result<()> {
+    let mut attempt = 0;
+    let mut backoff_ms = initial_backoff_ms;
+
+    loop {
+        attempt += 1;
+        match read_range_in_chunk(Arc::clone(&store), &key, offset, size, tx.clone()).await {
+            Ok(_) => {
+                return Ok(());
+            }
+            Err(e) => {
+                // If we've tried all attempts, bail
+                if attempt >= max_retries {
+                    return Err(eyre::eyre!(
+                        "Failed to read {} after {} retries: {:?}",
+                        key,
+                        attempt,
+                        e
+                    ));
+                }
+
+                tracing::warn!(
+                    "Error reading {} (attempt {} of {}): {:?}; retrying in {} ms",
+                    key,
+                    attempt,
+                    max_retries,
+                    e,
+                    backoff_ms
+                );
+
+                tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+                backoff_ms *= 2; // exponential backoff
+            }
+        }
+    }
 }
 
 // Read [offset_within_chunk, offset_within_chunk + range_size) range from the
@@ -734,7 +723,9 @@ mod tests {
     impl ObjectStore for HangingStore {
         async fn get_object(&self, _key: &str, _range: (usize, usize)) -> Result<ByteStream> {
             tokio::time::sleep(Duration::from_secs(3600)).await;
-            Err(eyre::eyre!("HangingStore: should have been cancelled before this"))
+            Err(eyre::eyre!(
+                "HangingStore: should have been cancelled before this"
+            ))
         }
 
         async fn list_objects(&self, _prefix: &str) -> Result<Vec<String>> {

--- a/iris-mpc-store/src/s3_importer.rs
+++ b/iris-mpc-store/src/s3_importer.rs
@@ -372,7 +372,12 @@ pub async fn fetch_and_parse_chunks(
                                 backoff_ms
                             );
 
-                            tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+                            tokio::select! {
+                                _ = tokio::time::sleep(Duration::from_millis(backoff_ms)) => {},
+                                _ = &mut shutdown_fut => {
+                                    return Err(eyre::eyre!("Shutdown requested"));
+                                }
+                            }
                             backoff_ms *= 2; // exponential backoff
                         }
                     }

--- a/iris-mpc-store/src/s3_importer.rs
+++ b/iris-mpc-store/src/s3_importer.rs
@@ -322,10 +322,14 @@ pub async fn fetch_and_parse_chunks(
         let key = format!("{}/{}.bin", prefix_name, chunk_id);
 
         async move {
-            tokio::select! {
-                res = fetch_single_chunk(store, key, offset_within_chunk, requested_range_size, tx, max_retries, initial_backoff_ms) => res,
-                _ = shutdown.wait_for_shutdown() => Err(eyre::eyre!("Shutdown requested")),
-            }
+            tokio::spawn(async move {
+                tokio::select! {
+                    res = fetch_single_chunk(store, key, offset_within_chunk, requested_range_size, tx, max_retries, initial_backoff_ms) => res,
+                    _ = shutdown.wait_for_shutdown() => Err(eyre::eyre!("Shutdown requested")),
+                }
+            })
+            .await
+            .map_err(|e| eyre::eyre!("Task join error: {e}"))?
         }
     });
 

--- a/iris-mpc-store/src/s3_importer.rs
+++ b/iris-mpc-store/src/s3_importer.rs
@@ -725,4 +725,104 @@ mod tests {
         assert_eq!(count, MOCK_ENTRIES);
         assert!(ids.is_empty(), "All entries should have been received");
     }
+
+    /// A store whose `get_object` hangs indefinitely, simulating a stalled S3 read.
+    #[derive(Clone, Default)]
+    pub struct HangingStore;
+
+    #[async_trait]
+    impl ObjectStore for HangingStore {
+        async fn get_object(&self, _key: &str, _range: (usize, usize)) -> Result<ByteStream> {
+            tokio::time::sleep(Duration::from_secs(3600)).await;
+            Err(eyre::eyre!("HangingStore: should have been cancelled before this"))
+        }
+
+        async fn list_objects(&self, _prefix: &str) -> Result<Vec<String>> {
+            Ok(vec![])
+        }
+    }
+
+    /// Helper: a LastSnapshotDetails covering `n` entries in chunks of `chunk_size`.
+    fn snapshot(n: usize, chunk_size: usize) -> LastSnapshotDetails {
+        LastSnapshotDetails {
+            timestamp: 0,
+            last_serial_id: n as i64,
+            chunk_size: chunk_size as i64,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_fetch_and_parse_chunks_cancels_on_shutdown_during_read() {
+        let store = Arc::new(HangingStore);
+        let (tx, _rx) = mpsc::channel::<S3StoredIris>(1024);
+        let shutdown = Arc::new(ShutdownHandler::new(1));
+
+        // Trigger shutdown after a short delay, well before the 1-hour hang would complete.
+        let shutdown_clone = shutdown.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            shutdown_clone.trigger_manual_shutdown();
+        });
+
+        let now = Instant::now();
+        let result = fetch_and_parse_chunks(
+            store,
+            1,
+            "out".to_string(),
+            snapshot(10, 10),
+            None,
+            tx,
+            3,
+            10_000, // 10s backoff — should never be reached
+            shutdown,
+        )
+        .await;
+
+        assert!(result.is_err(), "Expected Err on shutdown during read");
+        assert!(
+            now.elapsed() < Duration::from_millis(500),
+            "Expected fast cancellation during read, took {:?}",
+            now.elapsed()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fetch_and_parse_chunks_cancels_on_shutdown_during_backoff() {
+        // Build a store whose first read always fails so the task enters a long backoff sleep.
+        let mut mock_store = MockStore::new();
+        mock_store.add_test_data("out/1.bin", (1..=10).map(dummy_entry).collect());
+        // i8::MAX failures ensures the task never succeeds within our retry budget.
+        let store = Arc::new(IntentionalFailureStore::new(mock_store, i8::MAX));
+
+        let (tx, _rx) = mpsc::channel::<S3StoredIris>(1024);
+        let shutdown = Arc::new(ShutdownHandler::new(1));
+
+        // Trigger shutdown after the first read fails but well before the 10s backoff expires.
+        let shutdown_clone = shutdown.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            shutdown_clone.trigger_manual_shutdown();
+        });
+
+        let now = Instant::now();
+        let result = fetch_and_parse_chunks(
+            store,
+            1,
+            "out".to_string(),
+            snapshot(10, 10),
+            None,
+            tx,
+            20,     // plenty of retries — shutdown should interrupt first
+            10_000, // 10s initial backoff
+            shutdown,
+        )
+        .await;
+
+        assert!(result.is_err(), "Expected Err on shutdown during backoff");
+        assert!(
+            now.elapsed() < Duration::from_millis(500),
+            "Expected fast cancellation during backoff sleep, took {:?}",
+            now.elapsed()
+        );
+    }
 }

--- a/iris-mpc-store/src/s3_importer.rs
+++ b/iris-mpc-store/src/s3_importer.rs
@@ -815,6 +815,10 @@ mod tests {
         .await
         .expect("cancellation should complete within 500ms of virtual time");
 
-        assert!(result.is_err(), "Expected Err on shutdown during backoff");
+        let err = result.err().expect("result should be err");
+        assert!(
+            format!("{err:#}").contains("Shutdown"),
+            "Expected Err on shutdown during backoff"
+        );
     }
 }

--- a/iris-mpc-store/src/s3_importer.rs
+++ b/iris-mpc-store/src/s3_importer.rs
@@ -1,3 +1,4 @@
+use ampc_server_utils::ShutdownHandler;
 use async_trait::async_trait;
 use aws_config::{retry::RetryConfig, timeout::TimeoutConfig};
 use aws_sdk_s3::config::StalledStreamProtectionConfig;
@@ -277,6 +278,7 @@ pub async fn fetch_and_parse_chunks(
     tx: Sender<S3StoredIris>,
     max_retries: usize,
     initial_backoff_ms: u64,
+    shutdown_handler: Arc<ShutdownHandler>,
 ) -> Result<()> {
     let effective_last_serial_id = max_serial_id_to_load
         .map(|max_serial_id| {
@@ -320,6 +322,7 @@ pub async fn fetch_and_parse_chunks(
             handle.await??;
         }
 
+        let shutdown = shutdown_handler.clone();
         handles.push_back(task::spawn({
             let store = Arc::clone(&store);
             let tx = tx.clone();
@@ -331,15 +334,19 @@ pub async fn fetch_and_parse_chunks(
                 // Retry reading the range with exponential backoff
                 loop {
                     attempt += 1;
-                    match read_range_in_chunk(
-                        Arc::clone(&store),
-                        &key,
-                        offset_within_chunk,
-                        requested_range_size,
-                        tx.clone(),
-                    )
-                    .await
-                    {
+                    let res = tokio::select! {
+                        r = read_range_in_chunk(
+                            Arc::clone(&store),
+                            &key,
+                            offset_within_chunk,
+                            requested_range_size,
+                            tx.clone(),
+                        ) => r,
+                        _ = shutdown.wait_for_shutdown() => {
+                            return Err(eyre::eyre!("Shutdown requested"));
+                        },
+                    };
+                    match res {
                         Ok(_) => {
                             return Ok(());
                         }

--- a/iris-mpc-store/src/s3_importer.rs
+++ b/iris-mpc-store/src/s3_importer.rs
@@ -815,7 +815,7 @@ mod tests {
         .await
         .expect("cancellation should complete within 500ms of virtual time");
 
-        let err = result.err().expect("result should be err");
+        let err = result.expect_err("result should be err");
         assert!(
             format!("{err:#}").contains("Shutdown"),
             "Expected Err on shutdown during backoff"

--- a/iris-mpc-store/src/s3_importer.rs
+++ b/iris-mpc-store/src/s3_importer.rs
@@ -330,7 +330,6 @@ pub async fn fetch_and_parse_chunks(
     });
 
     let mut results = stream.buffer_unordered(concurrency);
-
     while let Some(result) = results.next().await {
         result?;
     }
@@ -522,6 +521,24 @@ mod tests {
         }
     }
 
+    /// A store whose `get_object` hangs indefinitely, simulating a stalled S3 read.
+    #[derive(Clone, Default)]
+    pub struct HangingStore;
+
+    #[async_trait]
+    impl ObjectStore for HangingStore {
+        async fn get_object(&self, _key: &str, _range: (usize, usize)) -> Result<ByteStream> {
+            tokio::time::sleep(Duration::from_secs(3600)).await;
+            Err(eyre::eyre!(
+                "HangingStore: should have been cancelled before this"
+            ))
+        }
+
+        async fn list_objects(&self, _prefix: &str) -> Result<Vec<String>> {
+            Ok(vec![])
+        }
+    }
+
     fn random_bytes(len: usize) -> Vec<u8> {
         let mut rng = rand::thread_rng();
         let mut v = vec![0u8; len];
@@ -537,6 +554,15 @@ mod tests {
             left_mask: random_bytes(MASK_CODE_LENGTH * mem::size_of::<u16>()),
             right_code: random_bytes(IRIS_CODE_LENGTH * mem::size_of::<u16>()),
             right_mask: random_bytes(MASK_CODE_LENGTH * mem::size_of::<u16>()),
+        }
+    }
+
+    /// Helper: a LastSnapshotDetails covering `n` entries in chunks of `chunk_size`.
+    fn snapshot(n: usize, chunk_size: usize) -> LastSnapshotDetails {
+        LastSnapshotDetails {
+            timestamp: 0,
+            last_serial_id: n as i64,
+            chunk_size: chunk_size as i64,
         }
     }
 
@@ -715,69 +741,40 @@ mod tests {
         assert!(ids.is_empty(), "All entries should have been received");
     }
 
-    /// A store whose `get_object` hangs indefinitely, simulating a stalled S3 read.
-    #[derive(Clone, Default)]
-    pub struct HangingStore;
-
-    #[async_trait]
-    impl ObjectStore for HangingStore {
-        async fn get_object(&self, _key: &str, _range: (usize, usize)) -> Result<ByteStream> {
-            tokio::time::sleep(Duration::from_secs(3600)).await;
-            Err(eyre::eyre!(
-                "HangingStore: should have been cancelled before this"
-            ))
-        }
-
-        async fn list_objects(&self, _prefix: &str) -> Result<Vec<String>> {
-            Ok(vec![])
-        }
-    }
-
-    /// Helper: a LastSnapshotDetails covering `n` entries in chunks of `chunk_size`.
-    fn snapshot(n: usize, chunk_size: usize) -> LastSnapshotDetails {
-        LastSnapshotDetails {
-            timestamp: 0,
-            last_serial_id: n as i64,
-            chunk_size: chunk_size as i64,
-        }
-    }
-
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_fetch_and_parse_chunks_cancels_on_shutdown_during_read() {
         let store = Arc::new(HangingStore);
         let (tx, _rx) = mpsc::channel::<S3StoredIris>(1024);
         let shutdown = Arc::new(ShutdownHandler::new(1));
 
-        // Trigger shutdown after a short delay, well before the 1-hour hang would complete.
+        // The HangingStore will never return, ensuring that shutdown triggers while a read is in progress.
         let shutdown_clone = shutdown.clone();
         tokio::spawn(async move {
             tokio::time::sleep(Duration::from_millis(50)).await;
             shutdown_clone.trigger_manual_shutdown();
         });
 
-        let now = Instant::now();
-        let result = fetch_and_parse_chunks(
-            store,
-            1,
-            "out".to_string(),
-            snapshot(10, 10),
-            None,
-            tx,
-            3,
-            10_000, // 10s backoff — should never be reached
-            shutdown,
+        let result = tokio::time::timeout(
+            Duration::from_millis(500),
+            fetch_and_parse_chunks(
+                store,
+                1,
+                "out".to_string(),
+                snapshot(10, 10),
+                None,
+                tx,
+                3,
+                10_000, // 10s backoff — should never be reached
+                shutdown,
+            ),
         )
-        .await;
+        .await
+        .expect("cancellation should complete within 500ms of virtual time");
 
         assert!(result.is_err(), "Expected Err on shutdown during read");
-        assert!(
-            now.elapsed() < Duration::from_millis(500),
-            "Expected fast cancellation during read, took {:?}",
-            now.elapsed()
-        );
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_fetch_and_parse_chunks_cancels_on_shutdown_during_backoff() {
         // Build a store whose first read always fails so the task enters a long backoff sleep.
         let mut mock_store = MockStore::new();
@@ -788,32 +785,32 @@ mod tests {
         let (tx, _rx) = mpsc::channel::<S3StoredIris>(1024);
         let shutdown = Arc::new(ShutdownHandler::new(1));
 
-        // Trigger shutdown after the first read fails but well before the 10s backoff expires.
+        // IntentionalFailureStore returns Err immediately (no timer, no sleep), so by the
+        // time any Tokio timer fires the code is already inside the backoff sleep.
+        // The 50ms shutdown fires well before the 10s backoff expires.
         let shutdown_clone = shutdown.clone();
         tokio::spawn(async move {
             tokio::time::sleep(Duration::from_millis(50)).await;
             shutdown_clone.trigger_manual_shutdown();
         });
 
-        let now = Instant::now();
-        let result = fetch_and_parse_chunks(
-            store,
-            1,
-            "out".to_string(),
-            snapshot(10, 10),
-            None,
-            tx,
-            20,     // plenty of retries — shutdown should interrupt first
-            10_000, // 10s initial backoff
-            shutdown,
+        let result = tokio::time::timeout(
+            Duration::from_millis(500),
+            fetch_and_parse_chunks(
+                store,
+                1,
+                "out".to_string(),
+                snapshot(10, 10),
+                None,
+                tx,
+                20,     // plenty of retries — shutdown should interrupt first
+                10_000, // 10s initial backoff
+                shutdown,
+            ),
         )
-        .await;
+        .await
+        .expect("cancellation should complete within 500ms of virtual time");
 
         assert!(result.is_err(), "Expected Err on shutdown during backoff");
-        assert!(
-            now.elapsed() < Duration::from_millis(500),
-            "Expected fast cancellation during backoff sleep, took {:?}",
-            now.elapsed()
-        );
     }
 }

--- a/iris-mpc-store/src/s3_importer.rs
+++ b/iris-mpc-store/src/s3_importer.rs
@@ -330,6 +330,8 @@ pub async fn fetch_and_parse_chunks(
                 let mut attempt = 0;
                 let mut backoff_ms = initial_backoff_ms;
                 let key = format!("{}/{}.bin", prefix_name, chunk_id);
+                let shutdown_fut = shutdown.wait_for_shutdown();
+                tokio::pin!(shutdown_fut);
 
                 // Retry reading the range with exponential backoff
                 loop {
@@ -342,7 +344,7 @@ pub async fn fetch_and_parse_chunks(
                             requested_range_size,
                             tx.clone(),
                         ) => r,
-                        _ = shutdown.wait_for_shutdown() => {
+                        _ = &mut shutdown_fut => {
                             return Err(eyre::eyre!("Shutdown requested"));
                         },
                     };


### PR DESCRIPTION
Make `load_iris_db` respond to SIGTERM via the shutdown handler. 

Also redesign `fetch_and_parse_chunks` to allow waiting for the shutdown signal at the top level, so that it wouldn't get blocked by `sleep`.  using `stream::iter` also removes the head of line blocking, caused by waiting for the next handle in the `VecDeque`.

Failure modes:
1. SIGTERM → shutdown handler fires → `select!` in `load_iris_db` cancels `load_iris_db_internal`. Tasks spawned by `fetch_and_parse_chunks` also catch the signal and terminate.                                                                             
  2. Task error in `fetch_and_parse_chunks` → surfaces via `handle.await??` → `fetch_handle` resolves with `Err` → receiver loop returns it
  3. Shutdown before `RuntimeShutdownGuard` is created → safe because `fetch_and_parse_chunks` tasks also listen for shutdown directly, so `import_runtime` completes quickly regardless