### PR TITLE
wal-sidecar: --one-shot flag + completion logging

### DIFF
--- a/iris-mpc-bins/bin/iris-mpc-cpu/sidecar.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/sidecar.rs
@@ -12,6 +12,7 @@ use std::time::Duration;
 
 use ampc_actor_utils::network::tcp::TlsConfig;
 use iris_mpc_common::postgres::{AccessMode, PostgresClient};
+use iris_mpc_common::tracing::initialize_tracing;
 use iris_mpc_cpu::{
     checkpoint_protocol::{sidecar_main, SidecarConfig},
     execution::hawk_main::{build_hawk_network_handle, HawkArgs},
@@ -77,6 +78,11 @@ pub struct SidecarArgs {
     #[clap(long, default_value_t = false)]
     pub is_archival: bool,
 
+    /// Run a single cycle and exit, rather than looping at `cycle_interval`.
+    /// Required when deployed as a CronJob (one fire = one cycle).
+    #[clap(long, default_value_t = false)]
+    pub one_shot: bool,
+
     #[clap(long, default_value = "1")]
     pub connection_parallelism: usize,
 
@@ -131,6 +137,10 @@ fn hawk_args_from(args: &SidecarArgs) -> HawkArgs {
 async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
+    // Logs go to stdout (captured by the k8s log pipeline); no StatsD recorder.
+    // Holds the handle for the process lifetime so the subscriber stays live.
+    let _tracing = initialize_tracing(None)?;
+
     let args = SidecarArgs::parse();
     let pruning_mode = if let Some(mode_str) = args.pruning_mode.as_ref() {
         mode_str.parse::<PruningMode>().map_err(|e| {
@@ -181,6 +191,7 @@ async fn main() -> Result<()> {
         checkpoint_window: args.checkpoint_window,
         is_archival: args.is_archival,
         pruning_mode,
+        one_shot: args.one_shot,
     };
 
     match sidecar_main(cfg, &graph_store, &s3_client, &mut networking, shutdown_ct).await {

--- a/iris-mpc-cpu/src/checkpoint_protocol/runner.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/runner.rs
@@ -5,7 +5,7 @@
 //! cycle boundaries, so per-cycle failures stay isolated.
 
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use ampc_actor_utils::network::mpc::NetworkHandle;
 use aws_sdk_s3::Client as S3Client;
@@ -51,6 +51,11 @@ pub struct SidecarConfig {
     pub is_archival: bool,
     /// Optionally remove old checkpoints from S3
     pub pruning_mode: PruningMode,
+    /// Run exactly one cycle and exit instead of looping. Used when deployed
+    /// as a CronJob: a transient/fatal cycle error returns `Err` (the next
+    /// scheduled fire is the retry), so no party retries independently and
+    /// desyncs the ring.
+    pub one_shot: bool,
 }
 
 /// Daemon loop. Returns `Ok(())` only on graceful shutdown via
@@ -75,7 +80,45 @@ pub async fn sidecar_main<V: VectorStore + Send + Sync>(
             return Ok(());
         }
 
-        let sleep_after = match sidecar_cycle(&cfg, graph_store, s3_client, networking).await {
+        let cycle_start = Instant::now();
+        let outcome = sidecar_cycle(&cfg, graph_store, s3_client, networking).await;
+
+        if cfg.one_shot {
+            // Single completion line per outcome; a fire that never logs this
+            // (e.g. wedged dialling an absent peer until activeDeadlineSeconds)
+            // is itself the signal. Derive a log-based metric off `outcome`.
+            let duration_secs = cycle_start.elapsed().as_secs_f64();
+            return match outcome {
+                Ok(Outcome::Finalized { height, .. }) => {
+                    tracing::info!(
+                        outcome = "finalized",
+                        duration_secs,
+                        height,
+                        "sidecar one-shot complete"
+                    );
+                    Ok(())
+                }
+                Ok(Outcome::Skipped(reason)) => {
+                    tracing::info!(
+                        outcome = "skipped",
+                        duration_secs,
+                        ?reason,
+                        "sidecar one-shot complete"
+                    );
+                    Ok(())
+                }
+                Err(CycleError::Transient(msg)) => {
+                    tracing::warn!(outcome = "transient", duration_secs, error = %msg, "sidecar one-shot complete");
+                    Err(eyre!("sidecar one-shot transient error: {msg}"))
+                }
+                Err(CycleError::Fatal(msg)) => {
+                    tracing::error!(outcome = "fatal", duration_secs, error = %msg, "sidecar one-shot complete");
+                    Err(eyre!("sidecar fatal: {msg}"))
+                }
+            };
+        }
+
+        let sleep_after = match outcome {
             Ok(Outcome::Finalized { height, .. }) => {
                 tracing::info!(height, "sidecar cycle finalized");
                 cfg.cycle_interval


### PR DESCRIPTION
## What

Adds the `--one-shot` flag to the `wal-sidecar` binary (the App-team item in the infra deploy brief) plus the logging needed to actually observe a fire.

### `--one-shot`
Runs a single cycle and exits, for CronJob deployment:
- `Finalized` / `Skipped` → exit 0
- `Transient` / `Fatal` → exit 1

A single attempt per fire is deliberate: with `backoffLimit: 0` the next scheduled fire is the retry path, so no party retries independently and desyncs the consensus ring. Daemon behavior (looping at `cycle_interval`) is unchanged when the flag is absent.

### Logging
- The binary previously installed **no tracing subscriber**, so every `tracing::*` line in the daemon loop (cycle finalized / transient / fatal) was silently dropped — only the two `println!` lines reached the pod log. Now calls `initialize_tracing(None)` → stdout fmt subscriber honoring `RUST_LOG`.
- Emits one structured completion line per cycle: `outcome` (finalized/skipped/transient/fatal) + `duration_secs`. A fire that wedges dialling an absent peer never logs this line — that absence (and the k8s `DeadlineExceeded`) is the stall signal. Drives a Datadog log-based metric without a StatsD recorder (avoids the UDP-flush-on-short-lived-pod and `exit()`-bypasses-`Drop` problems).

## Test
`cargo check -p iris-mpc-bins --bin wal-sidecar` clean. No `SidecarConfig` constructors outside the binary, so no other call sites to update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)