### PR TITLE
Elenagryaznova/pop 3951 staging costs adjust requests and limits p2

### DIFF
--- a/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw.yaml
@@ -109,7 +109,7 @@ env:
     value: "wf-smpcv2-stage-sns-requests"
 
   - name: SMPC__ENABLE_S3_IMPORTER
-    value: "false"
+    value: "true"
 
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "ampc-hnsw-db-exporter-store-node-0-stage--eun1-az3--x-s3"

--- a/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw.yaml
@@ -109,7 +109,7 @@ env:
     value: "wf-smpcv2-stage-sns-requests"
 
   - name: SMPC__ENABLE_S3_IMPORTER
-    value: "true"
+    value: "false"
 
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "ampc-hnsw-db-exporter-store-node-0-stage--eun1-az3--x-s3"

--- a/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw.yaml
@@ -109,7 +109,7 @@ env:
     value: "wf-smpcv2-stage-sns-requests"
 
   - name: SMPC__ENABLE_S3_IMPORTER
-    value: "true"
+    value: "false"
 
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "ampc-hnsw-db-exporter-store-node-1-stage--eun1-az3--x-s3"

--- a/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw.yaml
@@ -109,7 +109,7 @@ env:
     value: "wf-smpcv2-stage-sns-requests"
 
   - name: SMPC__ENABLE_S3_IMPORTER
-    value: "false"
+    value: "true"
 
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "ampc-hnsw-db-exporter-store-node-1-stage--eun1-az3--x-s3"

--- a/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw.yaml
@@ -109,7 +109,7 @@ env:
     value: "wf-smpcv2-stage-sns-requests"
 
   - name: SMPC__ENABLE_S3_IMPORTER
-    value: "true"
+    value: "false"
 
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "ampc-hnsw-db-exporter-store-node-2-stage--eun1-az3--x-s3"

--- a/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw.yaml
+++ b/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw.yaml
@@ -109,7 +109,7 @@ env:
     value: "wf-smpcv2-stage-sns-requests"
 
   - name: SMPC__ENABLE_S3_IMPORTER
-    value: "false"
+    value: "true"
 
   - name: SMPC__DB_CHUNKS_BUCKET_NAME
     value: "ampc-hnsw-db-exporter-store-node-2-stage--eun1-az3--x-s3"

--- a/deploy/stage/common-values-ampc-hnsw-anon-stats-server.yaml
+++ b/deploy/stage/common-values-ampc-hnsw-anon-stats-server.yaml
@@ -44,11 +44,11 @@ readinessProbe:
 
 resources:
   limits:
-    cpu: "2"
-    memory: 10Gi
+    cpu: "1"
+    memory: 1Gi
   requests:
-    cpu: "2"
-    memory: 10Gi
+    cpu: "1"
+    memory: 1Gi
 
 imagePullSecrets:
   - name: github-secret

--- a/deploy/stage/common-values-ampc-hnsw.yaml
+++ b/deploy/stage/common-values-ampc-hnsw.yaml
@@ -46,11 +46,11 @@ startupProbe:
 
 resources:
   limits:
-    cpu: "6.5"
-    memory: 100Gi
+    cpu: "4"
+    memory: 16Gi
   requests:
-    cpu: "6.5"
-    memory: 100Gi
+    cpu: "4"
+    memory: 16Gi
 
 imagePullSecrets:
   - name: github-secret
@@ -61,7 +61,6 @@ podAnnotations:
 nodeSelector:
   kubernetes.io/arch: arm64
   karpenter.sh/capacity-type: on-demand
-  node.kubernetes.io/instance-type: "x8g.2xlarge"
   topology.k8s.aws/zone-id: "euc1-az1"
 
 podSecurityContext:

--- a/deploy/stage/common-values-ampc-hnsw.yaml
+++ b/deploy/stage/common-values-ampc-hnsw.yaml
@@ -70,7 +70,7 @@ affinity:
         - matchExpressions:
             - key: karpenter.k8s.aws/instance-family
               operator: In
-              values: ["c8g"]
+              values: ["r8g", "c8g", "m8g"]
 
 podSecurityContext:
   runAsUser: 65534

--- a/deploy/stage/common-values-ampc-hnsw.yaml
+++ b/deploy/stage/common-values-ampc-hnsw.yaml
@@ -46,10 +46,10 @@ startupProbe:
 
 resources:
   limits:
-    cpu: "4"
+    cpu: "1"
     memory: 16Gi
   requests:
-    cpu: "4"
+    cpu: "1"
     memory: 16Gi
 
 imagePullSecrets:

--- a/deploy/stage/common-values-ampc-hnsw.yaml
+++ b/deploy/stage/common-values-ampc-hnsw.yaml
@@ -63,6 +63,15 @@ nodeSelector:
   karpenter.sh/capacity-type: on-demand
   topology.k8s.aws/zone-id: "euc1-az1"
 
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: karpenter.k8s.aws/instance-family
+              operator: In
+              values: ["c8g"]
+
 podSecurityContext:
   runAsUser: 65534
   runAsGroup: 65534


### PR DESCRIPTION
Reduce requests and limits for hnsw pods on stage. The pod uses 6 GB and doesn't need 100. Remove instance type and rely on karpenter

Real usage graphs here:
<img width="1817" height="556" alt="image" src="https://github.com/user-attachments/assets/301b81c3-a1f9-4503-ac01-1558b30a68f2" />
