### PR TITLE
Type-state for graph mutation sequence numbers

### DIFF
--- a/iris-mpc-cpu/src/execution/hawk_main/insert.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/insert.rs
@@ -1,5 +1,8 @@
 use crate::hnsw::{
-    graph::{mutation::EdgeType, GraphMutation, MutationOp, UpdateEntryPoint},
+    graph::{
+        mutation::{EdgeType, UnstampedMutation},
+        MutationOp, UpdateEntryPoint,
+    },
     searcher::{ConnectPlanV, LayerMode},
     vector_store::VectorStoreMut,
     GraphMem, HnswSearcher, VectorStore,
@@ -42,26 +45,6 @@ impl<V: VectorStore> Clone for InsertPlanV<V> {
             links: self.links.clone(),
             update_ep: self.update_ep.clone(),
         }
-    }
-}
-
-/// Mints sequential `u64` sequence numbers for `GraphMutation` groups built
-/// during a single `insert` call. Seeded from `GraphMem::next_sequence_number()`;
-/// never touches the graph itself. The graph's `last_update_seq_no` only
-/// advances when each stamped group is later applied via `GraphMem::insert_apply`.
-struct UpdateSeqNoAllocator {
-    next: u64,
-}
-
-impl UpdateSeqNoAllocator {
-    fn new(start: u64) -> Self {
-        Self { next: start }
-    }
-
-    fn mint(&mut self) -> u64 {
-        let seq_no = self.next;
-        self.next += 1;
-        seq_no
     }
 }
 
@@ -112,7 +95,6 @@ pub async fn insert<V: VectorStoreMut>(
     let insert_plans = join_plans(plans, &searcher.layer_mode);
     validate_ep_updates(&insert_plans, &searcher.layer_mode)?;
 
-    let mut seq_no_allocator = UpdateSeqNoAllocator::new(graph.next_sequence_number());
     let mut intra_batch_inserted = vec![];
     let m = searcher.params.get_M(0);
 
@@ -127,11 +109,9 @@ pub async fn insert<V: VectorStoreMut>(
 
         // (a) Delete first: own GraphMutation with the lower seq_no.
         if let Some(rid) = replace_id {
-            let mutation = GraphMutation {
-                seq_no: seq_no_allocator.mint(),
+            let mutation = graph.apply_new(UnstampedMutation {
                 ops: vec![MutationOp::RemoveNode { id: rid.clone() }],
-            };
-            graph.insert_apply(&mutation)?;
+            })?;
             slot_outputs[idx].push(mutation);
         }
 
@@ -171,17 +151,14 @@ pub async fn insert<V: VectorStoreMut>(
                     edge_type: EdgeType::All,
                 });
             }
-            let mutation = GraphMutation {
-                seq_no: seq_no_allocator.mint(),
-                ops,
-            };
-            for pair in mutation.updated_neighborhoods() {
+            let unstamped = UnstampedMutation { ops };
+            for pair in unstamped.updated_neighborhoods() {
                 slot_updated.insert(pair);
             }
-            for pair in mutation.expanded_neighborhoods() {
+            for pair in unstamped.expanded_neighborhoods() {
                 batch_expanded.insert(pair);
             }
-            graph.insert_apply(&mutation)?;
+            let mutation = graph.apply_new(unstamped)?;
             slot_outputs[idx].push(mutation);
         }
 
@@ -197,11 +174,7 @@ pub async fn insert<V: VectorStoreMut>(
                 .prune_invalid_links(store, graph, &slot_updated)
                 .await?;
             if !ops.is_empty() {
-                let mutation = GraphMutation {
-                    seq_no: seq_no_allocator.mint(),
-                    ops,
-                };
-                graph.insert_apply(&mutation)?;
+                let mutation = graph.apply_new(UnstampedMutation { ops })?;
                 slot_outputs[idx].push(mutation);
             }
         }
@@ -214,11 +187,7 @@ pub async fn insert<V: VectorStoreMut>(
             .compact_batch(store, graph, &batch_expanded)
             .await?;
         if !ops.is_empty() {
-            let mutation = GraphMutation {
-                seq_no: seq_no_allocator.mint(),
-                ops,
-            };
-            graph.insert_apply(&mutation)?;
+            let mutation = graph.apply_new(UnstampedMutation { ops })?;
             let last_idx = slot_outputs
                 .iter()
                 .rposition(|v| !v.is_empty())
@@ -337,6 +306,7 @@ fn validate_ep_updates<V: VectorStore>(
 #[cfg(test)]
 mod tests {
     use crate::hawkers::plaintext_store::PlaintextStore;
+    use crate::hnsw::graph::GraphMutation;
     use iris_mpc_common::iris_db::iris::IrisCode;
     use itertools::Itertools;
     use std::sync::Arc;

--- a/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
@@ -7,7 +7,10 @@ use crate::{
     execution::hawk_main::state_check::SetHash,
     hawkers::ideal_knn_engines::{read_knn_results_from_file, Engine, EngineChoice, KNNResult},
     hnsw::{
-        graph::{mutation::EdgeType, GraphMutation, MutationOp, UpdateEntryPoint},
+        graph::{
+            mutation::{EdgeType, UnstampedMutation},
+            GraphMutation, MutationOp, UpdateEntryPoint,
+        },
         searcher::LayerMode,
         vector_store::Ref,
         HnswSearcher,
@@ -369,6 +372,25 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
 
         self.last_update_seq_no = mutation.seq_no;
         Ok(())
+    }
+
+    /// Stamp a locally-built [`UnstampedMutation`] with the next sequence
+    /// number, apply it, and return the resulting [`GraphMutation`].
+    ///
+    /// This is the sole minter of sequence numbers for in-process mutations:
+    /// the number is assigned from `next_sequence_number()` and consumed by the
+    /// apply in one step, so `last_update_seq_no` can never lag behind the
+    /// highest minted id and two mutations can never share a number. Mutations
+    /// that already carry a sequence number (replayed from a WAL or checkpoint)
+    /// go through `insert_apply`/`insert_apply_all` instead, where the strict
+    /// monotonicity check guards the externally-supplied `seq_no`.
+    pub fn apply_new(&mut self, mutation: UnstampedMutation<V>) -> Result<GraphMutation<V>> {
+        let stamped = GraphMutation {
+            seq_no: self.next_sequence_number(),
+            ops: mutation.ops,
+        };
+        self.insert_apply(&stamped)?;
+        Ok(stamped)
     }
 
     pub fn insert_apply_all(&mut self, mutations: &[GraphMutation<V>]) -> Result<()> {

--- a/iris-mpc-cpu/src/hnsw/graph/mutation.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/mutation.rs
@@ -6,6 +6,19 @@ pub struct GraphMutation<V: Ord> {
     pub ops: Vec<MutationOp<V>>,
 }
 
+/// A graph mutation that has not yet been assigned a sequence number.
+///
+/// Holds the ops describing *what* to change without committing to *where* in
+/// the mutation sequence the change lands. The only way to turn one into a
+/// stamped [`GraphMutation`] is [`crate::hnsw::GraphMem::apply_new`], which
+/// assigns the sequence number and applies it in a single step — so a sequence
+/// number can never be minted in-process without immediately advancing the
+/// graph.
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
+pub struct UnstampedMutation<V: Ord> {
+    pub ops: Vec<MutationOp<V>>,
+}
+
 // NOTE: if a new version of any mutation is needed (ex: InsertNodeV2) such that
 // the new variant would behave differently than before and it is desired to
 // still process old variants apppropriately, simply add the new variant to the
@@ -81,7 +94,7 @@ impl<V: std::fmt::Debug + Ord> std::fmt::Debug for MutationOp<V> {
     }
 }
 
-impl<V: Clone + Ord> GraphMutation<V> {
+impl<V: Clone + Ord> UnstampedMutation<V> {
     /// Subset of `updated_neighborhoods` restricted to neighborhoods that
     /// may have *grown* — i.e. those affected by `AddEdges` ops in this
     /// mutation. Used as the candidate set for batch compaction. The
@@ -329,7 +342,7 @@ mod tests {
 
     // ── expanded_neighborhoods ────────────────────────────────────────────────
 
-    use super::{EdgeType, GraphMutation, MutationOp, UpdateEntryPoint};
+    use super::{EdgeType, MutationOp, UnstampedMutation, UpdateEntryPoint};
 
     fn mk_add_edges(
         base: i32,
@@ -347,8 +360,7 @@ mod tests {
 
     #[test]
     fn expanded_neighborhoods_addedges_all_yields_base_and_neighbors() {
-        let mutation = GraphMutation {
-            seq_no: 1,
+        let mutation = UnstampedMutation {
             ops: vec![mk_add_edges(1, vec![2, 3], 0, EdgeType::All)],
         };
         let mut got = mutation.expanded_neighborhoods();
@@ -358,8 +370,7 @@ mod tests {
 
     #[test]
     fn expanded_neighborhoods_addedges_base_yields_only_base() {
-        let mutation = GraphMutation {
-            seq_no: 1,
+        let mutation = UnstampedMutation {
             ops: vec![mk_add_edges(1, vec![2, 3], 1, EdgeType::Base)],
         };
         assert_eq!(mutation.expanded_neighborhoods(), vec![(1, 1)]);
@@ -367,8 +378,7 @@ mod tests {
 
     #[test]
     fn expanded_neighborhoods_addedges_neighbors_yields_only_neighbors() {
-        let mutation = GraphMutation {
-            seq_no: 1,
+        let mutation = UnstampedMutation {
             ops: vec![mk_add_edges(1, vec![2, 3], 2, EdgeType::Neighbors)],
         };
         let mut got = mutation.expanded_neighborhoods();
@@ -378,8 +388,7 @@ mod tests {
 
     #[test]
     fn expanded_neighborhoods_ignores_non_addedges_ops() {
-        let mutation = GraphMutation {
-            seq_no: 1,
+        let mutation = UnstampedMutation {
             ops: vec![
                 MutationOp::AddNode {
                     id: 1,
@@ -405,8 +414,7 @@ mod tests {
 
     #[test]
     fn updated_neighborhoods_includes_removeedges() {
-        let mutation = GraphMutation {
-            seq_no: 1,
+        let mutation = UnstampedMutation {
             ops: vec![
                 MutationOp::RemoveEdges {
                     base: 1,
@@ -429,8 +437,7 @@ mod tests {
 
     #[test]
     fn updated_neighborhoods_removeedges_respects_edge_type() {
-        let mutation = GraphMutation {
-            seq_no: 1,
+        let mutation = UnstampedMutation {
             ops: vec![
                 MutationOp::RemoveEdges {
                     base: 1,
@@ -453,8 +460,7 @@ mod tests {
 
     #[test]
     fn updated_neighborhoods_ignores_addnode_removenode() {
-        let mutation = GraphMutation {
-            seq_no: 1,
+        let mutation = UnstampedMutation {
             ops: vec![
                 MutationOp::AddNode {
                     id: 1,

--- a/iris-mpc-cpu/src/hnsw/searcher.rs
+++ b/iris-mpc-cpu/src/hnsw/searcher.rs
@@ -10,7 +10,7 @@ use super::{
 };
 use crate::hnsw::{
     graph::{
-        mutation::{EdgeType, GraphMutation},
+        mutation::{EdgeType, GraphMutation, UnstampedMutation},
         neighborhood::Neighborhood,
         MutationOp, UpdateEntryPoint,
     },
@@ -1685,24 +1685,17 @@ impl HnswSearcher {
                 edge_type: EdgeType::All,
             });
         }
-        let plan = GraphMutation {
-            seq_no: graph.next_sequence_number(),
-            ops,
-        };
+        let plan = UnstampedMutation { ops };
         let updated: BTreeSet<_> = plan.updated_neighborhoods().into_iter().collect();
         let expanded: BTreeSet<_> = plan.expanded_neighborhoods().into_iter().collect();
-        graph.insert_apply(&plan)?;
+        graph.apply_new(plan)?;
 
         // Per-slot invalid-link prune (single-slot here). To be removed once
         // neighborhood-versioning makes this implicit.
         if !updated.is_empty() {
             let ops = self.prune_invalid_links(store, graph, &updated).await?;
             if !ops.is_empty() {
-                let m = GraphMutation {
-                    seq_no: graph.next_sequence_number(),
-                    ops,
-                };
-                graph.insert_apply(&m)?;
+                graph.apply_new(UnstampedMutation { ops })?;
             }
         }
 
@@ -1710,11 +1703,7 @@ impl HnswSearcher {
         if !expanded.is_empty() {
             let ops = self.compact_batch(store, graph, &expanded).await?;
             if !ops.is_empty() {
-                let m = GraphMutation {
-                    seq_no: graph.next_sequence_number(),
-                    ops,
-                };
-                graph.insert_apply(&m)?;
+                graph.apply_new(UnstampedMutation { ops })?;
             }
         }
 


### PR DESCRIPTION
## What

Adds compile-time type safety to the graph mutation sequence-number ("mutation id") logic, and removes the now-redundant `UpdateSeqNoAllocator`.

- **`UnstampedMutation<V> { ops }`** — a mutation's ops with *no* seq_no yet ("what to do", no position in the sequence). The neighborhood helpers (`updated_`/`expanded_neighborhoods`) move onto it, since they're computed pre-apply.
- **`GraphMem::apply_new(UnstampedMutation) -> Result<GraphMutation>`** — the sole in-process minter. It stamps with `next_sequence_number()` and applies in a single step, returning the stamped `GraphMutation` for collection/persistence.
- **`insert_apply` / `insert_apply_all` unchanged** — they remain the *apply-already-stamped* path for WAL/checkpoint replay (and test literals), with the strict-monotonicity check as the runtime backstop for externally-supplied `seq_no`s.

All live mint sites (`insert.rs` ×4, `searcher.rs` ×3) now build `UnstampedMutation` + `apply_new`.

## Why

Previously ordering was enforced *only at runtime*: `GraphMutation` was a plain struct anyone could build with any `seq_no`, and two construction patterns coexisted (per-mutation `next_sequence_number()` vs. a separate allocator minting a contiguous run). Nothing in the types prevented minting out of order, reusing an id, or applying a never-stamped mutation.

The key invariant now holds *structurally*: by **fusing stamp + apply** into `apply_new` (rather than exposing a standalone `stamp()` whose result a caller could sit on), a seq_no is never observable until it has already been assigned and applied — so `last_update_seq_no` can't lag the highest minted id and in-process mutations can't collide on a number.

`UpdateSeqNoAllocator` is deleted because every `mint()` was already immediately followed by `insert_apply()`, so the allocator's counter never diverged from the graph's — the graph is the single source of truth.

## Trust boundary (deliberate)

`GraphMutation` is still freely constructible with an arbitrary `seq_no` (needed for `Deserialize` on WAL/checkpoint replay). In-process minting is sealed behind `apply_new`; persisted/cross-process seq_nos can't be compile-time-trusted and are validated at runtime in `insert_apply`. A `SeqNo(u64)` newtype was considered and rejected — the only hand-written `seq_no` literals are tests and replay (both legitimate), so it'd be ceremony guarding no real failure mode.

## Tests

`cargo test -p iris-mpc-cpu` (mutation / layered_graph / insert / searcher) green; `cargo clippy --tests` + `cargo fmt` clean. No behavioral change — `apply_new` returns exactly what the allocator-minted path did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)