### PR TITLE
 [POP-3930] add option to run sidecar in the same process as the iris-mpc server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2942,6 +2942,7 @@ dependencies = [
  "sodiumoxide",
  "sqlx",
  "tokio",
+ "tokio-util",
  "tracing",
  "uuid",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1258,6 +1258,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1326,7 +1335,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9225bdcf4e4a9a4c08bf16607908eb2fbf746828d5e0b5e019726dbf6571f201"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn",
@@ -1772,8 +1781,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -1791,12 +1810,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn",
 ]
@@ -1887,6 +1930,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -1954,6 +1998,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
@@ -2806,6 +2856,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -2816,6 +2867,7 @@ checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.0",
+ "serde",
 ]
 
 [[package]]
@@ -3033,6 +3085,7 @@ dependencies = [
  "bytes",
  "cached",
  "clap",
+ "config",
  "core_affinity",
  "criterion",
  "crossbeam",
@@ -3057,6 +3110,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
+ "serde_with",
  "siphasher",
  "socket2 0.6.0",
  "sqlx",
@@ -4689,6 +4743,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5038,6 +5112,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5196,6 +5294,38 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+dependencies = [
+ "base64",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.6.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ async-trait = "0.1.83"
 axum = "0.7"
 blake3 = "1.8.2"
 clap = { version = "4.5.51", features = ["derive", "env"] }
+config = { version = "0.15.19", default-features = false, features = ["json"] }
 core_affinity = "0.8"
 cudarc = { version = "0.13.9", features = ["cuda-12080", "nccl"] }
 chrono = "0.4.42"
@@ -63,6 +64,7 @@ memmap2 = "0.9.5"
 serde = { version = "1.0", features = ["derive"] }
 serde-big-array = "0.5.1"
 serde_json = "1"
+serde_with = { version = "3", features = ["std"] }
 bincode = "1.3.3"
 sqlx = { version = "0.8", features = ["runtime-tokio-native-tls", "postgres"] }
 sodiumoxide = "0.2.7"

--- a/iris-mpc-common/Cargo.toml
+++ b/iris-mpc-common/Cargo.toml
@@ -43,7 +43,7 @@ tracing-subscriber.workspace = true
 uuid.workspace = true
 sqlx.workspace = true
 telemetry-batteries.workspace = true
-config = { version = "0.15.19", default-features = false, features = ["json"] }
+config.workspace = true
 chrono = { version = "0.4.38", features = ["serde"] }
 reqwest = { workspace = true, optional = true, features = ["blocking", "json"] }
 sodiumoxide = "0.2.7"

--- a/iris-mpc-cpu/Cargo.toml
+++ b/iris-mpc-cpu/Cargo.toml
@@ -19,6 +19,7 @@ bytes = "1.7"
 bytemuck.workspace = true
 cached = "0.56.0"
 clap.workspace = true
+config.workspace = true
 core_affinity.workspace = true
 crossbeam = "0.8.4"
 csv = "*"
@@ -37,6 +38,7 @@ rayon.workspace = true
 rstest = "0.23.0"
 serde.workspace = true
 serde_json.workspace = true
+serde_with.workspace = true
 serde_path_to_error = "*"
 siphasher = "1"
 socket2 = { version = "0.6.0", features = ["all"] }

--- a/iris-mpc-cpu/src/checkpoint_protocol/runner.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/runner.rs
@@ -8,8 +8,11 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use ampc_actor_utils::network::mpc::NetworkHandle;
+use ampc_actor_utils::network::tcp::config::deserialize_yaml_json_string;
 use aws_sdk_s3::Client as S3Client;
 use eyre::{eyre, Result};
+use serde::Deserialize;
+use serde_with::{serde_as, DurationSeconds};
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 
@@ -26,21 +29,64 @@ use crate::hnsw::{
 };
 use iris_mpc_common::vector_id::VectorId;
 
+// ── In-process Sidecar  ───────────────────────────────────────────────────────
+
+// the sidecar daemeon gets these passed in via the CLI but for in-process these need to be
+// environment variables.
+//
+// The sidecar process will not be run if the config field is None.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SidecarConfigWrapper {
+    /// listen addresses per party for the networking handle.
+    /// corresponds to both inbound addrs and outbound addrs
+    #[serde(default, deserialize_with = "deserialize_yaml_json_string")]
+    pub addresses: Vec<String>,
+    #[serde(default = "default_sidecar_parallelism")]
+    pub request_parallelism: usize,
+    #[serde(default = "default_sidecar_parallelism")]
+    pub connection_parallelism: usize,
+    #[serde(default)]
+    pub config: Option<SidecarConfig>,
+}
+
+fn default_sidecar_parallelism() -> usize {
+    1
+}
+
+impl SidecarConfigWrapper {
+    pub fn load_config(prefix: &str) -> Result<Self> {
+        let settings = config::Config::builder();
+        let settings = settings
+            .add_source(
+                config::Environment::with_prefix(prefix)
+                    .separator("__")
+                    .try_parsing(true),
+            )
+            .build()?;
+        let config: Self = settings.try_deserialize::<Self>()?;
+        Ok(config)
+    }
+}
+
 // ── Sidecar daemon ───────────────────────────────────────────────────────
 
 /// Sidecar daemon configuration. Construct from the binary's CLI args /
 /// environment.
-#[derive(Debug, Clone)]
+#[serde_as]
+#[derive(Debug, Clone, Deserialize)]
 pub struct SidecarConfig {
     /// Bucket containing the checkpoint S3 objects.
     pub bucket: String,
     /// Party index (0, 1, 2). Drives S3 key prefix and metric labels.
     pub party_id: usize,
     /// Sleep between successful (or skipped) cycles.
+    #[serde_as(as = "DurationSeconds<u64>")]
     pub cycle_interval: Duration,
     /// Sleep after a transient cycle error before retrying.
+    #[serde_as(as = "DurationSeconds<u64>")]
     pub retry_interval: Duration,
     /// Per-peer-round timeout passed into the protocol's `CycleConfig`.
+    #[serde_as(as = "DurationSeconds<u64>")]
     pub peer_round_timeout: Duration,
     /// Lower-bound for cycle work; below this the cycle is skipped (no
     /// upload / no DB write) to avoid hammering S3 with near-empty deltas.

--- a/iris-mpc-cpu/src/checkpoint_protocol/runner.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/runner.rs
@@ -31,7 +31,7 @@ use iris_mpc_common::vector_id::VectorId;
 
 // ── In-process Sidecar  ───────────────────────────────────────────────────────
 
-// the sidecar daemeon gets these passed in via the CLI but for in-process these need to be
+// the sidecar daemon gets these passed in via the CLI but for in-process these need to be
 // environment variables.
 //
 // The sidecar process will not be run if the config field is None.

--- a/iris-mpc-cpu/src/checkpoint_protocol/runner.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/runner.rs
@@ -347,6 +347,7 @@ mod tests {
             ("WRAPPERTEST__CONFIG__CHECKPOINT_WINDOW", "8"),
             ("WRAPPERTEST__CONFIG__IS_ARCHIVAL", "false"),
             ("WRAPPERTEST__CONFIG__PRUNING_MODE", "older-non-archival"),
+            ("WRAPPERTEST__CONFIG__ONE_SHOT", "false"),
         ];
         for (k, v) in vars {
             std::env::set_var(k, v);

--- a/iris-mpc-cpu/src/checkpoint_protocol/runner.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/runner.rs
@@ -279,3 +279,69 @@ pub async fn restart_from_checkpoint<V: VectorStore + Send + Sync>(
         )),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph_checkpoint::PruningMode;
+
+    // Unique prefix per test: env is process-global and tests run in parallel.
+    #[test]
+    fn load_config_round_trips_env() {
+        let vars = [
+            (
+                "WRAPPERTEST__ADDRESSES",
+                r#"["10.0.0.1:7000","10.0.0.2:7000","10.0.0.3:7000"]"#,
+            ),
+            ("WRAPPERTEST__REQUEST_PARALLELISM", "4"),
+            ("WRAPPERTEST__CONNECTION_PARALLELISM", "2"),
+            ("WRAPPERTEST__CONFIG__BUCKET", "my-bucket"),
+            ("WRAPPERTEST__CONFIG__PARTY_ID", "1"),
+            ("WRAPPERTEST__CONFIG__CYCLE_INTERVAL", "30"),
+            ("WRAPPERTEST__CONFIG__RETRY_INTERVAL", "5"),
+            ("WRAPPERTEST__CONFIG__PEER_ROUND_TIMEOUT", "10"),
+            ("WRAPPERTEST__CONFIG__MIN_MUTATIONS_PER_CYCLE", "100"),
+            ("WRAPPERTEST__CONFIG__CHECKPOINT_WINDOW", "8"),
+            ("WRAPPERTEST__CONFIG__IS_ARCHIVAL", "false"),
+            ("WRAPPERTEST__CONFIG__PRUNING_MODE", "older-non-archival"),
+        ];
+        for (k, v) in vars {
+            std::env::set_var(k, v);
+        }
+
+        let wrapper =
+            SidecarConfigWrapper::load_config("WRAPPERTEST").expect("env should deserialize");
+
+        assert_eq!(
+            wrapper.addresses,
+            vec!["10.0.0.1:7000", "10.0.0.2:7000", "10.0.0.3:7000"]
+        );
+        assert_eq!(wrapper.request_parallelism, 4);
+        assert_eq!(wrapper.connection_parallelism, 2);
+
+        let cfg = wrapper.config.expect("config section should be present");
+        assert_eq!(cfg.bucket, "my-bucket");
+        assert_eq!(cfg.party_id, 1);
+        assert_eq!(cfg.cycle_interval, Duration::from_secs(30));
+        assert_eq!(cfg.retry_interval, Duration::from_secs(5));
+        assert_eq!(cfg.peer_round_timeout, Duration::from_secs(10));
+        assert_eq!(cfg.min_mutations_per_cycle, 100);
+        assert_eq!(cfg.checkpoint_window, 8);
+        assert!(!cfg.is_archival);
+        assert_eq!(cfg.pruning_mode, PruningMode::OlderNonArchival);
+
+        for (k, _) in vars {
+            std::env::remove_var(k);
+        }
+    }
+
+    #[test]
+    fn missing_config_section_disables_sidecar() {
+        // No env set: wrapper parses via defaults, config=None disables the sidecar.
+        let wrapper = SidecarConfigWrapper::load_config("WRAPPERTESTNONE")
+            .expect("empty env should still deserialize");
+        assert!(wrapper.config.is_none());
+        assert!(wrapper.addresses.is_empty());
+        assert_eq!(wrapper.request_parallelism, 1);
+    }
+}

--- a/iris-mpc-cpu/src/graph_checkpoint/data.rs
+++ b/iris-mpc-cpu/src/graph_checkpoint/data.rs
@@ -11,7 +11,8 @@ pub const GRAPH_CHECKPOINT_ROUTE: &str = "/graph-checkpoint";
 pub const GRAPH_CHECKPOINT_ENDPOINT: &str = "graph-checkpoint";
 
 /// Controls which older checkpoints are deleted during cleanup.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum PruningMode {
     /// Do not prune any checkpoints.
     None,

--- a/iris-mpc/Cargo.toml
+++ b/iris-mpc/Cargo.toml
@@ -15,6 +15,7 @@ aws-sdk-s3.workspace = true
 aws-sdk-secretsmanager.workspace = true
 axum.workspace = true
 tokio.workspace = true
+tokio-util.workspace = true
 tracing.workspace = true
 serde_json.workspace = true
 eyre.workspace = true

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -3,9 +3,10 @@ use crate::services::processors::batch::receive_batch_stream;
 use crate::services::processors::job::process_job_result;
 use aws_sdk_s3::Client;
 use aws_sdk_sns::types::MessageAttributeValue;
-use iris_mpc_cpu::checkpoint_protocol::{restart_from_checkpoint, RestartOutcome};
+use iris_mpc_cpu::checkpoint_protocol::{restart_from_checkpoint, sidecar_main, RestartOutcome};
 use iris_mpc_cpu::graph_checkpoint::sync_graph_mutations;
 use iris_mpc_cpu::hnsw::GraphMem;
+use iris_mpc_cpu::network::mpc::{build_network_handle, NetworkHandleArgs};
 
 use crate::services::processors::modifications_sync::{
     send_last_modifications_to_sns, sync_modifications,
@@ -35,6 +36,7 @@ use iris_mpc_common::helpers::sqs_s3_helper::upload_file_to_s3;
 use iris_mpc_common::helpers::sync::{SyncResult, SyncState};
 use iris_mpc_common::job::JobSubmissionHandle;
 use iris_mpc_common::postgres::{AccessMode, PostgresClient};
+use iris_mpc_cpu::checkpoint_protocol::runner::SidecarConfigWrapper;
 use iris_mpc_cpu::execution::hawk_main::worker_pool_initializer::{
     DbLoadParams, LocalWorkerPoolInitializer, WorkerPoolInitializer,
 };
@@ -203,7 +205,7 @@ pub async fn server_main(config: Config) -> Result<()> {
 
     background_tasks.check_tasks();
 
-    run_main_server_loop(
+    let main_future = run_main_server_loop(
         &config,
         &iris_store,
         &aws_clients,
@@ -214,9 +216,53 @@ pub async fn server_main(config: Config) -> Result<()> {
         tx_results,
         current_batch_id_atomic.clone(),
         batch_sync_shared_state,
-    )
-    .await?;
+    );
 
+    // Extract what the sidecar needs from config/aws_clients before the async
+    // move block, since main_future already holds &config and &aws_clients.
+    let sidecar_party_id = config.party_id;
+    let sidecar_tls = config.tls.clone();
+    let sidecar_s3 = aws_clients.checkpoint_s3_client.clone();
+    let shutdown_ct = shutdown_handler.get_network_cancellation_token();
+    // the sidecar needs its own graph store and this function transforms config to the appropriate
+    // schema name when creating the pg client
+    let (_iris_store, graph_store) = prepare_stores(&config).await?;
+
+    let sidecar_future = async move {
+        let sidecar_config = match SidecarConfigWrapper::load_config("SIDECAR") {
+            Ok(r) => r,
+            Err(e) => {
+                // don't block server_main if this fails
+                tracing::warn!("failed to parse sidecar config: {e}");
+                return Ok(());
+            }
+        };
+
+        let Some(sc_config) = sidecar_config.config else {
+            return Ok(());
+        };
+
+        let network_args = NetworkHandleArgs {
+            party_index: sidecar_party_id,
+            addresses: sidecar_config.addresses.clone(),
+            outbound_addresses: sidecar_config.addresses,
+            connection_parallelism: sidecar_config.connection_parallelism,
+            request_parallelism: sidecar_config.request_parallelism,
+            sessions_per_request: 1, // these aren't used by the sidecar anyway
+            tls: sidecar_tls,
+        };
+        let mut network_handle = build_network_handle(network_args, shutdown_ct.clone()).await?;
+        sidecar_main(
+            sc_config.clone(),
+            &graph_store,
+            &sidecar_s3,
+            &mut network_handle,
+            shutdown_ct.clone(),
+        )
+        .await
+    };
+
+    tokio::try_join!(main_future, sidecar_future)?;
     Ok(())
 }
 

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -231,7 +231,8 @@ pub async fn server_main(config: Config) -> Result<()> {
         r
     };
 
-    let sidecar_future = {
+    let sidecar_future = async move {
+        let config = config.read().await;
         // ensure the sidecar specific setup code only runs if sidecar is enabled in the config
         // if sidecar returns an error, log it and return Ok so that it doesn't interfere with server_main()
         let sidecar_config = match SidecarConfigWrapper::load_config("SIDECAR") {
@@ -245,48 +246,46 @@ pub async fn server_main(config: Config) -> Result<()> {
             return Ok(());
         };
 
-        let config = config.read().await;
         // Keep S3 prefix / metric labels aligned with the network identity.
         sc_config.party_id = config.party_id;
-        async move {
-            let result: Result<()> = async {
-                let aws_clients = AwsClients::new(&config)
-                    .await
-                    .wrap_err("failed to create AWS clients")?;
-                // the sidecar needs its own graph store and this function transforms config to the
-                // appropriate schema name when creating the pg client
-                let (_iris_store, graph_store) = prepare_stores(&config)
-                    .await
-                    .wrap_err("failed to prepare stores")?;
-                let network_args = NetworkHandleArgs {
-                    party_index: config.party_id,
-                    addresses: sidecar_config.addresses.clone(),
-                    outbound_addresses: sidecar_config.addresses,
-                    connection_parallelism: sidecar_config.connection_parallelism,
-                    request_parallelism: sidecar_config.request_parallelism,
-                    sessions_per_request: 1, // these aren't used by the sidecar
-                    tls: config.tls.clone(),
-                };
-                let mut network_handle = build_network_handle(network_args, sidecar_ct.clone())
-                    .await
-                    .wrap_err("failed to build network handle")?;
-                sidecar_main(
-                    sc_config,
-                    &graph_store,
-                    &aws_clients.checkpoint_s3_client,
-                    &mut network_handle,
-                    sidecar_ct,
-                )
+
+        let result: Result<()> = async {
+            let aws_clients = AwsClients::new(&config)
                 .await
-                .wrap_err("sidecar_main exited with error")?;
-                Ok(())
-            }
-            .await;
-            if let Err(e) = result {
-                tracing::error!("sidecar: {e:#}");
-            }
+                .wrap_err("failed to create AWS clients")?;
+            // the sidecar needs its own graph store and this function transforms config to the
+            // appropriate schema name when creating the pg client
+            let (_iris_store, graph_store) = prepare_stores(&config)
+                .await
+                .wrap_err("failed to prepare stores")?;
+            let network_args = NetworkHandleArgs {
+                party_index: config.party_id,
+                addresses: sidecar_config.addresses.clone(),
+                outbound_addresses: sidecar_config.addresses,
+                connection_parallelism: sidecar_config.connection_parallelism,
+                request_parallelism: sidecar_config.request_parallelism,
+                sessions_per_request: 1, // these aren't used by the sidecar
+                tls: config.tls.clone(),
+            };
+            let mut network_handle = build_network_handle(network_args, sidecar_ct.clone())
+                .await
+                .wrap_err("failed to build network handle")?;
+            sidecar_main(
+                sc_config,
+                &graph_store,
+                &aws_clients.checkpoint_s3_client,
+                &mut network_handle,
+                sidecar_ct,
+            )
+            .await
+            .wrap_err("sidecar_main exited with error")?;
             Ok(())
         }
+        .await;
+        if let Err(e) = result {
+            tracing::error!("sidecar: {e:#}");
+        }
+        Ok(())
     };
 
     tokio::try_join!(main_future, sidecar_future)?;

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -7,6 +7,7 @@ use iris_mpc_cpu::checkpoint_protocol::{restart_from_checkpoint, sidecar_main, R
 use iris_mpc_cpu::graph_checkpoint::sync_graph_mutations;
 use iris_mpc_cpu::hnsw::GraphMem;
 use iris_mpc_cpu::network::mpc::{build_network_handle, NetworkHandleArgs};
+use tokio_util::sync::CancellationToken;
 
 use crate::services::processors::modifications_sync::{
     send_last_modifications_to_sns, sync_modifications,
@@ -205,30 +206,32 @@ pub async fn server_main(config: Config) -> Result<()> {
 
     background_tasks.check_tasks();
 
-    let main_future = run_main_server_loop(
-        &config,
-        &iris_store,
-        &aws_clients,
-        shares_encryption_key_pair,
-        background_tasks,
-        &shutdown_handler,
-        hawk_actor,
-        tx_results,
-        current_batch_id_atomic.clone(),
-        batch_sync_shared_state,
-    );
+    // ensure sidecar doesn't outlive main
+    let sidecar_ct = CancellationToken::new();
+    let main_finished = sidecar_ct.clone();
+    let config = Arc::new(RwLock::new(config));
+    let config2 = config.clone();
 
-    // Extract what the sidecar needs from config/aws_clients before the async
-    // move block, since main_future already holds &config and &aws_clients.
-    let sidecar_party_id = config.party_id;
-    let sidecar_tls = config.tls.clone();
-    let sidecar_s3 = aws_clients.checkpoint_s3_client.clone();
-    let shutdown_ct = shutdown_handler.get_network_cancellation_token();
-    // the sidecar needs its own graph store and this function transforms config to the appropriate
-    // schema name when creating the pg client
-    let (_iris_store, graph_store) = prepare_stores(&config).await?;
+    let main_future = async move {
+        let config = config2.read().await;
+        let r = run_main_server_loop(
+            &config,
+            &iris_store,
+            &aws_clients,
+            shares_encryption_key_pair,
+            background_tasks,
+            &shutdown_handler,
+            hawk_actor,
+            tx_results,
+            current_batch_id_atomic.clone(),
+            batch_sync_shared_state,
+        )
+        .await;
+        main_finished.cancel();
+        r
+    };
 
-    let sidecar_future = async move {
+    let sidecar_future = {
         let sidecar_config = match SidecarConfigWrapper::load_config("SIDECAR") {
             Ok(r) => r,
             Err(e) => {
@@ -242,24 +245,32 @@ pub async fn server_main(config: Config) -> Result<()> {
             return Ok(());
         };
 
-        let network_args = NetworkHandleArgs {
-            party_index: sidecar_party_id,
-            addresses: sidecar_config.addresses.clone(),
-            outbound_addresses: sidecar_config.addresses,
-            connection_parallelism: sidecar_config.connection_parallelism,
-            request_parallelism: sidecar_config.request_parallelism,
-            sessions_per_request: 1, // these aren't used by the sidecar anyway
-            tls: sidecar_tls,
-        };
-        let mut network_handle = build_network_handle(network_args, shutdown_ct.clone()).await?;
-        sidecar_main(
-            sc_config.clone(),
-            &graph_store,
-            &sidecar_s3,
-            &mut network_handle,
-            shutdown_ct.clone(),
-        )
-        .await
+        let config = config.read().await;
+        let aws_clients = AwsClients::new(&config).await?;
+        // the sidecar needs its own graph store and this function transforms config to the appropriate
+        // schema name when creating the pg client
+        let (_iris_store, graph_store) = prepare_stores(&config).await?;
+
+        async move {
+            let network_args = NetworkHandleArgs {
+                party_index: config.party_id,
+                addresses: sidecar_config.addresses.clone(),
+                outbound_addresses: sidecar_config.addresses,
+                connection_parallelism: sidecar_config.connection_parallelism,
+                request_parallelism: sidecar_config.request_parallelism,
+                sessions_per_request: 1, // these aren't used by the sidecar
+                tls: config.tls.clone(),
+            };
+            let mut network_handle = build_network_handle(network_args, sidecar_ct.clone()).await?;
+            sidecar_main(
+                sc_config.clone(),
+                &graph_store,
+                &aws_clients.checkpoint_s3_client,
+                &mut network_handle,
+                sidecar_ct,
+            )
+            .await
+        }
     };
 
     tokio::try_join!(main_future, sidecar_future)?;

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -237,7 +237,7 @@ pub async fn server_main(config: Config) -> Result<()> {
         let sidecar_config = match SidecarConfigWrapper::load_config("SIDECAR") {
             Ok(r) => r,
             Err(e) => {
-                tracing::warn!("failed to parse sidecar config: {e}");
+                tracing::error!("failed to parse sidecar config: {e}");
                 return Ok(());
             }
         };

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -233,14 +233,16 @@ pub async fn server_main(config: Config) -> Result<()> {
             Ok(r) => r,
             Err(e) => {
                 // don't block server_main if this fails
-                tracing::warn!("failed to parse sidecar config: {e}");
+                tracing::error!("failed to parse sidecar config: {e}");
                 return Ok(());
             }
         };
 
-        let Some(sc_config) = sidecar_config.config else {
+        let Some(mut sc_config) = sidecar_config.config else {
             return Ok(());
         };
+        // Keep S3 prefix / metric labels aligned with the network identity.
+        sc_config.party_id = sidecar_party_id;
 
         let network_args = NetworkHandleArgs {
             party_index: sidecar_party_id,
@@ -253,7 +255,7 @@ pub async fn server_main(config: Config) -> Result<()> {
         };
         let mut network_handle = build_network_handle(network_args, shutdown_ct.clone()).await?;
         sidecar_main(
-            sc_config.clone(),
+            sc_config,
             &graph_store,
             &sidecar_s3,
             &mut network_handle,

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -23,7 +23,7 @@ use ampc_server_utils::{
     wait_for_others_ready, wait_for_others_unready, BatchSyncSharedState, TaskMonitor,
 };
 use chrono::Utc;
-use eyre::{bail, eyre, Report, Result};
+use eyre::{bail, eyre, Report, Result, WrapErr};
 use iris_mpc_common::config::{CommonConfig, Config};
 use iris_mpc_common::helpers::key_pair::SharesEncryptionKeyPairs;
 use iris_mpc_common::helpers::sha256::sha256_bytes;
@@ -232,44 +232,58 @@ pub async fn server_main(config: Config) -> Result<()> {
     };
 
     let sidecar_future = {
+        // ensure the sidecar specific setup code only runs if sidecar is enabled in the config
+        // if sidecar returns an error, log it and return Ok so that it doesn't interfere with server_main()
         let sidecar_config = match SidecarConfigWrapper::load_config("SIDECAR") {
             Ok(r) => r,
             Err(e) => {
-                // don't block server_main if this fails
                 tracing::warn!("failed to parse sidecar config: {e}");
                 return Ok(());
             }
         };
-
         let Some(sc_config) = sidecar_config.config else {
             return Ok(());
         };
 
         let config = config.read().await;
-        let aws_clients = AwsClients::new(&config).await?;
-        // the sidecar needs its own graph store and this function transforms config to the appropriate
-        // schema name when creating the pg client
-        let (_iris_store, graph_store) = prepare_stores(&config).await?;
-
         async move {
-            let network_args = NetworkHandleArgs {
-                party_index: config.party_id,
-                addresses: sidecar_config.addresses.clone(),
-                outbound_addresses: sidecar_config.addresses,
-                connection_parallelism: sidecar_config.connection_parallelism,
-                request_parallelism: sidecar_config.request_parallelism,
-                sessions_per_request: 1, // these aren't used by the sidecar
-                tls: config.tls.clone(),
-            };
-            let mut network_handle = build_network_handle(network_args, sidecar_ct.clone()).await?;
-            sidecar_main(
-                sc_config.clone(),
-                &graph_store,
-                &aws_clients.checkpoint_s3_client,
-                &mut network_handle,
-                sidecar_ct,
-            )
-            .await
+            let result: Result<()> = async {
+                let aws_clients = AwsClients::new(&config)
+                    .await
+                    .wrap_err("failed to create AWS clients")?;
+                // the sidecar needs its own graph store and this function transforms config to the
+                // appropriate schema name when creating the pg client
+                let (_iris_store, graph_store) = prepare_stores(&config)
+                    .await
+                    .wrap_err("failed to prepare stores")?;
+                let network_args = NetworkHandleArgs {
+                    party_index: config.party_id,
+                    addresses: sidecar_config.addresses.clone(),
+                    outbound_addresses: sidecar_config.addresses,
+                    connection_parallelism: sidecar_config.connection_parallelism,
+                    request_parallelism: sidecar_config.request_parallelism,
+                    sessions_per_request: 1, // these aren't used by the sidecar
+                    tls: config.tls.clone(),
+                };
+                let mut network_handle = build_network_handle(network_args, sidecar_ct.clone())
+                    .await
+                    .wrap_err("failed to build network handle")?;
+                sidecar_main(
+                    sc_config.clone(),
+                    &graph_store,
+                    &aws_clients.checkpoint_s3_client,
+                    &mut network_handle,
+                    sidecar_ct,
+                )
+                .await
+                .wrap_err("sidecar_main exited with error")?;
+                Ok(())
+            }
+            .await;
+            if let Err(e) = result {
+                tracing::error!("sidecar: {e:#}");
+            }
+            Ok(())
         }
     };
 

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -241,11 +241,13 @@ pub async fn server_main(config: Config) -> Result<()> {
                 return Ok(());
             }
         };
-        let Some(sc_config) = sidecar_config.config else {
+        let Some(mut sc_config) = sidecar_config.config else {
             return Ok(());
         };
 
         let config = config.read().await;
+        // Keep S3 prefix / metric labels aligned with the network identity.
+        sc_config.party_id = config.party_id;
         async move {
             let result: Result<()> = async {
                 let aws_clients = AwsClients::new(&config)
@@ -269,7 +271,7 @@ pub async fn server_main(config: Config) -> Result<()> {
                     .await
                     .wrap_err("failed to build network handle")?;
                 sidecar_main(
-                    sc_config.clone(),
+                    sc_config,
                     &graph_store,
                     &aws_clients.checkpoint_s3_client,
                     &mut network_handle,


### PR DESCRIPTION
this is to facilitate sidecar testing. although a separate service is desirable, it will take time before the dev cluster is set up for that. In the mean time, this will allow us to continue testing. 