### PR TITLE
Bump ampc-common dependency hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 [[package]]
 name = "ampc-actor-utils"
 version = "0.1.0"
-source = "git+https://github.com/worldcoin/ampc-common.git?rev=9025be09d85f0bb1ebf236d7c836f286b796f72c#9025be09d85f0bb1ebf236d7c836f286b796f72c"
+source = "git+https://github.com/worldcoin/ampc-common.git?rev=2dc1f945f609d718c5e35eace83d9a1f57e4ee11#2dc1f945f609d718c5e35eace83d9a1f57e4ee11"
 dependencies = [
  "aes-prng",
  "ampc-secret-sharing",
@@ -111,7 +111,7 @@ dependencies = [
 [[package]]
 name = "ampc-anon-stats"
 version = "0.1.0"
-source = "git+https://github.com/worldcoin/ampc-common.git?rev=9025be09d85f0bb1ebf236d7c836f286b796f72c#9025be09d85f0bb1ebf236d7c836f286b796f72c"
+source = "git+https://github.com/worldcoin/ampc-common.git?rev=2dc1f945f609d718c5e35eace83d9a1f57e4ee11#2dc1f945f609d718c5e35eace83d9a1f57e4ee11"
 dependencies = [
  "ampc-actor-utils",
  "ampc-secret-sharing",
@@ -137,9 +137,10 @@ dependencies = [
 [[package]]
 name = "ampc-secret-sharing"
 version = "0.1.0"
-source = "git+https://github.com/worldcoin/ampc-common.git?rev=9025be09d85f0bb1ebf236d7c836f286b796f72c#9025be09d85f0bb1ebf236d7c836f286b796f72c"
+source = "git+https://github.com/worldcoin/ampc-common.git?rev=2dc1f945f609d718c5e35eace83d9a1f57e4ee11#2dc1f945f609d718c5e35eace83d9a1f57e4ee11"
 dependencies = [
  "aes-prng",
+ "base64",
  "bytemuck",
  "eyre",
  "itertools 0.13.0",
@@ -152,7 +153,7 @@ dependencies = [
 [[package]]
 name = "ampc-server-utils"
 version = "0.1.0"
-source = "git+https://github.com/worldcoin/ampc-common.git?rev=9025be09d85f0bb1ebf236d7c836f286b796f72c#9025be09d85f0bb1ebf236d7c836f286b796f72c"
+source = "git+https://github.com/worldcoin/ampc-common.git?rev=2dc1f945f609d718c5e35eace83d9a1f57e4ee11#2dc1f945f609d718c5e35eace83d9a1f57e4ee11"
 dependencies = [
  "aws-sdk-secretsmanager",
  "aws-sdk-sqs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,10 +83,10 @@ tokio-util = "0.7.15"
 toml = { version = "0.8.23", features = ["preserve_order"] }
 uuid = { version = "1", features = ["v4"] }
 iris-mpc-cpu = { path = "./iris-mpc-cpu" }
-ampc-anon-stats = { git = "https://github.com/worldcoin/ampc-common.git", rev = "9025be09d85f0bb1ebf236d7c836f286b796f72c" }
-ampc-actor-utils = { git = "https://github.com/worldcoin/ampc-common.git", rev = "9025be09d85f0bb1ebf236d7c836f286b796f72c" }
-ampc-secret-sharing = { git = "https://github.com/worldcoin/ampc-common.git", rev = "9025be09d85f0bb1ebf236d7c836f286b796f72c" }
-ampc-server-utils = { git = "https://github.com/worldcoin/ampc-common.git", rev = "9025be09d85f0bb1ebf236d7c836f286b796f72c" }
+ampc-anon-stats = { git = "https://github.com/worldcoin/ampc-common.git", rev = "2dc1f945f609d718c5e35eace83d9a1f57e4ee11" }
+ampc-actor-utils = { git = "https://github.com/worldcoin/ampc-common.git", rev = "2dc1f945f609d718c5e35eace83d9a1f57e4ee11" }
+ampc-secret-sharing = { git = "https://github.com/worldcoin/ampc-common.git", rev = "2dc1f945f609d718c5e35eace83d9a1f57e4ee11" }
+ampc-server-utils = { git = "https://github.com/worldcoin/ampc-common.git", rev = "2dc1f945f609d718c5e35eace83d9a1f57e4ee11" }
 
 # Abort on panics rather than unwinding.
 # This improves performance and makes panic propagation more reliable.

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -19,15 +19,15 @@ use ampc_anon_stats::store::postgres::AccessMode as AnonStatsAccessMode;
 use ampc_anon_stats::store::postgres::PostgresClient as AnonStatsPgClient;
 use ampc_anon_stats::AnonStatsStore;
 use ampc_server_utils::batch_sync::{CURRENT_BATCH_SHA, CURRENT_BATCH_VALID_ENTRIES};
+use ampc_server_utils::server_coordination::wait_until_startup_visibility_is_complete;
 use ampc_server_utils::shutdown_handler::ShutdownHandler;
 use ampc_server_utils::{
     delete_messages_until_sequence_num, get_next_sns_seq_num, get_others_sync_state,
     init_heartbeat_task, set_node_ready, start_coordination_server_with_extra_routes,
-    try_get_endpoint_other_nodes, wait_for_others_ready, wait_for_others_unready,
-    BatchSyncSharedState, ReadyProbeResponse, ServerCoordinationConfig, TaskMonitor,
+    wait_for_others_ready, wait_for_others_unready, BatchSyncSharedState, TaskMonitor,
 };
 use chrono::Utc;
-use eyre::{bail, eyre, Report, Result, WrapErr};
+use eyre::{bail, eyre, Report, Result};
 use iris_mpc_common::config::{CommonConfig, Config};
 use iris_mpc_common::helpers::key_pair::SharesEncryptionKeyPairs;
 use iris_mpc_common::helpers::sha256::sha256_bytes;
@@ -54,7 +54,7 @@ use iris_mpc_store::Store;
 use pprof::protos::Message;
 use pprof::ProfilerGuardBuilder;
 use sodiumoxide::hex;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::process::exit;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -284,121 +284,6 @@ fn process_config(config: &Config) {
     }
     // Load batch_size config
     tracing::info!("Set max batch size to {}", config.max_batch_size);
-}
-
-/// Waits until every node has observed every other node during startup.
-///
-/// `wait_for_others_unready` proves that this node saw its peers, but not that
-/// all peers have also observed each other. HNSW startup does heavy loading
-/// immediately after the startup checks, so hold here until cluster visibility
-/// is complete.
-async fn wait_until_startup_visibility_is_complete(
-    config: &ServerCoordinationConfig,
-    verified_peers: &Arc<tokio::sync::Mutex<HashSet<String>>>,
-    my_uuid: &str,
-) -> Result<()> {
-    tracing::info!("Waiting for full peer visibility during startup");
-
-    let started = Instant::now();
-    let startup_timeout = Duration::from_secs(config.startup_sync_timeout_secs);
-    let retry_duration = Duration::from_millis(config.http_query_retry_delay_ms);
-    loop {
-        let connected_health_resps = match try_get_endpoint_other_nodes(config, "health").await {
-            Ok(resps) => resps,
-            Err(err) if started.elapsed() < startup_timeout => {
-                tracing::warn!(
-                    "Failed to query peer health while waiting for full startup visibility: {:?}",
-                    err
-                );
-                tokio::time::sleep(retry_duration).await;
-                continue;
-            }
-            Err(err) => {
-                return Err(
-                    err.wrap_err("timed out waiting for full peer visibility during startup")
-                );
-            }
-        };
-
-        let mut peer_responses = Vec::with_capacity(connected_health_resps.len());
-        for (_status, body) in connected_health_resps {
-            let probe_response: ReadyProbeResponse = serde_json::from_slice(&body)
-                .wrap_err("Failed to deserialize ReadyProbeResponse")?;
-            peer_responses.push(probe_response);
-        }
-
-        {
-            let mut verified = verified_peers.lock().await;
-            for probe_response in &peer_responses {
-                verified.insert(probe_response.uuid.clone());
-            }
-        }
-
-        let expected_uuids = current_startup_uuid_set(my_uuid, &peer_responses);
-
-        let mut incomplete_visibility = Vec::new();
-        for probe_response in peer_responses {
-            let missing_uuids = missing_startup_visibility(
-                &expected_uuids,
-                &probe_response.uuid,
-                &probe_response.verified_peers,
-            );
-
-            if !missing_uuids.is_empty() {
-                incomplete_visibility.push((
-                    probe_response.uuid,
-                    probe_response.verified_peers,
-                    missing_uuids,
-                ));
-            }
-        }
-
-        if incomplete_visibility.is_empty() {
-            tracing::info!("All nodes have full peer visibility during startup");
-            return Ok(());
-        }
-
-        if started.elapsed() >= startup_timeout {
-            bail!(
-                "Timed out waiting for full peer visibility during startup: {:?}",
-                incomplete_visibility
-            );
-        }
-
-        tracing::debug!(
-            "Waiting for full peer visibility during startup: {:?}",
-            incomplete_visibility
-        );
-        tokio::time::sleep(retry_duration).await;
-    }
-}
-
-fn current_startup_uuid_set(
-    my_uuid: &str,
-    peer_responses: &[ReadyProbeResponse],
-) -> HashSet<String> {
-    let mut expected_uuids = HashSet::from([my_uuid.to_owned()]);
-    expected_uuids.extend(
-        peer_responses
-            .iter()
-            .map(|probe_response| probe_response.uuid.clone()),
-    );
-    expected_uuids
-}
-
-fn missing_startup_visibility(
-    expected_uuids: &HashSet<String>,
-    peer_uuid: &str,
-    peer_verified_peers: &HashSet<String>,
-) -> Vec<String> {
-    let mut missing_uuids = expected_uuids
-        .iter()
-        .filter(|uuid| uuid.as_str() != peer_uuid)
-        .filter(|uuid| !peer_verified_peers.contains(*uuid))
-        .cloned()
-        .collect::<Vec<_>>();
-    missing_uuids.sort();
-    missing_uuids
 }
 
 /// Returns initialized PostgreSQL clients for interacting
@@ -1058,32 +943,4 @@ async fn run_main_server_loop(
         }
     }
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn set(values: &[&str]) -> HashSet<String> {
-        values.iter().map(|value| value.to_string()).collect()
-    }
-
-    #[test]
-    fn missing_startup_visibility_ignores_peer_own_uuid() {
-        let expected = set(&["node-0", "node-1", "node-2"]);
-        let verified = set(&["node-0"]);
-
-        assert_eq!(
-            missing_startup_visibility(&expected, "node-1", &verified),
-            vec!["node-2".to_string()]
-        );
-    }
-
-    #[test]
-    fn missing_startup_visibility_accepts_full_peer_visibility() {
-        let expected = set(&["node-0", "node-1", "node-2"]);
-        let verified = set(&["node-0", "node-2", "stale-node-2"]);
-
-        assert!(missing_startup_visibility(&expected, "node-1", &verified).is_empty());
-    }
 }


### PR DESCRIPTION
Bumps the version hash of `ampc-common` import to the most recent one.  This especially incorporates some hardening on batch sync logic, and finishes a migration of some node synchronization logic in the `wait_until_startup_visibility_is_complete` function.