### PR TITLE
Enable mTLS in WAL sidecar

### DIFF
--- a/iris-mpc-bins/bin/iris-mpc-cpu/sidecar.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/sidecar.rs
@@ -11,6 +11,7 @@ use std::process::exit;
 use std::time::Duration;
 
 use ampc_actor_utils::network::tcp::TlsConfig;
+use iris_mpc_common::config::Config;
 use iris_mpc_common::postgres::{AccessMode, PostgresClient};
 use iris_mpc_common::tracing::initialize_tracing;
 use iris_mpc_cpu::{
@@ -111,7 +112,7 @@ impl SidecarArgs {
     }
 }
 
-fn hawk_args_from(args: &SidecarArgs) -> HawkArgs {
+fn hawk_args_from(args: &SidecarArgs, tls: Option<TlsConfig>) -> HawkArgs {
     HawkArgs {
         party_index: args.party_index,
         addresses: args.addresses.clone(),
@@ -128,7 +129,7 @@ fn hawk_args_from(args: &SidecarArgs) -> HawkArgs {
         hnsw_prf_key: None,
         disable_persistence: true,
         hnsw_disable_memory_persistence: true,
-        tls: None::<TlsConfig>,
+        tls,
         numa: false,
     }
 }
@@ -178,7 +179,10 @@ async fn main() -> Result<()> {
     let aws_cfg = aws_config::from_env().load().await;
     let s3_client = aws_sdk_s3::Client::new(&aws_cfg);
 
-    let hawk_args = hawk_args_from(&args);
+    // TLS is supplied via SMPC__TLS__* env vars (same path as Hawk Main), not
+    // CLI flags; load it from the SMPC-prefixed config and feed it through.
+    let tls = Config::load_config("SMPC")?.tls;
+    let hawk_args = hawk_args_from(&args, tls);
     let mut networking = build_hawk_network_handle(&hawk_args, shutdown_ct.clone()).await?;
 
     let cfg = SidecarConfig {


### PR DESCRIPTION
## Summary

The WAL sidecar hardcoded `tls: None` when building its `HawkArgs`, so the `SMPC__TLS__*` env vars set in the deploy manifests were silently ignored and sidecar peers talked plain TCP.

This loads TLS from the SMPC-prefixed config (`Config::load_config("SMPC")`) and threads `config.tls` into `HawkArgs`, exactly as production Hawk Main does in `iris-mpc/src/server/mod.rs`. The deployment supplies TLS via env vars (not CLI flags), so a `#[clap(flatten)]` on the args struct would not have worked — `TlsConfig` carries no `#[clap(env)]` bindings. The serde/`load_config` path is the one that reads those env vars.

## Behavior note

`peer_connector` only ever constructs `Mutual` TLS — when a `TlsConfig` is present, all three parties present leaf certs and verify peers against `root_certs`. So enabling TLS here means **mTLS**, not server-only. All three sidecar pods must present valid leaf certs signed by CAs in every peer's `root_certs` or the handshake fails. (The `SMPC__TLS__CLIENT_ONLY_TLS` key in the manifests maps to no field in the current `TlsConfig` rev — dead config, ignored.)

## Test plan

- `cargo clippy -p iris-mpc-bins --bin wal-sidecar` clean
- `Config::load_config("SMPC")` deserializes against the sidecar's sparse env (all `Config` fields default; `DbConfig.url` supplied by `SMPC__CPU_DATABASE__URL`); same loader and `root_certs` JSON-array env format already proven by Hawk Main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)