### PR TITLE
[POP-4030] Concretize searcher to SortedNeighborhood, remove Neighborhood trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1967,17 +1967,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "delegate"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3318,7 +3307,6 @@ dependencies = [
  "crossbeam",
  "csv",
  "dashmap",
- "delegate",
  "eyre",
  "futures",
  "hex",

--- a/docs/hawk-actor.md
+++ b/docs/hawk-actor.md
@@ -38,7 +38,6 @@ type Aby3Ref = Arc<RwLock<Aby3Store>>;
 HAWK_DISTANCE_FN = DistanceFn::MinFhd      // Distance function choice
 HAWK_MINFHD_ROTATIONS = 11                 // Rotations for MinFhd
 HAWK_BASE_ROTATIONS_MASK = CENTER_AND_10_MASK  // Base rotations for HNSW search
-NEIGHBORHOOD_MODE = NeighborhoodMode::Sorted   // Candidate list strategy
 LINEAR_SCAN_MAX_GRAPH_LAYER = 1
 ```
 

--- a/iris-mpc-bins/bin/iris-mpc-cpu/hnsw_algorithm_metrics.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/hnsw_algorithm_metrics.rs
@@ -10,7 +10,7 @@ use iris_mpc_cpu::{
             OpCountersLayer, Operation, ParamVertexOpeningsCounter, StaticCounter,
         },
         searcher::LayerDistribution,
-        GraphMem, HnswSearcher, SortedNeighborhood,
+        GraphMem, HnswSearcher,
     },
 };
 use rand::SeedableRng;
@@ -113,12 +113,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 let query = Arc::new(raw_query.clone());
                 let insertion_layer = searcher.gen_layer_rng(&mut rng)?;
                 searcher
-                    .insert::<_, SortedNeighborhood<_>>(
-                        &mut vector,
-                        &mut graph,
-                        &query,
-                        insertion_layer,
-                    )
+                    .insert(&mut vector, &mut graph, &query, insertion_layer)
                     .await?;
 
                 if idx % 1000 == 999 {
@@ -144,12 +139,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 let query = Arc::new(raw_query.clone());
                 let insertion_layer = searcher.gen_layer_rng(&mut rng)?;
                 searcher
-                    .insert::<_, SortedNeighborhood<_>>(
-                        &mut vector,
-                        &mut graph,
-                        &query,
-                        insertion_layer,
-                    )
+                    .insert(&mut vector, &mut graph, &query, insertion_layer)
                     .await?;
 
                 if idx % 1000 == 999 {

--- a/iris-mpc-bins/bin/iris-mpc-cpu/init_test_dbs.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/init_test_dbs.rs
@@ -11,7 +11,7 @@ use iris_mpc_cpu::{
     hawkers::plaintext_store::PlaintextStore,
     hnsw::{
         graph::test_utils::DbContext, searcher::LayerDistribution, vector_store::VectorStoreMut,
-        GraphMem, HnswSearcher, SortedNeighborhood,
+        GraphMem, HnswSearcher,
     },
     protocol::shared_iris::{GaloisRingSharedIris, GaloisRingSharedIrisPair},
     utils::{
@@ -397,12 +397,7 @@ async fn main() -> Result<()> {
 
                 let insertion_layer = searcher.gen_layer_prf(&prf_seed, &(inserted_id, side))?;
                 let (neighbors, update_ep) = searcher
-                    .search_to_insert::<_, SortedNeighborhood<_>>(
-                        &mut vector_store,
-                        &graph,
-                        &query,
-                        insertion_layer,
-                    )
+                    .search_to_insert(&mut vector_store, &graph, &query, insertion_layer)
                     .await?;
                 searcher
                     .insert_from_search_results(

--- a/iris-mpc-bins/bin/iris-mpc-cpu/run_accuracy_analysis.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/run_accuracy_analysis.rs
@@ -232,7 +232,6 @@ output_format = "rate"
 output_path = "out.csv"
 rotations = { start = 0, end = 1 }
 mutations = [0.0]
-neighborhood_mode = "Sorted"
 distance_ops = "fhd"
 [analysis.search_hnsw_config]
 ef_construction = 32
@@ -268,7 +267,6 @@ k_neighbors = 1
 output_format = "rate"
 output_path = "out.csv"
 noise_levels = [0.0, 0.05]
-neighborhood_mode = "Sorted"
 [analysis.search_hnsw_config]
 ef_construction = 32
 ef_search = 32

--- a/iris-mpc-bins/resources/iris-mpc-cpu/accuracy1.toml
+++ b/iris-mpc-bins/resources/iris-mpc-cpu/accuracy1.toml
@@ -21,7 +21,6 @@ sample_size = 20
 seed = 123
 distance_ops = "fhd"                  # Must be "fhd" or "nhd"
 distance_fn = "min_rotation"         # Must be "simple" or "min_rotation"
-neighborhood_mode = "Unsorted"  # Must be "Sorted" or "Unsorted"
 k_neighbors = 128
 mutations = [0.33, 0.37, 0.51]
 output_format = "rate"          # Must be "full_csv", "rate" or "histogram"

--- a/iris-mpc-bins/resources/iris-mpc-cpu/accuracy_deepid.toml
+++ b/iris-mpc-bins/resources/iris-mpc-cpu/accuracy_deepid.toml
@@ -22,7 +22,6 @@ k_neighbors = 1
 output_format = "rate"
 output_path = "data/accuracy_deepid_results.csv"
 noise_levels = [0.0, 0.05, 0.1, 0.2]
-neighborhood_mode = "Sorted"
 
 [analysis.search_hnsw_config]
 ef_construction = 64

--- a/iris-mpc-cpu/Cargo.toml
+++ b/iris-mpc-cpu/Cargo.toml
@@ -23,7 +23,6 @@ config.workspace = true
 core_affinity.workspace = true
 crossbeam = "0.8.4"
 csv = "*"
-delegate = "0.13.5"
 hex.workspace = true
 dashmap = "6.1.0"
 eyre.workspace = true

--- a/iris-mpc-cpu/benches/hnsw.rs
+++ b/iris-mpc-cpu/benches/hnsw.rs
@@ -13,7 +13,7 @@ use iris_mpc_cpu::{
         },
         plaintext_store::PlaintextStore,
     },
-    hnsw::{GraphMem, HnswSearcher, SortedNeighborhood},
+    hnsw::{GraphMem, HnswSearcher},
     protocol::{
         ops::{galois_ring_pairwise_distance, galois_ring_to_rep3},
         shared_iris::GaloisRingSharedIris,
@@ -53,12 +53,7 @@ fn bench_plaintext_hnsw(c: &mut Criterion) {
                 let query = Arc::new(raw_query.clone());
                 let insertion_layer = searcher.gen_layer_rng(&mut rng).unwrap();
                 searcher
-                    .insert::<_, SortedNeighborhood<_>>(
-                        &mut vector,
-                        &mut graph,
-                        &query,
-                        insertion_layer,
-                    )
+                    .insert(&mut vector, &mut graph, &query, insertion_layer)
                     .await
                     .unwrap();
             }
@@ -75,12 +70,7 @@ fn bench_plaintext_hnsw(c: &mut Criterion) {
                     let query = Arc::new(on_the_fly_query);
                     let insertion_layer = searcher.gen_layer_rng(&mut rng).unwrap();
                     searcher
-                        .insert::<_, SortedNeighborhood<_>>(
-                            &mut db_vectors,
-                            &mut graph,
-                            &query,
-                            insertion_layer,
-                        )
+                        .insert(&mut db_vectors, &mut graph, &query, insertion_layer)
                         .await
                         .unwrap();
                 },
@@ -297,7 +287,7 @@ fn bench_gr_ready_made_hnsw(c: &mut Criterion) {
                                 let mut vector_store = vector_store.lock().await;
                                 let insertion_layer = searcher.gen_layer_rng(&mut rng).unwrap();
                                 searcher
-                                    .insert::<_, SortedNeighborhood<_>>(
+                                    .insert(
                                         &mut *vector_store,
                                         &mut graph_store,
                                         &query,
@@ -341,12 +331,7 @@ fn bench_gr_ready_made_hnsw(c: &mut Criterion) {
                             jobs.spawn(async move {
                                 let mut vector_store = vector_store.lock().await;
                                 let neighbors = searcher
-                                    .search::<_, SortedNeighborhood<_>>(
-                                        &mut *vector_store,
-                                        &graph_store,
-                                        &query,
-                                        1,
-                                    )
+                                    .search(&mut *vector_store, &graph_store, &query, 1)
                                     .await
                                     .unwrap();
                                 searcher

--- a/iris-mpc-cpu/examples/hnsw-ex.rs
+++ b/iris-mpc-cpu/examples/hnsw-ex.rs
@@ -5,7 +5,7 @@ use eyre::Result;
 use iris_mpc_common::iris_db::iris::IrisCode;
 use iris_mpc_cpu::{
     hawkers::{aby3::aby3_store::FhdOps, plaintext_store::PlaintextStore},
-    hnsw::{GraphMem, HnswSearcher, SortedNeighborhood},
+    hnsw::{GraphMem, HnswSearcher},
 };
 use rand::SeedableRng;
 
@@ -28,12 +28,7 @@ fn main() -> Result<()> {
             let query = Arc::new(raw_query);
             let insertion_layer = searcher.gen_layer_rng(&mut rng)?;
             searcher
-                .insert::<_, SortedNeighborhood<_>>(
-                    &mut vector,
-                    &mut graph,
-                    &query,
-                    insertion_layer,
-                )
+                .insert(&mut vector, &mut graph, &query, insertion_layer)
                 .await?;
             if idx % 100 == 99 {
                 println!("{}", idx + 1);

--- a/iris-mpc-cpu/src/analysis/accuracy.rs
+++ b/iris-mpc-cpu/src/analysis/accuracy.rs
@@ -4,8 +4,7 @@ use crate::{
         plaintext_store::{PlaintextStore, SharedPlaintextStore},
     },
     hnsw::{
-        graph::neighborhood::{UnsortedNeighborhood, WrappedNeighborhood},
-        searcher::{LayerDistribution, LayerMode, NeighborhoodMode, N_PARAM_LAYERS},
+        searcher::{LayerDistribution, LayerMode, N_PARAM_LAYERS},
         GraphMem, HnswParams, HnswSearcher, SortedNeighborhood,
     },
     utils::serialization::{
@@ -53,8 +52,6 @@ pub struct AnalysisConfig {
     pub mutations: Vec<f64>,
     /// Config for HNSW searcher to use for search during analysis.
     pub search_hnsw_config: HnswConfig,
-    /// Search using sorted or unsorted neighborhoods
-    pub neighborhood_mode: NeighborhoodMode,
     /// Distance ops type: "fhd" (Fractional Hamming) or "nhd" (Normalized Hamming).
     pub distance_ops: String,
 }
@@ -150,30 +147,12 @@ pub async fn run_analysis<D: DistanceOps>(
                 let query_ref = Arc::new(query_code_inner);
                 let analysis_searcher_clone = analysis_searcher.clone();
                 let mut store_clone = store.clone();
-                let nb_mode = config.neighborhood_mode.clone();
                 let graph_clone = Arc::clone(&graph);
 
                 let future = async move {
-                    let neighbors: WrappedNeighborhood<_> = match nb_mode {
-                        NeighborhoodMode::Sorted => analysis_searcher_clone
-                            .search::<_, SortedNeighborhood<_>>(
-                                &mut store_clone,
-                                &graph_clone,
-                                &query_ref,
-                                k_neighbors,
-                            )
-                            .await?
-                            .into(),
-                        NeighborhoodMode::Unsorted => analysis_searcher_clone
-                            .search::<_, UnsortedNeighborhood<_>>(
-                                &mut store_clone,
-                                &graph_clone,
-                                &query_ref,
-                                k_neighbors,
-                            )
-                            .await?
-                            .into(),
-                    };
+                    let neighbors: SortedNeighborhood<_> = analysis_searcher_clone
+                        .search(&mut store_clone, &graph_clone, &query_ref, k_neighbors)
+                        .await?;
 
                     let found = neighbors
                         .as_ref()

--- a/iris-mpc-cpu/src/analysis/accuracy_deep_id.rs
+++ b/iris-mpc-cpu/src/analysis/accuracy_deep_id.rs
@@ -9,8 +9,7 @@ use crate::{
         Int4Vector, PlaintextDeepIDStore, SharedPlaintextDeepIDStore, INT4_DIM,
     },
     hnsw::{
-        graph::neighborhood::{UnsortedNeighborhood, WrappedNeighborhood},
-        searcher::{LayerDistribution, LayerMode, NeighborhoodMode, N_PARAM_LAYERS},
+        searcher::{LayerDistribution, LayerMode, N_PARAM_LAYERS},
         GraphMem, HnswParams, HnswSearcher, SortedNeighborhood,
     },
     utils::serialization::{
@@ -71,7 +70,6 @@ pub struct AnalysisConfig {
     pub metrics_path: Option<PathBuf>,
     pub noise_levels: Vec<f64>,
     pub search_hnsw_config: HnswConfig,
-    pub neighborhood_mode: NeighborhoodMode,
 }
 
 impl AnalysisConfig {
@@ -292,30 +290,12 @@ pub async fn run_analysis(
 
             let analysis_searcher_clone = analysis_searcher.clone();
             let mut store_clone = store.clone();
-            let nb_mode = config.neighborhood_mode.clone();
             let graph_clone = Arc::clone(&graph);
 
             let future = async move {
-                let neighbors: WrappedNeighborhood<_> = match nb_mode {
-                    NeighborhoodMode::Sorted => analysis_searcher_clone
-                        .search::<_, SortedNeighborhood<_>>(
-                            &mut store_clone,
-                            &graph_clone,
-                            &query_ref,
-                            k_neighbors,
-                        )
-                        .await?
-                        .into(),
-                    NeighborhoodMode::Unsorted => analysis_searcher_clone
-                        .search::<_, UnsortedNeighborhood<_>>(
-                            &mut store_clone,
-                            &graph_clone,
-                            &query_ref,
-                            k_neighbors,
-                        )
-                        .await?
-                        .into(),
-                };
+                let neighbors: SortedNeighborhood<_> = analysis_searcher_clone
+                    .search(&mut store_clone, &graph_clone, &query_ref, k_neighbors)
+                    .await?;
 
                 let found = neighbors
                     .as_ref()
@@ -456,7 +436,6 @@ mod tests {
             metrics_path: None,
             noise_levels: vec![0.0],
             search_hnsw_config: small_hnsw_config(),
-            neighborhood_mode: NeighborhoodMode::Sorted,
         };
 
         let mut analysis_rng: StdRng = SeedableRng::seed_from_u64(0);

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -56,14 +56,6 @@
 //! Finally, the constant `HAWK_BASE_ROTATIONS_MASK` should be set to indicate the set of "base rotations" for which
 //! the HawkActor will trigger independent HNSW searches. In practice, this set must be chosen so that the searches cover (at least)
 //! rotations in the [-15, 15] interval. For example, an example of suitable mask for MinRotation5 encodes the set `{-10, 0, 10}`.
-//!
-//! ### 3. Neighborhood Strategy: `Sorted` vs. `Unsorted`
-//!
-//! This strategy governs how nearest neighbors candidate lists are managed during HNSW graph traversal.
-//! - **`Sorted`**: Maintains a sorted list of candidates.
-//! - **`Unsorted`**: Maintains an unsorted list of candidates.
-//!
-//! It is set by passing `NEIGHBORHOOD_MODE` constant to the search/insertion orchestrator methods.
 
 #[allow(unused_imports)]
 use crate::hawkers::aby3::aby3_store::NhdOps;
@@ -86,7 +78,7 @@ use crate::{
     },
     hnsw::{
         graph::{graph_store, GraphMutation, MutationOp, UpdateEntryPoint},
-        searcher::{LayerDistribution, NeighborhoodMode},
+        searcher::LayerDistribution,
         GraphMem, HnswSearcher, VectorStore,
     },
     network::mpc::{build_network_handle, NetworkHandle, NetworkHandleArgs},
@@ -220,9 +212,6 @@ const _: () = {
 
 /// Rotation support as configured by SearchRotations.
 pub type VecRotations<T> = VecRotationSupport<T, HAWK_BASE_ROTATIONS_MASK>;
-
-/// The choice of HNSW candidate list strategy
-pub const NEIGHBORHOOD_MODE: NeighborhoodMode = NeighborhoodMode::Sorted;
 
 const LINEAR_SCAN_MAX_GRAPH_LAYER: usize = 1;
 
@@ -1823,7 +1812,6 @@ impl HawkHandle {
                 search_queries,
                 search_ids,
                 search_params,
-                NEIGHBORHOOD_MODE,
             )
             .await?;
 

--- a/iris-mpc-cpu/src/execution/hawk_main/identity_update.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/identity_update.rs
@@ -5,7 +5,7 @@ use super::{
     search::{self, SearchParams, SearchQueries, SearchResults},
     BothEyes, HawkActor, HawkRequest, HawkSession, LEFT, RIGHT,
 };
-use crate::execution::hawk_main::{iris_worker::QueryId, search::SearchIds, NEIGHBORHOOD_MODE};
+use crate::execution::hawk_main::{iris_worker::QueryId, search::SearchIds};
 use eyre::Result;
 use iris_mpc_common::vector_id::VectorId;
 
@@ -47,7 +47,6 @@ pub async fn search_to_identity_update(
         &updates.queries,
         &updates.request_ids,
         search_params,
-        NEIGHBORHOOD_MODE,
     )
     .await?;
 

--- a/iris-mpc-cpu/src/execution/hawk_main/search.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/search.rs
@@ -10,12 +10,7 @@ use crate::{
         InsertPlanV, StoreId,
     },
     hawkers::aby3::aby3_store::{Aby3DistanceRef, Aby3Query, Aby3Store, DistanceOps},
-    hnsw::{
-        graph::neighborhood::{Neighborhood, UnsortedNeighborhood},
-        graph::UpdateEntryPoint,
-        searcher::NeighborhoodMode,
-        GraphMem, HnswSearcher, SortedNeighborhood,
-    },
+    hnsw::{graph::UpdateEntryPoint, GraphMem, HnswSearcher},
 };
 use eyre::{OptionExt, Result};
 use iris_mpc_common::iris_db::iris::Threshold;
@@ -99,7 +94,6 @@ pub async fn search<const ROTMASK: u32>(
     search_queries: &SearchQueries<ROTMASK>,
     search_ids: &SearchIds,
     search_params: SearchParams,
-    mode: NeighborhoodMode,
 ) -> Result<SearchResults<ROTMASK>> {
     let n_sessions = sessions[LEFT].len();
     assert_eq!(n_sessions, sessions[RIGHT].len());
@@ -114,33 +108,17 @@ pub async fn search<const ROTMASK: u32>(
         let search_ids = search_ids.clone();
         let search_params = search_params.clone();
         let tx = tx.clone();
-        let mode = mode.clone();
 
         async move {
-            match mode {
-                NeighborhoodMode::Sorted => {
-                    per_session::<_, SortedNeighborhood<_>>(
-                        &session,
-                        &search_queries,
-                        &search_ids,
-                        &search_params,
-                        tx,
-                        batch,
-                    )
-                    .await
-                }
-                NeighborhoodMode::Unsorted => {
-                    per_session::<_, UnsortedNeighborhood<_>>(
-                        &session,
-                        &search_queries,
-                        &search_ids,
-                        &search_params,
-                        tx,
-                        batch,
-                    )
-                    .await
-                }
-            }
+            per_session(
+                &session,
+                &search_queries,
+                &search_ids,
+                &search_params,
+                tx,
+                batch,
+            )
+            .await
         }
     };
 
@@ -154,7 +132,7 @@ pub async fn search<const ROTMASK: u32>(
 }
 
 #[instrument(level = "trace", target = "searcher::network", skip_all)]
-async fn per_session<const ROTMASK: u32, N: Neighborhood<Aby3Store<HawkOps>>>(
+async fn per_session<const ROTMASK: u32>(
     session: &HawkSession,
     search_queries: &SearchQueries<ROTMASK>,
     search_ids: &SearchIds,
@@ -179,7 +157,7 @@ async fn per_session<const ROTMASK: u32, N: Neighborhood<Aby3Store<HawkOps>>>(
                 let insertion_layer = search_params
                     .hnsw
                     .gen_layer_prf(&session.hnsw_prf_key, &layer_selection_value)?;
-                per_insert_query::<N>(
+                per_insert_query(
                     query,
                     search_params,
                     &mut vector_store,
@@ -254,7 +232,7 @@ async fn classify_and_extend(
         metrics::counter!("supermatcher_extended_searches").increment(1);
 
         let supermatch_neighbors = hnsw_supermatch
-            .search::<_, SortedNeighborhood<_>>(aby3_store, graph_store, query, ef_supermatch)
+            .search(aby3_store, graph_store, query, ef_supermatch)
             .await?;
 
         let supermatch_classified = classify_edges(
@@ -334,7 +312,7 @@ async fn classify_edges(
     })
 }
 
-async fn per_insert_query<N: Neighborhood<Aby3Store<HawkOps>>>(
+async fn per_insert_query(
     query: Aby3Query,
     search_params: &SearchParams,
     aby3_store: &mut Aby3Store<HawkOps>,
@@ -345,7 +323,7 @@ async fn per_insert_query<N: Neighborhood<Aby3Store<HawkOps>>>(
 
     let (links, update_ep) = search_params
         .hnsw
-        .search_to_insert::<_, N>(aby3_store, graph_store, &query, insertion_layer)
+        .search_to_insert(aby3_store, graph_store, &query, insertion_layer)
         .await?;
 
     let classified = if search_params.do_match {
@@ -399,7 +377,7 @@ async fn per_search_query(
     let ef_search = search_params.hnsw.params.get_ef_search(0);
     let layer_0_neighbors = search_params
         .hnsw
-        .search::<_, SortedNeighborhood<_>>(aby3_store, graph_store, &query, ef_search)
+        .search(aby3_store, graph_store, &query, ef_search)
         .await?;
 
     let links_unstructured = vec![layer_0_neighbors.edge_ids()];
@@ -447,7 +425,7 @@ pub async fn search_single_query_no_match_count<H: std::hash::Hash>(
     let insertion_layer = searcher.gen_layer_prf(&session.hnsw_prf_key, identifier)?;
 
     let (links, update_ep) = searcher
-        .search_to_insert::<_, SortedNeighborhood<_>>(&mut *store, &graph, &query, insertion_layer)
+        .search_to_insert(&mut *store, &graph, &query, insertion_layer)
         .await?;
 
     // Trim and extract unstructured vector lists
@@ -513,14 +491,7 @@ mod tests {
             'T',
         );
 
-        let result = search(
-            &sessions,
-            search_queries,
-            &request.ids,
-            search_params,
-            NeighborhoodMode::Sorted,
-        )
-        .await?;
+        let result = search(&sessions, search_queries, &request.ids, search_params).await?;
 
         for side in result {
             assert_eq!(side.len(), batch_size);

--- a/iris-mpc-cpu/src/genesis/plaintext.rs
+++ b/iris-mpc-cpu/src/genesis/plaintext.rs
@@ -34,10 +34,7 @@ use crate::{
     genesis::{BatchSize, BatchSizeConfig},
     graph_checkpoint::PruningMode,
     hawkers::plaintext_store::PlaintextStore,
-    hnsw::{
-        graph::neighborhood::Neighborhood, vector_store::VectorStoreMut, GraphMem, HnswSearcher,
-        SortedNeighborhood,
-    },
+    hnsw::{vector_store::VectorStoreMut, GraphMem, HnswSearcher},
 };
 
 /// Represents irises db table, mapping serial ids to version, and left and right iris codes.
@@ -243,12 +240,7 @@ pub async fn run_plaintext_genesis(mut state: GenesisState) -> Result<GenesisSta
                     let insertion_layer = searcher.gen_layer_prf(&prf_key, &identifier)?;
 
                     let (links, update_ep) = searcher
-                        .search_to_insert::<_, SortedNeighborhood<_>>(
-                            store,
-                            graph,
-                            &query,
-                            insertion_layer,
-                        )
+                        .search_to_insert(store, graph, &query, insertion_layer)
                         .await?;
 
                     // Trim and extract unstructured vector lists
@@ -348,12 +340,7 @@ pub async fn run_plaintext_genesis(mut state: GenesisState) -> Result<GenesisSta
                 let insertion_layer = searcher.gen_layer_prf(&prf_key, &identifier)?;
 
                 let (links, update_ep) = searcher
-                    .search_to_insert::<_, SortedNeighborhood<_>>(
-                        store,
-                        graph,
-                        &query,
-                        insertion_layer,
-                    )
+                    .search_to_insert(store, graph, &query, insertion_layer)
                     .await?;
 
                 // Trim and extract unstructured vector lists

--- a/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
@@ -809,12 +809,7 @@ mod tests {
                 for query in queries.iter() {
                     let insertion_layer = db.gen_layer_rng(&mut rng).unwrap();
                     let inserted_vector = db
-                        .insert::<_, SortedNeighborhood<_>>(
-                            &mut *store,
-                            &mut aby3_graph,
-                            query,
-                            insertion_layer,
-                        )
+                        .insert(&mut *store, &mut aby3_graph, query, insertion_layer)
                         .await
                         .unwrap();
                     inserted.push(inserted_vector)
@@ -824,7 +819,7 @@ mod tests {
                 for v in inserted.into_iter() {
                     let query = store.cache_query_from_store(&v).await.unwrap();
                     let neighbors = db
-                        .search::<_, SortedNeighborhood<_>>(&mut *store, &aby3_graph, &query, 1)
+                        .search(&mut *store, &aby3_graph, &query, 1)
                         .await
                         .unwrap();
                     tracing::debug!("Finished checking query");
@@ -881,12 +876,7 @@ mod tests {
                 .unwrap()
                 .clone();
             let cleartext_neighbors = hawk_searcher
-                .search::<_, SortedNeighborhood<_>>(
-                    &mut cleartext_data.0,
-                    &cleartext_data.1,
-                    &query,
-                    1,
-                )
+                .search(&mut cleartext_data.0, &cleartext_data.1, &query, 1)
                 .await?;
             assert!(
                 hawk_searcher
@@ -1545,12 +1535,7 @@ mod tests {
         for (iris, &layer) in cleartext_db.iter().zip(insertion_layers.iter()) {
             let query = Arc::new(iris.clone());
             searcher
-                .insert::<_, SortedNeighborhood<_>>(
-                    &mut plaintext_store,
-                    &mut plaintext_graph,
-                    &query,
-                    layer,
-                )
+                .insert(&mut plaintext_store, &mut plaintext_graph, &query, layer)
                 .instrument(plaintext_span.clone())
                 .await?;
         }
@@ -1572,7 +1557,7 @@ mod tests {
                 let mut graph: GraphMem = GraphMem::new();
                 for (query, &layer) in queries.iter().zip(layers.iter()) {
                     searcher
-                        .insert::<_, SortedNeighborhood<_>>(&mut *store, &mut graph, query, layer)
+                        .insert(&mut *store, &mut graph, query, layer)
                         .instrument(mpc_span.clone())
                         .await?;
                 }

--- a/iris-mpc-cpu/src/hawkers/aby3/test_utils.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3/test_utils.rs
@@ -16,7 +16,7 @@ use crate::{
     hawkers::{
         aby3::aby3_store::Aby3SharedIrisesRef, plaintext_store::PlaintextStore, TEST_DISTANCE_MODE,
     },
-    hnsw::{GraphMem, HnswSearcher, SortedNeighborhood, VectorStore},
+    hnsw::{GraphMem, HnswSearcher, VectorStore},
     network::mpc::NetworkType,
     protocol::shared_iris::{ArcIris, GaloisRingSharedIris},
     shares::{RingElement, Share},
@@ -332,12 +332,7 @@ pub async fn shared_random_setup<R: RngCore + Clone + CryptoRng>(
             for query in queries.iter() {
                 let insertion_layer = searcher.gen_layer_rng(&mut rng_searcher)?;
                 searcher
-                    .insert::<_, SortedNeighborhood<_>>(
-                        &mut *store_lock,
-                        &mut graph_store,
-                        query,
-                        insertion_layer,
-                    )
+                    .insert(&mut *store_lock, &mut graph_store, query, insertion_layer)
                     .await?;
             }
             let qids = queries.iter().map(|q| q.query_id).collect();

--- a/iris-mpc-cpu/src/hawkers/build_plaintext.rs
+++ b/iris-mpc-cpu/src/hawkers/build_plaintext.rs
@@ -13,7 +13,7 @@
 //! `parallel_batch_insert<V: VectorStoreMut>` is because the per-query search
 //! is spawned onto a multi-threaded [`JoinSet`], which requires the spawned
 //! future to be `Send`. The `VectorStore`/`VectorStoreMut` operations (and the
-//! `DistanceOps`/`Neighborhood` methods they call) are `async fn`s in traits,
+//! `DistanceOps` methods they call) are `async fn`s in traits,
 //! which carry no `Send` bound. For a *concrete* store the compiler still
 //! proves each future `Send` by auto-trait leakage, so each function below
 //! compiles; for a *generic* `V` that guarantee is unavailable and the spawn is
@@ -21,7 +21,7 @@
 //!
 //! Plausible upgrade path: add `+ Send` to those trait methods (desugaring the
 //! `async fn`s to `-> impl Future<..> + Send`, which cascades through
-//! `VectorStore`/`VectorStoreMut` into `DistanceOps` and `Neighborhood`), or
+//! `VectorStore`/`VectorStoreMut` into `DistanceOps`), or
 //! push the spawned work behind a higher-order closure whose concrete future is
 //! `Send` at each call site. Either then collapses these two routines into one
 //! generic `parallel_batch_insert<V>`.
@@ -38,7 +38,7 @@ use crate::hawkers::plaintext_deep_id_store::{Int4Vector, SharedPlaintextDeepIDS
 use crate::{
     execution::hawk_main::insert::{self, InsertPlanV},
     hawkers::{aby3::aby3_store::DistanceOps, plaintext_store::SharedPlaintextStore},
-    hnsw::{graph::neighborhood::Neighborhood, GraphMem, HnswSearcher, SortedNeighborhood},
+    hnsw::{GraphMem, HnswSearcher},
 };
 
 /// Number of entries to insert before reporting a new info log entry
@@ -72,12 +72,7 @@ pub async fn plaintext_parallel_batch_insert<D: DistanceOps>(
                 let insertion_layer = searcher.gen_layer_prf(&prf_seed, &(vector_id))?;
 
                 let (links, update_ep) = searcher
-                    .search_to_insert::<_, SortedNeighborhood<_>>(
-                        &mut store,
-                        &graph,
-                        &query,
-                        insertion_layer,
-                    )
+                    .search_to_insert(&mut store, &graph, &query, insertion_layer)
                     .await?;
 
                 // Trim and extract unstructured vector lists
@@ -162,12 +157,7 @@ pub async fn deep_id_parallel_batch_insert(
                 let insertion_layer = searcher.gen_layer_prf(&prf_seed, &(vector_id))?;
 
                 let (links, update_ep) = searcher
-                    .search_to_insert::<_, SortedNeighborhood<_>>(
-                        &mut store,
-                        &graph,
-                        &query,
-                        insertion_layer,
-                    )
+                    .search_to_insert(&mut store, &graph, &query, insertion_layer)
                     .await?;
 
                 // Trim and extract unstructured vector lists
@@ -227,7 +217,10 @@ pub async fn deep_id_parallel_batch_insert(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{hawkers::plaintext_store::PlaintextStore, hnsw::HnswSearcher};
+    use crate::{
+        hawkers::plaintext_store::PlaintextStore,
+        hnsw::{HnswSearcher, SortedNeighborhood},
+    };
     use aes_prng::AesRng;
     use iris_mpc_common::iris_db::db::IrisDB;
     use rand::SeedableRng;
@@ -286,9 +279,7 @@ mod tests {
         // Check if each inserted iris can be found and matched correctly
         for (_vector_id, iris_code) in irises {
             let query = Arc::new(iris_code);
-            let result = searcher
-                .search::<_, SortedNeighborhood<_>>(&mut store, &graph, &query, 1)
-                .await?;
+            let result = searcher.search(&mut store, &graph, &query, 1).await?;
             assert!(
                 searcher.is_match(&mut store, &[result]).await?,
                 "Match verification failed for an inserted iris"

--- a/iris-mpc-cpu/src/hawkers/plaintext_deep_id_store.rs
+++ b/iris-mpc-cpu/src/hawkers/plaintext_deep_id_store.rs
@@ -11,7 +11,7 @@ use crate::{
     hnsw::{
         metrics::ops_counter::Operation::{CompareDistance, EvaluateDistance},
         vector_store::VectorStoreMut,
-        GraphMem, HnswSearcher, SortedNeighborhood, VectorStore,
+        GraphMem, HnswSearcher, VectorStore,
     },
 };
 use aes_prng::AesRng;
@@ -243,7 +243,7 @@ impl PlaintextDeepIDStore {
                 .unwrap_or_else(|| VectorId::from_serial_id(serial_id));
             let insertion_layer = searcher.gen_layer_rng(&mut rng)?;
             let (neighbors, update_ep) = searcher
-                .search_to_insert::<_, SortedNeighborhood<_>>(self, &graph, &query, insertion_layer)
+                .search_to_insert(self, &graph, &query, insertion_layer)
                 .await?;
             searcher
                 .insert_from_search_results(self, &mut graph, query_id, neighbors, update_ep)
@@ -454,6 +454,7 @@ impl VectorStoreMut for SharedPlaintextDeepIDStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::hnsw::SortedNeighborhood;
     use tokio::task::JoinSet;
 
     #[test]

--- a/iris-mpc-cpu/src/hawkers/plaintext_store.rs
+++ b/iris-mpc-cpu/src/hawkers/plaintext_store.rs
@@ -7,7 +7,7 @@ use crate::{
     hnsw::{
         metrics::ops_counter::Operation::{CompareDistance, EvaluateDistance},
         vector_store::VectorStoreMut,
-        GraphMem, HnswSearcher, SortedNeighborhood, VectorStore,
+        GraphMem, HnswSearcher, VectorStore,
     },
 };
 use aes_prng::AesRng;
@@ -128,7 +128,7 @@ impl<D: DistanceOps> PlaintextStore<D> {
             let query_id = VectorId::from_serial_id(serial_id);
             let insertion_layer = searcher.gen_layer_rng(&mut rng)?;
             let (neighbors, update_ep) = searcher
-                .search_to_insert::<_, SortedNeighborhood<_>>(self, &graph, &query, insertion_layer)
+                .search_to_insert(self, &graph, &query, insertion_layer)
                 .await?;
             searcher
                 .insert_from_search_results(self, &mut graph, query_id, neighbors, update_ep)
@@ -359,7 +359,7 @@ impl<D: DistanceOps> VectorStoreMut for SharedPlaintextStore<D> {
 mod tests {
     use super::*;
     use crate::hawkers::aby3::aby3_store::FhdOps;
-    use crate::hnsw::HnswSearcher;
+    use crate::hnsw::{HnswSearcher, SortedNeighborhood};
     use aes_prng::AesRng;
     use iris_mpc_common::iris_db::db::IrisDB;
     use itertools::Itertools;

--- a/iris-mpc-cpu/src/hnsw/graph/graph_diff/explicit.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/graph_diff/explicit.rs
@@ -130,7 +130,7 @@ impl Differ for ExplicitNeighborhoodDiffer {
             jaccard_state,
         };
 
-        self.current_layer_diffs.push((node.clone(), diff));
+        self.current_layer_diffs.push((*node, diff));
     }
 
     fn end_layer(&mut self, layer_index: usize) {
@@ -141,7 +141,7 @@ impl Differ for ExplicitNeighborhoodDiffer {
                         .sort_by(|a, b| a.1.jaccard_state.compare_as_fractions(&b.1.jaccard_state));
                 }
                 SortBy::Index => {
-                    self.current_layer_diffs.sort_by(|a, b| a.0.cmp(&b.0));
+                    self.current_layer_diffs.sort_by_key(|a| a.0);
                 }
             }
             self.per_layer_results.push(LayerDiffResult {

--- a/iris-mpc-cpu/src/hnsw/graph/graph_diff/jaccard.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/graph_diff/jaccard.rs
@@ -117,7 +117,7 @@ impl Differ for DetailedJaccardDiffer {
         let intersection = lhs_set.intersection(&rhs_set).count();
         let union = lhs_set.union(&rhs_set).count();
         let node_state = JaccardState::new(intersection, union);
-        self.current_layer_details.push((node.clone(), node_state));
+        self.current_layer_details.push((*node, node_state));
     }
 
     fn end_layer(&mut self, _layer_index: usize) {

--- a/iris-mpc-cpu/src/hnsw/graph/graph_diff/node_equiv.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/graph_diff/node_equiv.rs
@@ -46,7 +46,7 @@ pub fn ensure_node_equivalence(lhs: &GraphMem, rhs: &GraphMem) -> Result<(), Nod
         if let Some(missing_node) = lhs_nodes.difference(&rhs_nodes).next() {
             return Err(NodeEquivalenceError::NodeMissingInRhs {
                 layer_index: i,
-                node: missing_node.clone(),
+                node: *missing_node,
             });
         }
 
@@ -54,7 +54,7 @@ pub fn ensure_node_equivalence(lhs: &GraphMem, rhs: &GraphMem) -> Result<(), Nod
         if let Some(missing_node) = rhs_nodes.difference(&lhs_nodes).next() {
             return Err(NodeEquivalenceError::NodeMissingInLhs {
                 layer_index: i,
-                node: missing_node.clone(),
+                node: *missing_node,
             });
         }
     }

--- a/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
@@ -168,17 +168,13 @@ impl GraphMem {
             .iter()
             .enumerate()
             .rfind(|(_lc, layer)| !layer.links.is_empty())
-            .and_then(|(lc, layer)| layer.links.keys().min().map(|x| (x.clone(), lc)))
+            .and_then(|(lc, layer)| layer.links.keys().min().map(|x| (*x, lc)))
     }
 
     /// Gets the list of entry points.
     /// If this list is empty in LinearScan mode, `get_temporary_entry_point` may be used instead.
     pub fn get_entry_points(&self) -> Option<Vec<IrisVectorId>> {
-        let v: Vec<_> = self
-            .entry_points
-            .iter()
-            .map(|ep| ep.point.clone())
-            .collect();
+        let v: Vec<_> = self.entry_points.iter().map(|ep| ep.point).collect();
         if v.is_empty() {
             None
         } else {
@@ -225,13 +221,13 @@ impl GraphMem {
                                 self.layers.resize(*layer + 1, Layer::new());
                             }
                             self.entry_points = vec![EntryPoint {
-                                point: id.clone(),
+                                point: *id,
                                 layer: *layer,
                             }];
                         }
                         UpdateEntryPoint::Append { layer } => {
                             self.entry_points.push(EntryPoint {
-                                point: id.clone(),
+                                point: *id,
                                 layer: *layer,
                             });
                         }
@@ -399,9 +395,7 @@ impl GraphMem {
     }
 
     pub async fn get_first_entry_point(&self) -> Option<(IrisVectorId, usize)> {
-        self.entry_points
-            .first()
-            .map(|ep| (ep.point.clone(), ep.layer))
+        self.entry_points.first().map(|ep| (ep.point, ep.layer))
     }
 
     pub async fn init_entry_points(&mut self, points: Vec<IrisVectorId>, layer: usize) {
@@ -696,7 +690,7 @@ impl Layer {
     }
 
     pub fn insert_node(&mut self, id: &IrisVectorId, neighbors: Vec<IrisVectorId>) {
-        self.set_links(id.clone(), neighbors.clone());
+        self.set_links(*id, neighbors.clone());
     }
 
     /// Insert `id` as an incoming edge into each target's neighbor list,
@@ -710,7 +704,7 @@ impl Layer {
                 if let Err(pos) = target_links.binary_search(node) {
                     self.set_hash
                         .remove_unordered_set(target, target_links.iter());
-                    target_links.insert(pos, node.clone());
+                    target_links.insert(pos, *node);
                     self.set_hash.add_unordered_set(target, target_links.iter());
                 }
             }
@@ -748,10 +742,10 @@ impl Layer {
             for neighbor in neighbors {
                 if let Some(neighbor_links) = self.links.get_mut(&neighbor) {
                     self.set_hash
-                        .remove_unordered_set(&neighbor, neighbor_links.iter());
+                        .remove_unordered_set(neighbor, neighbor_links.iter());
                     neighbor_links.retain(|x| x != id);
                     self.set_hash
-                        .add_unordered_set(&neighbor, neighbor_links.iter());
+                        .add_unordered_set(neighbor, neighbor_links.iter());
                 }
             }
         }
@@ -913,7 +907,7 @@ where
         .entry_points
         .iter()
         .map(|ep| EntryPoint {
-            point: vector_map(ep.point.clone()),
+            point: vector_map(ep.point),
             layer: ep.layer,
         })
         .collect();

--- a/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
@@ -945,7 +945,7 @@ mod tests {
         hawkers::{aby3::aby3_store::FhdOps, plaintext_store::PlaintextStore},
         hnsw::{
             graph::layered_graph::migrate, vector_store::VectorStoreMut, GraphMem, HnswSearcher,
-            SortedNeighborhood, VectorStore,
+            VectorStore,
         },
     };
     use aes_prng::AesRng;
@@ -1041,12 +1041,7 @@ mod tests {
             let query = Arc::new(raw_query);
             let insertion_layer = searcher.gen_layer_rng(&mut rng)?;
             let (neighbors, update_ep) = searcher
-                .search_to_insert::<_, SortedNeighborhood<_>>(
-                    &mut vector_store,
-                    &graph_store,
-                    &query,
-                    insertion_layer,
-                )
+                .search_to_insert(&mut vector_store, &graph_store, &query, insertion_layer)
                 .await?;
             let inserted = vector_store.insert(&query).await;
             searcher
@@ -1104,12 +1099,7 @@ mod tests {
             let query = Arc::new(raw_query);
             let insertion_layer = searcher.gen_layer_rng(&mut rng)?;
             let (neighbors, update_ep) = searcher
-                .search_to_insert::<_, SortedNeighborhood<_>>(
-                    &mut vector_store,
-                    &graph_store,
-                    &query,
-                    insertion_layer,
-                )
+                .search_to_insert(&mut vector_store, &graph_store, &query, insertion_layer)
                 .await?;
             let inserted = vector_store.insert(&query).await;
             searcher

--- a/iris-mpc-cpu/src/hnsw/graph/mutation.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/mutation.rs
@@ -112,11 +112,11 @@ impl UnstampedMutation {
             } = op
             {
                 if matches!(edge_type, EdgeType::Base | EdgeType::All) {
-                    out.push((base.clone(), *layer));
+                    out.push((*base, *layer));
                 }
                 if matches!(edge_type, EdgeType::Neighbors | EdgeType::All) {
                     for n in neighbors {
-                        out.push((n.clone(), *layer));
+                        out.push((*n, *layer));
                     }
                 }
             }
@@ -146,11 +146,11 @@ impl UnstampedMutation {
                     edge_type,
                 } => {
                     if matches!(edge_type, EdgeType::Base | EdgeType::All) {
-                        out.push((base.clone(), *layer));
+                        out.push((*base, *layer));
                     }
                     if matches!(edge_type, EdgeType::Neighbors | EdgeType::All) {
                         for n in neighbors {
-                            out.push((n.clone(), *layer));
+                            out.push((*n, *layer));
                         }
                     }
                 }

--- a/iris-mpc-cpu/src/hnsw/graph/neighborhood.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/neighborhood.rs
@@ -5,80 +5,15 @@
 
 use crate::hnsw::{
     sorting::{
-        batcher::partial_batcher_network, quickselect::run_quickselect_with_store,
-        quicksort::apply_quicksort, swap_network::apply_swap_network,
+        batcher::partial_batcher_network, quicksort::apply_quicksort,
+        swap_network::apply_swap_network,
     },
     VectorStore,
 };
-use delegate::delegate;
 use eyre::Result;
 use iris_mpc_common::vector_id::VectorId;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
-
-/// Trait that captures the requirements for an HNSW candidate list container/data-structure.
-/// Implementers should ensure the following post-condition for calls to `trim` methods:
-/// - The elements in the container are the smallest `container.length` ones among all insertions.
-/// - The last element in the container is the largest one.
-#[allow(async_fn_in_trait)]
-pub trait Neighborhood<V: VectorStore>:
-    Send + Sync + Clone + AsRef<[(VectorId, V::DistanceRef)]> + Into<WrappedNeighborhood<V>>
-{
-    fn new() -> Self;
-
-    fn len(&self) -> usize {
-        self.as_ref().len()
-    }
-
-    fn is_empty(&self) -> bool {
-        self.as_ref().is_empty()
-    }
-
-    fn from_singleton(element: (VectorId, V::DistanceRef)) -> Self;
-
-    fn edge_ids(&self) -> Vec<VectorId> {
-        self.as_ref().iter().map(|(v, _)| *v).collect::<Vec<_>>()
-    }
-
-    /// Inserts a batch of elements into the neighborhood and applies the necessary
-    /// changes to ensure the neighborhood invariant holds
-    /// Note that in general maintaining the invariant may incur significant overhead.
-    /// Consult implementer for performance specs
-    async fn insert_batch_and_trim(
-        &mut self,
-        store: &mut V,
-        vals: &[(VectorId, V::DistanceRef)],
-        k: usize,
-    ) -> Result<()>;
-
-    /// Apply the invariant-maintaining algorithm
-    /// Note that in general maintaining the invariant may incur significant overhead.
-    /// Consult implementer for performance specs.
-    async fn trim(&mut self, store: &mut V, k: usize) -> Result<()> {
-        self.insert_batch_and_trim(store, &[], k).await
-    }
-
-    /// Inserts a single element into the neighborhood.
-    /// By default calls batched version with size 1.
-    /// Note that in general maintaining the invariant may incur significant overhead.
-    /// Consult implementer for performance specs.
-    async fn insert_and_trim(
-        &mut self,
-        store: &mut V,
-        to: VectorId,
-        dist: V::DistanceRef,
-        k: usize,
-    ) -> Result<()> {
-        self.insert_batch_and_trim(store, &[(to, dist)], k).await
-    }
-
-    /// Returns matching records in the neighborhood.
-    /// No specific order should be assumed.
-    async fn matches(&self, store: &mut V) -> Result<Vec<(VectorId, V::DistanceRef)>>;
-
-    /// Returns the node with maximum distance in the neighborhood
-    fn get_furthest(&self) -> Option<&(VectorId, V::DistanceRef)>;
-}
 
 /// SortedNeighborhood maintains a collection of distance-weighted oriented
 /// graph edges for an HNSW graph which are stored in increasing order of edge
@@ -178,29 +113,53 @@ impl<V: VectorStore> AsRef<[(VectorId, V::DistanceRef)]> for SortedNeighborhood<
     }
 }
 
-#[allow(async_fn_in_trait)]
-impl<V: VectorStore> Neighborhood<V> for SortedNeighborhood<V> {
-    /// Insert the element `to` with distance `dist` into the list, maintaining
-    /// the ascending order.
-    ///
-    /// Calls the `VectorStore` to find the insertion index.
-    fn new() -> Self {
+impl<V: VectorStore> SortedNeighborhood<V> {
+    pub fn new() -> Self {
         Self {
             edges: Default::default(),
         }
     }
 
-    fn from_singleton(element: (VectorId, V::DistanceRef)) -> Self {
+    pub fn len(&self) -> usize {
+        self.edges.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.edges.is_empty()
+    }
+
+    pub fn from_singleton(element: (VectorId, V::DistanceRef)) -> Self {
         SortedNeighborhood {
             edges: vec![element],
         }
+    }
+
+    pub fn edge_ids(&self) -> Vec<VectorId> {
+        self.edges.iter().map(|(v, _)| *v).collect::<Vec<_>>()
+    }
+
+    /// Apply the invariant-maintaining algorithm so the elements are the
+    /// smallest `k` ones among all insertions, with the last element largest.
+    pub async fn trim(&mut self, store: &mut V, k: usize) -> Result<()> {
+        self.insert_batch_and_trim(store, &[], k).await
+    }
+
+    /// Inserts a single element into the neighborhood and trims to length `k`.
+    pub async fn insert_and_trim(
+        &mut self,
+        store: &mut V,
+        to: VectorId,
+        dist: V::DistanceRef,
+        k: usize,
+    ) -> Result<()> {
+        self.insert_batch_and_trim(store, &[(to, dist)], k).await
     }
 
     /// Appends `vals` to the neighborhood, applies quicksort and truncates to length `k`.
     /// Expected bandwitdh: loglinear in `|self.edges| + |vals|`, but `|vals| log |self.edges|` for small `|vals|`.
     /// Expected rounds: logarithmic in `|self.edges| + |vals|`.
     /// Consult quicksort implementation for details on performance.
-    async fn insert_batch_and_trim(
+    pub async fn insert_batch_and_trim(
         &mut self,
         store: &mut V,
         vals: &[(VectorId, V::DistanceRef)],
@@ -220,12 +179,12 @@ impl<V: VectorStore> Neighborhood<V> for SortedNeighborhood<V> {
         Ok(())
     }
 
-    fn get_furthest(&self) -> Option<&(VectorId, V::DistanceRef)> {
+    pub fn get_furthest(&self) -> Option<&(VectorId, V::DistanceRef)> {
         self.edges.last()
     }
     /// Count the neighbors that match according to `store.is_match`.
     /// The nearest `count` elements are matches and the rest are non-matches.
-    async fn matches(&self, store: &mut V) -> Result<Vec<(VectorId, V::DistanceRef)>> {
+    pub async fn matches(&self, store: &mut V) -> Result<Vec<(VectorId, V::DistanceRef)>> {
         let mut left = 0;
         let mut right = self.edges.len();
 
@@ -243,161 +202,6 @@ impl<V: VectorStore> Neighborhood<V> for SortedNeighborhood<V> {
     }
 }
 
-pub struct UnsortedNeighborhood<V: VectorStore> {
-    /// List of distance-weighted directed edges, specified as tuples
-    /// `(target, weight)`
-    pub edges: Vec<(VectorId, V::DistanceRef)>,
-}
-
-impl<V: VectorStore> Clone for UnsortedNeighborhood<V>
-where
-    VectorId: Clone,
-    V::DistanceRef: Clone,
-{
-    fn clone(&self) -> Self {
-        UnsortedNeighborhood {
-            edges: self.edges.clone(),
-        }
-    }
-}
-
-impl<V: VectorStore> UnsortedNeighborhood<V> {
-    async fn quickselect(&mut self, store: &mut V, k: usize) -> Result<()> {
-        assert!(0 < k && k <= self.edges.len());
-        let values = self
-            .edges
-            .iter()
-            .map(|(_, dist)| dist.clone())
-            .collect::<Vec<_>>();
-        // Get the permutation which describes the partitioned sequence
-        let indices = run_quickselect_with_store(store, &values, k).await?;
-        self.edges = indices
-            .into_iter()
-            .take(k) // truncate to smallest k
-            .map(|i| self.edges[i].clone())
-            .collect::<Vec<_>>();
-        Ok(())
-    }
-}
-
-impl<V: VectorStore> AsRef<[(VectorId, V::DistanceRef)]> for UnsortedNeighborhood<V> {
-    fn as_ref(&self) -> &[(VectorId, V::DistanceRef)] {
-        &self.edges
-    }
-}
-
-impl<V: VectorStore> Neighborhood<V> for UnsortedNeighborhood<V> {
-    fn new() -> Self {
-        Self {
-            edges: Default::default(),
-        }
-    }
-
-    fn from_singleton(element: (VectorId, V::DistanceRef)) -> Self {
-        UnsortedNeighborhood {
-            edges: vec![element],
-        }
-    }
-
-    /// Appends `vals` to the neighborhood, applies quickselect and truncates to length k.
-    /// Expected bandwitdh: linear in `|self.edges| + |vals|`
-    /// Expected rounds: logarithmic in `|self.edges| + |vals|`
-    async fn insert_batch_and_trim(
-        &mut self,
-        store: &mut V,
-        vals: &[(VectorId, V::DistanceRef)],
-        k: usize,
-    ) -> Result<()> {
-        debug!(batch_size = vals.len(), "Insert batch into neighborhood");
-        self.edges.extend(vals.to_vec());
-
-        // TODO: this case can be optimized if needed
-        let k = k.min(self.edges.len());
-
-        if k == 0 {
-            self.edges.clear();
-        } else {
-            self.quickselect(store, k).await?;
-        }
-        Ok(())
-    }
-
-    fn get_furthest(&self) -> Option<&(VectorId, V::DistanceRef)> {
-        self.edges.last()
-    }
-
-    /// Count the neighbors that match according to `store.is_match`.
-    async fn matches(&self, store: &mut V) -> Result<Vec<(VectorId, V::DistanceRef)>> {
-        let distances = self
-            .edges
-            .iter()
-            .map(|(_, dist)| dist.clone())
-            .collect::<Vec<_>>();
-        let results = store.is_match_batch(&distances).await?;
-        Ok(self
-            .edges
-            .iter()
-            .enumerate()
-            .filter_map(|(i, (v, d))| {
-                if results[i] {
-                    Some((*v, d.clone()))
-                } else {
-                    None
-                }
-            })
-            .collect())
-    }
-}
-
-/// Datatype which covers all used implementers of Neighborhood
-#[allow(dead_code)]
-pub enum WrappedNeighborhood<V: VectorStore> {
-    Sorted(SortedNeighborhood<V>),
-    Unsorted(UnsortedNeighborhood<V>),
-}
-
-impl<V: VectorStore> From<SortedNeighborhood<V>> for WrappedNeighborhood<V> {
-    fn from(value: SortedNeighborhood<V>) -> Self {
-        Self::Sorted(value)
-    }
-}
-
-impl<V: VectorStore> From<UnsortedNeighborhood<V>> for WrappedNeighborhood<V> {
-    fn from(value: UnsortedNeighborhood<V>) -> Self {
-        Self::Unsorted(value)
-    }
-}
-
-#[allow(dead_code)]
-impl<V: VectorStore> WrappedNeighborhood<V> {
-    delegate! {
-        to match self {
-            WrappedNeighborhood::Sorted(nb) => nb,
-            WrappedNeighborhood::Unsorted(nb) => nb,
-        } {
-            async fn insert_batch_and_trim(
-                &mut self,
-                store: &mut V,
-                vals: &[(VectorId, V::DistanceRef)],
-                k: usize,
-            ) -> Result<()>;
-
-            async fn matches(&self, store: &mut V) -> Result<Vec<(VectorId, V::DistanceRef)>>;
-
-            fn get_furthest(&self) -> Option<&(VectorId, V::DistanceRef)>;
-        }
-    }
-}
-
-impl<V: VectorStore> AsRef<[(VectorId, V::DistanceRef)]> for WrappedNeighborhood<V> {
-    fn as_ref(&self) -> &[(VectorId, V::DistanceRef)] {
-        match self {
-            WrappedNeighborhood::Sorted(nb) => nb.as_ref(),
-            WrappedNeighborhood::Unsorted(nb) => nb.as_ref(),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -407,10 +211,10 @@ mod tests {
     use iris_mpc_common::{iris_db::iris::IrisCode, IrisVectorId};
     use rand::thread_rng;
 
-    async fn insert_batch_store_and_nbhd<N: Neighborhood<PlaintextStore>>(
+    async fn insert_batch_store_and_nbhd(
         query: Arc<IrisCode>,
         store: &mut PlaintextStore,
-        nbhd: &mut N,
+        nbhd: &mut SortedNeighborhood<PlaintextStore>,
         irises: &[Arc<IrisCode>],
     ) -> Result<()> {
         let mut pairs = Vec::new();
@@ -426,11 +230,11 @@ mod tests {
         Ok(())
     }
 
-    async fn test_neighborhood_generic<N: Neighborhood<PlaintextStore>>() -> Result<()> {
+    async fn test_neighborhood_generic() -> Result<()> {
         let mut rng = thread_rng();
         let mut store = PlaintextStore::new();
         let query = Arc::new(IrisCode::random_rng(&mut rng));
-        let mut nbhd = N::new();
+        let mut nbhd = SortedNeighborhood::<PlaintextStore>::new();
 
         let randos = (0..3)
             .map(|_| Arc::new(IrisCode::random_rng(&mut rng)))
@@ -487,15 +291,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_sorted_neighborhood() {
-        test_neighborhood_generic::<SortedNeighborhood<PlaintextStore>>()
-            .await
-            .unwrap();
-    }
-
-    #[tokio::test]
-    async fn test_unsorted_neighborhood() {
-        test_neighborhood_generic::<UnsortedNeighborhood<PlaintextStore>>()
-            .await
-            .unwrap();
+        test_neighborhood_generic().await.unwrap();
     }
 }

--- a/iris-mpc-cpu/src/hnsw/graph/neighborhood.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/neighborhood.rs
@@ -230,7 +230,8 @@ mod tests {
         Ok(())
     }
 
-    async fn test_neighborhood_generic() -> Result<()> {
+    #[tokio::test]
+    async fn test_sorted_neighborhood() -> Result<()> {
         let mut rng = thread_rng();
         let mut store = PlaintextStore::new();
         let query = Arc::new(IrisCode::random_rng(&mut rng));
@@ -287,10 +288,5 @@ mod tests {
         assert!(nbhd.get_furthest().is_none());
 
         Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_sorted_neighborhood() {
-        test_neighborhood_generic().await.unwrap();
     }
 }

--- a/iris-mpc-cpu/src/hnsw/graph/test_utils.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/test_utils.rs
@@ -18,7 +18,6 @@ use crate::{
                 run_diff,
             },
             mutation::EdgeType,
-            neighborhood::Neighborhood,
             GraphMutation, MutationOp, UpdateEntryPoint,
         },
         vector_store::{VectorStore, VectorStoreMut},

--- a/iris-mpc-cpu/src/hnsw/searcher.rs
+++ b/iris-mpc-cpu/src/hnsw/searcher.rs
@@ -11,7 +11,7 @@ use super::{
 use crate::hnsw::{
     graph::{
         mutation::{EdgeType, GraphMutation, UnstampedMutation},
-        neighborhood::Neighborhood,
+        neighborhood::SortedNeighborhood,
         MutationOp, UpdateEntryPoint,
     },
     metrics::ops_counter::Operation,
@@ -208,12 +208,6 @@ pub enum LayerMode {
     },
 }
 
-#[derive(Clone, Debug, Deserialize)]
-pub enum NeighborhoodMode {
-    Sorted,
-    Unsorted,
-}
-
 /// Struct specifies the probability distribution used to generate insertion
 /// layers for new nodes in an HNSW graph.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -268,8 +262,8 @@ impl LayerDistribution {
 ///
 /// Evaluation and comparison of vector distances are delegated to an implementor of the
 /// `VectorStore` trait, and management of the hierarchical graph is delegated to a `GraphMem`
-/// struct. Queries and updates to the active neighbor candidate list are delegated to an implementor
-/// of the `Neighborhood` trait.
+/// struct. Queries and updates to the active neighbor candidate list use the
+/// `SortedNeighborhood` candidate-list container.
 ///
 /// Graph search in this implementation is optimized to reduce the number of sequential distance
 /// evaluation and distance comparison operations, because we use SMPC protocols to implement these
@@ -403,13 +397,13 @@ impl HnswSearcher {
     /// - Enum designating how to handle entry point update
     #[allow(non_snake_case)]
     #[instrument(level = "trace", target = "searcher::cpu_time", skip_all)]
-    async fn search_init<V: VectorStore, N: Neighborhood<V>>(
+    async fn search_init<V: VectorStore>(
         &self,
         store: &mut V,
         graph: &GraphMem,
         query: &V::QueryRef,
         insertion_layer: usize,
-    ) -> Result<(N, usize, usize, UpdateEntryPoint)> {
+    ) -> Result<(SortedNeighborhood<V>, usize, usize, UpdateEntryPoint)> {
         match self.layer_mode {
             LayerMode::Standard { max_graph_layer } => {
                 let ep = graph.get_first_entry_point().await;
@@ -463,7 +457,7 @@ impl HnswSearcher {
                 } else {
                     let nearest_point =
                         Self::linear_search_min_distance(store, query, ep_vectors).await?;
-                    let W = N::from_singleton(nearest_point);
+                    let W = SortedNeighborhood::from_singleton(nearest_point);
 
                     // Entry points are in layer `max_graph_layer`, so number of layers is one more since layers are 0-indexed.
                     let n_layers = max_graph_layer + 1;
@@ -494,19 +488,19 @@ impl HnswSearcher {
     ///
     /// If `ep` is specified as `None` (no entry point available), then returns
     /// an empty neighborhood and `None` for its layer.
-    async fn init_nbhd_from_ep<V: VectorStore, N: Neighborhood<V>>(
+    async fn init_nbhd_from_ep<V: VectorStore>(
         &self,
         store: &mut V,
         ep: Option<(VectorId, usize)>,
         query: &V::QueryRef,
-    ) -> Result<(N, Option<usize>)> {
+    ) -> Result<(SortedNeighborhood<V>, Option<usize>)> {
         if let Some((entry_point, layer)) = ep {
             let distance = store.eval_distance(query, &entry_point).await?;
 
-            let W = N::from_singleton((entry_point, distance));
+            let W = SortedNeighborhood::from_singleton((entry_point, distance));
             Ok((W, Some(layer)))
         } else {
-            Ok((N::new(), None))
+            Ok((SortedNeighborhood::new(), None))
         }
     }
 
@@ -520,11 +514,11 @@ impl HnswSearcher {
         fields(event_type = Operation::LayerSearch.id()),
         skip(store, graph, q, W))]
     #[allow(non_snake_case)]
-    async fn search_layer<V: VectorStore, N: Neighborhood<V>>(
+    async fn search_layer<V: VectorStore>(
         store: &mut V,
         graph: &GraphMem,
         q: &V::QueryRef,
-        W: &mut N,
+        W: &mut SortedNeighborhood<V>,
         ef: usize,
         lc: usize,
         fixed_batch_size: Option<usize>,
@@ -536,7 +530,7 @@ impl HnswSearcher {
             1 => {
                 let start = W.as_ref().first().ok_or(eyre!("W cannot be empty"))?;
                 let nearest = Self::layer_search_greedy(store, graph, q, start, lc).await?;
-                *W = N::from_singleton(nearest);
+                *W = SortedNeighborhood::from_singleton(nearest);
             }
             2..32 => {
                 Self::layer_search_std(store, graph, q, W, ef, lc).await?;
@@ -560,11 +554,11 @@ impl HnswSearcher {
     /// neighbors inspected, which is recorded in an additional `HashSet` of
     /// vector ids.
     #[instrument(level = "debug", skip(store, graph, q, W))]
-    async fn layer_search_std<V: VectorStore, N: Neighborhood<V>>(
+    async fn layer_search_std<V: VectorStore>(
         store: &mut V,
         graph: &GraphMem,
         q: &V::QueryRef,
-        W: &mut N,
+        W: &mut SortedNeighborhood<V>,
         ef: usize,
         lc: usize,
     ) -> Result<()> {
@@ -707,11 +701,11 @@ impl HnswSearcher {
     /// returns.
     #[allow(dead_code)]
     #[instrument(level = "debug", skip(store, graph, q, W))]
-    async fn layer_search_batched<V: VectorStore, N: Neighborhood<V>>(
+    async fn layer_search_batched<V: VectorStore>(
         store: &mut V,
         graph: &GraphMem,
         q: &V::QueryRef,
-        W: &mut N,
+        W: &mut SortedNeighborhood<V>,
         ef: usize,
         lc: usize,
     ) -> Result<()> {
@@ -955,7 +949,7 @@ impl HnswSearcher {
     /// neighborhood from which the main search can proceed.  Once neighbors are
     /// chosen, the distances between all new neighbors and the search query are
     /// evaluated as a batch, and the nodes are organized into a candidate
-    /// neighborhood. The specifics of this organization depend on the generic parameter `N`.
+    /// neighborhood.
     ///
     /// Once `W` has size `ef`, the second phase of graph traversal starts. In
     /// this phase, batches of unopened elements of `W` are opened and
@@ -993,11 +987,11 @@ impl HnswSearcher {
     /// not allow batching of distance evaluation, which has become a
     /// significant latency bottleneck in practice.
     #[instrument(level = "debug", skip(store, graph, q, W))]
-    async fn layer_search_batched_v2<V: VectorStore, N: Neighborhood<V>>(
+    async fn layer_search_batched_v2<V: VectorStore>(
         store: &mut V,
         graph: &GraphMem,
         q: &V::QueryRef,
-        W: &mut N,
+        W: &mut SortedNeighborhood<V>,
         ef: usize,
         lc: usize,
         fixed_batch_size: Option<usize>,
@@ -1388,16 +1382,16 @@ impl HnswSearcher {
     /// value for `ef` at layer 0 only, and `ef = 1` (greedy search) for all higher layers.
     #[allow(non_snake_case)]
     #[instrument(level = "trace", target = "searcher::network", skip_all)]
-    pub async fn search<V: VectorStore, N: Neighborhood<V>>(
+    pub async fn search<V: VectorStore>(
         &self,
         store: &mut V,
         graph: &GraphMem,
         query: &V::QueryRef,
         k: usize,
-    ) -> Result<N> {
+    ) -> Result<SortedNeighborhood<V>> {
         // insertion layer doesn't matter here because set_ep is ignored
         let init_start = std::time::Instant::now();
-        let (mut W, n_layers, _, _) = self.search_init::<_, N>(store, graph, query, 0).await?;
+        let (mut W, n_layers, _, _) = self.search_init(store, graph, query, 0).await?;
         metrics::histogram!("search_init_duration").record(init_start.elapsed().as_secs_f64());
 
         // Search from the top layer down to layer 0
@@ -1425,7 +1419,7 @@ impl HnswSearcher {
     /// Insert `query` into the HNSW index represented by `store` and `graph`.
     /// Return a `VectorId` representing the inserted vector.
     #[instrument(level = "trace", skip_all, target = "searcher::network")]
-    pub async fn insert<V: VectorStoreMut, N: Neighborhood<V>>(
+    pub async fn insert<V: VectorStoreMut>(
         &self,
         store: &mut V,
         graph: &mut GraphMem,
@@ -1433,7 +1427,7 @@ impl HnswSearcher {
         insertion_layer: usize,
     ) -> Result<VectorId> {
         let (neighbors, update_ep) = self
-            .search_to_insert::<_, N>(store, graph, query, insertion_layer)
+            .search_to_insert(store, graph, query, insertion_layer)
             .await?;
         let inserted = store.insert(query).await;
         self.insert_from_search_results(store, graph, inserted, neighbors, update_ep)
@@ -1467,18 +1461,18 @@ impl HnswSearcher {
         skip(self, store, graph, query)
     )]
     #[allow(non_snake_case)]
-    pub async fn search_to_insert<V: VectorStore, N: Neighborhood<V>>(
+    pub async fn search_to_insert<V: VectorStore>(
         &self,
         store: &mut V,
         graph: &GraphMem,
         query: &V::QueryRef,
         insertion_layer: usize,
-    ) -> Result<(Vec<N>, UpdateEntryPoint)> {
+    ) -> Result<(Vec<SortedNeighborhood<V>>, UpdateEntryPoint)> {
         // Initialize candidate neighborhood, index of highest search layer,
         // finalized layer of node insertion, and entry point update outcome.
         let init_start = std::time::Instant::now();
         let (mut W, n_layers, insertion_layer, update_ep) = self
-            .search_init::<_, N>(store, graph, query, insertion_layer)
+            .search_init(store, graph, query, insertion_layer)
             .await?;
         metrics::histogram!("search_init_duration").record(init_start.elapsed().as_secs_f64());
 
@@ -1519,7 +1513,7 @@ impl HnswSearcher {
         // If query is to be inserted at a new highest layer as a new entry
         // point, insert additional empty neighborhoods for any new layers
         for _ in links.len()..insertion_layer + 1 {
-            links.push(N::new());
+            links.push(SortedNeighborhood::new());
         }
 
         assert_eq!(links.len(), insertion_layer + 1);
@@ -1651,12 +1645,12 @@ impl HnswSearcher {
         target = "searcher::cpu_time",
         skip(self, store, graph, inserted_vector, links)
     )]
-    pub async fn insert_from_search_results<V: VectorStore, N: Neighborhood<V>>(
+    pub async fn insert_from_search_results<V: VectorStore>(
         &self,
         store: &mut V,
         graph: &mut GraphMem,
         inserted_vector: VectorId,
-        links: Vec<N>,
+        links: Vec<SortedNeighborhood<V>>,
         update_ep: UpdateEntryPoint,
     ) -> Result<()> {
         // Trim and extract unstructured vector lists.
@@ -1708,10 +1702,10 @@ impl HnswSearcher {
         Ok(())
     }
 
-    pub async fn is_match<V: VectorStore, N: Neighborhood<V>>(
+    pub async fn is_match<V: VectorStore>(
         &self,
         store: &mut V,
-        neighbors: &[N],
+        neighbors: &[SortedNeighborhood<V>],
     ) -> Result<bool> {
         match neighbors.first() {
             None => Ok(false),
@@ -1719,10 +1713,10 @@ impl HnswSearcher {
         }
     }
 
-    pub async fn matches<V: VectorStore, N: Neighborhood<V>>(
+    pub async fn matches<V: VectorStore>(
         &self,
         store: &mut V,
-        neighbors: &[N],
+        neighbors: &[SortedNeighborhood<V>],
     ) -> Result<Vec<(VectorId, V::DistanceRef)>> {
         match neighbors.first() {
             None => Ok(vec![]),
@@ -1741,7 +1735,7 @@ mod tests {
     use super::*;
     use crate::{
         hawkers::{aby3::aby3_store::FhdOps, plaintext_store::PlaintextStore},
-        hnsw::{GraphMem, SortedNeighborhood},
+        hnsw::GraphMem,
     };
     use aes_prng::AesRng;
     use iris_mpc_common::{
@@ -1766,12 +1760,7 @@ mod tests {
         for query in queries1.iter() {
             let insertion_layer = db.gen_layer_rng(rng)?;
             let (neighbors, update_ep) = db
-                .search_to_insert::<_, SortedNeighborhood<PlaintextStore>>(
-                    vector_store,
-                    graph_store,
-                    query,
-                    insertion_layer,
-                )
+                .search_to_insert(vector_store, graph_store, query, insertion_layer)
                 .await?;
             assert!(!db.is_match(vector_store, &neighbors).await?);
 
@@ -1796,20 +1785,13 @@ mod tests {
         // Insert the codes with helper function
         for query in queries2.iter() {
             let insertion_layer = db.gen_layer_rng(rng)?;
-            db.insert::<_, SortedNeighborhood<_>>(
-                vector_store,
-                graph_store,
-                query,
-                insertion_layer,
-            )
-            .await?;
+            db.insert(vector_store, graph_store, query, insertion_layer)
+                .await?;
         }
 
         // Search for the same codes and find matches.
         for query in queries1.iter().chain(queries2.iter()) {
-            let neighbors = db
-                .search::<_, SortedNeighborhood<_>>(vector_store, graph_store, query, 1)
-                .await?;
+            let neighbors = db.search(vector_store, graph_store, query, 1).await?;
             assert!(db.is_match(vector_store, &[neighbors]).await?);
         }
 
@@ -1864,7 +1846,7 @@ mod tests {
             let query = queries.next().unwrap();
 
             let (neighbors, update_ep) = searcher_default
-                .search_to_insert::<_, SortedNeighborhood<PlaintextStore>>(
+                .search_to_insert(
                     vector_store_default,
                     graph_store_default,
                     &query,
@@ -1876,7 +1858,7 @@ mod tests {
             assert_eq!(update_ep, expected_update_ep);
 
             searcher_default
-                .insert::<_, SortedNeighborhood<_>>(
+                .insert(
                     vector_store_default,
                     graph_store_default,
                     &query,
@@ -1903,7 +1885,7 @@ mod tests {
             let query = queries_copy.next().unwrap();
 
             let (neighbors, update_ep) = searcher_linear
-                .search_to_insert::<_, SortedNeighborhood<PlaintextStore>>(
+                .search_to_insert(
                     vector_store_linear,
                     graph_store_linear,
                     &query,
@@ -1915,7 +1897,7 @@ mod tests {
             assert_eq!(update_ep, expected_update_ep);
 
             searcher_linear
-                .insert::<_, SortedNeighborhood<_>>(
+                .insert(
                     vector_store_linear,
                     graph_store_linear,
                     &query,

--- a/iris-mpc-cpu/src/hnsw/searcher.rs
+++ b/iris-mpc-cpu/src/hnsw/searcher.rs
@@ -647,7 +647,7 @@ impl HnswSearcher {
     /// First, as `W` is initially filled up to size `ef`, the entire neighborhoods
     /// of nodes are inserted into `W` via a batched insertion operation
     /// such as a low-depth sorting network. (This functionality is provided
-    /// by `neighborhood::insert_batch`.) This continues
+    /// by `SortedNeighborhood::insert_batch_and_trim`.) This continues
     /// until `W` has reached size `ef`, so that additional insertions will
     /// result in truncation of farthest elements.
     ///

--- a/iris-mpc-cpu/src/py_bindings/hnsw.rs
+++ b/iris-mpc-cpu/src/py_bindings/hnsw.rs
@@ -47,7 +47,7 @@ pub fn insert(
         let query = Arc::new(iris);
         let insertion_layer = searcher.gen_layer_rng(&mut rng).unwrap();
         searcher
-            .insert::<_, SortedNeighborhood<_>>(vector, graph, &query, insertion_layer)
+            .insert(vector, graph, &query, insertion_layer)
             .await
             .unwrap()
     })
@@ -82,7 +82,7 @@ pub fn fill_uniform_random(
             let query = Arc::new(IrisCode::random_rng(&mut rng));
             let insertion_layer = searcher.gen_layer_rng(&mut rng).unwrap();
             searcher
-                .insert::<_, SortedNeighborhood<_>>(vector, graph, &query, insertion_layer)
+                .insert(vector, graph, &query, insertion_layer)
                 .await
                 .unwrap();
             if idx % 100 == 99 {
@@ -115,7 +115,7 @@ pub fn fill_from_ndjson_file(
             let query = Arc::new(raw_query);
             let insertion_layer = searcher.gen_layer_rng(&mut rng).unwrap();
             searcher
-                .insert::<_, SortedNeighborhood<_>>(vector, graph, &query, insertion_layer)
+                .insert(vector, graph, &query, insertion_layer)
                 .await
                 .unwrap();
         }

--- a/iris-mpc-cpu/tests/counter_subscriber.rs
+++ b/iris-mpc-cpu/tests/counter_subscriber.rs
@@ -18,7 +18,6 @@ use iris_mpc_common::iris_db::iris::IrisCode;
 use iris_mpc_cpu::{
     hawkers::plaintext_store::PlaintextStore,
     hnsw::{
-        graph::neighborhood::SortedNeighborhood,
         metrics::ops_counter::{
             OpCountersLayer, Operation, ParamCounterRef, ParamVertexOpeningsCounter, StaticCounter,
         },
@@ -188,9 +187,7 @@ async fn hnsw_search_queries_seq(
     query2: Arc<IrisCode>,
 ) -> Result<()> {
     for q in [query1, query2].into_iter() {
-        searcher
-            .search::<_, SortedNeighborhood<PlaintextStore>>(vector_store, graph_store, &q, 1)
-            .await?;
+        searcher.search(vector_store, graph_store, &q, 1).await?;
     }
 
     Ok(())
@@ -210,12 +207,7 @@ async fn hnsw_search_queries_par(
         let graph_store = graph_store.clone();
         jobs.spawn(async move {
             searcher
-                .search::<_, SortedNeighborhood<PlaintextStore>>(
-                    &mut vector_store,
-                    &graph_store,
-                    &q,
-                    1,
-                )
+                .search(&mut vector_store, &graph_store, &q, 1)
                 .await?;
 
             Ok(())


### PR DESCRIPTION
## What

Removes the generic `Neighborhood<V>` abstraction from the HNSW searcher and works directly with the concrete `SortedNeighborhood` used by Hawk Main.

- Remove the `Neighborhood<V>` trait, `UnsortedNeighborhood`, and `WrappedNeighborhood`.
- Remove the `NeighborhoodMode { Sorted, Unsorted }` enum, the `NEIGHBORHOOD_MODE` const, and the runtime mode dispatch in `hawk_main/search.rs`.
- Convert `SortedNeighborhood`'s former trait methods to inherent methods.
- Make all `HnswSearcher` methods non-generic over the neighborhood (`SortedNeighborhood<V>` directly); strip `::<_, SortedNeighborhood<_>>` turbofish at call sites.
- Drop the `neighborhood_mode` analysis config field + its TOML keys.
- Drop the now-unused `delegate` dependency (was only used by `WrappedNeighborhood`).

## Why

Hawk Main always ran `NeighborhoodMode::Sorted`; the trait + runtime selection carried no live-path value. `UnsortedNeighborhood` existed only for the analysis/accuracy benchmarking tooling, which now always uses `SortedNeighborhood`.

## Behavior

No change on the Hawk Main runtime path — pure type/generic plumbing. Both live callers (request path and reauth/identity-update path) already passed `Sorted`.

Net **−567/+161** lines. Stacked on `sw/concretize_graph_mem`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)