### PR TITLE
Join the restart ring even when the local checkpoint table is empty

### DIFF
--- a/iris-mpc-cpu/src/checkpoint_protocol/mod.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/mod.rs
@@ -129,8 +129,14 @@ pub enum SkipReason {
         base: GraphMutationId,
     },
     /// [`BaseSelector::pick`] returned `None` — no checkpoint shared across
-    /// all parties.
+    /// all parties. A party with a non-empty checkpoint table lands here
+    /// when any peer advertises an empty list.
     NoCommonBase,
+    /// No party advertised any checkpoint — a fresh deployment. Distinct
+    /// from [`SkipReason::NoCommonBase`] so callers can treat "everyone is
+    /// empty" (expected, proceed empty) differently from "someone lost
+    /// their checkpoints" (divergence, fail loudly).
+    NoCheckpoints,
 }
 
 #[derive(Debug, Error)]
@@ -275,6 +281,12 @@ where
             cfg.peer_round_timeout,
         )
         .await?;
+    // A party with an empty table must still reach this point (i.e. it must
+    // participate in the exchange above): silently sitting out the ring
+    // would leave its peers timing out with no indication of the cause.
+    if my_recent.is_empty() && peer_lists.iter().all(|l| l.is_empty()) {
+        return Ok(Outcome::Skipped(SkipReason::NoCheckpoints));
+    }
     let agreed_base = match selector.pick(&my_recent, &peer_lists) {
         Some(b) => b,
         None => return Ok(Outcome::Skipped(SkipReason::NoCommonBase)),

--- a/iris-mpc-cpu/src/checkpoint_protocol/runner.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/runner.rs
@@ -241,8 +241,9 @@ async fn sidecar_cycle<V: VectorStore + Send + Sync>(
 pub enum RestartOutcome {
     /// A graph was installed at the reported height.
     Installed { height: GraphMutationId },
-    /// No `genesis_graph_checkpoint` row exists; caller falls back to its
-    /// own bootstrap path (empty graph, plaintext checkpoint migration).
+    /// No party has any `genesis_graph_checkpoint` row (agreed via the ring,
+    /// not inferred locally); caller falls back to its own bootstrap path
+    /// (empty graph, plaintext checkpoint migration).
     NoCheckpoint,
     /// A peer's `current_max_mutation_id` came in below the agreed base.
     /// Restart can be retried once peers catch up; not a fatal error.
@@ -267,15 +268,10 @@ pub async fn restart_from_checkpoint<V: VectorStore + Send + Sync>(
     peer_round_timeout: Duration,
     checkpoint_window: usize,
 ) -> Result<RestartOutcome> {
-    if graph_store
-        .get_latest_genesis_graph_checkpoint()
-        .await
-        .map_err(|e| eyre!("get_latest_genesis_graph_checkpoint: {e}"))?
-        .is_none()
-    {
-        return Ok(RestartOutcome::NoCheckpoint);
-    }
-
+    // No local-table fast path here: a party with an empty table must still
+    // join the ring, or its peers block in the Phase 1 exchange until
+    // timeout and crash-loop while this party silently boots empty.
+    // "Nobody has a checkpoint" is a consensus outcome, not a local one.
     let channel = networking
         .control_channel()
         .await
@@ -312,6 +308,10 @@ pub async fn restart_from_checkpoint<V: VectorStore + Send + Sync>(
         Outcome::Skipped(SkipReason::PeerBehindBase { freeze, base }) => {
             tracing::warn!(freeze, base, "restart skipped: peer behind base");
             Ok(RestartOutcome::PeerBehindBase { freeze, base })
+        }
+        Outcome::Skipped(SkipReason::NoCheckpoints) => {
+            tracing::info!("restart: no party has any checkpoint");
+            Ok(RestartOutcome::NoCheckpoint)
         }
         Outcome::Skipped(SkipReason::NoCommonBase) => {
             tracing::warn!("restart skipped: no common base across parties");

--- a/iris-mpc-cpu/src/checkpoint_protocol/tests.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/tests.rs
@@ -423,6 +423,96 @@ async fn restart_with_min_zero_runs_even_with_no_new_mutations() {
     assert_eq!(fin.calls.lock().unwrap().len(), 1);
 }
 
+// ── empty checkpoint tables ──────────────────────────────────────────────
+
+/// All parties empty → consistent `NoCheckpoints` skip, decided *after*
+/// participating in the Phase 1 exchange — a party that sat out the ring
+/// instead would leave its peers timing out with no indication why.
+#[tokio::test]
+async fn all_parties_empty_skips_with_no_checkpoints() {
+    let mut mat = MockMaterializer::new();
+    let mut fin = MockFinalizer::new();
+    let store = MockStore {
+        recent: vec![],
+        max_id: 0,
+    };
+    let canned = vec![vec![ConsensusMessage::BaseProposal { recent: vec![] }]];
+    let transport = MockTransport::new(canned);
+    let hasher = ConstHasher(hash_a());
+
+    let outcome = run_cycle(
+        &mut mat,
+        &mut fin,
+        &transport,
+        &store,
+        &hasher,
+        &MostRecentCommon,
+        &cfg(0),
+    )
+    .await
+    .expect("all-empty is a skip, not an error");
+
+    assert!(matches!(
+        outcome,
+        Outcome::Skipped(SkipReason::NoCheckpoints)
+    ));
+    assert_eq!(
+        transport.calls.lock().unwrap().len(),
+        1,
+        "the Phase 1 exchange must have run"
+    );
+    assert!(mat.freezes.lock().unwrap().is_empty());
+    assert!(fin.calls.lock().unwrap().is_empty());
+}
+
+/// Asymmetric emptiness is `NoCommonBase`, not `NoCheckpoints`, from both
+/// sides: the empty party and its non-empty peer reach the same conclusion.
+#[tokio::test]
+async fn asymmetric_empty_table_skips_no_common_base_on_both_sides() {
+    // Empty party's view: peer advertises a checkpoint.
+    let store = MockStore {
+        recent: vec![],
+        max_id: 0,
+    };
+    let canned = vec![vec![ConsensusMessage::BaseProposal {
+        recent: vec![meta(1, Some(100))],
+    }]];
+    let outcome = run_cycle(
+        &mut MockMaterializer::new(),
+        &mut MockFinalizer::new(),
+        &MockTransport::new(canned),
+        &store,
+        &ConstHasher(hash_a()),
+        &MostRecentCommon,
+        &cfg(0),
+    )
+    .await
+    .expect("skip, not error");
+    assert!(matches!(
+        outcome,
+        Outcome::Skipped(SkipReason::NoCommonBase)
+    ));
+
+    // Non-empty party's view: peer advertises nothing.
+    let store = MockStore::with_latest(meta(1, Some(100)), 100);
+    let canned = vec![vec![ConsensusMessage::BaseProposal { recent: vec![] }]];
+    let outcome = run_cycle(
+        &mut MockMaterializer::new(),
+        &mut MockFinalizer::new(),
+        &MockTransport::new(canned),
+        &store,
+        &ConstHasher(hash_a()),
+        &MostRecentCommon,
+        &cfg(0),
+    )
+    .await
+    .expect("skip, not error");
+    assert!(matches!(
+        outcome,
+        Outcome::Skipped(SkipReason::NoCommonBase)
+    ));
+}
+
 // ── base disagreement: StrictLatest skips; MostRecentCommon falls back ──
 
 #[tokio::test]


### PR DESCRIPTION
`restart_from_checkpoint` decided `NoCheckpoint` from a **local-only** table check, before opening the control channel. A party with a wiped/lagging checkpoint table never joined the restart consensus: it silently booted with an empty graph while its two peers blocked in the Phase 1 exchange, hit `peer_round_timeout`, errored out of boot, and crash-looped — and no log line anywhere named the actual cause (the only party at fault was the only one not erroring).

Whether anyone has a checkpoint is a consensus question, not a local one. Now the party always joins the ring and advertises an empty list:

- **All parties empty** (fresh deployment) → new `SkipReason::NoCheckpoints`, agreed identically by everyone → `RestartOutcome::NoCheckpoint`, same empty-graph fallback as before.
- **Asymmetric empty table** → `NoCommonBase` on **all three** parties consistently, so the cluster fails loudly together instead of two crash-looping against one silent empty boot.

The extra Phase 1 round on empty-DB boots is cheap: `build_hawk_network_handle` (full mesh) immediately precedes this point, so all parties enter the exchange together.

Sidecar behavior against an all-empty cluster improves incidentally: daemon/one-shot cycles now skip with an explicit `NoCheckpoints` instead of a misleading `NoCommonBase`.

Tests: all-empty → `NoCheckpoints` with the exchange asserted to have run; asymmetric emptiness → `NoCommonBase` from both the empty and non-empty party's perspective.

🤖 Generated with [Claude Code](https://claude.com/claude-code)