### PR TITLE
graph_v4: deterministic Layer serialization (sorted links)

### DIFF
--- a/iris-mpc-cpu/src/utils/serialization/graph.rs
+++ b/iris-mpc-cpu/src/utils/serialization/graph.rs
@@ -806,3 +806,43 @@ fn read_hashed_layer_streaming<R: std::io::Read + ?Sized>(
 
     Ok(layer)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Multi-node layer inserted out of key order, so `HashMap` iteration order
+    /// is overwhelmingly unlikely to coincide with sorted order — i.e. the test
+    /// actually exercises the link sorting.
+    fn sample_graph() -> GraphMem<IrisVectorId> {
+        let v = IrisVectorId::from_serial_id;
+        let mut layer = Layer::new();
+        for &n in &[7u32, 3, 9, 1, 5, 8, 2, 6, 4] {
+            layer.set_links(v(n), vec![v(n + 1), v(n + 2)]);
+        }
+        let mut g = GraphMem::new();
+        g.entry_points = vec![layered_graph::EntryPoint {
+            point: v(1),
+            layer: 0,
+        }];
+        g.layers = vec![layer];
+        g
+    }
+
+    /// The `Current` (GraphV4) file format must serialize byte-identically to the
+    /// raw `GraphMem` wire format used by `upload_graph_checkpoint` and the
+    /// materializer. If they drift, checkpoints minted via `graph-utils` won't
+    /// match those minted by the sidecar and cross-party BLAKE3 consensus breaks.
+    #[test]
+    fn current_serialization_matches_raw_graphmem() {
+        let g = sample_graph();
+        let mut cur = Vec::new();
+        write_graph_current(&mut cur, g.clone()).unwrap();
+        let mut raw = Vec::new();
+        write_graph_raw(&mut raw, g).unwrap();
+        assert_eq!(
+            cur, raw,
+            "GraphV4/Current serialization diverged from raw GraphMem bytes"
+        );
+    }
+}

--- a/iris-mpc-cpu/src/utils/serialization/types/graph_v4.rs
+++ b/iris-mpc-cpu/src/utils/serialization/types/graph_v4.rs
@@ -1,3 +1,4 @@
+use serde::ser::{SerializeMap, SerializeStruct, Serializer};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -20,10 +21,41 @@ pub struct EntryPoint {
 }
 
 /// Type associated with the `GraphV4` serialization type.
-#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+///
+/// `Serialize` is hand-written to emit `links` in sorted key order, mirroring
+/// `layered_graph::Layer`. `HashMap`'s derived serialization is iteration-order
+/// dependent, which would make checkpoint bytes (and their BLAKE3) nondeterministic
+/// across processes and parties, breaking cross-party checkpoint consensus.
+#[derive(Default, Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct Layer {
     pub links: HashMap<VectorId, EdgeIds>,
     pub set_hash: u64,
+}
+
+struct SortedLinks<'a> {
+    links: &'a HashMap<VectorId, EdgeIds>,
+}
+
+impl Serialize for SortedLinks<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut entries: Vec<_> = self.links.iter().collect();
+        entries.sort_by_key(|(key, _)| **key);
+
+        let mut map = serializer.serialize_map(Some(entries.len()))?;
+        for (key, value) in entries {
+            map.serialize_entry(key, value)?;
+        }
+        map.end()
+    }
+}
+
+impl Serialize for Layer {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut state = serializer.serialize_struct("Layer", 2)?;
+        state.serialize_field("links", &SortedLinks { links: &self.links })?;
+        state.serialize_field("set_hash", &self.set_hash)?;
+        state.end()
+    }
 }
 
 /// Type associated with the `GraphV4` serialization type.
@@ -31,7 +63,9 @@ pub struct Layer {
 pub struct EdgeIds(pub Vec<VectorId>);
 
 /// Type associated with the `GraphV4` serialization type.
-#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[derive(
+    Copy, Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Hash,
+)]
 pub struct VectorId {
     pub id: u32,
     pub version: i16,


### PR DESCRIPTION
## Problem
`GraphV4::Layer` derived `Serialize` over an unsorted `HashMap` → bytes (and BLAKE3) are iteration-order dependent, i.e. nondeterministic across processes/parties. The live path (`upload_graph_checkpoint`, materializer) serializes raw `GraphMem` (which sorts links) and is fine, but the `GraphFormat::Current` file path (`write_graph_current`, used by `graph-utils upgrade-format`) goes through `GraphV4` — so checkpoints minted that way diverge per party and break cross-party consensus on boot.

## Fix
Hand-write `Serialize` for `GraphV4::Layer` to emit `links` in sorted key order, mirroring `layered_graph::Layer`'s `SortedLinks`. The two structs already share an identical bincode layout, so sorting makes `Current` output byte-identical to the raw wire format. Adds `Copy/PartialOrd/Ord` to `graph_v4::VectorId` for the sort key.

## Guard
New test `current_serialization_matches_raw_graphmem` asserts `write_graph_current == write_graph_raw`, so the two encodings can't drift again.

## Testing
`cargo test -p iris-mpc-cpu` graph + serialization suites pass (incl. existing `consensus_hash_matches_upload_path_serialization`); fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)