### PR TITLE
Retain the agreed base checkpoint when pruning after a sidecar cycle

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -33,6 +33,8 @@ ignore = [
     { id = "RUSTSEC-2026-0099", reason = "same rustls-webpki 0.101.7 chain as RUSTSEC-2026-0098; sibling bug accepts DNS name constraints for wildcard-asserting certs. Same misissuance-required exploit model, same AWS-TLS-only attack surface, same fix path (bump aws-config off the legacy rustls 0.21 chain)." },
     { id = "RUSTSEC-2026-0104", reason = "rustls-webpki 0.101.7 pulled transitively through aws-config 1.5.x via the legacy rustls 0.21 chain; reachable panic in certificate revocation list parsing — only triggered when parsing CRLs, which iris-mpc does not do (TLS to AWS endpoints only). The 0.101.x line has no fix; drop once aws-config is bumped to drop the legacy rustls 0.21 chain." },
     { id = "RUSTSEC-2026-0002", reason = "lru 0.12.5 pulled transitively through aws-sdk-s3 1.65.0; Stacked Borrows soundness issue in IterMut — iris-mpc does not use lru directly and aws-sdk-s3 uses it for internal endpoint/credential caching that does not iterate mutably. Patched in lru >=0.16.3; drop once aws-sdk-s3 is bumped to a release pulling the patched lru. Note: cargo-deny 0.19+ demotes unsound informational advisories to notes locally, so this is only surfaced by the CI action (currently pinned to cargo-deny 0.18.6)." },
+    { id = "RUSTSEC-2026-0176", reason = "pyo3 0.24.2 out-of-bounds read in PyList/PyTuple iterators; fixed in >=0.29.0. iris-mpc-py is a test-only tool with no production exposure; drop once iris-mpc-py updates to pyo3 >=0.29.0" },
+    { id = "RUSTSEC-2026-0177", reason = "pyo3 0.24.2 missing Sync bound on PyCFunction::new_closure; fixed in >=0.29.0. iris-mpc-py is a test-only tool with no production exposure; drop once iris-mpc-py updates to pyo3 >=0.29.0" },
 ]
 
 [sources]

--- a/iris-mpc-cpu/src/checkpoint_protocol/terminal.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/terminal.rs
@@ -139,10 +139,14 @@ impl<V: VectorStore + Send + Sync> TerminalAction for UploadAndRecord<'_, V> {
             graph_version: GraphFormat::Current.version(),
             is_archival: self.is_archival,
         };
+        // Retain the agreed base (and anything newer): peers provably hold
+        // the base durably, but may not have recorded the new checkpoint yet.
+        // See `cleanup_checkpoints` docs.
         if let Err(e) = cleanup_checkpoints(
             &self.bucket,
             self.s3_client,
             &graph_checkpoint,
+            Some(base.checkpoint_id),
             self.graph_store,
             self.pruning_mode,
         )

--- a/iris-mpc-cpu/src/graph_checkpoint/s3_client/mod.rs
+++ b/iris-mpc-cpu/src/graph_checkpoint/s3_client/mod.rs
@@ -270,10 +270,20 @@ pub async fn save_checkpoint_state<V: VectorStore>(
 /// reached consensus on a common checkpoint.
 /// if the parties have not reached agreement, then
 /// calling this function could make rollback impossible
+///
+/// `retain_from_id`: local row-id watermark; rows with `id >= retain_from_id`
+/// are kept regardless of pruning mode. Callers pruning right after recording
+/// a checkpoint that peers have NOT yet confirmed durable (the sidecar's
+/// `UploadAndRecord`) must pass the cycle's agreed base id here: the base was
+/// advertised by every party in Phase 1, so retaining it guarantees a common
+/// checkpoint survives even if a peer crashes before recording the new one.
+/// `None` is only safe when `current_state` itself is known to be durably
+/// recorded by all parties (the startup-agreed common checkpoint).
 pub async fn cleanup_checkpoints<V: VectorStore>(
     bucket: &str,
     s3_client: &S3Client,
     current_state: &GraphCheckpointState,
+    retain_from_id: Option<i64>,
     graph_store: &GraphPg<V>,
     pruning_mode: PruningMode,
 ) -> Result<()> {
@@ -298,6 +308,7 @@ pub async fn cleanup_checkpoints<V: VectorStore>(
     for checkpoint in all_checkpoints
         .into_iter()
         .filter(|x| x.s3_key != current_state.s3_key)
+        .filter(|x| retain_from_id.map_or(true, |min_id| x.id < min_id))
         .filter(|x| match pruning_mode {
             PruningMode::AllOlder => true,
             PruningMode::OlderNonArchival => !x.is_archival,

--- a/iris-mpc-cpu/src/graph_checkpoint/s3_client/mod.rs
+++ b/iris-mpc-cpu/src/graph_checkpoint/s3_client/mod.rs
@@ -308,7 +308,7 @@ pub async fn cleanup_checkpoints<V: VectorStore>(
     for checkpoint in all_checkpoints
         .into_iter()
         .filter(|x| x.s3_key != current_state.s3_key)
-        .filter(|x| retain_from_id.map_or(true, |min_id| x.id < min_id))
+        .filter(|x| retain_from_id.is_none_or(|min_id| x.id < min_id))
         .filter(|x| match pruning_mode {
             PruningMode::AllOlder => true,
             PruningMode::OlderNonArchival => !x.is_archival,

--- a/iris-mpc-upgrade-hawk/src/genesis/mod.rs
+++ b/iris-mpc-upgrade-hawk/src/genesis/mod.rs
@@ -459,10 +459,13 @@ async fn exec_setup(
     // the old checkpoints could still be found;
     // if the peers are consistent and stores are consistent, then clean up s3 checkpoints
     if let Some(graph_checkpoint) = graph_checkpoint.as_ref() {
+        // `graph_checkpoint` is the startup-agreed common checkpoint, so all
+        // parties hold it durably; no extra watermark needed.
         if let Err(e) = cleanup_checkpoints(
             &config.graph_checkpoint_bucket_name,
             &checkpoint_s3_client,
             graph_checkpoint,
+            None,
             &graph_store_arc,
             args.pruning_mode,
         )

--- a/iris-mpc/tests/workflows/wal_104.rs
+++ b/iris-mpc/tests/workflows/wal_104.rs
@@ -83,15 +83,16 @@ impl TestRun for Wal104 {
         builder.add_nodes(MIN_MUTATIONS_PER_SIDECAR_CYCLE);
         builder.build(nodes).await?;
 
-        // OlderNonArchival: removes the 3 non-archival older checkpoints; archival survives → 2 remain.
+        // OlderNonArchival: removes non-archival checkpoints older than the
+        // agreed base (the cycle-1 product); archival + base + new survive → 3.
         run_cycle(ctx, PruningMode::OlderNonArchival).await?;
-        nodes.assert_checkpoint_count(2).await?;
+        nodes.assert_checkpoint_count(3).await?;
 
         // Sidecar requires new mutations to trigger a cycle.
         builder.add_nodes(MIN_MUTATIONS_PER_SIDECAR_CYCLE);
         builder.build(nodes).await?;
 
-        // AllOlder: only the latest checkpoint survives.
+        // AllOlder: everything below the agreed base goes; base + new survive.
         run_cycle(ctx, PruningMode::AllOlder).await?;
 
         Ok(())
@@ -101,7 +102,7 @@ impl TestRun for Wal104 {
         let nodes = self.nodes.as_ref().unwrap();
 
         // assert_checkpoint_count already verifies the S3 object count per party matches.
-        let post = WalAssertions::new().assert_checkpoint_count(1);
+        let post = WalAssertions::new().assert_checkpoint_count(2);
         nodes.apply_uniform_assertions(&post).await?;
 
         nodes.assert_checkpoint_hashes_agree().await


### PR DESCRIPTION
`UploadAndRecord::finalize` pruned everything except the checkpoint it just recorded, without confirming peers also recorded it. Phase-5 hash consensus proves all parties can *produce* identical bytes — not that they *durably committed* the row. A peer crashing between consensus and its insert (the exact case `MostRecentCommon` exists to tolerate) was left holding only checkpoints the other two had pruned: empty intersection → `NoCommonBase` on every cycle and every restart, permanently, with no self-healing path (the survivors' older checkpoints are deleted from DB **and** S3).

Fix: `cleanup_checkpoints` takes a `retain_from_id` watermark; the sidecar passes the cycle's agreed base. The base was advertised by all parties in Phase 1, so retaining rows at-or-above it guarantees a common checkpoint always survives a single-party crash at any point in the cycle. The genesis startup call site passes `None` — there `current_state` is itself the startup-agreed common checkpoint, so the old semantics were already safe.

Net effect on steady-state retention: the sidecar keeps base + new (2 rows) instead of 1; wal_104 expectations updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)