### PR TITLE
Support deep-ID Int4 vectors in generate_ideal_neighborhoods

### DIFF
--- a/iris-mpc-bins/bin/iris-mpc-cpu/generate_ideal_neighborhoods.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/generate_ideal_neighborhoods.rs
@@ -5,10 +5,13 @@ use std::{
 };
 
 use clap::Parser;
-use iris_mpc_common::{iris_db::iris::IrisCode, IrisSerialId};
+use iris_mpc_common::{iris_db::iris::IrisCode, vector_id::SerialId};
 use iris_mpc_cpu::{
-    hawkers::ideal_knn_engines::{Engine, EngineChoice, KNNResult},
-    utils::serialization::iris_ndjson::{irises_from_ndjson_iter, IrisSelection},
+    hawkers::ideal_knn_engines::{Engine, EngineInt4, EngineKind, KNNResult},
+    utils::serialization::{
+        int4_ndjson::int4_vectors_from_ndjson,
+        iris_ndjson::{irises_from_ndjson_iter, IrisSelection},
+    },
 };
 use metrics::IntoF64;
 
@@ -18,21 +21,53 @@ use std::time::Instant;
 /// A struct to hold the metadata stored in the first line of the results file.
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 struct ResultsHeader {
-    iris_selection: IrisSelection,
-    num_irises: usize,
+    /// Iris selection used to load the input. `Some(..)` for iris engines,
+    /// `None` for the deep-ID Int4 engine (the Int4 loader has no selection).
+    iris_selection: Option<IrisSelection>,
+    /// Engine identity, so resuming a file rejects a mismatched distance/store.
+    engine_choice: EngineKind,
+    num_vectors: usize,
     k: usize,
+}
+
+/// Dispatch wrapper so the chunk/append loop is written once regardless of
+/// store kind. Both inner engines return `Vec<KNNResult<SerialId>>`.
+enum AnyEngine {
+    Iris(Engine),
+    Int4(EngineInt4),
+}
+
+impl AnyEngine {
+    fn next_id(&self) -> SerialId {
+        match self {
+            AnyEngine::Iris(e) => e.next_id(),
+            AnyEngine::Int4(e) => e.next_id(),
+        }
+    }
+
+    fn compute_chunk(&mut self, chunk_size: usize) -> Vec<KNNResult<SerialId>> {
+        match self {
+            AnyEngine::Iris(e) => e.compute_chunk(chunk_size),
+            AnyEngine::Int4(e) => e.compute_chunk(chunk_size),
+        }
+    }
 }
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
     /// Number of irises to process
-    #[arg(long, default_value_t = 1000)]
-    num_irises: usize,
+    #[arg(long, alias = "num_irises", default_value_t = 1000)]
+    num_vectors: usize,
 
-    /// Path to the iris codes file
-    #[arg(long, default_value = "data/store.ndjson")]
-    path_to_iris_codes: PathBuf,
+    /// Path to the input file of vectors: iris codes ndjson for iris engines,
+    /// or Int4 vectors ndjson when --engine-choice is NaiveInt4Dot.
+    #[arg(
+        long = "input",
+        alias = "path-to-iris-codes",
+        default_value = "data/store.ndjson"
+    )]
+    path_to_vectors: PathBuf,
 
     /// The k for k-NN
     #[arg(long)]
@@ -42,17 +77,26 @@ struct Args {
     #[arg(long)]
     results_file: PathBuf,
 
-    /// Selection of irises to process
+    /// Selection of irises to process (iris engines only; ignored for NaiveInt4Dot).
     #[arg(long, value_enum, default_value_t = IrisSelection::All)]
     irises_selection: IrisSelection,
 
-    /// Selection of irises to process
-    #[arg(long, value_enum, default_value_t = EngineChoice::NaiveFHD)]
-    engine_choice: EngineChoice,
+    /// Engine (distance + store kind). Iris variants use --irises-selection;
+    /// NaiveInt4Dot reads a deep-ID Int4 ndjson and ignores --irises-selection.
+    #[arg(long, value_enum, default_value_t = EngineKind::NaiveFHD)]
+    engine_choice: EngineKind,
 }
 #[tokio::main]
 async fn main() {
     let args = Args::parse();
+
+    // Iris selection only applies to iris engines; the Int4 loader has none.
+    let header_selection = if args.engine_choice.is_int4() {
+        None
+    } else {
+        Some(args.irises_selection)
+    };
+
     let (num_already_processed, nodes) = match File::open(&args.results_file) {
         Ok(file) => {
             let reader = BufReader::new(file);
@@ -88,8 +132,9 @@ async fn main() {
 
             // 2. Check for configuration mismatches with a single comparison
             let expected_header = ResultsHeader {
-                iris_selection: args.irises_selection,
-                num_irises: args.num_irises,
+                iris_selection: header_selection,
+                engine_choice: args.engine_choice,
+                num_vectors: args.num_vectors,
                 k: args.k,
             };
 
@@ -102,11 +147,10 @@ async fn main() {
             }
 
             // 3. Process the rest of the lines as KNN results
-            let results: Result<Vec<KNNResult<IrisSerialId>>, _> = lines
+            let results: Result<Vec<KNNResult<SerialId>>, _> = lines
                 .map(|line_result| {
                     let line = line_result.map_err(|e| e.to_string())?;
-                    serde_json::from_str::<KNNResult<IrisSerialId>>(&line)
-                        .map_err(|e| e.to_string())
+                    serde_json::from_str::<KNNResult<SerialId>>(&line).map_err(|e| e.to_string())
                 })
                 .collect();
 
@@ -124,18 +168,19 @@ async fn main() {
                 }
             };
 
-            let nodes: Vec<IrisSerialId> = deserialized_results
+            let nodes: Vec<SerialId> = deserialized_results
                 .into_iter()
                 .map(|result| result.node)
                 .collect();
-            (nodes.len() as IrisSerialId, nodes)
+            (nodes.len() as SerialId, nodes)
         }
         Err(_) => {
             // File doesn't exist, create it and write the header.
             let mut file = File::create(&args.results_file).expect("Unable to create results file");
             let header = ResultsHeader {
-                iris_selection: args.irises_selection,
-                num_irises: args.num_irises,
+                iris_selection: header_selection,
+                engine_choice: args.engine_choice,
+                num_vectors: args.num_vectors,
                 k: args.k,
             };
             let header_str =
@@ -146,7 +191,7 @@ async fn main() {
     };
 
     if num_already_processed > 0 {
-        let expected_nodes: Vec<IrisSerialId> = (1..num_already_processed + 1).collect();
+        let expected_nodes: Vec<SerialId> = (1..num_already_processed + 1).collect();
         if nodes != expected_nodes {
             eprintln!(
                 "Error: The result nodes in the file are not a contiguous sequence from 1 to N."
@@ -159,54 +204,75 @@ async fn main() {
         }
     }
 
-    let path_to_iris_codes = args.path_to_iris_codes;
-    assert!(args.num_irises > args.k);
+    let path_to_vectors = args.path_to_vectors;
+    assert!(args.num_vectors > args.k);
 
-    let mut irises: Vec<IrisCode> = Vec::with_capacity(args.num_irises);
-
-    let stream_iterator_res = irises_from_ndjson_iter(
-        path_to_iris_codes.as_path(),
-        Some(args.num_irises),
-        args.irises_selection,
-    );
-    let stream_iterator = match stream_iterator_res {
-        Ok(iter) => iter,
-        Err(e) => {
-            eprintln!("Error: Failed to open irises input file.");
-            eprintln!(" -> Error details: {}", e);
-            std::process::exit(1);
-        }
+    let next_id = num_already_processed + 1;
+    let (num_vectors, mut engine): (SerialId, AnyEngine) = if args.engine_choice.is_int4() {
+        let echoice = args
+            .engine_choice
+            .as_int4()
+            .expect("is_int4() implies as_int4() is Some");
+        let vectors =
+            match int4_vectors_from_ndjson(path_to_vectors.as_path(), Some(args.num_vectors)) {
+                Ok(v) => v,
+                Err(e) => {
+                    eprintln!("Error: Failed to load Int4 vectors input file.");
+                    eprintln!(" -> Error details: {}", e);
+                    std::process::exit(1);
+                }
+            };
+        assert_eq!(vectors.len(), args.num_vectors);
+        let n = vectors.len() as SerialId;
+        (
+            n,
+            AnyEngine::Int4(EngineInt4::init(echoice, vectors, args.k, next_id)),
+        )
+    } else {
+        let echoice = args
+            .engine_choice
+            .as_iris()
+            .expect("non-int4 implies as_iris() is Some");
+        let mut irises: Vec<IrisCode> = Vec::with_capacity(args.num_vectors);
+        let stream_iterator = match irises_from_ndjson_iter(
+            path_to_vectors.as_path(),
+            Some(args.num_vectors),
+            args.irises_selection,
+        ) {
+            Ok(iter) => iter,
+            Err(e) => {
+                eprintln!("Error: Failed to open irises input file.");
+                eprintln!(" -> Error details: {}", e);
+                std::process::exit(1);
+            }
+        };
+        irises.extend(stream_iterator);
+        assert_eq!(irises.len(), args.num_vectors);
+        let n = irises.len() as SerialId;
+        (
+            n,
+            AnyEngine::Iris(Engine::init(echoice, irises, args.k, next_id)),
+        )
     };
-
-    irises.extend(stream_iterator);
-    assert!(irises.len() == args.num_irises);
-
-    let num_irises = irises.len() as IrisSerialId;
-    let mut engine = Engine::init(
-        args.engine_choice,
-        irises,
-        args.k,
-        num_already_processed + 1,
-    );
 
     let chunk_size = 2000;
     let mut evaluated_pairs = 0u64;
     println!("Starting work at serial id: {}", engine.next_id());
 
     let start_t = Instant::now();
-    while engine.next_id() <= num_irises {
+    while engine.next_id() <= num_vectors {
         let start = engine.next_id();
         let results = engine.compute_chunk(chunk_size);
         let end = engine.next_id();
 
-        evaluated_pairs += ((end - start) as u64) * (num_irises as u64);
+        evaluated_pairs += ((end - start) as u64) * (num_vectors as u64);
 
         let mut file = OpenOptions::new()
             .append(true)
             .open(&args.results_file)
             .expect("Unable to open results file for appending");
 
-        println!("Appending iris results from {} to {}", start, end - 1);
+        println!("Appending results from {} to {}", start, end - 1);
         for result in &results {
             let json_line = serde_json::to_string(result).expect("Failed to serialize KNNResult");
             writeln!(file, "{}", json_line).expect("Failed to write to results file");
@@ -217,4 +283,39 @@ async fn main() {
         "naive_knn took {:?} (per evaluated pair)",
         duration.into_f64() / (evaluated_pairs as f64)
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn header_roundtrip_iris() {
+        let header = ResultsHeader {
+            iris_selection: Some(IrisSelection::Odd),
+            engine_choice: EngineKind::NaiveFHD,
+            num_vectors: 1000,
+            k: 16,
+        };
+        let s = serde_json::to_string(&header).unwrap();
+        let back: ResultsHeader = serde_json::from_str(&s).unwrap();
+        assert_eq!(header, back);
+        assert_eq!(back.iris_selection, Some(IrisSelection::Odd));
+        assert!(!back.engine_choice.is_int4());
+    }
+
+    #[test]
+    fn header_roundtrip_int4() {
+        let header = ResultsHeader {
+            iris_selection: None,
+            engine_choice: EngineKind::NaiveInt4Dot,
+            num_vectors: 4096,
+            k: 32,
+        };
+        let s = serde_json::to_string(&header).unwrap();
+        let back: ResultsHeader = serde_json::from_str(&s).unwrap();
+        assert_eq!(header, back);
+        assert_eq!(back.iris_selection, None);
+        assert!(back.engine_choice.is_int4());
+    }
 }

--- a/iris-mpc-cpu/src/hawkers/ideal_knn_engines.rs
+++ b/iris-mpc-cpu/src/hawkers/ideal_knn_engines.rs
@@ -155,6 +155,45 @@ pub enum EngineChoiceInt4 {
     NaiveInt4Dot,
 }
 
+/// Unified CLI-facing engine selector spanning both the iris-code engines and
+/// the deep-ID Int4 engine. Used by binaries that accept either store kind via
+/// a single `--engine-choice` flag; the concrete sub-enum is recovered with
+/// [`EngineKind::as_iris`] / [`EngineKind::as_int4`].
+#[derive(Clone, Debug, ValueEnum, Copy, Serialize, Deserialize, PartialEq)]
+pub enum EngineKind {
+    NaiveFHD,
+    NaiveMinFHD,
+    NaiveNHD,
+    NaiveMinNHD,
+    NaiveInt4Dot,
+}
+
+impl EngineKind {
+    /// Whether this selects the deep-ID Int4 engine (vs an iris-code engine).
+    pub fn is_int4(&self) -> bool {
+        matches!(self, EngineKind::NaiveInt4Dot)
+    }
+
+    /// The iris-code [`EngineChoice`], or `None` for the Int4 variant.
+    pub fn as_iris(&self) -> Option<EngineChoice> {
+        match self {
+            EngineKind::NaiveFHD => Some(EngineChoice::NaiveFHD),
+            EngineKind::NaiveMinFHD => Some(EngineChoice::NaiveMinFHD),
+            EngineKind::NaiveNHD => Some(EngineChoice::NaiveNHD),
+            EngineKind::NaiveMinNHD => Some(EngineChoice::NaiveMinNHD),
+            EngineKind::NaiveInt4Dot => None,
+        }
+    }
+
+    /// The deep-ID [`EngineChoiceInt4`], or `None` for an iris variant.
+    pub fn as_int4(&self) -> Option<EngineChoiceInt4> {
+        match self {
+            EngineKind::NaiveInt4Dot => Some(EngineChoiceInt4::NaiveInt4Dot),
+            _ => None,
+        }
+    }
+}
+
 /* -------------------------- Generic naive engine ------------------------ */
 
 pub struct NaiveKNN<K: IdealKnn> {
@@ -312,6 +351,45 @@ impl EngineInt4 {
         match self {
             Self::Int4Dot(engine) => engine.next_id(),
         }
+    }
+}
+
+#[cfg(test)]
+mod engine_kind_tests {
+    use super::*;
+
+    #[test]
+    fn is_int4_only_for_int4_variant() {
+        assert!(!EngineKind::NaiveFHD.is_int4());
+        assert!(!EngineKind::NaiveMinFHD.is_int4());
+        assert!(!EngineKind::NaiveNHD.is_int4());
+        assert!(!EngineKind::NaiveMinNHD.is_int4());
+        assert!(EngineKind::NaiveInt4Dot.is_int4());
+    }
+
+    #[test]
+    fn as_iris_maps_the_four_iris_variants() {
+        assert_eq!(EngineKind::NaiveFHD.as_iris(), Some(EngineChoice::NaiveFHD));
+        assert_eq!(
+            EngineKind::NaiveMinFHD.as_iris(),
+            Some(EngineChoice::NaiveMinFHD)
+        );
+        assert_eq!(EngineKind::NaiveNHD.as_iris(), Some(EngineChoice::NaiveNHD));
+        assert_eq!(
+            EngineKind::NaiveMinNHD.as_iris(),
+            Some(EngineChoice::NaiveMinNHD)
+        );
+        assert_eq!(EngineKind::NaiveInt4Dot.as_iris(), None);
+    }
+
+    #[test]
+    fn as_int4_maps_only_the_int4_variant() {
+        assert_eq!(
+            EngineKind::NaiveInt4Dot.as_int4(),
+            Some(EngineChoiceInt4::NaiveInt4Dot)
+        );
+        assert_eq!(EngineKind::NaiveFHD.as_int4(), None);
+        assert_eq!(EngineKind::NaiveNHD.as_int4(), None);
     }
 }
 

--- a/iris-mpc-cpu/tests/deep_id_neighborhoods_format.rs
+++ b/iris-mpc-cpu/tests/deep_id_neighborhoods_format.rs
@@ -1,0 +1,56 @@
+//! Verifies that an Int4 neighborhoods results file (body lines only) parses
+//! via the same reader `generate_ideal_graph.rs` uses, and that node ids form
+//! the contiguous 1..=N sequence the consumer's zip relies on.
+
+use std::io::Write;
+
+use aes_prng::AesRng;
+use iris_mpc_cpu::hawkers::ideal_knn_engines::{
+    read_knn_results_from_file, EngineChoiceInt4, EngineInt4, KNNResult,
+};
+use iris_mpc_cpu::hawkers::plaintext_deep_id_store::Int4Vector;
+use rand::SeedableRng;
+use tempfile::tempdir;
+
+#[test]
+fn int4_neighborhoods_file_is_consumable_and_contiguous() {
+    let mut rng = AesRng::seed_from_u64(0xD00D);
+    let n = 32usize;
+    let k = 4usize;
+    let vectors: Vec<Int4Vector> = (0..n).map(|_| Int4Vector::random(&mut rng)).collect();
+
+    // Compute neighborhoods exactly as the binary does (engine path).
+    let mut engine = EngineInt4::init(EngineChoiceInt4::NaiveInt4Dot, vectors, k, 1);
+    let results: Vec<KNNResult<u32>> = engine.compute_chunk(n);
+
+    // Write a results file: a header line (ignored by the consumer) + body lines.
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("layer0.ndjson");
+    {
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, "{{\"some\":\"header the consumer skips\"}}").unwrap();
+        for r in &results {
+            writeln!(f, "{}", serde_json::to_string(r).unwrap()).unwrap();
+        }
+    }
+
+    // Parse with the SAME reader generate_ideal_graph.rs uses.
+    let parsed = read_knn_results_from_file(path).unwrap();
+    assert_eq!(parsed.len(), n, "one result per node");
+
+    // Node ids must be the contiguous 1..=N sequence (the consumer zips
+    // sorted ids against vectors loaded in file order).
+    let mut nodes: Vec<u32> = parsed.iter().map(|r| r.node).collect();
+    nodes.sort_unstable();
+    let expected: Vec<u32> = (1..=n as u32).collect();
+    assert_eq!(nodes, expected, "node ids form 1..=N");
+
+    // Each neighborhood has k entries, all in range and excluding self.
+    for r in &parsed {
+        assert_eq!(r.neighbors.len(), k);
+        for &nb in &r.neighbors {
+            assert!((1..=n as u32).contains(&nb));
+            assert_ne!(nb, r.node, "self must be excluded");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Extends the `generate_ideal_neighborhoods` binary (previously iris-only) to compute ideal top-k neighborhoods for deep-ID Int4 vectors.
- Adds a unified `EngineKind` CLI enum so a single `--engine-choice` selects either an iris engine (`NaiveFHD/MinFHD/NHD/MinNHD`) or `NaiveInt4Dot`; int4 mode loads an Int4 ndjson via `int4_vectors_from_ndjson` and runs `EngineInt4`, else the iris path runs as before.
- Introduces an `AnyEngine { Iris, Int4 }` dispatch wrapper so the chunk/append/timing loop stays single-copy.
- Records engine identity in the resume header and makes `iris_selection` optional (`None` for int4), closing a latent gap where a results file built with one distance could be silently resumed with another.
- Output line format is unchanged (`KNNResult<u32>`), so the sibling binary `generate_ideal_graph.rs` consumes the produced layer-0 file with no changes — verified by a new integration test against the consumer's exact reader (`read_knn_results_from_file`).

The neighborhoods binary uses the engine path (`NaiveKNN`), not `PlaintextDeepIDStore`, mirroring how the iris path uses `Engine` rather than the iris store; the store itself is untouched.

## Test Plan
- [x] `cargo test -p iris-mpc-cpu engine_kind_tests` — 3 pass (EngineKind helpers)
- [x] `cargo test -p iris-mpc-bins --bin generate_ideal_neighborhoods` — 2 pass (header serde round-trip, iris + int4)
- [x] `cargo test -p iris-mpc-cpu --test deep_id_neighborhoods_format` — 1 pass (int4 output consumable by graph reader; node ids contiguous `1..=N`)
- [x] `cargo clippy -p iris-mpc-cpu --all-targets -- -D warnings` and the binary — clean
- [x] `cargo fmt` — no diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)