### PR TITLE
Fix inverted persisted flag for reauth modifications

### DIFF
--- a/iris-mpc/src/services/processors/job.rs
+++ b/iris-mpc/src/services/processors/job.rs
@@ -190,7 +190,7 @@ pub async fn process_job_result(
                 .wrap_err("failed to serialize reauth result")?;
 
             let modification_key = RequestSerialId(serial_id);
-            let persisted = success && skip_persistence.get(i).copied().unwrap_or(false);
+            let persisted = success && !skip_persistence.get(i).copied().unwrap_or(false);
             modifications
                 .get_mut(&modification_key)
                 .unwrap()


### PR DESCRIPTION
The WAL merge commit (`1b968e06`) inlined `reauth_modification_persistence` and dropped the `!`:

```rust
// before (main, #2111):  persisted = success && !skip_persistence
// after the merge:       persisted = success && skip_persistence
```

So successful reauths were recorded `persisted=false` and skip-persistence reauths `persisted=true`. The flag drives rollforward decisions in `sync_modifications` and equality in `compare_modifications` — a party restarting after a missed batch would skip re-applying real iris share updates.

Branch-only; main is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)