### PR TITLE
[POP-3915] use new sidecar functions for iris-mpc-hawk and genesis

### DIFF
--- a/iris-mpc-bins/bin/iris-mpc-cpu/sidecar.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/sidecar.rs
@@ -15,6 +15,7 @@ use iris_mpc_common::postgres::{AccessMode, PostgresClient};
 use iris_mpc_cpu::{
     checkpoint_protocol::{sidecar_main, SidecarConfig},
     execution::hawk_main::{build_hawk_network_handle, HawkArgs},
+    graph_checkpoint::PruningMode,
     hnsw::graph::graph_store::GraphPg,
 };
 use tokio::signal::unix::{signal, SignalKind};
@@ -81,6 +82,15 @@ pub struct SidecarArgs {
 
     #[clap(long, default_value = "1")]
     pub request_parallelism: usize,
+
+    /// Pruning mode for old checkpoints after uploading a new checkpoint
+    ///
+    /// Accepted values:
+    ///   - none                 — do not prune any checkpoints
+    ///   - older-non-archival   — prune older non-archival checkpoints (default)
+    ///   - all-older            — prune all older checkpoints
+    #[clap(long("pruning-mode"))]
+    pruning_mode: Option<String>,
 }
 
 impl SidecarArgs {
@@ -122,6 +132,15 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     let args = SidecarArgs::parse();
+    let pruning_mode = if let Some(mode_str) = args.pruning_mode.as_ref() {
+        mode_str.parse::<PruningMode>().map_err(|e| {
+            eprintln!("Error: --pruning-mode argument invalid: {}", e);
+            e
+        })?
+    } else {
+        PruningMode::OlderNonArchival
+    };
+
     println!(
         "Starting WAL sidecar daemon: party={}, bucket={}",
         args.party_index, args.bucket
@@ -161,6 +180,7 @@ async fn main() -> Result<()> {
         min_mutations_per_cycle: args.min_mutations_per_cycle,
         checkpoint_window: args.checkpoint_window,
         is_archival: args.is_archival,
+        pruning_mode,
     };
 
     match sidecar_main(cfg, &graph_store, &s3_client, &mut networking, shutdown_ct).await {

--- a/iris-mpc-cpu/src/checkpoint_protocol/runner.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/runner.rs
@@ -19,6 +19,7 @@ use crate::checkpoint_protocol::{
     UploadAndRecord,
 };
 use crate::execution::hawk_main::BothEyes;
+use crate::graph_checkpoint::PruningMode;
 use crate::hnsw::{
     graph::{graph_store::GraphPg, layered_graph::GraphMem},
     VectorStore,
@@ -48,6 +49,8 @@ pub struct SidecarConfig {
     pub checkpoint_window: usize,
     /// Marks the produced row as archival (skipped by pruning).
     pub is_archival: bool,
+    /// Optionally remove old checkoints from S3
+    pub pruning_mode: PruningMode,
 }
 
 /// Daemon loop. Returns `Ok(())` only on graceful shutdown via
@@ -120,6 +123,7 @@ async fn sidecar_cycle<V: VectorStore + Send + Sync>(
         cfg.bucket.clone(),
         cfg.party_id,
         cfg.is_archival,
+        cfg.pruning_mode,
     );
     let hasher = Blake3GraphHasher::new();
 

--- a/iris-mpc-cpu/src/checkpoint_protocol/runner.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/runner.rs
@@ -49,7 +49,7 @@ pub struct SidecarConfig {
     pub checkpoint_window: usize,
     /// Marks the produced row as archival (skipped by pruning).
     pub is_archival: bool,
-    /// Optionally remove old checkoints from S3
+    /// Optionally remove old checkpoints from S3
     pub pruning_mode: PruningMode,
 }
 

--- a/iris-mpc-cpu/src/checkpoint_protocol/terminal.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/terminal.rs
@@ -8,8 +8,8 @@ use crate::checkpoint_protocol::{
 };
 use crate::execution::hawk_main::{BothEyes, LEFT, RIGHT};
 use crate::graph_checkpoint::{
-    stream_serialize_and_upload_with, BlakeTeeWriter, DEFAULT_STREAMING_PARALLELISM,
-    DEFAULT_STREAMING_PART_SIZE,
+    cleanup_checkpoints, stream_serialize_and_upload_with, BlakeTeeWriter, GraphCheckpointState,
+    PruningMode, DEFAULT_STREAMING_PARALLELISM, DEFAULT_STREAMING_PART_SIZE,
 };
 use crate::hnsw::{
     graph::{graph_store::GraphPg, layered_graph::GraphMem},
@@ -29,6 +29,7 @@ pub struct UploadAndRecord<'a, V: VectorStore> {
     pub bucket: String,
     pub party_id: usize,
     pub is_archival: bool,
+    pub pruning_mode: PruningMode,
 }
 
 impl<'a, V: VectorStore + Send + Sync> UploadAndRecord<'a, V> {
@@ -38,6 +39,7 @@ impl<'a, V: VectorStore + Send + Sync> UploadAndRecord<'a, V> {
         bucket: String,
         party_id: usize,
         is_archival: bool,
+        pruning_mode: PruningMode,
     ) -> Self {
         Self {
             graph_store,
@@ -45,6 +47,7 @@ impl<'a, V: VectorStore + Send + Sync> UploadAndRecord<'a, V> {
             bucket,
             party_id,
             is_archival,
+            pruning_mode,
         }
     }
 }
@@ -126,6 +129,27 @@ impl<V: VectorStore + Send + Sync> TerminalAction for UploadAndRecord<'_, V> {
             .commit()
             .await
             .map_err(|e| CycleError::Transient(format!("commit tx: {e}")))?;
+
+        let graph_checkpoint = GraphCheckpointState {
+            s3_key,
+            last_indexed_iris_id: base.last_indexed_iris_id as _,
+            last_indexed_modification_id: freeze.0,
+            graph_mutation_id: Some(freeze.0),
+            blake3_hash: blake3_hash_hex,
+            graph_version: GraphFormat::Current.version(),
+            is_archival: self.is_archival,
+        };
+        if let Err(e) = cleanup_checkpoints(
+            &self.bucket,
+            self.s3_client,
+            &graph_checkpoint,
+            &self.graph_store,
+            self.pruning_mode,
+        )
+        .await
+        {
+            tracing::warn!("failed to clean up old s3 checkpoints: {e}");
+        }
 
         Ok(())
     }

--- a/iris-mpc-cpu/src/checkpoint_protocol/terminal.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/terminal.rs
@@ -143,7 +143,7 @@ impl<V: VectorStore + Send + Sync> TerminalAction for UploadAndRecord<'_, V> {
             &self.bucket,
             self.s3_client,
             &graph_checkpoint,
-            &self.graph_store,
+            self.graph_store,
             self.pruning_mode,
         )
         .await

--- a/iris-mpc-cpu/src/graph_checkpoint/s3_client/mod.rs
+++ b/iris-mpc-cpu/src/graph_checkpoint/s3_client/mod.rs
@@ -304,8 +304,8 @@ pub async fn cleanup_checkpoints<V: VectorStore>(
             PruningMode::None => unreachable!(),
         })
     {
-        delete_graph(s3_client, bucket, &checkpoint.s3_key).await?;
         graph_store.delete_genesis_checkpoint(checkpoint.id).await?;
+        delete_graph(s3_client, bucket, &checkpoint.s3_key).await?;
     }
     Ok(())
 }

--- a/iris-mpc-cpu/src/graph_checkpoint/s3_client/mod.rs
+++ b/iris-mpc-cpu/src/graph_checkpoint/s3_client/mod.rs
@@ -18,7 +18,7 @@ use crate::{
         },
         VectorStore,
     },
-    utils::serialization::graph::{read_graph_pair, GraphFormat},
+    utils::serialization::graph::GraphFormat,
 };
 
 use crate::graph_checkpoint::data::*;
@@ -178,12 +178,23 @@ pub async fn download_graph_checkpoint(
     if format == GraphFormat::Raw {
         bail!("Unexpected graph checkpoint format: Raw");
     }
-    let binary_graph = download_and_hash(s3_client, bucket, state).await?;
+    let start = Instant::now();
+    let (graphs, hash_bytes) =
+        stream_download_and_deserialize_graph_pair(s3_client, bucket, &state.s3_key, format)
+            .await?;
+    metrics::histogram!("genesis_checkpoint_download_duration")
+        .record(start.elapsed().as_secs_f64());
 
-    // todo: deserialize in a way that does not require holding 2 graphs in memory at once.
-    // currently binary_graph and graphs make two graphs in RAM at once
-    let mut cursor = Cursor::new(&binary_graph);
-    let graphs = read_graph_pair(&mut cursor, format)?;
+    // Verify BLAKE3 hash after download
+    let computed_hash = blake3::Hash::from_bytes(hash_bytes).to_hex().to_string();
+    if computed_hash != state.blake3_hash {
+        return Err(eyre!(
+            "BLAKE3 hash mismatch: expected {}, got {}",
+            state.blake3_hash,
+            computed_hash
+        ));
+    }
+    tracing::info!("BLAKE3 hash verified successfully: {}", computed_hash);
     Ok(graphs)
 }
 

--- a/iris-mpc-cpu/src/graph_checkpoint/s3_client/streaming_download.rs
+++ b/iris-mpc-cpu/src/graph_checkpoint/s3_client/streaming_download.rs
@@ -55,7 +55,7 @@ use tokio_util::io::{StreamReader, SyncIoBridge};
 
 use crate::{
     hnsw::graph::layered_graph::GraphMem,
-    utils::serialization::graph::{GraphFormat, read_graph_pair_streaming},
+    utils::serialization::graph::{read_graph_pair_streaming, GraphFormat},
 };
 
 const RANGE_MAX_RETRIES: u32 = 3;
@@ -308,10 +308,7 @@ async fn fetch_range(s3_client: &S3Client, bucket: &str, key: &str, range: &str)
 ///
 /// Delegates to [`deserialize_and_hash_from_fn`] with the standard bincode
 /// deserializer closure.
-async fn deserialize_and_hash_from<R, T>(
-    reader: R,
-    pipe_capacity: usize,
-) -> Result<(T, [u8; 32])>
+async fn deserialize_and_hash_from<R, T>(reader: R, pipe_capacity: usize) -> Result<(T, [u8; 32])>
 where
     R: AsyncRead + Unpin + Send + 'static,
     T: DeserializeOwned + Send + 'static,

--- a/iris-mpc-cpu/src/graph_checkpoint/s3_client/streaming_download.rs
+++ b/iris-mpc-cpu/src/graph_checkpoint/s3_client/streaming_download.rs
@@ -177,6 +177,10 @@ pub async fn stream_download_and_deserialize_graph_pair_with(
         return Err(eyre!("range_size must be > 0"));
     }
 
+    if pipe_capacity == 0 {
+        return Err(eyre!("pipe_capacity must be > 0"));
+    }
+
     let total_size = head_object_size_with_retry(s3_client, bucket, key).await?;
     let stream = Box::pin(range_stream(
         s3_client.clone(),

--- a/iris-mpc-cpu/src/graph_checkpoint/s3_client/streaming_download.rs
+++ b/iris-mpc-cpu/src/graph_checkpoint/s3_client/streaming_download.rs
@@ -47,10 +47,16 @@ use aws_sdk_s3::Client as S3Client;
 use bytes::Bytes;
 use eyre::{eyre, Result};
 use futures::stream::{self, Stream};
+use iris_mpc_common::IrisVectorId;
 use serde::de::DeserializeOwned;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
 use tokio::time::sleep;
 use tokio_util::io::{StreamReader, SyncIoBridge};
+
+use crate::{
+    hnsw::graph::layered_graph::GraphMem,
+    utils::serialization::graph::{GraphFormat, read_graph_pair_streaming},
+};
 
 const RANGE_MAX_RETRIES: u32 = 3;
 const RANGE_RETRY_DELAY: Duration = Duration::from_secs(2);
@@ -123,6 +129,67 @@ where
     ));
     let reader = StreamReader::new(stream);
     deserialize_and_hash_from(reader, pipe_capacity).await
+}
+
+/// Stream the object at `s3://{bucket}/{key}` through BLAKE3 and directly
+/// into a `[GraphMem<IrisVectorId>; 2]` using a format-aware layer-by-layer
+/// reader that converts each layer immediately upon arrival.
+///
+/// Unlike `stream_download_and_deserialize::<[GraphVN; 2]>` followed by
+/// `.into()`, this never holds a full intermediate `GraphVN` alongside the
+/// destination `GraphMem` — it reads one set of links at a time and calls
+/// [`Layer::set_links`] immediately.  For `Current`/V4 and V3 the peak
+/// transient allocation above the final `GraphMem` is roughly one layer's
+/// link data; older formats fall back to the standard path.
+pub async fn stream_download_and_deserialize_graph_pair(
+    s3_client: &S3Client,
+    bucket: &str,
+    key: &str,
+    format: GraphFormat,
+) -> Result<([GraphMem<IrisVectorId>; 2], [u8; 32])> {
+    stream_download_and_deserialize_graph_pair_with(
+        s3_client,
+        bucket,
+        key,
+        format,
+        DEFAULT_DOWNLOAD_PIPE_CAPACITY,
+        DEFAULT_DOWNLOAD_RANGE_SIZE,
+    )
+    .await
+}
+
+/// Like [`stream_download_and_deserialize_graph_pair`] but with explicit
+/// `pipe_capacity` and `range_size` knobs.
+pub async fn stream_download_and_deserialize_graph_pair_with(
+    s3_client: &S3Client,
+    bucket: &str,
+    key: &str,
+    format: GraphFormat,
+    pipe_capacity: usize,
+    range_size: usize,
+) -> Result<([GraphMem<IrisVectorId>; 2], [u8; 32])> {
+    tracing::info!(
+        "Streaming download + deserialize graph pair: bucket={bucket}, key={key}, \
+         format={format}, pipe_capacity={pipe_capacity}, range_size={range_size}"
+    );
+
+    if range_size == 0 {
+        return Err(eyre!("range_size must be > 0"));
+    }
+
+    let total_size = head_object_size_with_retry(s3_client, bucket, key).await?;
+    let stream = Box::pin(range_stream(
+        s3_client.clone(),
+        bucket.to_string(),
+        key.to_string(),
+        total_size,
+        range_size as u64,
+    ));
+    let reader = StreamReader::new(stream);
+    deserialize_and_hash_from_fn(reader, pipe_capacity, move |r| {
+        read_graph_pair_streaming(r, format)
+    })
+    .await
 }
 
 /// `HeadObject` for `content_length`, retried per [`RANGE_MAX_RETRIES`].
@@ -237,14 +304,42 @@ async fn fetch_range(s3_client: &S3Client, bucket: &str, key: &str, range: &str)
 }
 
 /// Core: tee an `AsyncRead` through BLAKE3 into a pipe; deserialize from
-/// the pipe on a blocking thread.
+/// the pipe on a blocking thread using `bincode::deserialize_from`.
+///
+/// Delegates to [`deserialize_and_hash_from_fn`] with the standard bincode
+/// deserializer closure.
 async fn deserialize_and_hash_from<R, T>(
-    mut reader: R,
+    reader: R,
     pipe_capacity: usize,
 ) -> Result<(T, [u8; 32])>
 where
     R: AsyncRead + Unpin + Send + 'static,
     T: DeserializeOwned + Send + 'static,
+{
+    deserialize_and_hash_from_fn(reader, pipe_capacity, |r| {
+        bincode::deserialize_from(r).map_err(|e| eyre!("bincode deserialize: {e}"))
+    })
+    .await
+}
+
+/// Core: tee an `AsyncRead` through BLAKE3 into a pipe; call `deser_fn` on
+/// the pipe from a blocking thread.
+///
+/// `deser_fn` receives a `&mut dyn Read` over the pipe and must consume
+/// **exactly** the bytes that represent the serialised value — the same
+/// contract as [`deserialize_and_hash_from`].  Any unread bytes after
+/// `deser_fn` returns will cause the tee task to see `BrokenPipe` and
+/// surface an error.  Any attempt to read past EOF will be surfaced as an
+/// IO error from `deser_fn`.
+async fn deserialize_and_hash_from_fn<R, T, F>(
+    mut reader: R,
+    pipe_capacity: usize,
+    deser_fn: F,
+) -> Result<(T, [u8; 32])>
+where
+    R: AsyncRead + Unpin + Send + 'static,
+    T: Send + 'static,
+    F: FnOnce(&mut dyn std::io::Read) -> Result<T> + Send + 'static,
 {
     let (mut pipe_writer, pipe_reader) = tokio::io::duplex(pipe_capacity);
 
@@ -273,11 +368,11 @@ where
         Ok::<[u8; 32], eyre::Report>(*hasher.finalize().as_bytes())
     });
 
-    // Blocking task: bincode reads synchronously from the pipe through
+    // Blocking task: `deser_fn` reads synchronously from the pipe through
     // SyncIoBridge. Runs concurrently with the tee task.
     let de_handle = tokio::task::spawn_blocking(move || -> Result<T> {
-        let bridge = SyncIoBridge::new(pipe_reader);
-        bincode::deserialize_from(bridge).map_err(|e| eyre!("bincode deserialize: {e}"))
+        let mut bridge = SyncIoBridge::new(pipe_reader);
+        deser_fn(&mut bridge)
     });
 
     // Surface the deserialize error first if both fail — usually more

--- a/iris-mpc-cpu/src/utils/serialization/graph.rs
+++ b/iris-mpc-cpu/src/utils/serialization/graph.rs
@@ -666,3 +666,129 @@ impl From<GraphMem<IrisVectorId>> for graph_v4::GraphV4 {
         }
     }
 }
+
+/* ----------- Streaming Deserialization (single-copy path) ---------- */
+
+/// Read a pair of [`GraphMem`] structs layer-by-layer into [`GraphMem`]
+/// directly, without ever materialising the full intermediate `GraphVN`
+/// struct alongside the destination graph.
+///
+/// For V4/Current each [`graph_v4::Layer`] (one `HashMap`) is read
+/// entry-by-entry and fed into [`Layer::set_links`] immediately, so peak
+/// transient memory is roughly one layer's worth of link data rather than
+/// one entire graph.  V3 uses the same path — its layer binary layout is
+/// identical to V4 (same field types, no `last_update_seq_no`).
+///
+/// V0/V1/V2/Raw fall back to [`read_graph_pair`]; those are rare migration
+/// paths and the graphs tend to be smaller.
+pub fn read_graph_pair_streaming<R: std::io::Read>(
+    reader: &mut R,
+    format: GraphFormat,
+) -> Result<[GraphMem<IrisVectorId>; 2]> {
+    match format {
+        GraphFormat::Current | GraphFormat::V4 => Ok([
+            read_graph_v4_streaming(reader)?,
+            read_graph_v4_streaming(reader)?,
+        ]),
+        GraphFormat::V3 => Ok([
+            read_graph_v3_streaming(reader)?,
+            read_graph_v3_streaming(reader)?,
+        ]),
+        _ => read_graph_pair(reader, format),
+    }
+}
+
+/// Streaming reader for a single `GraphV4`.
+///
+/// Reads `entry_points`, then deserialises each `Layer` individually via
+/// [`read_hashed_layer_streaming`], then reads `last_update_seq_no`.  Each
+/// layer is converted to [`Layer<IrisVectorId>`] and appended before the
+/// next layer is read, so no two full-graph copies coexist.
+fn read_graph_v4_streaming<R: std::io::Read>(reader: &mut R) -> Result<GraphMem<IrisVectorId>> {
+    let entry_points: Vec<graph_v4::EntryPoint> = bincode::deserialize_from(&mut *reader)
+        .map_err(|e| eyre::eyre!("v4 streaming entry_points: {e}"))?;
+
+    let layer_count: u64 = bincode::deserialize_from(&mut *reader)
+        .map_err(|e| eyre::eyre!("v4 streaming layer_count: {e}"))?;
+    let mut layers = Vec::with_capacity(layer_count as usize);
+    for i in 0..layer_count {
+        layers.push(
+            read_hashed_layer_streaming(reader)
+                .map_err(|e| eyre::eyre!("v4 streaming layer {i}: {e}"))?,
+        );
+    }
+
+    let last_update_seq_no: u64 = bincode::deserialize_from(&mut *reader)
+        .map_err(|e| eyre::eyre!("v4 streaming last_update_seq_no: {e}"))?;
+
+    Ok(GraphMem {
+        entry_points: entry_points.into_iter().map(|e| e.into()).collect(),
+        layers,
+        last_update_seq_no,
+    })
+}
+
+/// Streaming reader for a single `GraphV3`.
+///
+/// V3 differs from V4 only in having `entry_point` (same binary layout) and
+/// no `last_update_seq_no` field.  Layers share the same on-wire layout as
+/// V4 (see [`read_hashed_layer_streaming`]).
+fn read_graph_v3_streaming<R: std::io::Read>(reader: &mut R) -> Result<GraphMem<IrisVectorId>> {
+    // Field name is `entry_point` in GraphV3 vs `entry_points` in GraphV4,
+    // but bincode uses positional encoding so the bytes are identical.
+    let entry_points: Vec<graph_v3::EntryPoint> = bincode::deserialize_from(&mut *reader)
+        .map_err(|e| eyre::eyre!("v3 streaming entry_points: {e}"))?;
+
+    let layer_count: u64 = bincode::deserialize_from(&mut *reader)
+        .map_err(|e| eyre::eyre!("v3 streaming layer_count: {e}"))?;
+    let mut layers = Vec::with_capacity(layer_count as usize);
+    for i in 0..layer_count {
+        layers.push(
+            read_hashed_layer_streaming(reader)
+                .map_err(|e| eyre::eyre!("v3 streaming layer {i}: {e}"))?,
+        );
+    }
+
+    // V3 has no `last_update_seq_no`; default to 0.
+    Ok(GraphMem {
+        entry_points: entry_points.into_iter().map(|e| e.into()).collect(),
+        layers,
+        last_update_seq_no: 0,
+    })
+}
+
+/// Deserialise one layer entry-by-entry into [`Layer<IrisVectorId>`].
+///
+/// Works for both V3 and V4 layers because their on-wire layout is
+/// identical: both store `HashMap<{u32, i16}, Vec<{u32, i16}>>`
+/// (bincode: `u64 count` + N × `(VectorId, EdgeIds)`) followed by a
+/// `u64 set_hash`.  We decode using `graph_v4` types — safe because
+/// `graph_v3::VectorId` and `graph_v4::VectorId` are the same struct.
+///
+/// The serialised `set_hash` is read and discarded; [`Layer::set_links`]
+/// recomputes it incrementally as each edge list is inserted.
+fn read_hashed_layer_streaming<R: std::io::Read>(
+    reader: &mut R,
+) -> Result<Layer<IrisVectorId>> {
+    // HashMap bincode layout: u64 count + count × (key, value)
+    let link_count: u64 = bincode::deserialize_from(&mut *reader)
+        .map_err(|e| eyre::eyre!("link_count: {e}"))?;
+
+    let mut layer = Layer::new();
+    for _ in 0..link_count {
+        let v: graph_v4::VectorId = bincode::deserialize_from(&mut *reader)
+            .map_err(|e| eyre::eyre!("VectorId: {e}"))?;
+        let edges: graph_v4::EdgeIds = bincode::deserialize_from(&mut *reader)
+            .map_err(|e| eyre::eyre!("EdgeIds: {e}"))?;
+        layer.set_links(
+            v.into(),
+            edges.0.into_iter().map(|x: graph_v4::VectorId| x.into()).collect(),
+        );
+    }
+
+    // Discard the stored set_hash; Layer::set_links already recomputed it.
+    let _: u64 = bincode::deserialize_from(&mut *reader)
+        .map_err(|e| eyre::eyre!("set_hash: {e}"))?;
+
+    Ok(layer)
+}

--- a/iris-mpc-cpu/src/utils/serialization/graph.rs
+++ b/iris-mpc-cpu/src/utils/serialization/graph.rs
@@ -751,7 +751,7 @@ fn read_graph_v3_streaming<R: std::io::Read + ?Sized>(
         .map_err(|e| eyre::eyre!("v3 streaming layer_count: {e}"))?;
     let layer_count = usize::try_from(layer_count_u64)
         .map_err(|_| eyre::eyre!("v3 streaming layer_count overflows usize: {layer_count_u64}"))?;
-    let mut layers = Vec::with_capacity(layer_count as usize);
+    let mut layers = Vec::with_capacity(layer_count);
     for i in 0..layer_count {
         layers.push(
             read_hashed_layer_streaming(reader)

--- a/iris-mpc-cpu/src/utils/serialization/graph.rs
+++ b/iris-mpc-cpu/src/utils/serialization/graph.rs
@@ -267,14 +267,16 @@ pub fn write_graph_to_file<P: AsRef<Path>>(path: P, data: GraphMem<IrisVectorId>
 /* ------------------ Graph Pair Serialization ---------------------- */
 
 /// Method to read a pair of serialized structs of the same type.
-fn read_pair<R: std::io::Read, G: for<'a> Deserialize<'a>>(reader: &mut R) -> Result<[G; 2]> {
+fn read_pair<R: std::io::Read + ?Sized, G: for<'a> Deserialize<'a>>(
+    reader: &mut R,
+) -> Result<[G; 2]> {
     let data = bincode::deserialize_from(reader)?;
     Ok(data)
 }
 
 /// Designated method for reading a pair of `GraphMem` structs. Currently goes
 /// through the `GraphV4` serialization type.
-pub fn read_graph_pair_current<R: std::io::Read>(
+pub fn read_graph_pair_current<R: std::io::Read + ?Sized>(
     reader: &mut R,
 ) -> Result<[GraphMem<IrisVectorId>; 2]> {
     let data = read_pair::<_, GraphV4>(reader)?.map(|graph| graph.into());
@@ -297,7 +299,7 @@ pub fn write_graph_pair_current<W: std::io::Write>(
 ///
 /// _Provided for compatibility only_ -- please prefer use of stable serialization
 /// formats.
-pub fn read_graph_pair_raw<R: std::io::Read>(
+pub fn read_graph_pair_raw<R: std::io::Read + ?Sized>(
     reader: &mut R,
 ) -> Result<[GraphMem<IrisVectorId>; 2]> {
     let data = read_pair::<_, GraphMem<IrisVectorId>>(reader)?;
@@ -318,7 +320,7 @@ pub fn write_graph_pair_raw<W: std::io::Write>(
 }
 
 /// Read a pair of `GraphMem` structs with a specified serialization format.
-pub fn read_graph_pair<R: std::io::Read>(
+pub fn read_graph_pair<R: std::io::Read + ?Sized>(
     reader: &mut R,
     format: GraphFormat,
 ) -> Result<[GraphMem<IrisVectorId>; 2]> {
@@ -681,7 +683,7 @@ impl From<GraphMem<IrisVectorId>> for graph_v4::GraphV4 {
 ///
 /// V0/V1/V2/Raw fall back to [`read_graph_pair`]; those are rare migration
 /// paths and the graphs tend to be smaller.
-pub fn read_graph_pair_streaming<R: std::io::Read>(
+pub fn read_graph_pair_streaming<R: std::io::Read + ?Sized>(
     reader: &mut R,
     format: GraphFormat,
 ) -> Result<[GraphMem<IrisVectorId>; 2]> {
@@ -704,7 +706,9 @@ pub fn read_graph_pair_streaming<R: std::io::Read>(
 /// [`read_hashed_layer_streaming`], then reads `last_update_seq_no`.  Each
 /// layer is converted to [`Layer<IrisVectorId>`] and appended before the
 /// next layer is read, so no two full-graph copies coexist.
-fn read_graph_v4_streaming<R: std::io::Read>(reader: &mut R) -> Result<GraphMem<IrisVectorId>> {
+fn read_graph_v4_streaming<R: std::io::Read + ?Sized>(
+    reader: &mut R,
+) -> Result<GraphMem<IrisVectorId>> {
     let entry_points: Vec<graph_v4::EntryPoint> = bincode::deserialize_from(&mut *reader)
         .map_err(|e| eyre::eyre!("v4 streaming entry_points: {e}"))?;
 
@@ -733,7 +737,9 @@ fn read_graph_v4_streaming<R: std::io::Read>(reader: &mut R) -> Result<GraphMem<
 /// V3 differs from V4 only in having `entry_point` (same binary layout) and
 /// no `last_update_seq_no` field.  Layers share the same on-wire layout as
 /// V4 (see [`read_hashed_layer_streaming`]).
-fn read_graph_v3_streaming<R: std::io::Read>(reader: &mut R) -> Result<GraphMem<IrisVectorId>> {
+fn read_graph_v3_streaming<R: std::io::Read + ?Sized>(
+    reader: &mut R,
+) -> Result<GraphMem<IrisVectorId>> {
     // Field name is `entry_point` in GraphV3 vs `entry_points` in GraphV4,
     // but bincode uses positional encoding so the bytes are identical.
     let entry_points: Vec<graph_v3::EntryPoint> = bincode::deserialize_from(&mut *reader)
@@ -767,28 +773,32 @@ fn read_graph_v3_streaming<R: std::io::Read>(reader: &mut R) -> Result<GraphMem<
 ///
 /// The serialised `set_hash` is read and discarded; [`Layer::set_links`]
 /// recomputes it incrementally as each edge list is inserted.
-fn read_hashed_layer_streaming<R: std::io::Read>(
+fn read_hashed_layer_streaming<R: std::io::Read + ?Sized>(
     reader: &mut R,
 ) -> Result<Layer<IrisVectorId>> {
     // HashMap bincode layout: u64 count + count × (key, value)
-    let link_count: u64 = bincode::deserialize_from(&mut *reader)
-        .map_err(|e| eyre::eyre!("link_count: {e}"))?;
+    let link_count: u64 =
+        bincode::deserialize_from(&mut *reader).map_err(|e| eyre::eyre!("link_count: {e}"))?;
 
     let mut layer = Layer::new();
     for _ in 0..link_count {
-        let v: graph_v4::VectorId = bincode::deserialize_from(&mut *reader)
-            .map_err(|e| eyre::eyre!("VectorId: {e}"))?;
-        let edges: graph_v4::EdgeIds = bincode::deserialize_from(&mut *reader)
-            .map_err(|e| eyre::eyre!("EdgeIds: {e}"))?;
+        let v: graph_v4::VectorId =
+            bincode::deserialize_from(&mut *reader).map_err(|e| eyre::eyre!("VectorId: {e}"))?;
+        let edges: graph_v4::EdgeIds =
+            bincode::deserialize_from(&mut *reader).map_err(|e| eyre::eyre!("EdgeIds: {e}"))?;
         layer.set_links(
             v.into(),
-            edges.0.into_iter().map(|x: graph_v4::VectorId| x.into()).collect(),
+            edges
+                .0
+                .into_iter()
+                .map(|x: graph_v4::VectorId| x.into())
+                .collect(),
         );
     }
 
     // Discard the stored set_hash; Layer::set_links already recomputed it.
-    let _: u64 = bincode::deserialize_from(&mut *reader)
-        .map_err(|e| eyre::eyre!("set_hash: {e}"))?;
+    let _: u64 =
+        bincode::deserialize_from(&mut *reader).map_err(|e| eyre::eyre!("set_hash: {e}"))?;
 
     Ok(layer)
 }

--- a/iris-mpc-cpu/src/utils/serialization/graph.rs
+++ b/iris-mpc-cpu/src/utils/serialization/graph.rs
@@ -712,9 +712,11 @@ fn read_graph_v4_streaming<R: std::io::Read + ?Sized>(
     let entry_points: Vec<graph_v4::EntryPoint> = bincode::deserialize_from(&mut *reader)
         .map_err(|e| eyre::eyre!("v4 streaming entry_points: {e}"))?;
 
-    let layer_count: u64 = bincode::deserialize_from(&mut *reader)
+    let layer_count_u64: u64 = bincode::deserialize_from(&mut *reader)
         .map_err(|e| eyre::eyre!("v4 streaming layer_count: {e}"))?;
-    let mut layers = Vec::with_capacity(layer_count as usize);
+    let layer_count = usize::try_from(layer_count_u64)
+        .map_err(|_| eyre::eyre!("v4 streaming layer_count overflows usize: {layer_count_u64}"))?;
+    let mut layers = Vec::with_capacity(layer_count);
     for i in 0..layer_count {
         layers.push(
             read_hashed_layer_streaming(reader)
@@ -745,8 +747,10 @@ fn read_graph_v3_streaming<R: std::io::Read + ?Sized>(
     let entry_points: Vec<graph_v3::EntryPoint> = bincode::deserialize_from(&mut *reader)
         .map_err(|e| eyre::eyre!("v3 streaming entry_points: {e}"))?;
 
-    let layer_count: u64 = bincode::deserialize_from(&mut *reader)
+    let layer_count_u64: u64 = bincode::deserialize_from(&mut *reader)
         .map_err(|e| eyre::eyre!("v3 streaming layer_count: {e}"))?;
+    let layer_count = usize::try_from(layer_count_u64)
+        .map_err(|_| eyre::eyre!("v3 streaming layer_count overflows usize: {layer_count_u64}"))?;
     let mut layers = Vec::with_capacity(layer_count as usize);
     for i in 0..layer_count {
         layers.push(

--- a/iris-mpc-cpu/tests/streaming_s3_integration.rs
+++ b/iris-mpc-cpu/tests/streaming_s3_integration.rs
@@ -28,6 +28,10 @@ use iris_mpc_cpu::{
     utils::serialization::{
         graph::GraphFormat,
         types::graph_v3::{EdgeIds, EntryPoint, GraphV3, Layer as V3Layer, VectorId as V3Vid},
+        types::graph_v4::{
+            EdgeIds as V4EdgeIds, EntryPoint as V4EntryPoint, GraphV4, Layer as V4Layer,
+            VectorId as V4Vid,
+        },
     },
 };
 
@@ -230,14 +234,17 @@ fn make_v3_pair() -> [GraphV3; 2] {
     let make_graph = |base: u32| {
         let vid = |n: u32| V3Vid { id: n, version: 1 };
         GraphV3 {
-            entry_point: vec![EntryPoint { point: vid(base), layer: 1 }],
+            entry_point: vec![EntryPoint {
+                point: vid(base),
+                layer: 1,
+            }],
             layers: vec![
                 // Layer 0 — fully connected triangle
                 V3Layer {
                     links: HashMap::from([
-                        (vid(base),     EdgeIds(vec![vid(base + 1), vid(base + 2)])),
-                        (vid(base + 1), EdgeIds(vec![vid(base),     vid(base + 2)])),
-                        (vid(base + 2), EdgeIds(vec![vid(base),     vid(base + 1)])),
+                        (vid(base), EdgeIds(vec![vid(base + 1), vid(base + 2)])),
+                        (vid(base + 1), EdgeIds(vec![vid(base), vid(base + 2)])),
+                        (vid(base + 2), EdgeIds(vec![vid(base), vid(base + 1)])),
                     ]),
                     set_hash: 0xdead_beef_u64, // discarded on read
                 },
@@ -261,7 +268,7 @@ fn make_v3_pair() -> [GraphV3; 2] {
 ///   the standard `GraphV3 → GraphMem` path.
 /// - `last_update_seq_no` is 0 for both graphs (V3 has no seq_no field).
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn v3_graph_pair_streams_to_graphmem_seq_no_zero() -> Result<()> {
+async fn v3_graph_pair_streams_to_graphmem() -> Result<()> {
     let Some(endpoint) = s3_test_endpoint() else {
         eprintln!("S3_TEST_ENDPOINT not set; skipping");
         return Ok(());
@@ -294,11 +301,21 @@ async fn v3_graph_pair_streams_to_graphmem_seq_no_zero() -> Result<()> {
         return Err(e);
     }
 
+    // Compute the expected BLAKE3 hash from the raw serialized bytes — the
+    // same bytes the upload wrote and the download read.
+    let expected_hash = {
+        let bytes = bincode::serialize(&pair).map_err(|e| eyre!("bincode: {e}"))?;
+        *blake3::hash(&bytes).as_bytes()
+    };
+
     // Stream-download V3 bytes → `[GraphMem<IrisVectorId>; 2]`.
     let download =
         stream_download_and_deserialize_graph_pair(&client, &bucket, key, GraphFormat::V3).await;
     cleanup_bucket(&client, &bucket).await;
-    let (graphs, _hash) = download?;
+    let (graphs, hash) = download?;
+
+    // Hash must equal BLAKE3 of the on-wire bytes.
+    assert_eq!(hash, expected_hash, "BLAKE3 hash mismatch");
 
     // Reference: standard `.into()` conversion on the original in-memory pair.
     let expected: [GraphMem<IrisVectorId>; 2] = pair.map(|g| g.into());
@@ -316,6 +333,120 @@ async fn v3_graph_pair_streams_to_graphmem_seq_no_zero() -> Result<()> {
         assert_eq!(
             graphs[i].last_update_seq_no, 0,
             "graph[{i}] last_update_seq_no must be 0 for V3"
+        );
+    }
+
+    Ok(())
+}
+
+/// Build a deterministic, non-trivial `[GraphV4; 2]`.
+///
+/// Mirror of `make_v3_pair` but for V4: same topology, `last_update_seq_no`
+/// set to a non-zero sentinel so the test can verify it survives the round-trip.
+fn make_v4_pair() -> [GraphV4; 2] {
+    let make_graph = |base: u32, seq_no: u64| {
+        let vid = |n: u32| V4Vid { id: n, version: 1 };
+        GraphV4 {
+            entry_points: vec![V4EntryPoint {
+                point: vid(base),
+                layer: 1,
+            }],
+            layers: vec![
+                // Layer 0 — fully connected triangle
+                V4Layer {
+                    links: HashMap::from([
+                        (vid(base), V4EdgeIds(vec![vid(base + 1), vid(base + 2)])),
+                        (vid(base + 1), V4EdgeIds(vec![vid(base), vid(base + 2)])),
+                        (vid(base + 2), V4EdgeIds(vec![vid(base), vid(base + 1)])),
+                    ]),
+                    set_hash: 0xdead_beef_u64, // discarded on read
+                },
+                // Layer 1 — single edge
+                V4Layer {
+                    links: HashMap::from([(vid(base), V4EdgeIds(vec![vid(base + 1)]))]),
+                    set_hash: 0xcafe_babe_u64, // discarded on read
+                },
+            ],
+            last_update_seq_no: seq_no,
+        }
+    };
+    [make_graph(100, 42), make_graph(200, 99)]
+}
+
+/// Upload a `[GraphV4; 2]` to localstack S3, stream-download it via
+/// `stream_download_and_deserialize_graph_pair(…, GraphFormat::V4)`, and
+/// assert the result matches the reference `.into()` conversion.
+///
+/// Specifically verifies:
+/// - `entry_points` and `layers` (including recomputed `set_hash`) match
+///   the standard `GraphV4 → GraphMem` path.
+/// - `last_update_seq_no` is preserved (V4 carries it; non-zero sentinel used).
+/// - The returned BLAKE3 hash equals `blake3::hash(bincode_bytes)`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn v4_graph_pair_streams_to_graphmem_seq_no_preserved() -> Result<()> {
+    let Some(endpoint) = s3_test_endpoint() else {
+        eprintln!("S3_TEST_ENDPOINT not set; skipping");
+        return Ok(());
+    };
+
+    let client = make_test_client(&endpoint);
+    let bucket = format!("streaming-v4-{}", uuid::Uuid::new_v4());
+    let key = "v4-pair.bin";
+
+    create_bucket(&client, &bucket).await?;
+
+    let pair = make_v4_pair();
+
+    // Compute the expected BLAKE3 hash before moving `pair` into the upload.
+    let expected_hash = {
+        let bytes = bincode::serialize(&pair).map_err(|e| eyre!("bincode: {e}"))?;
+        *blake3::hash(&bytes).as_bytes()
+    };
+
+    // Upload as `[GraphV4; 2]` bincode.
+    let pair_for_upload = pair.clone();
+    let upload = stream_serialize_and_upload_with(
+        &client,
+        &bucket,
+        key,
+        move |w| {
+            bincode::serialize_into(w, &pair_for_upload)
+                .map_err(|e| eyre!("bincode serialize: {e}"))
+        },
+        5 * 1024 * 1024,
+        4,
+    )
+    .await;
+    if let Err(e) = upload {
+        cleanup_bucket(&client, &bucket).await;
+        return Err(e);
+    }
+
+    // Stream-download V4 bytes → `[GraphMem<IrisVectorId>; 2]`.
+    let download =
+        stream_download_and_deserialize_graph_pair(&client, &bucket, key, GraphFormat::V4).await;
+    cleanup_bucket(&client, &bucket).await;
+    let (graphs, hash) = download?;
+
+    // Hash must equal BLAKE3 of the on-wire bytes.
+    assert_eq!(hash, expected_hash, "BLAKE3 hash mismatch");
+
+    // Reference: standard `.into()` conversion on the original in-memory pair.
+    let expected: [GraphMem<IrisVectorId>; 2] = pair.map(|g| g.into());
+
+    for i in 0..2 {
+        assert_eq!(
+            graphs[i].entry_points, expected[i].entry_points,
+            "graph[{i}] entry_points mismatch"
+        );
+        assert_eq!(
+            graphs[i].layers, expected[i].layers,
+            "graph[{i}] layers mismatch (links or set_hash diverged)"
+        );
+        // V4 carries last_update_seq_no; it must survive the round-trip.
+        assert_eq!(
+            graphs[i].last_update_seq_no, expected[i].last_update_seq_no,
+            "graph[{i}] last_update_seq_no mismatch"
         );
     }
 

--- a/iris-mpc-cpu/tests/streaming_s3_integration.rs
+++ b/iris-mpc-cpu/tests/streaming_s3_integration.rs
@@ -11,13 +11,24 @@
 //!     cargo test -p iris-mpc-cpu --test streaming_s3_integration
 //! ```
 
+use std::collections::HashMap;
+
 use aws_sdk_s3::{
     config::{BehaviorVersion, Credentials, Region},
     Client as S3Client, Config,
 };
 use eyre::{eyre, Result};
-use iris_mpc_cpu::graph_checkpoint::{
-    stream_download_and_deserialize_with, stream_serialize_and_upload_with,
+use iris_mpc_common::IrisVectorId;
+use iris_mpc_cpu::{
+    graph_checkpoint::{
+        stream_download_and_deserialize_graph_pair, stream_download_and_deserialize_with,
+        stream_serialize_and_upload_with,
+    },
+    hnsw::graph::layered_graph::GraphMem,
+    utils::serialization::{
+        graph::GraphFormat,
+        types::graph_v3::{EdgeIds, EntryPoint, GraphV3, Layer as V3Layer, VectorId as V3Vid},
+    },
 };
 
 fn s3_test_endpoint() -> Option<String> {
@@ -203,5 +214,110 @@ async fn streaming_download_round_trip() -> Result<()> {
 
     assert_eq!(got, payload, "deserialized value mismatch");
     assert_eq!(got_hash, expected_hash, "hash mismatch");
+    Ok(())
+}
+
+/// Build a deterministic, non-trivial `[GraphV3; 2]`.
+///
+/// Each graph has two layers.  `base` offsets the node IDs so the two
+/// graphs in the pair have disjoint node sets, making cross-graph
+/// contamination visible in assertions.
+///
+/// The stored `set_hash` values are arbitrary — the streaming reader
+/// discards them and lets `Layer::set_links` recompute from scratch,
+/// which is exactly what the test exercises.
+fn make_v3_pair() -> [GraphV3; 2] {
+    let make_graph = |base: u32| {
+        let vid = |n: u32| V3Vid { id: n, version: 1 };
+        GraphV3 {
+            entry_point: vec![EntryPoint { point: vid(base), layer: 1 }],
+            layers: vec![
+                // Layer 0 — fully connected triangle
+                V3Layer {
+                    links: HashMap::from([
+                        (vid(base),     EdgeIds(vec![vid(base + 1), vid(base + 2)])),
+                        (vid(base + 1), EdgeIds(vec![vid(base),     vid(base + 2)])),
+                        (vid(base + 2), EdgeIds(vec![vid(base),     vid(base + 1)])),
+                    ]),
+                    set_hash: 0xdead_beef_u64, // discarded on read
+                },
+                // Layer 1 — single edge
+                V3Layer {
+                    links: HashMap::from([(vid(base), EdgeIds(vec![vid(base + 1)]))]),
+                    set_hash: 0xcafe_babe_u64, // discarded on read
+                },
+            ],
+        }
+    };
+    [make_graph(100), make_graph(200)]
+}
+
+/// Upload a `[GraphV3; 2]` to localstack S3, stream-download it via
+/// `stream_download_and_deserialize_graph_pair(…, GraphFormat::V3)`, and
+/// assert the result matches the reference `.into()` conversion.
+///
+/// Specifically verifies:
+/// - `entry_points` and `layers` (including recomputed `set_hash`) match
+///   the standard `GraphV3 → GraphMem` path.
+/// - `last_update_seq_no` is 0 for both graphs (V3 has no seq_no field).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn v3_graph_pair_streams_to_graphmem_seq_no_zero() -> Result<()> {
+    let Some(endpoint) = s3_test_endpoint() else {
+        eprintln!("S3_TEST_ENDPOINT not set; skipping");
+        return Ok(());
+    };
+
+    let client = make_test_client(&endpoint);
+    let bucket = format!("streaming-v3-{}", uuid::Uuid::new_v4());
+    let key = "v3-pair.bin";
+
+    create_bucket(&client, &bucket).await?;
+
+    let pair = make_v3_pair();
+
+    // Upload as `[GraphV3; 2]` bincode.
+    let pair_for_upload = pair.clone();
+    let upload = stream_serialize_and_upload_with(
+        &client,
+        &bucket,
+        key,
+        move |w| {
+            bincode::serialize_into(w, &pair_for_upload)
+                .map_err(|e| eyre!("bincode serialize: {e}"))
+        },
+        5 * 1024 * 1024,
+        4,
+    )
+    .await;
+    if let Err(e) = upload {
+        cleanup_bucket(&client, &bucket).await;
+        return Err(e);
+    }
+
+    // Stream-download V3 bytes → `[GraphMem<IrisVectorId>; 2]`.
+    let download =
+        stream_download_and_deserialize_graph_pair(&client, &bucket, key, GraphFormat::V3).await;
+    cleanup_bucket(&client, &bucket).await;
+    let (graphs, _hash) = download?;
+
+    // Reference: standard `.into()` conversion on the original in-memory pair.
+    let expected: [GraphMem<IrisVectorId>; 2] = pair.map(|g| g.into());
+
+    for i in 0..2 {
+        assert_eq!(
+            graphs[i].entry_points, expected[i].entry_points,
+            "graph[{i}] entry_points mismatch"
+        );
+        assert_eq!(
+            graphs[i].layers, expected[i].layers,
+            "graph[{i}] layers mismatch (links or set_hash diverged)"
+        );
+        // V3 has no seq_no field; streaming path must yield 0.
+        assert_eq!(
+            graphs[i].last_update_seq_no, 0,
+            "graph[{i}] last_update_seq_no must be 0 for V3"
+        );
+    }
+
     Ok(())
 }

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -61,6 +61,8 @@ use tokio::time::timeout;
 const RNG_SEED_INIT_DB: u64 = 42;
 pub const SQS_POLLING_INTERVAL: Duration = Duration::from_secs(1);
 pub const MAX_CONCURRENT_REQUESTS: usize = 32;
+const PEER_ROUND_TIMEOUT: Duration = Duration::from_secs(10);
+const CHECKPOINT_WINDOW: usize = 10;
 
 /// Main logic for initialization and execution of AMPC iris uniqueness server
 /// nodes.
@@ -554,8 +556,6 @@ async fn init_hawk_actor(
     let now = Instant::now();
     let ct = shutdown_handler.get_network_cancellation_token();
     let mut networking = build_hawk_network_handle(&hawk_args, ct).await?;
-    const PEER_ROUND_TIMEOUT: Duration = Duration::from_secs(10);
-    const CHECKPOINT_WINDOW: usize = 10;
 
     let graph_load_future = async move {
         // Install the graph via the WAL-based consensus checkpoint protocol.

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -5,10 +5,12 @@ use aws_sdk_s3::Client;
 use aws_sdk_sns::types::MessageAttributeValue;
 use axum::routing::get;
 use axum::Router;
+use iris_mpc_cpu::checkpoint_protocol::{restart_from_checkpoint, RestartOutcome};
 use iris_mpc_cpu::graph_checkpoint::{
-    get_common_checkpoint, get_most_recent_checkpoints, load_graph_and_roll_forward, s3_key_exists,
-    sync_graph_mutations, GraphCheckpointState, GRAPH_CHECKPOINT_ROUTE,
+    get_common_checkpoint, get_most_recent_checkpoints, s3_key_exists, sync_graph_mutations,
+    GraphCheckpointState, GRAPH_CHECKPOINT_ROUTE,
 };
+use iris_mpc_cpu::hnsw::GraphMem;
 
 use crate::services::processors::modifications_sync::{
     send_last_modifications_to_sns, sync_modifications,
@@ -58,6 +60,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::Sender;
+use tokio::sync::RwLock;
 use tokio::time::timeout;
 
 const RNG_SEED_INIT_DB: u64 = 42;
@@ -551,7 +554,7 @@ async fn init_hawk_actor(
     checkpoint_bucket: &str,
     iris_store: &Store,
     graph_store: &GraphPg<Aby3Store<HawkOps>>,
-    checkpoint: Option<GraphCheckpointState>,
+    _checkpoint: Option<GraphCheckpointState>,
     shutdown_handler: &Arc<ShutdownHandler>,
 ) -> Result<HawkActor> {
     let (hawk_args, inbound, outbound) = build_hawk_args(config)?;
@@ -598,46 +601,57 @@ async fn init_hawk_actor(
 
     let now = Instant::now();
     let ct = shutdown_handler.get_network_cancellation_token();
+    let mut networking = build_hawk_network_handle(&hawk_args, ct).await?;
+    const PEER_ROUND_TIMEOUT: Duration = Duration::from_secs(10);
+    const CHECKPOINT_WINDOW: usize = 10;
 
-    // Network handle built up-front; iris and graph load in parallel.
-    let networking = build_hawk_network_handle(&hawk_args, ct).await?;
-
-    // Try to load graph from S3 checkpoint first, then fall back to an empty
-    // graph.  After loading from the checkpoint, replay any WAL mutations that
-    // were committed after it so all parties converge on the same graph state.
     let graph_load_future = async move {
-        // Fetch WAL mutations that were committed after the checkpoint was taken.
-        // Three cases:
-        //   • No checkpoint at all → replay the entire WAL (covers a fresh start
-        //     that crashed before its first checkpoint was written).
-        //   • Checkpoint with a known graph_mutation_id → replay only the rows
-        //     that follow that id (the common case).
-        //   • Checkpoint whose graph_mutation_id is None (genesis or pre-WAL checkpoint)
-        //     → replay the entire WAL on top of it so the in-memory graph converges
-        //     to the correct state.
-        let wal_mutation_rows = match checkpoint.as_ref() {
-            None => graph_store.get_hawk_graph_mutations_after(None).await?,
-            Some(cp) => {
-                let after = cp.graph_mutation_id;
-                match after {
-                    Some(id) => tracing::info!(
-                        last_mutation_id = id,
-                        "fetching WAL graph mutations to replay on top of checkpoint"
-                    ),
-                    None => tracing::info!(
-                        "checkpoint has no graph_mutation_id (genesis or pre-WAL); \
-                         replaying entire WAL on top of checkpoint"
-                    ),
-                }
-                graph_store.get_hawk_graph_mutations_after(after).await?
+        // Install the graph via the WAL-based consensus checkpoint protocol.
+        // Falls back to an empty graph when no checkpoint row exists yet
+        // (fresh deployment or pre-checkpoint migration path).
+        let graph_target = [
+            Arc::new(RwLock::new(GraphMem::new())),
+            Arc::new(RwLock::new(GraphMem::new())),
+        ];
+        let r = match restart_from_checkpoint(
+            graph_store,
+            s3_client,
+            checkpoint_bucket.to_string(),
+            &mut networking,
+            graph_target.clone(),
+            PEER_ROUND_TIMEOUT,
+            CHECKPOINT_WINDOW,
+        )
+        .await?
+        {
+            RestartOutcome::Installed { height } => {
+                tracing::info!(height, "restart: installed graph from checkpoint");
+                graph_target.map(|arc| {
+                    Arc::try_unwrap(arc)
+                        .expect("graph Arc has exactly one owner after restart")
+                        .into_inner()
+                })
+            }
+            RestartOutcome::NoCheckpoint => {
+                tracing::info!("no checkpoint found, starting with empty graph");
+                [GraphMem::new(), GraphMem::new()]
+            }
+            RestartOutcome::PeerBehindBase { freeze, base } => {
+                return Err(eyre!(
+                    "restart_from_checkpoint: peer behind base (freeze={freeze}, base={base})"
+                ));
+            }
+            RestartOutcome::NoCommonBase => {
+                return Err(eyre!(
+                    "restart_from_checkpoint: no checkpoint common to all peers"
+                ));
             }
         };
-
-        load_graph_and_roll_forward(s3_client, checkpoint_bucket, checkpoint, wal_mutation_rows)
-            .await
+        Ok((r, networking))
     };
 
-    let (initialized, graph) = tokio::try_join!(initializer.initialize(), graph_load_future)?;
+    let (initialized, (graph, networking)) =
+        tokio::try_join!(initializer.initialize(), graph_load_future)?;
     tracing::info!(
         "Loaded both iris and graph DBs into memory in {:?}",
         now.elapsed()

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -3,13 +3,8 @@ use crate::services::processors::batch::receive_batch_stream;
 use crate::services::processors::job::process_job_result;
 use aws_sdk_s3::Client;
 use aws_sdk_sns::types::MessageAttributeValue;
-use axum::routing::get;
-use axum::Router;
 use iris_mpc_cpu::checkpoint_protocol::{restart_from_checkpoint, RestartOutcome};
-use iris_mpc_cpu::graph_checkpoint::{
-    get_common_checkpoint, get_most_recent_checkpoints, s3_key_exists, sync_graph_mutations,
-    GraphCheckpointState, GRAPH_CHECKPOINT_ROUTE,
-};
+use iris_mpc_cpu::graph_checkpoint::sync_graph_mutations;
 use iris_mpc_cpu::hnsw::GraphMem;
 
 use crate::services::processors::modifications_sync::{
@@ -105,24 +100,13 @@ pub async fn server_main(config: Config) -> Result<()> {
         server_coord_config.healthcheck_ports
     );
 
-    let (graph_checkpoints, hashes) = get_most_recent_checkpoints(&graph_store).await?;
-
-    // Start coordination server
-    let extra_routes = Router::new().route(
-        GRAPH_CHECKPOINT_ROUTE,
-        get({
-            let hashes_json = serde_json::to_string(&hashes).unwrap();
-            move || async move { hashes_json }
-        }),
-    );
-
     let (is_ready_flag, verified_peers, my_uuid) = start_coordination_server_with_extra_routes(
         &server_coord_config,
         &mut background_tasks,
         &shutdown_handler,
         &my_state,
         Some(batch_sync_shared_state.clone()),
-        Some(extra_routes),
+        None,
     )
     .await;
     tracing::info!("Coordination server started");
@@ -132,36 +116,6 @@ pub async fn server_main(config: Config) -> Result<()> {
 
     let sync_result = get_sync_result(&config, &my_state).await?;
     sync_result.check_common_config()?;
-
-    let graph_checkpoint =
-        get_common_checkpoint(&server_coord_config, hashes, graph_checkpoints).await?;
-    tracing::info!("common graph checkpoint: {:?}", graph_checkpoint);
-
-    if let Some(cp) = graph_checkpoint.as_ref() {
-        // Stop if the checkpoint can not be found
-        if !s3_key_exists(
-            &aws_clients.checkpoint_s3_client,
-            &config.graph_checkpoint_bucket_name,
-            &cp.s3_key,
-        )
-        .await?
-        {
-            bail!(
-                "s3 checkpoint not found on AWS: s3://{}/{}",
-                config.graph_checkpoint_bucket_name,
-                cp.s3_key
-            );
-        }
-
-        // Validate checkpoint vs Iris DB consistency
-        let db_count = iris_store.count_irises().await?;
-        if cp.last_indexed_iris_id as usize != db_count {
-            tracing::warn!(
-                "Graph checkpoint last_indexed_iris_id={} differs from iris_db count={}. Shadow mode may produce mismatches.",
-                cp.last_indexed_iris_id, db_count
-            );
-        }
-    }
 
     // Handle modifications sync
     if config.enable_modifications_sync {
@@ -205,7 +159,6 @@ pub async fn server_main(config: Config) -> Result<()> {
         &config.graph_checkpoint_bucket_name,
         &iris_store,
         &graph_store,
-        graph_checkpoint,
         &shutdown_handler,
     )
     .await?;
@@ -554,7 +507,6 @@ async fn init_hawk_actor(
     checkpoint_bucket: &str,
     iris_store: &Store,
     graph_store: &GraphPg<Aby3Store<HawkOps>>,
-    _checkpoint: Option<GraphCheckpointState>,
     shutdown_handler: &Arc<ShutdownHandler>,
 ) -> Result<HawkActor> {
     let (hawk_args, inbound, outbound) = build_hawk_args(config)?;
@@ -625,6 +577,14 @@ async fn init_hawk_actor(
         .await?
         {
             RestartOutcome::Installed { height } => {
+                // Validate checkpoint vs Iris DB consistency
+                let db_count = iris_store.count_irises().await?;
+                if height as usize != db_count {
+                    tracing::warn!(
+                        "Graph checkpoint last_indexed_iris_id={} differs from iris_db count={}. Shadow mode may produce mismatches.",
+                        height, db_count
+                    );
+                }
                 tracing::info!(height, "restart: installed graph from checkpoint");
                 graph_target.map(|arc| {
                     Arc::try_unwrap(arc)
@@ -633,6 +593,12 @@ async fn init_hawk_actor(
                 })
             }
             RestartOutcome::NoCheckpoint => {
+                let db_count = iris_store.count_irises().await?;
+                if db_count != 0 {
+                    return Err(eyre!(
+                        "Graph checkpoint was not found but iris store contains {db_count} entries"
+                    ));
+                }
                 tracing::info!("no checkpoint found, starting with empty graph");
                 [GraphMem::new(), GraphMem::new()]
             }

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -595,9 +595,9 @@ async fn init_hawk_actor(
             RestartOutcome::NoCheckpoint => {
                 let db_count = iris_store.count_irises().await?;
                 if db_count != 0 {
-                    return Err(eyre!(
+                    tracing::warn!(
                         "Graph checkpoint was not found but iris store contains {db_count} entries"
-                    ));
+                    );
                 }
                 tracing::info!("no checkpoint found, starting with empty graph");
                 [GraphMem::new(), GraphMem::new()]


### PR DESCRIPTION
Consolidate checkpoint restart and memory-efficient graph loading

- Replaces load_graph_and_roll_forward with restart_from_checkpoint in server/mod.rs. Genesis did not get the update because Genesis does not save the WAL, should not be applying it, and has a different startup mechanism (rolling back the modifications and replaying irises from the GPU database). 
- Adds stream_download_and_deserialize_graph_pair — a streaming S3 download path that deserialises directly into GraphMem layer-by-layer, avoiding the peak memory spike of holding a full intermediate Graph alongside the destination graph. V4/Current and V3 use this single-copy path; older formats fall back to the unoptimized reader. download_graph_checkpoint is updated to use this new function.
- Also adds a pruning mode to the serialization layer and expands the streaming S3 integration tests to cover V3 and V4 graph round-trips. 