### PR TITLE
Use smaller instance type

### DIFF
--- a/deploy/dev/common-values-ampc-hnsw.yaml
+++ b/deploy/dev/common-values-ampc-hnsw.yaml
@@ -137,11 +137,11 @@ startupProbe:
 
 resources:
   limits:
-    cpu: 28
-    memory: 450Gi
+    cpu: "1"
+    memory: 16Gi
   requests:
-    cpu: 28
-    memory: 450Gi
+    cpu: "1"
+    memory: 16Gi
 
 imagePullSecrets:
   - name: github-secret
@@ -152,7 +152,16 @@ podAnnotations:
 nodeSelector:
   kubernetes.io/arch: arm64
   karpenter.sh/capacity-type: on-demand
-  node.kubernetes.io/instance-type: "x8g.8xlarge"
+  topology.k8s.aws/zone-id: "euc1-az1"
+
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: karpenter.k8s.aws/instance-family
+              operator: In
+              values: ["r8g", "c8g", "m8g"]
 
 podSecurityContext:
   runAsUser: 65534


### PR DESCRIPTION
This pull request makes significant updates to the Kubernetes deployment configuration in `deploy/dev/common-values-ampc-hnsw.yaml`. The changes focus on reducing resource allocations and updating the node selection and affinity rules to improve scheduling flexibility and cost efficiency.

<img width="1875" height="574" alt="image" src="https://github.com/user-attachments/assets/f20cb98f-2566-4c2a-b745-7dae81bbe543" />


Resource allocation updates:
* Reduced the `cpu` and `memory` resource limits and requests for the deployment from `28` CPUs and `450Gi` memory to `1` CPU and `16Gi` memory, which will lower resource usage and costs.

Node scheduling and affinity changes:
* Replaced the specific node instance type selector (`node.kubernetes.io/instance-type: "x8g.8xlarge"`) with a zone selector (`topology.k8s.aws/zone-id: "euc1-az1"`) and added node affinity rules to allow scheduling on instance families `r8g`, `c8g`, and `m8g`, increasing scheduling flexibility and potentially improving availability.