### PR TITLE
Derive checkpoint cycle nonce from content, not DB-local checkpoint_id

### DIFF
--- a/iris-mpc-cpu/src/checkpoint_protocol/mod.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/mod.rs
@@ -73,6 +73,34 @@ impl PartialEq for CheckpointMeta {
 
 impl Eq for CheckpointMeta {}
 
+impl CheckpointMeta {
+    /// Cycle nonce for Phases 2-5, derived from the same content fields as
+    /// `PartialEq` so every party computes the same value for the same
+    /// logical checkpoint. `checkpoint_id` must not feed this: it is
+    /// DB-local, and a nonce mismatch is fatal in the transport.
+    pub fn content_nonce(&self) -> u128 {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(&self.last_indexed_iris_id.to_le_bytes());
+        hasher.update(&self.last_indexed_modification_id.to_le_bytes());
+        match self.graph_mutation_id {
+            Some(id) => {
+                hasher.update(&[1]);
+                hasher.update(&id.to_le_bytes());
+            }
+            None => {
+                hasher.update(&[0]);
+            }
+        }
+        hasher.update(self.blake3_hash.as_bytes());
+        hasher.update(&self.graph_version.to_le_bytes());
+        u128::from_le_bytes(
+            hasher.finalize().as_bytes()[..16]
+                .try_into()
+                .expect("16-byte slice"),
+        )
+    }
+}
+
 /// Inclusive upper bound on `graph_mutation_id` to apply during materialization.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FreezeHeight(pub GraphMutationId);
@@ -209,8 +237,8 @@ pub trait GraphHasher: Send + Sync {
 /// Sentinel nonce for Phase 1's base-list exchange. The nonce-derived-from-
 /// agreed-base trick can't be used yet (we're trying to agree on the base),
 /// so we use a fixed value. Cross-cycle crossed-wire detection is weaker for
-/// Phase 1 only — Phases 2-5 use `agreed_base.checkpoint_id` as the nonce and
-/// remain fully protected.
+/// Phase 1 only — Phases 2-5 use the agreed base's content nonce and remain
+/// fully protected.
 const BASE_PHASE_NONCE: u128 = 0xC4EC_B45E_C4EC_B45E_C4EC_B45E_C4EC_B45E_u128;
 
 /// Runs one cycle of the protocol. No looping, no sleeping; the caller's
@@ -251,9 +279,11 @@ where
         Some(b) => b,
         None => return Ok(Outcome::Skipped(SkipReason::NoCommonBase)),
     };
-    // Phases 2-5 share a nonce derived from the agreed base — preserves the
-    // crossed-wire detection the original strict-equality design had.
-    let cycle_nonce = agreed_base.checkpoint_id as u128;
+    // Phases 2-5 share a nonce derived from the agreed base's content —
+    // preserves the crossed-wire detection the original strict-equality
+    // design had, and additionally catches parties that picked different
+    // bases at Phase 2 instead of at the Phase 5 hash mismatch.
+    let cycle_nonce = agreed_base.content_nonce();
 
     // Phase 2 — height agreement. Pick the min across parties so every party
     // is guaranteed to have all WAL rows up to and including the freeze.

--- a/iris-mpc-cpu/src/checkpoint_protocol/tests.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/tests.rs
@@ -46,6 +46,35 @@ fn meta(id: i64, mut_id: Option<i64>) -> CheckpointMeta {
     }
 }
 
+// ── content nonce ────────────────────────────────────────────────────────
+
+/// `checkpoint_id` (and `s3_key`) are party-local; the cycle nonce must be
+/// identical across parties for the same logical checkpoint, otherwise the
+/// transport's fatal nonce-mismatch check wedges Phases 2-5 whenever local
+/// ids diverge.
+#[test]
+fn content_nonce_ignores_party_local_fields() {
+    let a = meta(1, Some(100));
+    let mut b = meta(2, Some(100));
+    b.blake3_hash = a.blake3_hash.clone();
+    assert_ne!(a.checkpoint_id, b.checkpoint_id);
+    assert_ne!(a.s3_key, b.s3_key);
+    assert_eq!(a, b);
+    assert_eq!(a.content_nonce(), b.content_nonce());
+}
+
+/// Distinct content (different base) → distinct nonce, including the
+/// `graph_mutation_id` None/Some distinction.
+#[test]
+fn content_nonce_differs_for_different_content() {
+    let a = meta(1, Some(100));
+    assert_ne!(a.content_nonce(), meta(2, Some(100)).content_nonce());
+    assert_ne!(
+        meta(1, Some(0)).content_nonce(),
+        meta(1, None).content_nonce()
+    );
+}
+
 // ── mock MutationStore ───────────────────────────────────────────────────
 
 #[derive(Clone)]
@@ -289,7 +318,7 @@ async fn happy_path_finalizes() {
 
     // Phase 1 uses the fixed BASE_PHASE_NONCE sentinel (the agreed base
     // isn't known yet); Phases 2-5 share a nonce derived from the agreed
-    // base's checkpoint_id. Two distinct nonces overall.
+    // base's content. Two distinct nonces overall.
     let nonces: std::collections::HashSet<u128> = calls.iter().map(|c| c.nonce).collect();
     assert_eq!(nonces.len(), 2, "phase 1 nonce differs from phases 2-5");
     assert_eq!(


### PR DESCRIPTION
`checkpoint_id` is a per-party auto-increment — `CheckpointMeta::eq` excludes it for exactly this reason — but Phases 2-5 used it as the cycle nonce, and a nonce mismatch is `CycleError::Fatal` in the transport. The protocol only worked while all three parties' local row ids happened to coincide. Any divergence (party crashing between hash consensus and its checkpoint insert — the case `MostRecentCommon` exists to tolerate — or a burned Postgres sequence) wedges every subsequent cycle and restart with "nonce mismatch", on all parties, permanently.

Fix: derive the nonce via blake3 over the same content fields equality uses (`last_indexed_iris_id`, `last_indexed_modification_id`, `graph_mutation_id`, `blake3_hash`, `graph_version`). Bonus: parties that picked different bases now fail fast at Phase 2 instead of at the Phase 5 hash mismatch after a full materialization.

Added tests pinning that party-local fields (`checkpoint_id`, `s3_key`) don't influence the nonce and that distinct content yields distinct nonces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)