### PR TITLE
[POP-4028] Concretize GraphMem and related code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1968,17 +1968,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "delegate"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3319,7 +3308,6 @@ dependencies = [
  "crossbeam",
  "csv",
  "dashmap",
- "delegate",
  "eyre",
  "futures",
  "hex",

--- a/docs/hawk-actor.md
+++ b/docs/hawk-actor.md
@@ -38,7 +38,6 @@ type Aby3Ref = Arc<RwLock<Aby3Store>>;
 HAWK_DISTANCE_FN = DistanceFn::MinFhd      // Distance function choice
 HAWK_MINFHD_ROTATIONS = 11                 // Rotations for MinFhd
 HAWK_BASE_ROTATIONS_MASK = CENTER_AND_10_MASK  // Base rotations for HNSW search
-NEIGHBORHOOD_MODE = NeighborhoodMode::Sorted   // Candidate list strategy
 LINEAR_SCAN_MAX_GRAPH_LAYER = 1
 ```
 

--- a/iris-mpc-bins/bin/iris-mpc-cpu/communication_stats.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/communication_stats.rs
@@ -331,7 +331,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // 2. Build per-party secret-shared iris stores and graphs
     tracing::info!("Secret-sharing iris data for {} parties...", N_PARTIES);
     let party_iris_stores = build_party_iris_stores(&plain_store);
-    let party_graphs: Vec<BothEyes<GraphMem<_>>> = (0..N_PARTIES)
+    let party_graphs: Vec<BothEyes<GraphMem>> = (0..N_PARTIES)
         .map(|_| [plain_graph.clone(), plain_graph.clone()])
         .collect();
     tracing::info!("Secret sharing done.");

--- a/iris-mpc-bins/bin/iris-mpc-cpu/construct_graph_ptxt.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/construct_graph_ptxt.rs
@@ -449,7 +449,7 @@ number = 64
 seed = 1
 
 [searcher]
-layer_mode = { LinearScan = { max_graph_layer = 1 } }
+max_graph_layer = 1
 
 [searcher.params]
 option = "Standard"
@@ -479,7 +479,7 @@ number = 64
 seed = 1
 
 [searcher]
-layer_mode = { LinearScan = { max_graph_layer = 1 } }
+max_graph_layer = 1
 
 [searcher.params]
 option = "Standard"

--- a/iris-mpc-bins/bin/iris-mpc-cpu/construct_graph_ptxt.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/construct_graph_ptxt.rs
@@ -135,9 +135,7 @@ impl Checkpoints {
 
 /// Load an existing graph from `graph_spec` (or initialize a fresh one) and
 /// return it along with its highest layer-0 node serial id.
-fn load_existing_graph(
-    graph_spec: Option<LoadGraphConfig>,
-) -> Result<(GraphMem<IrisVectorId>, u32)> {
+fn load_existing_graph(graph_spec: Option<LoadGraphConfig>) -> Result<(GraphMem, u32)> {
     if let Some(graph_spec) = graph_spec {
         tracing::info!("Loading graph from file");
         let graph = graph_spec.read_graph_from_file()?;

--- a/iris-mpc-bins/bin/iris-mpc-cpu/db_sanity_check.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/db_sanity_check.rs
@@ -306,7 +306,7 @@ async fn main() -> Result<()> {
         bucket,
         checkpoint_state.s3_key
     );
-    let mut graphs: BothEyes<GraphMem<VectorId>> =
+    let mut graphs: BothEyes<GraphMem> =
         download_graph_checkpoint(&checkpoint_s3_client, bucket, &checkpoint_state).await?;
     rpt!(rpt, "  Checkpoint loaded and BLAKE3 verified.");
 
@@ -378,7 +378,7 @@ async fn main() -> Result<()> {
     );
     stats.add("checkpoint_blake3_hash", &checkpoint_state.blake3_hash);
 
-    let s3_graphs: Option<BothEyes<GraphMem<VectorId>>> = Some(graphs);
+    let s3_graphs: Option<BothEyes<GraphMem>> = Some(graphs);
 
     rpt!(rpt, "--- Collecting iris IDs ---");
     let iris_ids = collect_iris_ids(&hnsw_store, &mut stats).await?;
@@ -495,7 +495,7 @@ async fn collect_iris_ids(store: &Store, stats: &mut Stats) -> Result<HashSet<i6
 
 #[allow(clippy::too_many_arguments)]
 async fn run_graph_checks(
-    s3_graphs: Option<&BothEyes<GraphMem<VectorId>>>,
+    s3_graphs: Option<&BothEyes<GraphMem>>,
     iris_ids: &HashSet<i64>,
     exclusions: &Option<HashSet<u32>>,
     m: usize,
@@ -557,7 +557,7 @@ async fn run_graph_checks(
 #[allow(clippy::too_many_arguments)]
 fn check_single_graph(
     eye: &str,
-    graph: &GraphMem<VectorId>,
+    graph: &GraphMem,
     iris_ids: &HashSet<i64>,
     exclusions: &Option<HashSet<u32>>,
     m: usize,
@@ -956,7 +956,7 @@ async fn load_checkpoint_state(
 async fn run_persistent_state_checks(
     graph_pg: &GraphPg<Aby3Store>,
     iris_max_serial_id: usize,
-    s3_graphs: Option<&BothEyes<GraphMem<VectorId>>>,
+    s3_graphs: Option<&BothEyes<GraphMem>>,
     checks: &mut Vec<CheckResult>,
     stats: &mut Stats,
 ) -> Result<Option<i64>> {
@@ -1028,7 +1028,7 @@ async fn run_persistent_state_checks(
 /// Returns the maximum serial_id across all nodes in layer 0 of an in-memory
 /// graph, or 0 if the graph is empty. Matches the semantics of
 /// `GraphOps::get_max_serial_id`, which returns 0 when the links table is empty.
-fn graph_mem_max_serial_id(graph: &GraphMem<VectorId>) -> i64 {
+fn graph_mem_max_serial_id(graph: &GraphMem) -> i64 {
     graph
         .layers
         .first()

--- a/iris-mpc-bins/bin/iris-mpc-cpu/generate_ideal_graph.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/generate_ideal_graph.rs
@@ -5,7 +5,6 @@ use iris_mpc_cpu::hawkers::aby3::aby3_store::{DistanceOps, FhdOps, NhdOps};
 use iris_mpc_cpu::hawkers::ideal_knn_engines::{EngineChoice, EngineChoiceInt4};
 use iris_mpc_cpu::hawkers::plaintext_deep_id_store::{Int4Vector, PlaintextDeepIDStore};
 use iris_mpc_cpu::hawkers::plaintext_store::PlaintextStore;
-use iris_mpc_cpu::hnsw::searcher::LayerMode;
 use iris_mpc_cpu::hnsw::GraphMem;
 use iris_mpc_cpu::hnsw::{HnswSearcher, VectorStore};
 use iris_mpc_cpu::utils::serialization::check_store_kind_unambiguous;
@@ -87,16 +86,8 @@ async fn run_sanity_check_iris<D: DistanceOps>(
         }
     }
 
-    // Check layers and entry points are valid for layer mode
-    match searcher.layer_mode {
-        LayerMode::Standard { max_graph_layer } => {
-            assert!(!graph.entry_points.is_empty() || graph.num_layers() == 0);
-            assert!(graph.num_layers() <= max_graph_layer.map(|val| val + 1).unwrap_or(usize::MAX));
-        }
-        LayerMode::LinearScan { max_graph_layer } => {
-            assert!(graph.num_layers() <= max_graph_layer + 1);
-        }
-    }
+    // Check layers are valid for the max graph layer
+    assert!(graph.num_layers() <= searcher.max_graph_layer + 1);
 
     // All entry points should exist in the top graph layer as well
     let last_graph_layer = graph.layers.last().unwrap();
@@ -179,15 +170,7 @@ async fn run_sanity_check_deep_id(
         }
     }
 
-    match searcher.layer_mode {
-        LayerMode::Standard { max_graph_layer } => {
-            assert!(!graph.entry_points.is_empty() || graph.num_layers() == 0);
-            assert!(graph.num_layers() <= max_graph_layer.map(|val| val + 1).unwrap_or(usize::MAX));
-        }
-        LayerMode::LinearScan { max_graph_layer } => {
-            assert!(graph.num_layers() <= max_graph_layer + 1);
-        }
-    }
+    assert!(graph.num_layers() <= searcher.max_graph_layer + 1);
 
     let last_graph_layer = graph.layers.last().unwrap();
     for entry in &graph.entry_points {
@@ -344,7 +327,7 @@ echoice = "NaiveFHD"
 sanity_check = false
 
 [searcher]
-layer_mode = { Standard = { max_graph_layer = 4 } }
+max_graph_layer = 4
 layer_distribution = { Geometric = { layer_probability = 0.25 } }
 [searcher.params]
 M = [10, 10, 10, 10, 10]
@@ -372,7 +355,7 @@ threshold = 1000
 sanity_check = false
 
 [searcher]
-layer_mode = { Standard = { max_graph_layer = 4 } }
+max_graph_layer = 4
 layer_distribution = { Geometric = { layer_probability = 0.25 } }
 [searcher.params]
 M = [10, 10, 10, 10, 10]

--- a/iris-mpc-bins/bin/iris-mpc-cpu/generate_ideal_graph.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/generate_ideal_graph.rs
@@ -71,7 +71,7 @@ where
 }
 
 async fn run_sanity_check_iris<D: DistanceOps>(
-    graph: &GraphMem<IrisVectorId>,
+    graph: &GraphMem,
     searcher: &HnswSearcher,
     irises: Vec<iris_mpc_common::iris_db::iris::IrisCode>,
     echoice: EngineChoice,
@@ -164,7 +164,7 @@ async fn run_sanity_check_iris<D: DistanceOps>(
 }
 
 async fn run_sanity_check_deep_id(
-    graph: &GraphMem<IrisVectorId>,
+    graph: &GraphMem,
     searcher: &HnswSearcher,
     vectors: Vec<Int4Vector>,
     threshold: i32,

--- a/iris-mpc-bins/bin/iris-mpc-cpu/generate_ideal_neighborhoods.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/generate_ideal_neighborhoods.rs
@@ -31,7 +31,7 @@ struct ResultsHeader {
 }
 
 /// Dispatch wrapper so the chunk/append loop is written once regardless of
-/// store kind. Both inner engines return `Vec<KNNResult<SerialId>>`.
+/// store kind. Both inner engines return `Vec<KNNResult>`.
 enum AnyEngine {
     Iris(Engine),
     Int4(EngineInt4),
@@ -45,7 +45,7 @@ impl AnyEngine {
         }
     }
 
-    fn compute_chunk(&mut self, chunk_size: usize) -> Vec<KNNResult<SerialId>> {
+    fn compute_chunk(&mut self, chunk_size: usize) -> Vec<KNNResult> {
         match self {
             AnyEngine::Iris(e) => e.compute_chunk(chunk_size),
             AnyEngine::Int4(e) => e.compute_chunk(chunk_size),
@@ -147,10 +147,10 @@ async fn main() {
             }
 
             // 3. Process the rest of the lines as KNN results
-            let results: Result<Vec<KNNResult<SerialId>>, _> = lines
+            let results: Result<Vec<KNNResult>, _> = lines
                 .map(|line_result| {
                     let line = line_result.map_err(|e| e.to_string())?;
-                    serde_json::from_str::<KNNResult<SerialId>>(&line).map_err(|e| e.to_string())
+                    serde_json::from_str::<KNNResult>(&line).map_err(|e| e.to_string())
                 })
                 .collect();
 
@@ -170,7 +170,7 @@ async fn main() {
 
             let nodes: Vec<SerialId> = deserialized_results
                 .into_iter()
-                .map(|result| result.node)
+                .map(|result| result.node.serial_id())
                 .collect();
             (nodes.len() as SerialId, nodes)
         }

--- a/iris-mpc-bins/bin/iris-mpc-cpu/generate_ideal_neighborhoods.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/generate_ideal_neighborhoods.rs
@@ -7,7 +7,7 @@ use std::{
 use clap::Parser;
 use iris_mpc_common::{iris_db::iris::IrisCode, vector_id::SerialId};
 use iris_mpc_cpu::{
-    hawkers::ideal_knn_engines::{Engine, EngineInt4, EngineKind, KNNResult, KNNResultU32},
+    hawkers::ideal_knn_engines::{Engine, EngineInt4, EngineKind, KNNResult},
     utils::serialization::{
         int4_ndjson::int4_vectors_from_ndjson,
         iris_ndjson::{irises_from_ndjson_iter, IrisSelection},
@@ -31,7 +31,7 @@ struct ResultsHeader {
 }
 
 /// Dispatch wrapper so the chunk/append loop is written once regardless of
-/// store kind. Both inner engines return `Vec<KNNResult>`.
+/// store kind. Both inner engines return `Vec<KNNResult<SerialId>>`.
 enum AnyEngine {
     Iris(Engine),
     Int4(EngineInt4),
@@ -45,7 +45,7 @@ impl AnyEngine {
         }
     }
 
-    fn compute_chunk(&mut self, chunk_size: usize) -> Vec<KNNResult> {
+    fn compute_chunk(&mut self, chunk_size: usize) -> Vec<KNNResult<SerialId>> {
         match self {
             AnyEngine::Iris(e) => e.compute_chunk(chunk_size),
             AnyEngine::Int4(e) => e.compute_chunk(chunk_size),
@@ -147,12 +147,10 @@ async fn main() {
             }
 
             // 3. Process the rest of the lines as KNN results
-            let results: Result<Vec<KNNResult>, _> = lines
+            let results: Result<Vec<KNNResult<SerialId>>, _> = lines
                 .map(|line_result| {
                     let line = line_result.map_err(|e| e.to_string())?;
-                    serde_json::from_str::<KNNResultU32>(&line)
-                        .map(KNNResult::from)
-                        .map_err(|e| e.to_string())
+                    serde_json::from_str::<KNNResult<SerialId>>(&line).map_err(|e| e.to_string())
                 })
                 .collect();
 
@@ -172,7 +170,7 @@ async fn main() {
 
             let nodes: Vec<SerialId> = deserialized_results
                 .into_iter()
-                .map(|result| result.node.serial_id())
+                .map(|result| result.node)
                 .collect();
             (nodes.len() as SerialId, nodes)
         }
@@ -276,8 +274,7 @@ async fn main() {
 
         println!("Appending results from {} to {}", start, end - 1);
         for result in &results {
-            let json_line = serde_json::to_string(&KNNResultU32::from(result))
-                .expect("Failed to serialize KNNResult");
+            let json_line = serde_json::to_string(result).expect("Failed to serialize KNNResult");
             writeln!(file, "{}", json_line).expect("Failed to write to results file");
         }
     }

--- a/iris-mpc-bins/bin/iris-mpc-cpu/generate_ideal_neighborhoods.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/generate_ideal_neighborhoods.rs
@@ -7,7 +7,7 @@ use std::{
 use clap::Parser;
 use iris_mpc_common::{iris_db::iris::IrisCode, vector_id::SerialId};
 use iris_mpc_cpu::{
-    hawkers::ideal_knn_engines::{Engine, EngineInt4, EngineKind, KNNResult},
+    hawkers::ideal_knn_engines::{Engine, EngineInt4, EngineKind, KNNResult, KNNResultU32},
     utils::serialization::{
         int4_ndjson::int4_vectors_from_ndjson,
         iris_ndjson::{irises_from_ndjson_iter, IrisSelection},
@@ -150,7 +150,9 @@ async fn main() {
             let results: Result<Vec<KNNResult>, _> = lines
                 .map(|line_result| {
                     let line = line_result.map_err(|e| e.to_string())?;
-                    serde_json::from_str::<KNNResult>(&line).map_err(|e| e.to_string())
+                    serde_json::from_str::<KNNResultU32>(&line)
+                        .map(KNNResult::from)
+                        .map_err(|e| e.to_string())
                 })
                 .collect();
 
@@ -274,7 +276,8 @@ async fn main() {
 
         println!("Appending results from {} to {}", start, end - 1);
         for result in &results {
-            let json_line = serde_json::to_string(result).expect("Failed to serialize KNNResult");
+            let json_line = serde_json::to_string(&KNNResultU32::from(result))
+                .expect("Failed to serialize KNNResult");
             writeln!(file, "{}", json_line).expect("Failed to write to results file");
         }
     }

--- a/iris-mpc-bins/bin/iris-mpc-cpu/hnsw_algorithm_metrics.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/hnsw_algorithm_metrics.rs
@@ -10,7 +10,7 @@ use iris_mpc_cpu::{
             OpCountersLayer, Operation, ParamVertexOpeningsCounter, StaticCounter,
         },
         searcher::LayerDistribution,
-        GraphMem, HnswSearcher,
+        GraphMem, HnswSearcher, LINEAR_SCAN_MAX_GRAPH_LAYER,
     },
 };
 use rand::SeedableRng;
@@ -98,7 +98,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let mut rng = AesRng::seed_from_u64(42_u64);
     let mut graph = GraphMem::new();
-    let mut searcher = HnswSearcher::new_standard(ef_constr, ef_search, M);
+    let mut searcher =
+        HnswSearcher::new_linear_scan(ef_constr, ef_search, M, LINEAR_SCAN_MAX_GRAPH_LAYER);
     if let Some(q) = layer_probability {
         match &mut searcher.layer_distribution {
             LayerDistribution::Geometric { layer_probability } => *layer_probability = q,

--- a/iris-mpc-bins/bin/iris-mpc-cpu/hnsw_algorithm_metrics.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/hnsw_algorithm_metrics.rs
@@ -10,7 +10,7 @@ use iris_mpc_cpu::{
             OpCountersLayer, Operation, ParamVertexOpeningsCounter, StaticCounter,
         },
         searcher::LayerDistribution,
-        GraphMem, HnswSearcher, SortedNeighborhood,
+        GraphMem, HnswSearcher,
     },
 };
 use rand::SeedableRng;
@@ -113,12 +113,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 let query = Arc::new(raw_query.clone());
                 let insertion_layer = searcher.gen_layer_rng(&mut rng)?;
                 searcher
-                    .insert::<_, SortedNeighborhood<_>>(
-                        &mut vector,
-                        &mut graph,
-                        &query,
-                        insertion_layer,
-                    )
+                    .insert(&mut vector, &mut graph, &query, insertion_layer)
                     .await?;
 
                 if idx % 1000 == 999 {
@@ -144,12 +139,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 let query = Arc::new(raw_query.clone());
                 let insertion_layer = searcher.gen_layer_rng(&mut rng)?;
                 searcher
-                    .insert::<_, SortedNeighborhood<_>>(
-                        &mut vector,
-                        &mut graph,
-                        &query,
-                        insertion_layer,
-                    )
+                    .insert(&mut vector, &mut graph, &query, insertion_layer)
                     .await?;
 
                 if idx % 1000 == 999 {

--- a/iris-mpc-bins/bin/iris-mpc-cpu/init_test_dbs.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/init_test_dbs.rs
@@ -11,7 +11,7 @@ use iris_mpc_cpu::{
     hawkers::plaintext_store::PlaintextStore,
     hnsw::{
         graph::test_utils::DbContext, searcher::LayerDistribution, vector_store::VectorStoreMut,
-        GraphMem, HnswSearcher, SortedNeighborhood,
+        GraphMem, HnswSearcher,
     },
     protocol::shared_iris::{GaloisRingSharedIris, GaloisRingSharedIrisPair},
     utils::{
@@ -397,12 +397,7 @@ async fn main() -> Result<()> {
 
                 let insertion_layer = searcher.gen_layer_prf(&prf_seed, &(inserted_id, side))?;
                 let (neighbors, update_ep) = searcher
-                    .search_to_insert::<_, SortedNeighborhood<_>>(
-                        &mut vector_store,
-                        &graph,
-                        &query,
-                        insertion_layer,
-                    )
+                    .search_to_insert(&mut vector_store, &graph, &query, insertion_layer)
                     .await?;
                 searcher
                     .insert_from_search_results(

--- a/iris-mpc-bins/bin/iris-mpc-cpu/init_test_dbs.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/init_test_dbs.rs
@@ -11,7 +11,7 @@ use iris_mpc_cpu::{
     hawkers::plaintext_store::PlaintextStore,
     hnsw::{
         graph::test_utils::DbContext, searcher::LayerDistribution, vector_store::VectorStoreMut,
-        GraphMem, HnswSearcher,
+        GraphMem, HnswSearcher, LINEAR_SCAN_MAX_GRAPH_LAYER,
     },
     protocol::shared_iris::{GaloisRingSharedIris, GaloisRingSharedIrisPair},
     utils::{
@@ -185,7 +185,8 @@ impl Args {
 // Convertor: Args -> HnswSearcher.
 impl From<&Args> for HnswSearcher {
     fn from(args: &Args) -> Self {
-        let mut searcher = HnswSearcher::new_standard(args.ef, args.ef, args.M);
+        let mut searcher =
+            HnswSearcher::new_linear_scan(args.ef, args.ef, args.M, LINEAR_SCAN_MAX_GRAPH_LAYER);
         if let Some(q) = args.layer_probability {
             match &mut searcher.layer_distribution {
                 LayerDistribution::Geometric { layer_probability } => {

--- a/iris-mpc-bins/bin/iris-mpc-cpu/init_test_dbs.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/init_test_dbs.rs
@@ -480,7 +480,7 @@ async fn init_dbs(args: &Args) -> Vec<DbContext> {
     dbs
 }
 
-fn get_max_serial_id(graph: &GraphMem<IrisVectorId>) -> Option<u32> {
+fn get_max_serial_id(graph: &GraphMem) -> Option<u32> {
     if let Some(layer) = graph.layers.first() {
         layer
             .get_links_map()

--- a/iris-mpc-bins/bin/iris-mpc-cpu/run_accuracy_analysis.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/run_accuracy_analysis.rs
@@ -222,7 +222,7 @@ size = 16
 ef_construction = 32
 ef_search = 32
 M = 16
-layer_mode = { LinearScan = { max_graph_layer = 1 } }
+max_graph_layer = 1
 
 [analysis]
 sample_size = 4
@@ -237,7 +237,7 @@ distance_ops = "fhd"
 ef_construction = 32
 ef_search = 32
 M = 16
-layer_mode = { LinearScan = { max_graph_layer = 1 } }
+max_graph_layer = 1
 "#;
         let cfg: Config = toml::from_str(toml_str).expect("legacy iris accuracy TOML");
         assert!(matches!(cfg, Config::Iris(_)));
@@ -259,7 +259,7 @@ size = 16
 ef_construction = 32
 ef_search = 32
 M = 16
-layer_mode = { LinearScan = { max_graph_layer = 1 } }
+max_graph_layer = 1
 
 [analysis]
 sample_size = 4
@@ -271,7 +271,7 @@ noise_levels = [0.0, 0.05]
 ef_construction = 32
 ef_search = 32
 M = 16
-layer_mode = { LinearScan = { max_graph_layer = 1 } }
+max_graph_layer = 1
 "#;
         let cfg: Config = toml::from_str(toml_str).expect("deepid accuracy TOML");
         assert!(matches!(cfg, Config::DeepID(_)));

--- a/iris-mpc-bins/bin/iris-mpc-cpu/run_accuracy_analysis.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/run_accuracy_analysis.rs
@@ -232,7 +232,6 @@ output_format = "rate"
 output_path = "out.csv"
 rotations = { start = 0, end = 1 }
 mutations = [0.0]
-neighborhood_mode = "Sorted"
 distance_ops = "fhd"
 [analysis.search_hnsw_config]
 ef_construction = 32
@@ -268,7 +267,6 @@ k_neighbors = 1
 output_format = "rate"
 output_path = "out.csv"
 noise_levels = [0.0, 0.05]
-neighborhood_mode = "Sorted"
 [analysis.search_hnsw_config]
 ef_construction = 32
 ef_search = 32

--- a/iris-mpc-bins/resources/iris-mpc-cpu/accuracy1.toml
+++ b/iris-mpc-bins/resources/iris-mpc-cpu/accuracy1.toml
@@ -21,7 +21,6 @@ sample_size = 20
 seed = 123
 distance_ops = "fhd"                  # Must be "fhd" or "nhd"
 distance_fn = "min_rotation"         # Must be "simple" or "min_rotation"
-neighborhood_mode = "Unsorted"  # Must be "Sorted" or "Unsorted"
 k_neighbors = 128
 mutations = [0.33, 0.37, 0.51]
 output_format = "rate"          # Must be "full_csv", "rate" or "histogram"

--- a/iris-mpc-bins/resources/iris-mpc-cpu/accuracy1.toml
+++ b/iris-mpc-bins/resources/iris-mpc-cpu/accuracy1.toml
@@ -13,7 +13,7 @@ size = 500
 ef_construction = 65
 ef_search = 65
 M = 16
-layer_mode = { LinearScan = { max_graph_layer = 1 } }
+max_graph_layer = 1
 
 
 [analysis]
@@ -35,5 +35,5 @@ end = 4  # End of range is exclusive
 ef_construction = 320
 ef_search = [70, 5]
 M = 256
-layer_mode = { LinearScan = { max_graph_layer = 1} }
+max_graph_layer = 1
 # fixed_layer_search_batch_size = 128

--- a/iris-mpc-bins/resources/iris-mpc-cpu/accuracy_deepid.toml
+++ b/iris-mpc-bins/resources/iris-mpc-cpu/accuracy_deepid.toml
@@ -13,7 +13,7 @@ size = 64
 ef_construction = 64
 ef_search = 64
 M = 32
-layer_mode = { LinearScan = { max_graph_layer = 1 } }
+max_graph_layer = 1
 
 [analysis]
 sample_size = 8
@@ -27,4 +27,4 @@ noise_levels = [0.0, 0.05, 0.1, 0.2]
 ef_construction = 64
 ef_search = 64
 M = 32
-layer_mode = { LinearScan = { max_graph_layer = 1 } }
+max_graph_layer = 1

--- a/iris-mpc-bins/resources/iris-mpc-cpu/accuracy_deepid.toml
+++ b/iris-mpc-bins/resources/iris-mpc-cpu/accuracy_deepid.toml
@@ -22,7 +22,6 @@ k_neighbors = 1
 output_format = "rate"
 output_path = "data/accuracy_deepid_results.csv"
 noise_levels = [0.0, 0.05, 0.1, 0.2]
-neighborhood_mode = "Sorted"
 
 [analysis.search_hnsw_config]
 ef_construction = 64

--- a/iris-mpc-bins/resources/iris-mpc-cpu/communication_stats.toml
+++ b/iris-mpc-bins/resources/iris-mpc-cpu/communication_stats.toml
@@ -21,7 +21,7 @@ path = "data/graph-320-256-minfhd_100000.dat"
 format = "Raw"
 
 [searcher]
-layer_mode = { LinearScan = { max_graph_layer = 1 } }
+max_graph_layer = 1
 fixed_layer_search_batch_size = 8000
 
 [searcher.params]

--- a/iris-mpc-bins/resources/iris-mpc-cpu/construct_graph_ptxt.toml
+++ b/iris-mpc-bins/resources/iris-mpc-cpu/construct_graph_ptxt.toml
@@ -11,7 +11,7 @@ selection = "All"
 # path = "data/starting-graph.dat"
 
 [searcher]
-layer_mode = { LinearScan = { max_graph_layer = 1 } }
+max_graph_layer = 1
 
 [searcher.params]
 option = "Standard"

--- a/iris-mpc-bins/resources/iris-mpc-cpu/construct_graph_ptxt_benchmark.toml
+++ b/iris-mpc-bins/resources/iris-mpc-cpu/construct_graph_ptxt_benchmark.toml
@@ -9,7 +9,7 @@ seed = 42
 output_path = "data/store.ndjson"
 
 [searcher]
-layer_mode = { LinearScan = { max_graph_layer = 1 } }
+max_graph_layer = 1
 
 [searcher.params]
 option = "Standard"

--- a/iris-mpc-bins/resources/iris-mpc-cpu/construct_graph_ptxt_deepid.toml
+++ b/iris-mpc-bins/resources/iris-mpc-cpu/construct_graph_ptxt_deepid.toml
@@ -7,7 +7,7 @@ path = "iris-mpc-bins/resources/iris-mpc-cpu/deepid_sample.ndjson"
 limit = 64
 
 [searcher]
-layer_mode = { LinearScan = { max_graph_layer = 1 } }
+max_graph_layer = 1
 
 [searcher.params]
 option = "Standard"

--- a/iris-mpc-bins/resources/iris-mpc-cpu/ideal_config.toml
+++ b/iris-mpc-bins/resources/iris-mpc-cpu/ideal_config.toml
@@ -6,7 +6,7 @@ echoice = "NaiveFHD"
 sanity_check = true
 
 [searcher]
-layer_mode = "Standard"
+max_graph_layer = 1
 layer_distribution = { Geometric = { layer_probability = 0.25 } }
 
 [searcher.params]

--- a/iris-mpc-bins/resources/iris-mpc-cpu/ideal_config2.toml
+++ b/iris-mpc-bins/resources/iris-mpc-cpu/ideal_config2.toml
@@ -6,7 +6,7 @@ echoice = "NaiveFHD"
 sanity_check = true
 
 [searcher]
-layer_mode = { LinearScan = { max_graph_layer = 1 } }
+max_graph_layer = 1
 layer_distribution = { Geometric = { layer_probability = 0.25 } }
 
 [searcher.params]

--- a/iris-mpc-bins/resources/iris-mpc-cpu/ideal_config_deepid.toml
+++ b/iris-mpc-bins/resources/iris-mpc-cpu/ideal_config_deepid.toml
@@ -7,7 +7,7 @@ threshold = 5000
 sanity_check = false
 
 [searcher]
-layer_mode = { Standard = { max_graph_layer = 4 } }
+max_graph_layer = 4
 layer_distribution = { Geometric = { layer_probability = 0.25 } }
 
 [searcher.params]

--- a/iris-mpc-common/src/helpers/sync.rs
+++ b/iris-mpc-common/src/helpers/sync.rs
@@ -10,7 +10,7 @@ pub struct SyncState {
     pub modifications: Vec<Modification>,
     pub next_sns_sequence_num: Option<u128>,
     pub common_config: CommonConfig,
-    /// Bincode-serialized `BothEyes<Vec<GraphMutation<IrisVectorId>>>` for each
+    /// Bincode-serialized `BothEyes<Vec<GraphMutation>>` for each
     /// modification in `modifications` (parallel by index).  `None` means this
     /// party has no WAL entry for that modification.
     ///

--- a/iris-mpc-cpu/Cargo.toml
+++ b/iris-mpc-cpu/Cargo.toml
@@ -23,7 +23,6 @@ config.workspace = true
 core_affinity.workspace = true
 crossbeam = "0.8.4"
 csv = "*"
-delegate = "0.13.5"
 hex.workspace = true
 dashmap = "6.1.0"
 eyre.workspace = true

--- a/iris-mpc-cpu/benches/hnsw.rs
+++ b/iris-mpc-cpu/benches/hnsw.rs
@@ -13,7 +13,7 @@ use iris_mpc_cpu::{
         },
         plaintext_store::PlaintextStore,
     },
-    hnsw::{GraphMem, HnswSearcher, SortedNeighborhood},
+    hnsw::{GraphMem, HnswSearcher},
     protocol::{
         ops::{galois_ring_pairwise_distance, galois_ring_to_rep3},
         shared_iris::GaloisRingSharedIris,
@@ -53,12 +53,7 @@ fn bench_plaintext_hnsw(c: &mut Criterion) {
                 let query = Arc::new(raw_query.clone());
                 let insertion_layer = searcher.gen_layer_rng(&mut rng).unwrap();
                 searcher
-                    .insert::<_, SortedNeighborhood<_>>(
-                        &mut vector,
-                        &mut graph,
-                        &query,
-                        insertion_layer,
-                    )
+                    .insert(&mut vector, &mut graph, &query, insertion_layer)
                     .await
                     .unwrap();
             }
@@ -75,12 +70,7 @@ fn bench_plaintext_hnsw(c: &mut Criterion) {
                     let query = Arc::new(on_the_fly_query);
                     let insertion_layer = searcher.gen_layer_rng(&mut rng).unwrap();
                     searcher
-                        .insert::<_, SortedNeighborhood<_>>(
-                            &mut db_vectors,
-                            &mut graph,
-                            &query,
-                            insertion_layer,
-                        )
+                        .insert(&mut db_vectors, &mut graph, &query, insertion_layer)
                         .await
                         .unwrap();
                 },
@@ -297,7 +287,7 @@ fn bench_gr_ready_made_hnsw(c: &mut Criterion) {
                                 let mut vector_store = vector_store.lock().await;
                                 let insertion_layer = searcher.gen_layer_rng(&mut rng).unwrap();
                                 searcher
-                                    .insert::<_, SortedNeighborhood<_>>(
+                                    .insert(
                                         &mut *vector_store,
                                         &mut graph_store,
                                         &query,
@@ -341,12 +331,7 @@ fn bench_gr_ready_made_hnsw(c: &mut Criterion) {
                             jobs.spawn(async move {
                                 let mut vector_store = vector_store.lock().await;
                                 let neighbors = searcher
-                                    .search::<_, SortedNeighborhood<_>>(
-                                        &mut *vector_store,
-                                        &graph_store,
-                                        &query,
-                                        1,
-                                    )
+                                    .search(&mut *vector_store, &graph_store, &query, 1)
                                     .await
                                     .unwrap();
                                 searcher

--- a/iris-mpc-cpu/examples/hnsw-ex.rs
+++ b/iris-mpc-cpu/examples/hnsw-ex.rs
@@ -5,7 +5,7 @@ use eyre::Result;
 use iris_mpc_common::iris_db::iris::IrisCode;
 use iris_mpc_cpu::{
     hawkers::{aby3::aby3_store::FhdOps, plaintext_store::PlaintextStore},
-    hnsw::{GraphMem, HnswSearcher, SortedNeighborhood},
+    hnsw::{GraphMem, HnswSearcher},
 };
 use rand::SeedableRng;
 
@@ -28,12 +28,7 @@ fn main() -> Result<()> {
             let query = Arc::new(raw_query);
             let insertion_layer = searcher.gen_layer_rng(&mut rng)?;
             searcher
-                .insert::<_, SortedNeighborhood<_>>(
-                    &mut vector,
-                    &mut graph,
-                    &query,
-                    insertion_layer,
-                )
+                .insert(&mut vector, &mut graph, &query, insertion_layer)
                 .await?;
             if idx % 100 == 99 {
                 println!("{}", idx + 1);

--- a/iris-mpc-cpu/src/analysis/accuracy.rs
+++ b/iris-mpc-cpu/src/analysis/accuracy.rs
@@ -4,7 +4,7 @@ use crate::{
         plaintext_store::{PlaintextStore, SharedPlaintextStore},
     },
     hnsw::{
-        searcher::{LayerDistribution, LayerMode, N_PARAM_LAYERS},
+        searcher::{LayerDistribution, N_PARAM_LAYERS},
         GraphMem, HnswParams, HnswSearcher, SortedNeighborhood,
     },
     utils::serialization::{
@@ -322,7 +322,7 @@ pub struct HnswConfig {
     pub ef_construction: usize,
     pub ef_search: LayerValue<usize>,
     pub M: usize,
-    pub layer_mode: LayerMode,
+    pub max_graph_layer: usize,
     #[serde(default)]
     pub fixed_layer_search_batch_size: Option<usize>,
 }
@@ -348,12 +348,11 @@ impl From<&HnswConfig> for HnswSearcher {
             params.ef_constr_search = vals.try_into().unwrap();
         }
 
-        let layer_mode = value.layer_mode.clone();
         let layer_distribution = LayerDistribution::new_geometric_from_M(value.M);
 
         HnswSearcher {
             params,
-            layer_mode,
+            max_graph_layer: value.max_graph_layer,
             layer_distribution,
             fixed_layer_search_batch_size: value.fixed_layer_search_batch_size,
         }

--- a/iris-mpc-cpu/src/analysis/accuracy.rs
+++ b/iris-mpc-cpu/src/analysis/accuracy.rs
@@ -96,7 +96,7 @@ where
 pub async fn run_analysis<D: DistanceOps>(
     config: AnalysisConfig,
     store: PlaintextStore<D>,
-    graph: GraphMem<VectorId>,
+    graph: GraphMem,
     rng: &mut StdRng,
 ) -> Result<Vec<AnalysisResult>> {
     // Get all valid VectorIds from the store.
@@ -421,7 +421,7 @@ pub async fn load_graph<D: DistanceOps>(
     config: &GraphInit,
     store: &mut PlaintextStore<D>,
     rng: &mut StdRng,
-) -> Result<GraphMem<VectorId>> {
+) -> Result<GraphMem> {
     match config {
         GraphInit::BinFile { path, format } => {
             println!("Loading graph from binary file: {}", path.display());

--- a/iris-mpc-cpu/src/analysis/accuracy.rs
+++ b/iris-mpc-cpu/src/analysis/accuracy.rs
@@ -4,8 +4,7 @@ use crate::{
         plaintext_store::{PlaintextStore, SharedPlaintextStore},
     },
     hnsw::{
-        graph::neighborhood::{UnsortedNeighborhood, WrappedNeighborhood},
-        searcher::{LayerDistribution, LayerMode, NeighborhoodMode, N_PARAM_LAYERS},
+        searcher::{LayerDistribution, LayerMode, N_PARAM_LAYERS},
         GraphMem, HnswParams, HnswSearcher, SortedNeighborhood,
     },
     utils::serialization::{
@@ -53,8 +52,6 @@ pub struct AnalysisConfig {
     pub mutations: Vec<f64>,
     /// Config for HNSW searcher to use for search during analysis.
     pub search_hnsw_config: HnswConfig,
-    /// Search using sorted or unsorted neighborhoods
-    pub neighborhood_mode: NeighborhoodMode,
     /// Distance ops type: "fhd" (Fractional Hamming) or "nhd" (Normalized Hamming).
     pub distance_ops: String,
 }
@@ -150,30 +147,12 @@ pub async fn run_analysis<D: DistanceOps>(
                 let query_ref = Arc::new(query_code_inner);
                 let analysis_searcher_clone = analysis_searcher.clone();
                 let mut store_clone = store.clone();
-                let nb_mode = config.neighborhood_mode.clone();
                 let graph_clone = Arc::clone(&graph);
 
                 let future = async move {
-                    let neighbors: WrappedNeighborhood<_> = match nb_mode {
-                        NeighborhoodMode::Sorted => analysis_searcher_clone
-                            .search::<_, SortedNeighborhood<_>>(
-                                &mut store_clone,
-                                &graph_clone,
-                                &query_ref,
-                                k_neighbors,
-                            )
-                            .await?
-                            .into(),
-                        NeighborhoodMode::Unsorted => analysis_searcher_clone
-                            .search::<_, UnsortedNeighborhood<_>>(
-                                &mut store_clone,
-                                &graph_clone,
-                                &query_ref,
-                                k_neighbors,
-                            )
-                            .await?
-                            .into(),
-                    };
+                    let neighbors: SortedNeighborhood<_> = analysis_searcher_clone
+                        .search(&mut store_clone, &graph_clone, &query_ref, k_neighbors)
+                        .await?;
 
                     let found = neighbors
                         .as_ref()

--- a/iris-mpc-cpu/src/analysis/accuracy_deep_id.rs
+++ b/iris-mpc-cpu/src/analysis/accuracy_deep_id.rs
@@ -173,7 +173,7 @@ pub async fn load_graph(
     config: &GraphInit,
     store: &mut PlaintextDeepIDStore,
     rng: &mut StdRng,
-) -> Result<GraphMem<VectorId>> {
+) -> Result<GraphMem> {
     match config {
         GraphInit::BinFile { path, format } => {
             println!("Loading graph from binary file: {}", path.display());
@@ -239,7 +239,7 @@ where
 pub async fn run_analysis(
     config: AnalysisConfig,
     store: PlaintextDeepIDStore,
-    graph: GraphMem<VectorId>,
+    graph: GraphMem,
     rng: &mut StdRng,
 ) -> Result<Vec<AnalysisResult>> {
     config.validate()?;

--- a/iris-mpc-cpu/src/analysis/accuracy_deep_id.rs
+++ b/iris-mpc-cpu/src/analysis/accuracy_deep_id.rs
@@ -9,8 +9,7 @@ use crate::{
         Int4Vector, PlaintextDeepIDStore, SharedPlaintextDeepIDStore, INT4_DIM,
     },
     hnsw::{
-        graph::neighborhood::{UnsortedNeighborhood, WrappedNeighborhood},
-        searcher::{LayerDistribution, LayerMode, NeighborhoodMode, N_PARAM_LAYERS},
+        searcher::{LayerDistribution, LayerMode, N_PARAM_LAYERS},
         GraphMem, HnswParams, HnswSearcher, SortedNeighborhood,
     },
     utils::serialization::{
@@ -71,7 +70,6 @@ pub struct AnalysisConfig {
     pub metrics_path: Option<PathBuf>,
     pub noise_levels: Vec<f64>,
     pub search_hnsw_config: HnswConfig,
-    pub neighborhood_mode: NeighborhoodMode,
 }
 
 impl AnalysisConfig {
@@ -292,30 +290,12 @@ pub async fn run_analysis(
 
             let analysis_searcher_clone = analysis_searcher.clone();
             let mut store_clone = store.clone();
-            let nb_mode = config.neighborhood_mode.clone();
             let graph_clone = Arc::clone(&graph);
 
             let future = async move {
-                let neighbors: WrappedNeighborhood<_> = match nb_mode {
-                    NeighborhoodMode::Sorted => analysis_searcher_clone
-                        .search::<_, SortedNeighborhood<_>>(
-                            &mut store_clone,
-                            &graph_clone,
-                            &query_ref,
-                            k_neighbors,
-                        )
-                        .await?
-                        .into(),
-                    NeighborhoodMode::Unsorted => analysis_searcher_clone
-                        .search::<_, UnsortedNeighborhood<_>>(
-                            &mut store_clone,
-                            &graph_clone,
-                            &query_ref,
-                            k_neighbors,
-                        )
-                        .await?
-                        .into(),
-                };
+                let neighbors: SortedNeighborhood<_> = analysis_searcher_clone
+                    .search(&mut store_clone, &graph_clone, &query_ref, k_neighbors)
+                    .await?;
 
                 let found = neighbors
                     .as_ref()
@@ -456,7 +436,6 @@ mod tests {
             metrics_path: None,
             noise_levels: vec![0.0],
             search_hnsw_config: small_hnsw_config(),
-            neighborhood_mode: NeighborhoodMode::Sorted,
         };
 
         let mut analysis_rng: StdRng = SeedableRng::seed_from_u64(0);

--- a/iris-mpc-cpu/src/analysis/accuracy_deep_id.rs
+++ b/iris-mpc-cpu/src/analysis/accuracy_deep_id.rs
@@ -9,7 +9,7 @@ use crate::{
         Int4Vector, PlaintextDeepIDStore, SharedPlaintextDeepIDStore, INT4_DIM,
     },
     hnsw::{
-        searcher::{LayerDistribution, LayerMode, N_PARAM_LAYERS},
+        searcher::{LayerDistribution, N_PARAM_LAYERS},
         GraphMem, HnswParams, HnswSearcher, SortedNeighborhood,
     },
     utils::serialization::{
@@ -103,7 +103,7 @@ pub struct HnswConfig {
     pub ef_construction: usize,
     pub ef_search: LayerValue<usize>,
     pub M: usize,
-    pub layer_mode: LayerMode,
+    pub max_graph_layer: usize,
     #[serde(default)]
     pub fixed_layer_search_batch_size: Option<usize>,
 }
@@ -127,12 +127,11 @@ impl From<&HnswConfig> for HnswSearcher {
             params.ef_constr_search = vals.try_into().unwrap();
         }
 
-        let layer_mode = value.layer_mode.clone();
         let layer_distribution = LayerDistribution::new_geometric_from_M(value.M);
 
         HnswSearcher {
             params,
-            layer_mode,
+            max_graph_layer: value.max_graph_layer,
             layer_distribution,
             fixed_layer_search_batch_size: value.fixed_layer_search_batch_size,
         }
@@ -394,7 +393,6 @@ pub fn process_results(config: &AnalysisConfig, results: Vec<AnalysisResult>) ->
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::hnsw::searcher::LayerMode;
     use aes_prng::AesRng;
     use rand::SeedableRng;
 
@@ -403,7 +401,7 @@ mod tests {
             ef_construction: 32,
             ef_search: LayerValue::Single(32),
             M: 16,
-            layer_mode: LayerMode::LinearScan { max_graph_layer: 1 },
+            max_graph_layer: 1,
             fixed_layer_search_batch_size: None,
         }
     }

--- a/iris-mpc-cpu/src/checkpoint_protocol/hasher.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/hasher.rs
@@ -45,11 +45,10 @@ mod tests {
     /// Bypasses the planner so tests can pin serializer-level determinism
     /// independently of the planner's sortedness invariant.
     fn graph_from(eyes: [LayerInput; 2]) -> Graph {
-        let build = |layers_in: LayerInput| -> GraphMem<VectorId> {
-            let mut g = GraphMem::<VectorId>::new();
+        let build = |layers_in: LayerInput| -> GraphMem {
+            let mut g = GraphMem::new();
             let max_lc = layers_in.iter().map(|(lc, _)| *lc).max().unwrap_or(0);
-            let mut layers: Vec<Layer<VectorId>> =
-                (0..=max_lc).map(|_| Layer::<VectorId>::new()).collect();
+            let mut layers: Vec<Layer> = (0..=max_lc).map(|_| Layer::new()).collect();
             for (lc, pairs) in layers_in {
                 for (k, v) in pairs {
                     layers[lc].set_links(k, v);
@@ -142,8 +141,8 @@ mod tests {
 
     #[test]
     fn empty_graphs_hash_consistently() {
-        let g1: Graph = [GraphMem::<VectorId>::new(), GraphMem::<VectorId>::new()];
-        let g2: Graph = [GraphMem::<VectorId>::new(), GraphMem::<VectorId>::new()];
+        let g1: Graph = [GraphMem::new(), GraphMem::new()];
+        let g2: Graph = [GraphMem::new(), GraphMem::new()];
         let h = Blake3GraphHasher::new();
         assert_eq!(h.hash_canonical(&g1), h.hash_canonical(&g2));
     }
@@ -151,16 +150,16 @@ mod tests {
     #[test]
     fn left_right_swap_changes_hash() {
         let left = {
-            let mut l = Layer::<VectorId>::new();
+            let mut l = Layer::new();
             l.set_links(vid(1), vec![vid(2)]);
-            let mut g = GraphMem::<VectorId>::new();
+            let mut g = GraphMem::new();
             g.layers = vec![l];
             g
         };
         let right = {
-            let mut l = Layer::<VectorId>::new();
+            let mut l = Layer::new();
             l.set_links(vid(5), vec![vid(6)]);
-            let mut g = GraphMem::<VectorId>::new();
+            let mut g = GraphMem::new();
             g.layers = vec![l];
             g
         };

--- a/iris-mpc-cpu/src/checkpoint_protocol/materializer.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/materializer.rs
@@ -99,7 +99,7 @@ async fn apply_wal_stream(
     graph: &mut Graph,
     mut stream: futures::stream::BoxStream<
         '_,
-        Result<BothEyes<Vec<crate::hnsw::graph::mutation::GraphMutation<VectorId>>>, CycleError>,
+        Result<BothEyes<Vec<crate::hnsw::graph::mutation::GraphMutation>>, CycleError>,
     >,
 ) -> Result<usize, CycleError> {
     use crate::execution::hawk_main::{LEFT, RIGHT};
@@ -132,7 +132,7 @@ mod tests {
     // Use `n` itself as the seq_no — every test below picks node ids that
     // are strictly increasing within a given eye, so this satisfies the
     // strict-increase invariant `insert_apply_all` enforces.
-    fn add_node(n: u32) -> GraphMutation<VectorId> {
+    fn add_node(n: u32) -> GraphMutation {
         GraphMutation {
             seq_no: n as u64,
             ops: vec![MutationOp::AddNode {
@@ -143,10 +143,7 @@ mod tests {
         }
     }
 
-    fn row(
-        left: Vec<u32>,
-        right: Vec<u32>,
-    ) -> Result<BothEyes<Vec<GraphMutation<VectorId>>>, CycleError> {
+    fn row(left: Vec<u32>, right: Vec<u32>) -> Result<BothEyes<Vec<GraphMutation>>, CycleError> {
         Ok([
             left.into_iter().map(add_node).collect(),
             right.into_iter().map(add_node).collect(),

--- a/iris-mpc-cpu/src/checkpoint_protocol/materializer.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/materializer.rs
@@ -9,7 +9,6 @@ use crate::graph_checkpoint::stream_download_and_deserialize_graph_pair;
 use crate::hnsw::{graph::graph_store::GraphPg, VectorStore};
 use crate::utils::serialization::graph::GraphFormat;
 use futures::TryStreamExt;
-use iris_mpc_common::vector_id::VectorId;
 
 /// Rebuilds the graph from an S3 checkpoint plus WAL replay.
 pub struct RebuildFromCheckpoint<'a, V: VectorStore> {
@@ -124,9 +123,10 @@ mod tests {
     use crate::hnsw::graph::layered_graph::GraphMem;
     use crate::hnsw::graph::mutation::{GraphMutation, MutationOp, UpdateEntryPoint};
     use futures::{stream, StreamExt};
+    use iris_mpc_common::IrisVectorId;
 
-    fn vid(n: u32) -> VectorId {
-        VectorId::from_serial_id(n)
+    fn vid(n: u32) -> IrisVectorId {
+        IrisVectorId::from_serial_id(n)
     }
 
     // Use `n` itself as the seq_no — every test below picks node ids that

--- a/iris-mpc-cpu/src/checkpoint_protocol/mod.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/mod.rs
@@ -24,7 +24,6 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use futures::stream::BoxStream;
-use iris_mpc_common::vector_id::VectorId;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 

--- a/iris-mpc-cpu/src/checkpoint_protocol/mod.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/mod.rs
@@ -41,7 +41,7 @@ pub type GraphMutationId = i64;
 
 /// The graph each materializer produces and each terminal action consumes.
 /// Both eyes together — left then right — matching the rest of Hawk.
-pub type Graph = BothEyes<GraphMem<VectorId>>;
+pub type Graph = BothEyes<GraphMem>;
 
 /// Metadata for the base checkpoint a cycle starts from.
 ///
@@ -229,7 +229,7 @@ pub trait MutationStore {
         &self,
         lo_exclusive: GraphMutationId,
         hi_inclusive: GraphMutationId,
-    ) -> Result<BoxStream<'_, Result<BothEyes<Vec<GraphMutation<VectorId>>>, CycleError>>, CycleError>;
+    ) -> Result<BoxStream<'_, Result<BothEyes<Vec<GraphMutation>>, CycleError>>, CycleError>;
 
     /// Largest `graph_mutation_id` currently visible to this party.
     /// Used for the height-agreement round.

--- a/iris-mpc-cpu/src/checkpoint_protocol/runner.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/runner.rs
@@ -27,7 +27,6 @@ use crate::hnsw::{
     graph::{graph_store::GraphPg, layered_graph::GraphMem},
     VectorStore,
 };
-use iris_mpc_common::vector_id::VectorId;
 
 // ── In-process Sidecar  ───────────────────────────────────────────────────────
 

--- a/iris-mpc-cpu/src/checkpoint_protocol/runner.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/runner.rs
@@ -264,7 +264,7 @@ pub async fn restart_from_checkpoint<V: VectorStore + Send + Sync>(
     s3_client: &S3Client,
     bucket: String,
     networking: &mut Box<dyn NetworkHandle>,
-    target: BothEyes<Arc<RwLock<GraphMem<VectorId>>>>,
+    target: BothEyes<Arc<RwLock<GraphMem>>>,
     peer_round_timeout: Duration,
     checkpoint_window: usize,
 ) -> Result<RestartOutcome> {

--- a/iris-mpc-cpu/src/checkpoint_protocol/store.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/store.rs
@@ -13,7 +13,6 @@ use crate::hnsw::{
     graph::{graph_store::GraphPg, mutation::GraphMutation},
     VectorStore,
 };
-use iris_mpc_common::vector_id::VectorId;
 
 #[async_trait]
 impl<V: VectorStore + Send + Sync> MutationStore for GraphPg<V> {

--- a/iris-mpc-cpu/src/checkpoint_protocol/store.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/store.rs
@@ -43,8 +43,7 @@ impl<V: VectorStore + Send + Sync> MutationStore for GraphPg<V> {
         &self,
         lo_exclusive: GraphMutationId,
         hi_inclusive: GraphMutationId,
-    ) -> Result<BoxStream<'_, Result<BothEyes<Vec<GraphMutation<VectorId>>>, CycleError>>, CycleError>
-    {
+    ) -> Result<BoxStream<'_, Result<BothEyes<Vec<GraphMutation>>, CycleError>>, CycleError> {
         let stream = self
             .stream_hawk_graph_mutations_in_range(lo_exclusive, hi_inclusive)
             .map_err(|e| CycleError::Transient(format!("stream hawk_graph_mutations: {e}")))
@@ -84,9 +83,9 @@ mod tests {
         VectorId::from_serial_id(n)
     }
 
-    /// Builds a `BothEyes<Vec<GraphMutation<VectorId>>>` with one RemoveNode per eye,
+    /// Builds a `BothEyes<Vec<GraphMutation>>` with one RemoveNode per eye,
     /// targeting different ids so left/right are distinguishable in the test.
-    fn both_eyes_payload(left_id: u32, right_id: u32) -> BothEyes<Vec<GraphMutation<VectorId>>> {
+    fn both_eyes_payload(left_id: u32, right_id: u32) -> BothEyes<Vec<GraphMutation>> {
         let mk = |id: u32| GraphMutation {
             seq_no: 1,
             ops: vec![MutationOp::RemoveNode { id: vid(id) }],
@@ -97,7 +96,7 @@ mod tests {
     async fn insert_row(
         store: &TestGraphPg<PlaintextStore>,
         modification_id: i64,
-        payload: &BothEyes<Vec<GraphMutation<VectorId>>>,
+        payload: &BothEyes<Vec<GraphMutation>>,
     ) -> eyre::Result<()> {
         let bytes = bincode::serialize(payload)?;
         let mut graph_tx = store.tx().await?;
@@ -163,7 +162,7 @@ mod tests {
         insert_row(&store, 9, &both_eyes_payload(109, 209)).await?;
 
         let stream = MutationStore::mutations_in_range(&store.graph, 1, 9).await?;
-        let rows: Vec<BothEyes<Vec<GraphMutation<VectorId>>>> = stream.try_collect().await?;
+        let rows: Vec<BothEyes<Vec<GraphMutation>>> = stream.try_collect().await?;
 
         assert_eq!(rows.len(), 2, "(1,9] should include ids 5 and 9");
         for (row, expected) in rows.iter().zip([(105, 205), (109, 209)]) {

--- a/iris-mpc-cpu/src/checkpoint_protocol/terminal.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/terminal.rs
@@ -161,11 +161,11 @@ impl<V: VectorStore + Send + Sync> TerminalAction for UploadAndRecord<'_, V> {
 
 /// Swaps the materialized graph into the live in-Hawk graph reference.
 pub struct InstallAsServing {
-    pub target: BothEyes<Arc<RwLock<GraphMem<VectorId>>>>,
+    pub target: BothEyes<Arc<RwLock<GraphMem>>>,
 }
 
 impl InstallAsServing {
-    pub fn new(target: BothEyes<Arc<RwLock<GraphMem<VectorId>>>>) -> Self {
+    pub fn new(target: BothEyes<Arc<RwLock<GraphMem>>>) -> Self {
         Self { target }
     }
 }
@@ -212,7 +212,7 @@ mod tests {
     #[tokio::test]
     async fn install_as_serving_swaps_in_snapshot_graph() {
         // Target holds an existing graph with node 99.
-        let target: BothEyes<Arc<RwLock<GraphMem<VectorId>>>> = [
+        let target: BothEyes<Arc<RwLock<GraphMem>>> = [
             Arc::new(RwLock::new(GraphMem::new())),
             Arc::new(RwLock::new(GraphMem::new())),
         ];
@@ -279,8 +279,8 @@ mod tests {
         use crate::execution::hawk_main::{LEFT, RIGHT};
 
         // Distinct content per eye so any eye-order swap surfaces in the assertion.
-        let mut left = GraphMem::<VectorId>::new();
-        let mut right = GraphMem::<VectorId>::new();
+        let mut left = GraphMem::new();
+        let mut right = GraphMem::new();
         left.insert_apply(&GraphMutation {
             seq_no: 1,
             ops: vec![MutationOp::AddNode {

--- a/iris-mpc-cpu/src/checkpoint_protocol/terminal.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/terminal.rs
@@ -16,7 +16,6 @@ use crate::hnsw::{
     VectorStore,
 };
 use crate::utils::serialization::graph::GraphFormat;
-use iris_mpc_common::vector_id::VectorId;
 
 /// Uploads the materialized graph to S3 and inserts a new
 /// `genesis_graph_checkpoint` row.
@@ -190,9 +189,10 @@ impl TerminalAction for InstallAsServing {
 mod tests {
     use super::*;
     use crate::hnsw::graph::mutation::{GraphMutation, MutationOp, UpdateEntryPoint};
+    use iris_mpc_common::IrisVectorId;
 
-    fn vid(n: u32) -> VectorId {
-        VectorId::from_serial_id(n)
+    fn vid(n: u32) -> IrisVectorId {
+        IrisVectorId::from_serial_id(n)
     }
 
     fn cp_meta() -> CheckpointMeta {

--- a/iris-mpc-cpu/src/checkpoint_protocol/tests.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/tests.rs
@@ -6,7 +6,6 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use futures::stream::{self, BoxStream};
-use iris_mpc_common::vector_id::VectorId;
 
 use crate::checkpoint_protocol::{
     run_cycle, Blake3Hash, CheckpointMeta, ConsensusMessage, ConsensusTransport, CycleConfig,

--- a/iris-mpc-cpu/src/checkpoint_protocol/tests.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/tests.rs
@@ -19,7 +19,7 @@ use crate::hnsw::{graph::mutation::GraphMutation, GraphMem};
 // ── shared fixtures ──────────────────────────────────────────────────────
 
 fn empty_graph() -> Graph {
-    [GraphMem::<VectorId>::new(), GraphMem::<VectorId>::new()]
+    [GraphMem::new(), GraphMem::new()]
 }
 
 fn cfg(min: u64) -> CycleConfig {
@@ -102,8 +102,7 @@ impl MutationStore for MockStore {
         &self,
         _lo_exclusive: GraphMutationId,
         _hi_inclusive: GraphMutationId,
-    ) -> Result<BoxStream<'_, Result<BothEyes<Vec<GraphMutation<VectorId>>>, CycleError>>, CycleError>
-    {
+    ) -> Result<BoxStream<'_, Result<BothEyes<Vec<GraphMutation>>, CycleError>>, CycleError> {
         Ok(Box::pin(stream::empty()))
     }
     async fn current_max_mutation_id(&self) -> Result<GraphMutationId, CycleError> {

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -56,14 +56,6 @@
 //! Finally, the constant `HAWK_BASE_ROTATIONS_MASK` should be set to indicate the set of "base rotations" for which
 //! the HawkActor will trigger independent HNSW searches. In practice, this set must be chosen so that the searches cover (at least)
 //! rotations in the [-15, 15] interval. For example, an example of suitable mask for MinRotation5 encodes the set `{-10, 0, 10}`.
-//!
-//! ### 3. Neighborhood Strategy: `Sorted` vs. `Unsorted`
-//!
-//! This strategy governs how nearest neighbors candidate lists are managed during HNSW graph traversal.
-//! - **`Sorted`**: Maintains a sorted list of candidates.
-//! - **`Unsorted`**: Maintains an unsorted list of candidates.
-//!
-//! It is set by passing `NEIGHBORHOOD_MODE` constant to the search/insertion orchestrator methods.
 
 #[allow(unused_imports)]
 use crate::hawkers::aby3::aby3_store::NhdOps;
@@ -86,7 +78,7 @@ use crate::{
     },
     hnsw::{
         graph::{graph_store, GraphMutation, MutationOp, UpdateEntryPoint},
-        searcher::{LayerDistribution, NeighborhoodMode},
+        searcher::LayerDistribution,
         GraphMem, HnswSearcher, VectorStore,
     },
     network::mpc::{build_network_handle, NetworkHandle, NetworkHandleArgs},
@@ -220,9 +212,6 @@ const _: () = {
 
 /// Rotation support as configured by SearchRotations.
 pub type VecRotations<T> = VecRotationSupport<T, HAWK_BASE_ROTATIONS_MASK>;
-
-/// The choice of HNSW candidate list strategy
-pub const NEIGHBORHOOD_MODE: NeighborhoodMode = NeighborhoodMode::Sorted;
 
 const LINEAR_SCAN_MAX_GRAPH_LAYER: usize = 1;
 
@@ -1823,7 +1812,6 @@ impl HawkHandle {
                 search_queries,
                 search_ids,
                 search_params,
-                NEIGHBORHOOD_MODE,
             )
             .await?;
 

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -36,11 +36,9 @@
 //!
 //! ### 1. HNSW Entry Point Strategy
 //!
-//! - **`Standard`**: The HNSW search starts from a single, pre-defined entry point.
-//! - **`LinearScan`**: The HNSW search begins by evaluating a set of entry points
-//!   candidates and choosing the one closest to the query vector.
-//!
-//! The entry point strategy is determined by the `LayerMode` in the `HnswSearcher`.
+//! HNSW search begins by evaluating the set of entry point candidates in the
+//! top graph layer (`HnswSearcher::max_graph_layer`) and choosing the one
+//! closest to the query vector via a linear scan.
 
 //! ### 2. Distance Function and base rotations
 //!
@@ -79,7 +77,7 @@ use crate::{
     hnsw::{
         graph::{graph_store, GraphMutation, MutationOp, UpdateEntryPoint},
         searcher::LayerDistribution,
-        GraphMem, HnswSearcher, VectorStore,
+        GraphMem, HnswSearcher, VectorStore, LINEAR_SCAN_MAX_GRAPH_LAYER,
     },
     network::mpc::{build_network_handle, NetworkHandle, NetworkHandleArgs},
     protocol::{
@@ -212,8 +210,6 @@ const _: () = {
 
 /// Rotation support as configured by SearchRotations.
 pub type VecRotations<T> = VecRotationSupport<T, HAWK_BASE_ROTATIONS_MASK>;
-
-const LINEAR_SCAN_MAX_GRAPH_LAYER: usize = 1;
 
 #[derive(Clone, Parser)]
 pub struct HawkArgs {

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -403,8 +403,8 @@ type UseOrRule = bool;
 
 type Aby3Ref = Arc<RwLock<Aby3Store<HawkOps>>>;
 
-pub type GraphRef = Arc<RwLock<GraphMem<VectorId>>>;
-pub type GraphMut<'a> = RwLockWriteGuard<'a, GraphMem<VectorId>>;
+pub type GraphRef = Arc<RwLock<GraphMem>>;
+pub type GraphMut<'a> = RwLockWriteGuard<'a, GraphMem>;
 
 /// A container for state required to perform parallel MPC operations.
 ///
@@ -458,7 +458,7 @@ pub struct HawkInsertPlan {
 /// A `ConnectPlan` is one finalized step of the HNSW insertion pipeline —
 /// a `GraphMutation` produced by the per-slot insert loop or by the
 /// post-batch `compact_batch` / `prune_invalid_links` helpers.
-pub type ConnectPlan = GraphMutation<VectorId>;
+pub type ConnectPlan = GraphMutation;
 
 /// Build the MPC network handle. Cheap — just TCP listener setup.
 /// Callers that need peer sync before iris load (genesis) call
@@ -489,7 +489,7 @@ impl HawkActor {
         args: HawkArgs,
         networking: Box<dyn NetworkHandle>,
         initialized: worker_pool_initializer::InitializedWorkers,
-        graph: BothEyes<GraphMem<VectorId>>,
+        graph: BothEyes<GraphMem>,
     ) -> Self {
         let party_id = args.party_index;
 
@@ -548,7 +548,7 @@ impl HawkActor {
     pub async fn from_cli_with_graph_and_store(
         args: &HawkArgs,
         shutdown_ct: CancellationToken,
-        graph: BothEyes<GraphMem<VectorId>>,
+        graph: BothEyes<GraphMem>,
         iris_store: BothEyes<Aby3SharedIrises>,
     ) -> Result<Self> {
         use worker_pool_initializer::WorkerPoolInitializer;
@@ -1060,7 +1060,7 @@ pub struct GraphLoader<'a>(BothEyes<GraphMut<'a>>);
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> GraphLoader<'a> {
-    pub fn load_graphs_from_checkpoint(self, graphs: BothEyes<GraphMem<VectorId>>) {
+    pub fn load_graphs_from_checkpoint(self, graphs: BothEyes<GraphMem>) {
         let [left, right] = graphs;
         let GraphLoader(mut dest_graphs) = self;
         *dest_graphs[LEFT] = left;

--- a/iris-mpc-cpu/src/execution/hawk_main/identity_update.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/identity_update.rs
@@ -5,7 +5,7 @@ use super::{
     search::{self, SearchParams, SearchQueries, SearchResults},
     BothEyes, HawkActor, HawkRequest, HawkSession, LEFT, RIGHT,
 };
-use crate::execution::hawk_main::{iris_worker::QueryId, search::SearchIds, NEIGHBORHOOD_MODE};
+use crate::execution::hawk_main::{iris_worker::QueryId, search::SearchIds};
 use eyre::Result;
 use iris_mpc_common::vector_id::VectorId;
 
@@ -47,7 +47,6 @@ pub async fn search_to_identity_update(
         &updates.queries,
         &updates.request_ids,
         search_params,
-        NEIGHBORHOOD_MODE,
     )
     .await?;
 

--- a/iris-mpc-cpu/src/execution/hawk_main/insert.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/insert.rs
@@ -3,7 +3,7 @@ use crate::hnsw::{
         mutation::{EdgeType, UnstampedMutation},
         MutationOp, UpdateEntryPoint,
     },
-    searcher::{ConnectPlanV, LayerMode},
+    searcher::ConnectPlanV,
     vector_store::VectorStoreMut,
     GraphMem, HnswSearcher, VectorStore,
 };
@@ -93,8 +93,8 @@ pub async fn insert<V: VectorStoreMut>(
         "plans and insert_ids must be the same length"
     );
 
-    let insert_plans = join_plans(plans, &searcher.layer_mode);
-    validate_ep_updates(&insert_plans, &searcher.layer_mode)?;
+    let insert_plans = join_plans(plans);
+    validate_ep_updates(&insert_plans, searcher.max_graph_layer)?;
 
     let mut intra_batch_inserted = vec![];
     let m = searcher.params.get_M(0);
@@ -202,102 +202,30 @@ pub async fn insert<V: VectorStoreMut>(
 
 /// Combine insert plans from parallel searches, repairing any conflict.
 ///
-/// Currently just processes entry point update operations.
-fn join_plans<V: VectorStore>(
-    mut plans: Vec<Option<InsertPlanV<V>>>,
-    layer_mode: &LayerMode,
-) -> Vec<Option<InsertPlanV<V>>> {
-    match layer_mode {
-        LayerMode::Standard { .. } => {
-            // Requests to set unique entry point must have strictly increasing layer
-            let mut current_max_ep_layer: Option<usize> = None;
-            for plan in plans.iter_mut() {
-                let Some(plan) = plan else { continue };
-
-                if let UpdateEntryPoint::SetUnique { layer } = plan.update_ep {
-                    let update_valid = current_max_ep_layer
-                        .map(|max_ep_layer| max_ep_layer < layer)
-                        .unwrap_or(true);
-                    if update_valid {
-                        current_max_ep_layer = Some(layer);
-                    } else {
-                        plan.update_ep = UpdateEntryPoint::False;
-                    }
-                }
-            }
-        }
-        LayerMode::LinearScan { .. } => {}
-    }
-
+/// Linear-scan entry point updates ("append" at the max graph layer) need no
+/// cross-plan reconciliation, so this is currently a passthrough.
+fn join_plans<V: VectorStore>(plans: Vec<Option<InsertPlanV<V>>>) -> Vec<Option<InsertPlanV<V>>> {
     plans
 }
 
-/// Verify that entry point updates are sane for different searcher `LayerMode` variants.
+/// Verify that all entry point updates are "append" updates at the max graph layer.
 fn validate_ep_updates<V: VectorStore>(
     plans: &Vec<Option<InsertPlanV<V>>>,
-    layer_mode: &LayerMode,
+    max_graph_layer: usize,
 ) -> Result<()> {
-    // For standard mode, check that entry point updates have strictly
-    // increasing layers and no "append" updates
-    if let LayerMode::Standard { .. } = layer_mode {
-        let mut current_max_ep_layer: Option<usize> = None;
-        for plan in plans {
-            let Some(plan) = plan else { continue };
+    for plan in plans {
+        let Some(plan) = plan else { continue };
 
-            match plan.update_ep {
-                UpdateEntryPoint::SetUnique { layer } => {
-                    if current_max_ep_layer
-                        .map(|max_ep_layer| max_ep_layer < layer)
-                        .unwrap_or(true)
-                    {
-                        current_max_ep_layer = Some(layer)
-                    } else {
-                        bail!("InsertPlan sets entry point at or lower than the current maximum layer");
-                    }
-                }
-                UpdateEntryPoint::Append { .. } => {
-                    bail!("Append entry point update encountered during Standard or Bounded layer mode");
-                }
-                UpdateEntryPoint::False => {}
+        match plan.update_ep {
+            UpdateEntryPoint::SetUnique { .. } => {
+                bail!("SetUnique entry point update encountered during LinearScan layer mode");
             }
-        }
-    }
-
-    // For standard mode with a layer bound specified, check that all updates
-    // are at or below the layer bound
-    if let LayerMode::Standard {
-        max_graph_layer: Some(max_layer),
-    } = layer_mode
-    {
-        for plan in plans {
-            let Some(plan) = plan else { continue };
-
-            if let UpdateEntryPoint::SetUnique { layer } = plan.update_ep {
-                if layer > *max_layer {
-                    bail!(
-                        "InsertPlan sets entry point higher than layer bound in Bounded layer mode"
-                    );
+            UpdateEntryPoint::Append { layer } => {
+                if layer != max_graph_layer {
+                    bail!("InsertPlan adds entry point at different layer than max graph layer during LinearScan layer mode")
                 }
             }
-        }
-    }
-
-    // For linear scan mode, check that all updates are "append" updates at the layer bound
-    if let LayerMode::LinearScan { max_graph_layer } = layer_mode {
-        for plan in plans {
-            let Some(plan) = plan else { continue };
-
-            match plan.update_ep {
-                UpdateEntryPoint::SetUnique { .. } => {
-                    bail!("SetUnique entry point update encountered during LinearScan layer mode");
-                }
-                UpdateEntryPoint::Append { layer } => {
-                    if layer != *max_graph_layer {
-                        bail!("InsertPlan adds entry point at different layer than max graph layer during LinearScan layer mode")
-                    }
-                }
-                UpdateEntryPoint::False => {}
-            }
+            UpdateEntryPoint::False => {}
         }
     }
 
@@ -347,7 +275,6 @@ mod tests {
     fn test_join_plans_helper(
         test_cases: &[UpdateEntryPoint],
         expected_results: &[UpdateEntryPoint],
-        layer_mode: &LayerMode,
     ) {
         let mut plans = test_cases
             .iter()
@@ -356,106 +283,11 @@ mod tests {
             .map(Some)
             .collect_vec();
         plans.push(None); // Add a None plan as in the original tests
-        let result = join_plans(plans, layer_mode);
+        let result = join_plans(plans);
         assert_eq!(result.len(), expected_results.len() + 1);
         for (idx, expected_update_ep) in expected_results.iter().enumerate() {
             assert_eq!(result[idx].as_ref().unwrap().update_ep, *expected_update_ep);
         }
-    }
-
-    // Test standard operation mode
-    #[test]
-    fn test_join_plans_standard() {
-        // entry points in same layer
-        test_join_plans_helper(
-            &[
-                UpdateEntryPoint::SetUnique { layer: 2 },
-                UpdateEntryPoint::SetUnique { layer: 2 },
-            ],
-            &[
-                UpdateEntryPoint::SetUnique { layer: 2 },
-                UpdateEntryPoint::False,
-            ],
-            &LayerMode::Standard {
-                max_graph_layer: None,
-            },
-        );
-
-        // increasing layer order
-        test_join_plans_helper(
-            &[
-                UpdateEntryPoint::SetUnique { layer: 1 },
-                UpdateEntryPoint::SetUnique { layer: 2 },
-            ],
-            &[
-                UpdateEntryPoint::SetUnique { layer: 1 },
-                UpdateEntryPoint::SetUnique { layer: 2 },
-            ],
-            &LayerMode::Standard {
-                max_graph_layer: None,
-            },
-        );
-
-        // decreasing layer order
-        test_join_plans_helper(
-            &[
-                UpdateEntryPoint::SetUnique { layer: 2 },
-                UpdateEntryPoint::SetUnique { layer: 1 },
-            ],
-            &[
-                UpdateEntryPoint::SetUnique { layer: 2 },
-                UpdateEntryPoint::False,
-            ],
-            &LayerMode::Standard {
-                max_graph_layer: None,
-            },
-        );
-
-        // exercise more complex case
-        test_join_plans_helper(
-            &[
-                UpdateEntryPoint::False,
-                UpdateEntryPoint::SetUnique { layer: 1 },
-                UpdateEntryPoint::False,
-                UpdateEntryPoint::SetUnique { layer: 1 },
-                UpdateEntryPoint::SetUnique { layer: 2 },
-                UpdateEntryPoint::SetUnique { layer: 1 },
-                UpdateEntryPoint::SetUnique { layer: 2 },
-                UpdateEntryPoint::SetUnique { layer: 2 },
-            ],
-            &[
-                UpdateEntryPoint::False,
-                UpdateEntryPoint::SetUnique { layer: 1 },
-                UpdateEntryPoint::False,
-                UpdateEntryPoint::False,
-                UpdateEntryPoint::SetUnique { layer: 2 },
-                UpdateEntryPoint::False,
-                UpdateEntryPoint::False,
-                UpdateEntryPoint::False,
-            ],
-            &LayerMode::Standard {
-                max_graph_layer: None,
-            },
-        );
-    }
-
-    /// Test bounded operation mode
-    #[test]
-    fn test_join_plans_bounded() {
-        // `join_plans` does not modify entry point updates based on bounded `max_graph_layer`
-        test_join_plans_helper(
-            &[
-                UpdateEntryPoint::SetUnique { layer: 2 },
-                UpdateEntryPoint::SetUnique { layer: 2 },
-            ],
-            &[
-                UpdateEntryPoint::SetUnique { layer: 2 },
-                UpdateEntryPoint::False,
-            ],
-            &LayerMode::Standard {
-                max_graph_layer: Some(1),
-            },
-        );
     }
 
     /// Test linear scan operation mode
@@ -471,7 +303,6 @@ mod tests {
                 UpdateEntryPoint::Append { layer: 1 },
                 UpdateEntryPoint::Append { layer: 1 },
             ],
-            &LayerMode::LinearScan { max_graph_layer: 1 },
         );
 
         // `join_plans` does not modify append operations based on bounded `max_graph_layer`
@@ -484,7 +315,6 @@ mod tests {
                 UpdateEntryPoint::Append { layer: 2 },
                 UpdateEntryPoint::Append { layer: 2 },
             ],
-            &LayerMode::LinearScan { max_graph_layer: 1 },
         );
 
         // `join_plans` does not modify append operations in case of different update layers
@@ -497,14 +327,13 @@ mod tests {
                 UpdateEntryPoint::Append { layer: 0 },
                 UpdateEntryPoint::Append { layer: 1 },
             ],
-            &LayerMode::LinearScan { max_graph_layer: 1 },
         );
     }
 
     fn test_validate_ep_updates_helper(
         test_cases: &[UpdateEntryPoint],
         expect_ok: bool,
-        layer_mode: &LayerMode,
+        max_graph_layer: usize,
     ) {
         let mut plans = test_cases
             .iter()
@@ -513,7 +342,7 @@ mod tests {
             .map(Some)
             .collect_vec();
         plans.push(None);
-        let res = validate_ep_updates(&plans, layer_mode);
+        let res = validate_ep_updates(&plans, max_graph_layer);
         match res {
             Ok(_) => {
                 if !expect_ok {
@@ -534,134 +363,10 @@ mod tests {
         }
     }
 
-    /// Test ep validator Standard layer mode validity checks
-    #[test]
-    fn test_ep_updates_validator_standard() {
-        let standard_layer_mode = LayerMode::Standard {
-            max_graph_layer: None,
-        };
-
-        // Standard mode layers are strictly increasing
-        test_validate_ep_updates_helper(
-            &[
-                UpdateEntryPoint::SetUnique { layer: 0 },
-                UpdateEntryPoint::SetUnique { layer: 1 },
-                UpdateEntryPoint::SetUnique { layer: 1 },
-            ],
-            false,
-            &standard_layer_mode,
-        );
-        test_validate_ep_updates_helper(
-            &[
-                UpdateEntryPoint::SetUnique { layer: 1 },
-                UpdateEntryPoint::SetUnique { layer: 0 },
-            ],
-            false,
-            &standard_layer_mode,
-        );
-
-        // Standard mode doesn't allow Append updates
-        test_validate_ep_updates_helper(
-            &[
-                UpdateEntryPoint::SetUnique { layer: 0 },
-                UpdateEntryPoint::Append { layer: 1 },
-                UpdateEntryPoint::SetUnique { layer: 1 },
-            ],
-            false,
-            &standard_layer_mode,
-        );
-
-        // The following is valid for Standard mode
-        test_validate_ep_updates_helper(
-            &[
-                UpdateEntryPoint::False,
-                UpdateEntryPoint::SetUnique { layer: 0 },
-                UpdateEntryPoint::False,
-                UpdateEntryPoint::SetUnique { layer: 1 },
-                UpdateEntryPoint::False,
-                UpdateEntryPoint::False,
-                UpdateEntryPoint::SetUnique { layer: 3 },
-                UpdateEntryPoint::False,
-                UpdateEntryPoint::SetUnique { layer: 4 },
-                UpdateEntryPoint::SetUnique { layer: 5 },
-                UpdateEntryPoint::False,
-            ],
-            true,
-            &standard_layer_mode,
-        );
-    }
-
-    /// Test ep validator Bounded layer mode validity checks
-    #[test]
-    fn test_ep_updates_validator_bounded() {
-        let bounded_layer_mode = LayerMode::Standard {
-            max_graph_layer: Some(3),
-        };
-
-        // Bounded mode layers are strictly increasing
-        test_validate_ep_updates_helper(
-            &[
-                UpdateEntryPoint::SetUnique { layer: 0 },
-                UpdateEntryPoint::SetUnique { layer: 1 },
-                UpdateEntryPoint::SetUnique { layer: 1 },
-            ],
-            false,
-            &bounded_layer_mode,
-        );
-        test_validate_ep_updates_helper(
-            &[
-                UpdateEntryPoint::SetUnique { layer: 1 },
-                UpdateEntryPoint::SetUnique { layer: 0 },
-            ],
-            false,
-            &bounded_layer_mode,
-        );
-
-        // Bounded mode doesn't allow Append updates
-        test_validate_ep_updates_helper(
-            &[
-                UpdateEntryPoint::SetUnique { layer: 0 },
-                UpdateEntryPoint::Append { layer: 1 },
-                UpdateEntryPoint::SetUnique { layer: 1 },
-            ],
-            false,
-            &bounded_layer_mode,
-        );
-
-        // Bounded mode must set entry points at or below layer bound
-        test_validate_ep_updates_helper(
-            &[
-                UpdateEntryPoint::SetUnique { layer: 0 },
-                UpdateEntryPoint::SetUnique { layer: 1 },
-                UpdateEntryPoint::SetUnique { layer: 3 },
-                UpdateEntryPoint::SetUnique { layer: 4 },
-            ],
-            false,
-            &bounded_layer_mode,
-        );
-
-        // The following is valid for Bounded mode
-        test_validate_ep_updates_helper(
-            &[
-                UpdateEntryPoint::False,
-                UpdateEntryPoint::SetUnique { layer: 0 },
-                UpdateEntryPoint::False,
-                UpdateEntryPoint::SetUnique { layer: 1 },
-                UpdateEntryPoint::False,
-                UpdateEntryPoint::False,
-                UpdateEntryPoint::SetUnique { layer: 3 },
-                UpdateEntryPoint::False,
-                UpdateEntryPoint::False,
-            ],
-            true,
-            &bounded_layer_mode,
-        );
-    }
-
     /// Test ep validator LinearScan layer mode validity checks
     #[test]
     fn test_ep_updates_validator_linear_scan() {
-        let linear_scan_layer_mode = LayerMode::LinearScan { max_graph_layer: 3 };
+        let max_graph_layer = 3;
 
         // LinearScan mode cannot have SetUnique updates
         test_validate_ep_updates_helper(
@@ -671,7 +376,7 @@ mod tests {
                 UpdateEntryPoint::SetUnique { layer: 3 },
             ],
             false,
-            &linear_scan_layer_mode,
+            max_graph_layer,
         );
 
         // LinearScan mode cannot append entry points at layers besides the max graph layer
@@ -682,7 +387,7 @@ mod tests {
                 UpdateEntryPoint::Append { layer: 4 },
             ],
             false,
-            &linear_scan_layer_mode,
+            max_graph_layer,
         );
         test_validate_ep_updates_helper(
             &[
@@ -691,7 +396,7 @@ mod tests {
                 UpdateEntryPoint::Append { layer: 2 },
             ],
             false,
-            &linear_scan_layer_mode,
+            max_graph_layer,
         );
 
         // The following is valid for LinearScan mode
@@ -711,7 +416,7 @@ mod tests {
                 UpdateEntryPoint::False,
             ],
             true,
-            &linear_scan_layer_mode,
+            max_graph_layer,
         );
     }
 
@@ -733,11 +438,7 @@ mod tests {
         // slots, not the bilateral-edge logic which is tested elsewhere.
 
         // Batch: [insert C, delete A, delete B]
-        let plans = vec![
-            Some(dummy_insert_plan(UpdateEntryPoint::SetUnique { layer: 0 })),
-            None,
-            None,
-        ];
+        let plans = vec![Some(dummy_insert_plan(UpdateEntryPoint::False)), None, None];
         let insert_ids: VecRequests<Option<VectorId>> = vec![None, None, None];
         let replace_ids: VecRequests<Option<VectorId>> = vec![None, Some(a), Some(b)];
 
@@ -803,9 +504,7 @@ mod tests {
 
         let old = store.insert(&Arc::new(IrisCode::default())).await;
 
-        let plans = vec![Some(dummy_insert_plan(UpdateEntryPoint::SetUnique {
-            layer: 0,
-        }))];
+        let plans = vec![Some(dummy_insert_plan(UpdateEntryPoint::False))];
         let insert_ids: VecRequests<Option<VectorId>> = vec![None];
         let replace_ids: VecRequests<Option<VectorId>> = vec![Some(old)];
 
@@ -900,7 +599,7 @@ mod tests {
         let expected_start = graph.next_sequence_number();
 
         let plans = vec![
-            Some(dummy_insert_plan(UpdateEntryPoint::SetUnique { layer: 0 })),
+            Some(dummy_insert_plan(UpdateEntryPoint::False)),
             None,
             Some(dummy_insert_plan(UpdateEntryPoint::False)),
         ];

--- a/iris-mpc-cpu/src/execution/hawk_main/insert.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/insert.rs
@@ -71,7 +71,7 @@ impl<V: VectorStore> Clone for InsertPlanV<V> {
 ///   for pure deletions and no-op slots.
 pub async fn insert<V: VectorStoreMut>(
     store: &mut V,
-    graph: &mut GraphMem<VectorId>,
+    graph: &mut GraphMem,
     searcher: &HnswSearcher,
     plans: VecRequests<Option<InsertPlanV<V>>>,
     insert_ids: &VecRequests<Option<VectorId>>,
@@ -139,7 +139,7 @@ pub async fn insert<V: VectorStoreMut>(
             intra_batch_inserted.push(inserted_id);
             slot_inserted_ids[idx] = Some(inserted_id);
 
-            let mut ops: Vec<MutationOp<VectorId>> = vec![MutationOp::AddNode {
+            let mut ops: Vec<MutationOp> = vec![MutationOp::AddNode {
                 id: inserted_id,
                 height: links.len(),
                 update_ep,
@@ -721,7 +721,7 @@ mod tests {
     #[tokio::test]
     async fn test_insert_with_pure_deletion_preserves_slot_order() {
         let mut store = PlaintextStore::default();
-        let mut graph: GraphMem<VectorId> = GraphMem::new();
+        let mut graph: GraphMem = GraphMem::new();
         let searcher = HnswSearcher::new_with_test_parameters();
 
         // Seed the store/graph with two existing vectors A and B so we have something
@@ -798,7 +798,7 @@ mod tests {
     #[tokio::test]
     async fn test_insert_with_combined_replace_emits_removenode_then_addnode() {
         let mut store = PlaintextStore::default();
-        let mut graph: GraphMem<VectorId> = GraphMem::new();
+        let mut graph: GraphMem = GraphMem::new();
         let searcher = HnswSearcher::new_with_test_parameters();
 
         let old = store.insert(&Arc::new(IrisCode::default())).await;
@@ -863,7 +863,7 @@ mod tests {
     #[tokio::test]
     async fn test_insert_with_none_slot_yields_empty_vec() {
         let mut store = PlaintextStore::default();
-        let mut graph: GraphMem<VectorId> = GraphMem::new();
+        let mut graph: GraphMem = GraphMem::new();
         let searcher = HnswSearcher::new_with_test_parameters();
 
         let plans: VecRequests<Option<InsertPlanV<PlaintextStore>>> = vec![None];
@@ -894,7 +894,7 @@ mod tests {
     #[tokio::test]
     async fn test_insert_stamps_strictly_increasing_seq_nos_per_slot() {
         let mut store = PlaintextStore::default();
-        let mut graph: GraphMem<VectorId> = GraphMem::new();
+        let mut graph: GraphMem = GraphMem::new();
         let searcher = HnswSearcher::new_with_test_parameters();
 
         let expected_start = graph.next_sequence_number();
@@ -975,7 +975,7 @@ mod tests {
     #[tokio::test]
     async fn test_insert_appends_global_compaction_to_last_nonempty_slot() {
         let mut store = PlaintextStore::default();
-        let mut graph: GraphMem<VectorId> = GraphMem::new();
+        let mut graph: GraphMem = GraphMem::new();
         let searcher = HnswSearcher::new_with_test_parameters();
         let m_limit = searcher.params.get_M_limit(0);
 
@@ -994,7 +994,7 @@ mod tests {
         //     nodes (size m_limit, since there are m_limit + 1 seeds total).
         // EdgeType::Base ensures the back-edges aren't auto-created — keeps
         // each neighborhood exactly at m_limit.
-        let mut setup_ops: Vec<MutationOp<VectorId>> = Vec::with_capacity(seed_count * 2);
+        let mut setup_ops: Vec<MutationOp> = Vec::with_capacity(seed_count * 2);
         for (i, &id) in seed_ids.iter().enumerate() {
             setup_ops.push(MutationOp::AddNode {
                 id,

--- a/iris-mpc-cpu/src/execution/hawk_main/search.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/search.rs
@@ -10,12 +10,7 @@ use crate::{
         InsertPlanV, StoreId,
     },
     hawkers::aby3::aby3_store::{Aby3DistanceRef, Aby3Query, Aby3Store, DistanceOps},
-    hnsw::{
-        graph::neighborhood::{Neighborhood, UnsortedNeighborhood},
-        graph::UpdateEntryPoint,
-        searcher::NeighborhoodMode,
-        GraphMem, HnswSearcher, SortedNeighborhood,
-    },
+    hnsw::{graph::UpdateEntryPoint, GraphMem, HnswSearcher},
 };
 use eyre::{OptionExt, Result};
 use iris_mpc_common::iris_db::iris::Threshold;
@@ -99,7 +94,6 @@ pub async fn search<const ROTMASK: u32>(
     search_queries: &SearchQueries<ROTMASK>,
     search_ids: &SearchIds,
     search_params: SearchParams,
-    mode: NeighborhoodMode,
 ) -> Result<SearchResults<ROTMASK>> {
     let n_sessions = sessions[LEFT].len();
     assert_eq!(n_sessions, sessions[RIGHT].len());
@@ -114,33 +108,17 @@ pub async fn search<const ROTMASK: u32>(
         let search_ids = search_ids.clone();
         let search_params = search_params.clone();
         let tx = tx.clone();
-        let mode = mode.clone();
 
         async move {
-            match mode {
-                NeighborhoodMode::Sorted => {
-                    per_session::<_, SortedNeighborhood<_>>(
-                        &session,
-                        &search_queries,
-                        &search_ids,
-                        &search_params,
-                        tx,
-                        batch,
-                    )
-                    .await
-                }
-                NeighborhoodMode::Unsorted => {
-                    per_session::<_, UnsortedNeighborhood<_>>(
-                        &session,
-                        &search_queries,
-                        &search_ids,
-                        &search_params,
-                        tx,
-                        batch,
-                    )
-                    .await
-                }
-            }
+            per_session(
+                &session,
+                &search_queries,
+                &search_ids,
+                &search_params,
+                tx,
+                batch,
+            )
+            .await
         }
     };
 
@@ -154,7 +132,7 @@ pub async fn search<const ROTMASK: u32>(
 }
 
 #[instrument(level = "trace", target = "searcher::network", skip_all)]
-async fn per_session<const ROTMASK: u32, N: Neighborhood<Aby3Store<HawkOps>>>(
+async fn per_session<const ROTMASK: u32>(
     session: &HawkSession,
     search_queries: &SearchQueries<ROTMASK>,
     search_ids: &SearchIds,
@@ -179,7 +157,7 @@ async fn per_session<const ROTMASK: u32, N: Neighborhood<Aby3Store<HawkOps>>>(
                 let insertion_layer = search_params
                     .hnsw
                     .gen_layer_prf(&session.hnsw_prf_key, &layer_selection_value)?;
-                per_insert_query::<N>(
+                per_insert_query(
                     query,
                     search_params,
                     &mut vector_store,
@@ -254,7 +232,7 @@ async fn classify_and_extend(
         metrics::counter!("supermatcher_extended_searches").increment(1);
 
         let supermatch_neighbors = hnsw_supermatch
-            .search::<_, SortedNeighborhood<_>>(aby3_store, graph_store, query, ef_supermatch)
+            .search(aby3_store, graph_store, query, ef_supermatch)
             .await?;
 
         let supermatch_classified = classify_edges(
@@ -334,7 +312,7 @@ async fn classify_edges(
     })
 }
 
-async fn per_insert_query<N: Neighborhood<Aby3Store<HawkOps>>>(
+async fn per_insert_query(
     query: Aby3Query,
     search_params: &SearchParams,
     aby3_store: &mut Aby3Store<HawkOps>,
@@ -345,7 +323,7 @@ async fn per_insert_query<N: Neighborhood<Aby3Store<HawkOps>>>(
 
     let (links, update_ep) = search_params
         .hnsw
-        .search_to_insert::<_, N>(aby3_store, graph_store, &query, insertion_layer)
+        .search_to_insert(aby3_store, graph_store, &query, insertion_layer)
         .await?;
 
     let classified = if search_params.do_match {
@@ -399,7 +377,7 @@ async fn per_search_query(
     let ef_search = search_params.hnsw.params.get_ef_search(0);
     let layer_0_neighbors = search_params
         .hnsw
-        .search::<_, SortedNeighborhood<_>>(aby3_store, graph_store, &query, ef_search)
+        .search(aby3_store, graph_store, &query, ef_search)
         .await?;
 
     let links_unstructured = vec![layer_0_neighbors.edge_ids()];
@@ -447,7 +425,7 @@ pub async fn search_single_query_no_match_count<H: std::hash::Hash>(
     let insertion_layer = searcher.gen_layer_prf(&session.hnsw_prf_key, identifier)?;
 
     let (links, update_ep) = searcher
-        .search_to_insert::<_, SortedNeighborhood<_>>(&mut *store, &graph, &query, insertion_layer)
+        .search_to_insert(&mut *store, &graph, &query, insertion_layer)
         .await?;
 
     // Trim and extract unstructured vector lists
@@ -513,14 +491,7 @@ mod tests {
             'T',
         );
 
-        let result = search(
-            &sessions,
-            search_queries,
-            &request.ids,
-            search_params,
-            NeighborhoodMode::Sorted,
-        )
-        .await?;
+        let result = search(&sessions, search_queries, &request.ids, search_params).await?;
 
         for side in result {
             assert_eq!(side.len(), batch_size);

--- a/iris-mpc-cpu/src/execution/hawk_main/search.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/search.rs
@@ -228,7 +228,7 @@ async fn classify_and_extend(
     query: &Aby3Query,
     search_params: &SearchParams,
     aby3_store: &mut Aby3Store<HawkOps>,
-    graph_store: &GraphMem<VectorId>,
+    graph_store: &GraphMem,
     ef: usize,
 ) -> Result<ClassifiedMatches> {
     let margin = search_params.saturation_margin;
@@ -338,7 +338,7 @@ async fn per_insert_query<N: Neighborhood<Aby3Store<HawkOps>>>(
     query: Aby3Query,
     search_params: &SearchParams,
     aby3_store: &mut Aby3Store<HawkOps>,
-    graph_store: &GraphMem<VectorId>,
+    graph_store: &GraphMem,
     insertion_layer: usize,
 ) -> Result<HawkInsertPlan> {
     let start = Instant::now();
@@ -392,7 +392,7 @@ async fn per_search_query(
     query: Aby3Query,
     search_params: &SearchParams,
     aby3_store: &mut Aby3Store<HawkOps>,
-    graph_store: &GraphMem<VectorId>,
+    graph_store: &GraphMem,
 ) -> Result<HawkInsertPlan> {
     let start = Instant::now();
 

--- a/iris-mpc-cpu/src/execution/hawk_main/test_utils.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/test_utils.rs
@@ -15,10 +15,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::{
     execution::local::get_free_local_addresses,
-    hnsw::{
-        graph::{mutation::EdgeType, GraphMutation, MutationOp, UpdateEntryPoint},
-        searcher::LayerMode,
-    },
+    hnsw::graph::{mutation::EdgeType, GraphMutation, MutationOp, UpdateEntryPoint},
     protocol::shared_iris::GaloisRingSharedIris,
     utils::constants::N_PARTIES,
 };
@@ -84,7 +81,6 @@ pub async fn init_iris_db(actor: &mut HawkActor) -> Result<()> {
 /// Populate the graphs such that all vectors are reachable.
 pub async fn init_graph(actor: &mut HawkActor) -> Result<()> {
     let db_size = 5;
-    let layer_mode = actor.searcher().layer_mode.clone();
     let id = |i: usize| VectorId::from_0_index(i as u32);
     let next = |i: usize| (i + 1) % db_size;
     let edges = |i: usize| vec![id(next(i))];
@@ -92,14 +88,7 @@ pub async fn init_graph(actor: &mut HawkActor) -> Result<()> {
     for side in [LEFT, RIGHT] {
         let mut graph = actor.graph_store[side].write().await;
         for i in 0..db_size {
-            let update_ep = if i == 0 {
-                match layer_mode {
-                    LayerMode::Standard { .. } => UpdateEntryPoint::SetUnique { layer: 0 },
-                    LayerMode::LinearScan { .. } => UpdateEntryPoint::False,
-                }
-            } else {
-                UpdateEntryPoint::False
-            };
+            let update_ep = UpdateEntryPoint::False;
             let mutations = vec![
                 MutationOp::AddNode {
                     id: id(i),

--- a/iris-mpc-cpu/src/genesis/plaintext.rs
+++ b/iris-mpc-cpu/src/genesis/plaintext.rs
@@ -34,10 +34,7 @@ use crate::{
     genesis::{BatchSize, BatchSizeConfig},
     graph_checkpoint::PruningMode,
     hawkers::plaintext_store::PlaintextStore,
-    hnsw::{
-        graph::neighborhood::Neighborhood, vector_store::VectorStoreMut, GraphMem, HnswSearcher,
-        SortedNeighborhood,
-    },
+    hnsw::{vector_store::VectorStoreMut, GraphMem, HnswSearcher},
 };
 
 /// Represents irises db table, mapping serial ids to version, and left and right iris codes.
@@ -243,12 +240,7 @@ pub async fn run_plaintext_genesis(mut state: GenesisState) -> Result<GenesisSta
                     let insertion_layer = searcher.gen_layer_prf(&prf_key, &identifier)?;
 
                     let (links, update_ep) = searcher
-                        .search_to_insert::<_, SortedNeighborhood<_>>(
-                            store,
-                            graph,
-                            &query,
-                            insertion_layer,
-                        )
+                        .search_to_insert(store, graph, &query, insertion_layer)
                         .await?;
 
                     // Trim and extract unstructured vector lists
@@ -348,12 +340,7 @@ pub async fn run_plaintext_genesis(mut state: GenesisState) -> Result<GenesisSta
                 let insertion_layer = searcher.gen_layer_prf(&prf_key, &identifier)?;
 
                 let (links, update_ep) = searcher
-                    .search_to_insert::<_, SortedNeighborhood<_>>(
-                        store,
-                        graph,
-                        &query,
-                        insertion_layer,
-                    )
+                    .search_to_insert(store, graph, &query, insertion_layer)
                     .await?;
 
                 // Trim and extract unstructured vector lists

--- a/iris-mpc-cpu/src/genesis/plaintext.rs
+++ b/iris-mpc-cpu/src/genesis/plaintext.rs
@@ -48,7 +48,7 @@ pub type IrisesTable = HashMap<IrisSerialId, (IrisVersionId, IrisCode, IrisCode)
 pub type ModificationsTable = HashMap<i64, (IrisSerialId, String, bool, bool)>;
 
 /// Represents a left/right pair of plaintext in-memory HNSW graphs.
-pub type PlaintextGraphs = BothEyes<GraphMem<IrisVectorId>>;
+pub type PlaintextGraphs = BothEyes<GraphMem>;
 
 /// List of serial ids to treat as deleted enrollments in the source iris database.
 pub type GenesisDeletions = Vec<IrisSerialId>;

--- a/iris-mpc-cpu/src/genesis/plaintext.rs
+++ b/iris-mpc-cpu/src/genesis/plaintext.rs
@@ -34,7 +34,7 @@ use crate::{
     genesis::{BatchSize, BatchSizeConfig},
     graph_checkpoint::PruningMode,
     hawkers::plaintext_store::PlaintextStore,
-    hnsw::{vector_store::VectorStoreMut, GraphMem, HnswSearcher},
+    hnsw::{vector_store::VectorStoreMut, GraphMem, HnswSearcher, LINEAR_SCAN_MAX_GRAPH_LAYER},
 };
 
 /// Represents irises db table, mapping serial ids to version, and left and right iris codes.
@@ -175,7 +175,7 @@ pub async fn run_plaintext_genesis(mut state: GenesisState) -> Result<GenesisSta
         state.config.hnsw_ef_constr,
         state.config.hnsw_ef_search,
         state.config.hnsw_m,
-        1, // should match the constant LINEAR_SCAN_MAX_GRAPH_LAYER
+        LINEAR_SCAN_MAX_GRAPH_LAYER,
     );
 
     let prf_key: [u8; 16] = state

--- a/iris-mpc-cpu/src/graph_checkpoint/s3_client/mod.rs
+++ b/iris-mpc-cpu/src/graph_checkpoint/s3_client/mod.rs
@@ -70,7 +70,7 @@ pub async fn upload_graph_checkpoint(
 pub async fn upload_graph_checkpoint_plaintext(
     bucket: &str,
     party_id: usize,
-    graph_mem: &BothEyes<GraphMem<IrisVectorId>>,
+    graph_mem: &BothEyes<GraphMem>,
     s3_client: &S3Client,
     last_indexed_iris_id: IrisSerialId,
     last_indexed_modification_id: i64,
@@ -172,7 +172,7 @@ pub async fn download_graph_checkpoint(
     s3_client: &S3Client,
     bucket: &str,
     state: &GraphCheckpointState,
-) -> Result<BothEyes<GraphMem<IrisVectorId>>> {
+) -> Result<BothEyes<GraphMem>> {
     let format = GraphFormat::try_from(state.graph_version)?;
     if format == GraphFormat::Raw {
         bail!("Unexpected graph checkpoint format: Raw");
@@ -203,13 +203,13 @@ pub async fn download_genesis_checkpoint_plaintext(
     s3_client: &S3Client,
     bucket: &str,
     state: &GraphCheckpointState,
-) -> Result<BothEyes<GraphMem<IrisVectorId>>> {
+) -> Result<BothEyes<GraphMem>> {
     if state.graph_version != GraphFormat::Current.version() {
         bail!("unexpected graph version: {}", state.graph_version);
     }
     let binary_graph = download_and_hash(s3_client, bucket, state).await?;
     let mut cursor = Cursor::new(&binary_graph);
-    let graphs: BothEyes<GraphMem<_>> = bincode::deserialize_from(&mut cursor)?;
+    let graphs: BothEyes<GraphMem> = bincode::deserialize_from(&mut cursor)?;
     Ok(graphs)
 }
 

--- a/iris-mpc-cpu/src/graph_checkpoint/s3_client/mod.rs
+++ b/iris-mpc-cpu/src/graph_checkpoint/s3_client/mod.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 use crate::graph_checkpoint::data::*;
-use iris_mpc_common::{IrisSerialId, IrisVectorId};
+use iris_mpc_common::IrisSerialId;
 pub use multipart::*;
 pub use streaming::*;
 pub use streaming_download::*;

--- a/iris-mpc-cpu/src/graph_checkpoint/s3_client/streaming.rs
+++ b/iris-mpc-cpu/src/graph_checkpoint/s3_client/streaming.rs
@@ -46,7 +46,12 @@ pub const DEFAULT_STREAMING_PARALLELISM: usize = 8;
 /// Pairs with [`stream_serialize_and_upload_with`] when the caller needs
 /// the canonical-bytes hash (e.g. to record into a verification field):
 ///
-/// ```ignore
+/// ```no_run
+/// # use iris_mpc_cpu::graph_checkpoint::s3_client::streaming::{
+/// #     stream_serialize_and_upload_with, BlakeTeeWriter,
+/// #     DEFAULT_STREAMING_PART_SIZE, DEFAULT_STREAMING_PARALLELISM,
+/// # };
+/// # async fn example(s3: &aws_sdk_s3::Client, bucket: &str, key: &str, v: &impl serde::Serialize) -> eyre::Result<()> {
 /// let (hash_tx, hash_rx) = tokio::sync::oneshot::channel();
 /// stream_serialize_and_upload_with(s3, bucket, key, move |w| {
 ///     let mut tee = BlakeTeeWriter::new(w);
@@ -55,6 +60,8 @@ pub const DEFAULT_STREAMING_PARALLELISM: usize = 8;
 ///     Ok(())
 /// }, DEFAULT_STREAMING_PART_SIZE, DEFAULT_STREAMING_PARALLELISM).await?;
 /// let hash = hash_rx.await?;
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// Kept deliberately outside the upload primitive itself so the primitive

--- a/iris-mpc-cpu/src/graph_checkpoint/s3_client/streaming.rs
+++ b/iris-mpc-cpu/src/graph_checkpoint/s3_client/streaming.rs
@@ -46,22 +46,22 @@ pub const DEFAULT_STREAMING_PARALLELISM: usize = 8;
 /// Pairs with [`stream_serialize_and_upload_with`] when the caller needs
 /// the canonical-bytes hash (e.g. to record into a verification field):
 ///
-/// ```no_run
-/// # use iris_mpc_cpu::graph_checkpoint::s3_client::streaming::{
-/// #     stream_serialize_and_upload_with, BlakeTeeWriter,
-/// #     DEFAULT_STREAMING_PART_SIZE, DEFAULT_STREAMING_PARALLELISM,
-/// # };
-/// # async fn example(s3: &aws_sdk_s3::Client, bucket: &str, key: &str, v: &impl serde::Serialize) -> eyre::Result<()> {
-/// let (hash_tx, hash_rx) = tokio::sync::oneshot::channel();
-/// stream_serialize_and_upload_with(s3, bucket, key, move |w| {
-///     let mut tee = BlakeTeeWriter::new(w);
-///     bincode::serialize_into(&mut tee, &v)?;
-///     let _ = hash_tx.send(tee.finalize());
+/// ```ignore
+/// use iris_mpc_cpu::graph_checkpoint::s3_client::streaming::{
+///     stream_serialize_and_upload_with, BlakeTeeWriter,
+///     DEFAULT_STREAMING_PART_SIZE, DEFAULT_STREAMING_PARALLELISM,
+/// };
+/// async fn example(s3: &aws_sdk_s3::Client, bucket: &str, key: &str, v: &impl serde::Serialize) -> eyre::Result<()> {
+///     let (hash_tx, hash_rx) = tokio::sync::oneshot::channel();
+///     stream_serialize_and_upload_with(s3, bucket, key, move |w| {
+///         let mut tee = BlakeTeeWriter::new(w);
+///         bincode::serialize_into(&mut tee, &v)?;
+///         let _ = hash_tx.send(tee.finalize());
+///         Ok(())
+///     }, DEFAULT_STREAMING_PART_SIZE, DEFAULT_STREAMING_PARALLELISM).await?;
+///     let hash = hash_rx.await?;
 ///     Ok(())
-/// }, DEFAULT_STREAMING_PART_SIZE, DEFAULT_STREAMING_PARALLELISM).await?;
-/// let hash = hash_rx.await?;
-/// # Ok(())
-/// # }
+/// }
 /// ```
 ///
 /// Kept deliberately outside the upload primitive itself so the primitive

--- a/iris-mpc-cpu/src/graph_checkpoint/s3_client/streaming.rs
+++ b/iris-mpc-cpu/src/graph_checkpoint/s3_client/streaming.rs
@@ -44,25 +44,7 @@ pub const DEFAULT_STREAMING_PARALLELISM: usize = 8;
 /// no intermediate `Vec<u8>`.
 ///
 /// Pairs with [`stream_serialize_and_upload_with`] when the caller needs
-/// the canonical-bytes hash (e.g. to record into a verification field):
-///
-/// ```ignore
-/// use iris_mpc_cpu::graph_checkpoint::s3_client::streaming::{
-///     stream_serialize_and_upload_with, BlakeTeeWriter,
-///     DEFAULT_STREAMING_PART_SIZE, DEFAULT_STREAMING_PARALLELISM,
-/// };
-/// async fn example(s3: &aws_sdk_s3::Client, bucket: &str, key: &str, v: &impl serde::Serialize) -> eyre::Result<()> {
-///     let (hash_tx, hash_rx) = tokio::sync::oneshot::channel();
-///     stream_serialize_and_upload_with(s3, bucket, key, move |w| {
-///         let mut tee = BlakeTeeWriter::new(w);
-///         bincode::serialize_into(&mut tee, &v)?;
-///         let _ = hash_tx.send(tee.finalize());
-///         Ok(())
-///     }, DEFAULT_STREAMING_PART_SIZE, DEFAULT_STREAMING_PARALLELISM).await?;
-///     let hash = hash_rx.await?;
-///     Ok(())
-/// }
-/// ```
+/// the canonical-bytes hash (e.g. to record into a verification field)
 ///
 /// Kept deliberately outside the upload primitive itself so the primitive
 /// stays content-agnostic: callers that don't need a hash (or want a

--- a/iris-mpc-cpu/src/graph_checkpoint/s3_client/streaming_download.rs
+++ b/iris-mpc-cpu/src/graph_checkpoint/s3_client/streaming_download.rs
@@ -47,7 +47,6 @@ use aws_sdk_s3::Client as S3Client;
 use bytes::Bytes;
 use eyre::{eyre, Result};
 use futures::stream::{self, Stream};
-use iris_mpc_common::IrisVectorId;
 use serde::de::DeserializeOwned;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
 use tokio::time::sleep;

--- a/iris-mpc-cpu/src/graph_checkpoint/s3_client/streaming_download.rs
+++ b/iris-mpc-cpu/src/graph_checkpoint/s3_client/streaming_download.rs
@@ -132,7 +132,7 @@ where
 }
 
 /// Stream the object at `s3://{bucket}/{key}` through BLAKE3 and directly
-/// into a `[GraphMem<IrisVectorId>; 2]` using a format-aware layer-by-layer
+/// into a `[GraphMem; 2]` using a format-aware layer-by-layer
 /// reader that converts each layer immediately upon arrival.
 ///
 /// Unlike `stream_download_and_deserialize::<[GraphVN; 2]>` followed by
@@ -146,7 +146,7 @@ pub async fn stream_download_and_deserialize_graph_pair(
     bucket: &str,
     key: &str,
     format: GraphFormat,
-) -> Result<([GraphMem<IrisVectorId>; 2], [u8; 32])> {
+) -> Result<([GraphMem; 2], [u8; 32])> {
     stream_download_and_deserialize_graph_pair_with(
         s3_client,
         bucket,
@@ -167,7 +167,7 @@ pub async fn stream_download_and_deserialize_graph_pair_with(
     format: GraphFormat,
     pipe_capacity: usize,
     range_size: usize,
-) -> Result<([GraphMem<IrisVectorId>; 2], [u8; 32])> {
+) -> Result<([GraphMem; 2], [u8; 32])> {
     tracing::info!(
         "Streaming download + deserialize graph pair: bucket={bucket}, key={key}, \
          format={format}, pipe_capacity={pipe_capacity}, range_size={range_size}"

--- a/iris-mpc-cpu/src/graph_checkpoint/synchronize.rs
+++ b/iris-mpc-cpu/src/graph_checkpoint/synchronize.rs
@@ -2,10 +2,7 @@ use std::collections::HashMap;
 
 use aws_sdk_s3::Client;
 use eyre::{bail, eyre, Result};
-use iris_mpc_common::{
-    helpers::sync::{SyncResult, SyncState},
-    IrisVectorId,
-};
+use iris_mpc_common::helpers::sync::{SyncResult, SyncState};
 use itertools::izip;
 
 use super::{download_graph_checkpoint, GraphCheckpointState};
@@ -185,6 +182,7 @@ pub fn apply_graph_mutations(
 mod tests {
     use super::*;
     use crate::hnsw::graph::mutation::{MutationOp, UpdateEntryPoint};
+    use iris_mpc_common::IrisVectorId;
 
     // ── helpers ───────────────────────────────────────────────────────────────
 

--- a/iris-mpc-cpu/src/graph_checkpoint/synchronize.rs
+++ b/iris-mpc-cpu/src/graph_checkpoint/synchronize.rs
@@ -139,7 +139,7 @@ pub async fn load_graph_and_roll_forward(
     checkpoint_bucket: &str,
     checkpoint: Option<GraphCheckpointState>,
     wal_rows: Vec<GraphMutationRow>,
-) -> Result<BothEyes<GraphMem<IrisVectorId>>> {
+) -> Result<BothEyes<GraphMem>> {
     let mut both_eyes = if let Some(state) = checkpoint {
         tracing::info!(
             "Loading graph from common S3 checkpoint, hash: {}",
@@ -166,14 +166,14 @@ pub async fn load_graph_and_roll_forward(
 /// Rows must be ordered by `modification_id` ascending (which is the ordering
 /// guaranteed by all `get_hawk_graph_mutations_*` queries).
 pub fn apply_graph_mutations(
-    both_eyes: &mut BothEyes<GraphMem<IrisVectorId>>,
+    both_eyes: &mut BothEyes<GraphMem>,
     mutation_rows: Vec<GraphMutationRow>,
 ) -> Result<()> {
     debug_assert!(mutation_rows
         .windows(2)
         .all(|w| w[0].modification_id < w[1].modification_id));
     for row in mutation_rows {
-        let [left_mutations, right_mutations]: [Vec<GraphMutation<IrisVectorId>>; 2] =
+        let [left_mutations, right_mutations]: [Vec<GraphMutation>; 2] =
             row.deserialize_mutations()?;
         both_eyes[0].insert_apply_all(&left_mutations)?;
         both_eyes[1].insert_apply_all(&right_mutations)?;
@@ -190,18 +190,15 @@ mod tests {
 
     /// Serialize a pair of mutation lists into the bincode format expected by
     /// `GraphMutationRow`.
-    fn serialize_mutations(
-        left: Vec<GraphMutation<IrisVectorId>>,
-        right: Vec<GraphMutation<IrisVectorId>>,
-    ) -> Vec<u8> {
-        let both_eyes: [Vec<GraphMutation<IrisVectorId>>; 2] = [left, right];
+    fn serialize_mutations(left: Vec<GraphMutation>, right: Vec<GraphMutation>) -> Vec<u8> {
+        let both_eyes: [Vec<GraphMutation>; 2] = [left, right];
         bincode::serialize(&both_eyes).expect("bincode serialization failed")
     }
 
     fn make_row(
         modification_id: i64,
-        left: Vec<GraphMutation<IrisVectorId>>,
-        right: Vec<GraphMutation<IrisVectorId>>,
+        left: Vec<GraphMutation>,
+        right: Vec<GraphMutation>,
     ) -> GraphMutationRow {
         GraphMutationRow {
             modification_id,
@@ -216,7 +213,7 @@ mod tests {
 
     /// A minimal `AddNode` mutation that adds the node to layer 0 without
     /// updating entry points. Uses a static counter to assign incrementing seq_no.
-    fn add_node(id: IrisVectorId) -> GraphMutation<IrisVectorId> {
+    fn add_node(id: IrisVectorId) -> GraphMutation {
         use std::sync::atomic::{AtomicU64, Ordering};
         static SEQ_COUNTER: AtomicU64 = AtomicU64::new(1);
 

--- a/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
@@ -809,12 +809,7 @@ mod tests {
                 for query in queries.iter() {
                     let insertion_layer = db.gen_layer_rng(&mut rng).unwrap();
                     let inserted_vector = db
-                        .insert::<_, SortedNeighborhood<_>>(
-                            &mut *store,
-                            &mut aby3_graph,
-                            query,
-                            insertion_layer,
-                        )
+                        .insert(&mut *store, &mut aby3_graph, query, insertion_layer)
                         .await
                         .unwrap();
                     inserted.push(inserted_vector)
@@ -824,7 +819,7 @@ mod tests {
                 for v in inserted.into_iter() {
                     let query = store.cache_query_from_store(&v).await.unwrap();
                     let neighbors = db
-                        .search::<_, SortedNeighborhood<_>>(&mut *store, &aby3_graph, &query, 1)
+                        .search(&mut *store, &aby3_graph, &query, 1)
                         .await
                         .unwrap();
                     tracing::debug!("Finished checking query");
@@ -881,12 +876,7 @@ mod tests {
                 .unwrap()
                 .clone();
             let cleartext_neighbors = hawk_searcher
-                .search::<_, SortedNeighborhood<_>>(
-                    &mut cleartext_data.0,
-                    &cleartext_data.1,
-                    &query,
-                    1,
-                )
+                .search(&mut cleartext_data.0, &cleartext_data.1, &query, 1)
                 .await?;
             assert!(
                 hawk_searcher
@@ -1545,12 +1535,7 @@ mod tests {
         for (iris, &layer) in cleartext_db.iter().zip(insertion_layers.iter()) {
             let query = Arc::new(iris.clone());
             searcher
-                .insert::<_, SortedNeighborhood<_>>(
-                    &mut plaintext_store,
-                    &mut plaintext_graph,
-                    &query,
-                    layer,
-                )
+                .insert(&mut plaintext_store, &mut plaintext_graph, &query, layer)
                 .instrument(plaintext_span.clone())
                 .await?;
         }
@@ -1572,7 +1557,7 @@ mod tests {
                 let mut graph: GraphMem = GraphMem::new();
                 for (query, &layer) in queries.iter().zip(layers.iter()) {
                     searcher
-                        .insert::<_, SortedNeighborhood<_>>(&mut *store, &mut graph, query, layer)
+                        .insert(&mut *store, &mut graph, query, layer)
                         .instrument(mpc_span.clone())
                         .await?;
                 }

--- a/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
@@ -1540,7 +1540,7 @@ mod tests {
             .collect();
 
         let mut plaintext_store = PlaintextStore::<FhdOps>::new();
-        let mut plaintext_graph: GraphMem<VectorId> = GraphMem::new();
+        let mut plaintext_graph: GraphMem = GraphMem::new();
         let plaintext_span = info_span!("plaintext_insert");
         for (iris, &layer) in cleartext_db.iter().zip(insertion_layers.iter()) {
             let query = Arc::new(iris.clone());
@@ -1569,18 +1569,18 @@ mod tests {
                 let mpc_span = info_span!("mpc_insert", id = idx);
                 let mut store = store.lock().await;
                 let queries = cache_irises(store.workers.as_ref(), irises).await?;
-                let mut graph: GraphMem<VectorId> = GraphMem::new();
+                let mut graph: GraphMem = GraphMem::new();
                 for (query, &layer) in queries.iter().zip(layers.iter()) {
                     searcher
                         .insert::<_, SortedNeighborhood<_>>(&mut *store, &mut graph, query, layer)
                         .instrument(mpc_span.clone())
                         .await?;
                 }
-                Ok::<(usize, GraphMem<VectorId>), eyre::Report>((role, graph))
+                Ok::<(usize, GraphMem), eyre::Report>((role, graph))
             });
         }
 
-        let mut mpc_graphs: Vec<Option<GraphMem<VectorId>>> = (0..3).map(|_| None).collect();
+        let mut mpc_graphs: Vec<Option<GraphMem>> = (0..3).map(|_| None).collect();
         while let Some(res) = jobs.join_next().await {
             let (role, graph) = res??;
             mpc_graphs[role] = Some(graph);

--- a/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
@@ -766,7 +766,7 @@ mod tests {
                 explicit::{ExplicitNeighborhoodDiffer, SortBy},
                 node_equiv::ensure_node_equivalence,
             },
-            GraphMem, HnswSearcher, SortedNeighborhood,
+            GraphMem, HnswSearcher, SortedNeighborhood, LINEAR_SCAN_MAX_GRAPH_LAYER,
         },
         network::mpc::NetworkType,
         protocol::shared_iris::GaloisRingSharedIris,
@@ -1511,7 +1511,7 @@ mod tests {
         // density bumped to 4 so enough nodes roll onto layer 1 to exercise
         // `linear_search_min_distance` — default (M) gives <1 expected entry
         // point at this size and silently skips the branch.
-        let mut searcher = HnswSearcher::new_linear_scan(64, 32, 32, 1);
+        let mut searcher = HnswSearcher::new_linear_scan(64, 32, 32, LINEAR_SCAN_MAX_GRAPH_LAYER);
         searcher.layer_distribution =
             crate::hnsw::searcher::LayerDistribution::new_geometric_from_M(4);
         let searcher = searcher;

--- a/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
@@ -584,6 +584,15 @@ where
         vectors
     }
 
+    async fn only_valid_entry_points(
+        &mut self,
+        mut entry_points: Vec<(VectorId, usize)>,
+    ) -> Vec<(VectorId, usize)> {
+        let registry = self.registry.read().await;
+        entry_points.retain(|(v, _)| registry.contains(v));
+        entry_points
+    }
+
     #[instrument(level = "trace", target = "searcher::network", skip_all)]
     async fn eval_distance(
         &mut self,

--- a/iris-mpc-cpu/src/hawkers/aby3/test_utils.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3/test_utils.rs
@@ -162,7 +162,7 @@ pub async fn eval_vector_distance(
 ///
 /// Previously this involved conversion of cached distances, but since distances
 /// are not currently cached this operation is a clone plus type cast.
-async fn graph_from_plain(graph_store: &GraphMem<VectorId>) -> GraphMem<VectorId> {
+async fn graph_from_plain(graph_store: &GraphMem) -> GraphMem {
     graph_store.clone()
 }
 
@@ -178,10 +178,7 @@ pub async fn lazy_setup_from_files<R: RngCore + Clone + CryptoRng>(
     rng: &mut R,
     database_size: usize,
     network_t: NetworkType,
-) -> Result<(
-    (PlaintextStore, GraphMem<VectorId>),
-    Vec<(Aby3StoreRef, GraphMem<VectorId>)>,
-)> {
+) -> Result<((PlaintextStore, GraphMem), Vec<(Aby3StoreRef, GraphMem)>)> {
     if database_size > 100_000 {
         return Err(eyre::eyre!("Database size too large, max. 100,000"));
     }
@@ -193,7 +190,7 @@ pub async fn lazy_setup_from_files<R: RngCore + Clone + CryptoRng>(
         IrisSelection::All,
     )
     .map_err(|e| eyre::eyre!("Cannot find store: {e}. {generation_comment}"))?;
-    let plaintext_graph_store: GraphMem<VectorId> =
+    let plaintext_graph_store: GraphMem =
         read_graph_from_file(Path::new(plaingraph_file), GraphFormat::Raw)
             .map_err(|e| eyre::eyre!("Cannot find graph: {e}. {generation_comment}"))?;
 
@@ -229,10 +226,7 @@ pub async fn lazy_setup_from_files_with_grpc<R: RngCore + Clone + CryptoRng>(
     plaingraph_file: &str,
     rng: &mut R,
     database_size: usize,
-) -> Result<(
-    (PlaintextStore, GraphMem<VectorId>),
-    Vec<(Aby3StoreRef, GraphMem<VectorId>)>,
-)> {
+) -> Result<((PlaintextStore, GraphMem), Vec<(Aby3StoreRef, GraphMem)>)> {
     lazy_setup_from_files(
         plainstore_file,
         plaingraph_file,
@@ -253,10 +247,7 @@ pub async fn lazy_random_setup<R: RngCore + Clone + CryptoRng>(
     rng: &mut R,
     database_size: usize,
     network_t: NetworkType,
-) -> Result<(
-    (PlaintextStore, GraphMem<VectorId>),
-    Vec<(Aby3StoreRef, GraphMem<VectorId>)>,
-)> {
+) -> Result<((PlaintextStore, GraphMem), Vec<(Aby3StoreRef, GraphMem)>)> {
     let searcher = HnswSearcher::new_with_test_parameters();
 
     let mut plaintext_vector_store = PlaintextStore::new_random(rng, database_size);
@@ -294,10 +285,7 @@ pub async fn lazy_random_setup<R: RngCore + Clone + CryptoRng>(
 pub async fn lazy_random_setup_with_local_channel<R: RngCore + Clone + CryptoRng>(
     rng: &mut R,
     database_size: usize,
-) -> Result<(
-    (PlaintextStore, GraphMem<VectorId>),
-    Vec<(Aby3StoreRef, GraphMem<VectorId>)>,
-)> {
+) -> Result<((PlaintextStore, GraphMem), Vec<(Aby3StoreRef, GraphMem)>)> {
     lazy_random_setup(rng, database_size, NetworkType::Local).await
 }
 
@@ -307,10 +295,7 @@ pub async fn lazy_random_setup_with_local_channel<R: RngCore + Clone + CryptoRng
 pub async fn lazy_random_setup_with_grpc<R: RngCore + Clone + CryptoRng>(
     rng: &mut R,
     database_size: usize,
-) -> Result<(
-    (PlaintextStore, GraphMem<VectorId>),
-    Vec<(Aby3StoreRef, GraphMem<VectorId>)>,
-)> {
+) -> Result<((PlaintextStore, GraphMem), Vec<(Aby3StoreRef, GraphMem)>)> {
     lazy_random_setup(rng, database_size, NetworkType::default_tcp()).await
 }
 
@@ -320,7 +305,7 @@ pub async fn shared_random_setup<R: RngCore + Clone + CryptoRng>(
     rng: &mut R,
     database_size: usize,
     network_t: NetworkType,
-) -> Result<Vec<(Aby3StoreRef, GraphMem<VectorId>)>> {
+) -> Result<Vec<(Aby3StoreRef, GraphMem)>> {
     let rng_searcher = AesRng::from_rng(rng.clone())?;
     let cleartext_database = IrisDB::new_random_rng(database_size, rng).db;
     let shared_irises: Vec<_> = (0..database_size)
@@ -339,27 +324,26 @@ pub async fn shared_random_setup<R: RngCore + Clone + CryptoRng>(
             .map(|id| Arc::new(shared_irises[id][role].clone()))
             .collect();
         let store = store.clone();
-        let task: JoinHandle<Result<(Aby3StoreRef, GraphMem<VectorId>)>> =
-            tokio::spawn(async move {
-                let mut store_lock = store.lock().await;
-                let queries = cache_irises(store_lock.workers.as_ref(), irises).await?;
-                let mut graph_store = GraphMem::new();
-                let searcher = HnswSearcher::new_with_test_parameters();
-                for query in queries.iter() {
-                    let insertion_layer = searcher.gen_layer_rng(&mut rng_searcher)?;
-                    searcher
-                        .insert::<_, SortedNeighborhood<_>>(
-                            &mut *store_lock,
-                            &mut graph_store,
-                            query,
-                            insertion_layer,
-                        )
-                        .await?;
-                }
-                let qids = queries.iter().map(|q| q.query_id).collect();
-                store_lock.workers.evict_queries(qids).await?;
-                Ok((store.clone(), graph_store))
-            });
+        let task: JoinHandle<Result<(Aby3StoreRef, GraphMem)>> = tokio::spawn(async move {
+            let mut store_lock = store.lock().await;
+            let queries = cache_irises(store_lock.workers.as_ref(), irises).await?;
+            let mut graph_store = GraphMem::new();
+            let searcher = HnswSearcher::new_with_test_parameters();
+            for query in queries.iter() {
+                let insertion_layer = searcher.gen_layer_rng(&mut rng_searcher)?;
+                searcher
+                    .insert::<_, SortedNeighborhood<_>>(
+                        &mut *store_lock,
+                        &mut graph_store,
+                        query,
+                        insertion_layer,
+                    )
+                    .await?;
+            }
+            let qids = queries.iter().map(|q| q.query_id).collect();
+            store_lock.workers.evict_queries(qids).await?;
+            Ok((store.clone(), graph_store))
+        });
         jobs.push(task);
     }
     let res: Vec<_> = join_all(jobs)
@@ -381,7 +365,7 @@ pub async fn shared_random_setup<R: RngCore + Clone + CryptoRng>(
 pub async fn shared_random_setup_with_local_channel<R: RngCore + Clone + CryptoRng>(
     rng: &mut R,
     database_size: usize,
-) -> Result<Vec<(Aby3StoreRef, GraphMem<VectorId>)>> {
+) -> Result<Vec<(Aby3StoreRef, GraphMem)>> {
     shared_random_setup(rng, database_size, NetworkType::Local).await
 }
 
@@ -390,6 +374,6 @@ pub async fn shared_random_setup_with_local_channel<R: RngCore + Clone + CryptoR
 pub async fn shared_random_setup_with_grpc<R: RngCore + Clone + CryptoRng>(
     rng: &mut R,
     database_size: usize,
-) -> Result<Vec<(Aby3StoreRef, GraphMem<VectorId>)>> {
+) -> Result<Vec<(Aby3StoreRef, GraphMem)>> {
     shared_random_setup(rng, database_size, NetworkType::default_tcp()).await
 }

--- a/iris-mpc-cpu/src/hawkers/aby3/test_utils.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3/test_utils.rs
@@ -16,7 +16,7 @@ use crate::{
     hawkers::{
         aby3::aby3_store::Aby3SharedIrisesRef, plaintext_store::PlaintextStore, TEST_DISTANCE_MODE,
     },
-    hnsw::{GraphMem, HnswSearcher, SortedNeighborhood, VectorStore},
+    hnsw::{GraphMem, HnswSearcher, VectorStore},
     network::mpc::NetworkType,
     protocol::shared_iris::{ArcIris, GaloisRingSharedIris},
     shares::{RingElement, Share},
@@ -332,12 +332,7 @@ pub async fn shared_random_setup<R: RngCore + Clone + CryptoRng>(
             for query in queries.iter() {
                 let insertion_layer = searcher.gen_layer_rng(&mut rng_searcher)?;
                 searcher
-                    .insert::<_, SortedNeighborhood<_>>(
-                        &mut *store_lock,
-                        &mut graph_store,
-                        query,
-                        insertion_layer,
-                    )
+                    .insert(&mut *store_lock, &mut graph_store, query, insertion_layer)
                     .await?;
             }
             let qids = queries.iter().map(|q| q.query_id).collect();

--- a/iris-mpc-cpu/src/hawkers/build_plaintext.rs
+++ b/iris-mpc-cpu/src/hawkers/build_plaintext.rs
@@ -45,13 +45,13 @@ use crate::{
 const REPORTING_INTERVAL: usize = 1000;
 
 pub async fn plaintext_parallel_batch_insert<D: DistanceOps>(
-    graph: GraphMem<IrisVectorId>,
+    graph: GraphMem,
     mut store: SharedPlaintextStore<D>,
     irises: Vec<(IrisVectorId, IrisCode)>,
     searcher: &HnswSearcher,
     batch_size: usize,
     prf_seed: &[u8; 16],
-) -> Result<(GraphMem<IrisVectorId>, SharedPlaintextStore<D>)> {
+) -> Result<(GraphMem, SharedPlaintextStore<D>)> {
     let mut graph = Arc::new(graph);
 
     let mut inserted_count: usize = 0;
@@ -135,13 +135,13 @@ pub async fn plaintext_parallel_batch_insert<D: DistanceOps>(
 }
 
 pub async fn deep_id_parallel_batch_insert(
-    graph: GraphMem<IrisVectorId>,
+    graph: GraphMem,
     mut store: SharedPlaintextDeepIDStore,
     vectors: Vec<(IrisVectorId, Int4Vector)>,
     searcher: &HnswSearcher,
     batch_size: usize,
     prf_seed: &[u8; 16],
-) -> Result<(GraphMem<IrisVectorId>, SharedPlaintextDeepIDStore)> {
+) -> Result<(GraphMem, SharedPlaintextDeepIDStore)> {
     let mut graph = Arc::new(graph);
 
     let mut inserted_count: usize = 0;
@@ -237,7 +237,7 @@ mod tests {
         to_insert: usize,
     ) -> Result<(
         HnswSearcher,
-        GraphMem<IrisVectorId>,
+        GraphMem,
         SharedPlaintextStore,
         Vec<(IrisVectorId, IrisCode)>,
         [u8; 16],
@@ -272,7 +272,7 @@ mod tests {
 
     async fn check_results(
         mut store: SharedPlaintextStore,
-        graph: GraphMem<IrisVectorId>,
+        graph: GraphMem,
         irises: Vec<(IrisVectorId, IrisCode)>,
         searcher: &HnswSearcher,
         expected_total_size: usize,

--- a/iris-mpc-cpu/src/hawkers/build_plaintext.rs
+++ b/iris-mpc-cpu/src/hawkers/build_plaintext.rs
@@ -13,7 +13,7 @@
 //! `parallel_batch_insert<V: VectorStoreMut>` is because the per-query search
 //! is spawned onto a multi-threaded [`JoinSet`], which requires the spawned
 //! future to be `Send`. The `VectorStore`/`VectorStoreMut` operations (and the
-//! `DistanceOps`/`Neighborhood` methods they call) are `async fn`s in traits,
+//! `DistanceOps` methods they call) are `async fn`s in traits,
 //! which carry no `Send` bound. For a *concrete* store the compiler still
 //! proves each future `Send` by auto-trait leakage, so each function below
 //! compiles; for a *generic* `V` that guarantee is unavailable and the spawn is
@@ -21,7 +21,7 @@
 //!
 //! Plausible upgrade path: add `+ Send` to those trait methods (desugaring the
 //! `async fn`s to `-> impl Future<..> + Send`, which cascades through
-//! `VectorStore`/`VectorStoreMut` into `DistanceOps` and `Neighborhood`), or
+//! `VectorStore`/`VectorStoreMut` into `DistanceOps`), or
 //! push the spawned work behind a higher-order closure whose concrete future is
 //! `Send` at each call site. Either then collapses these two routines into one
 //! generic `parallel_batch_insert<V>`.
@@ -38,7 +38,7 @@ use crate::hawkers::plaintext_deep_id_store::{Int4Vector, SharedPlaintextDeepIDS
 use crate::{
     execution::hawk_main::insert::{self, InsertPlanV},
     hawkers::{aby3::aby3_store::DistanceOps, plaintext_store::SharedPlaintextStore},
-    hnsw::{graph::neighborhood::Neighborhood, GraphMem, HnswSearcher, SortedNeighborhood},
+    hnsw::{GraphMem, HnswSearcher},
 };
 
 /// Number of entries to insert before reporting a new info log entry
@@ -72,12 +72,7 @@ pub async fn plaintext_parallel_batch_insert<D: DistanceOps>(
                 let insertion_layer = searcher.gen_layer_prf(&prf_seed, &(vector_id))?;
 
                 let (links, update_ep) = searcher
-                    .search_to_insert::<_, SortedNeighborhood<_>>(
-                        &mut store,
-                        &graph,
-                        &query,
-                        insertion_layer,
-                    )
+                    .search_to_insert(&mut store, &graph, &query, insertion_layer)
                     .await?;
 
                 // Trim and extract unstructured vector lists
@@ -162,12 +157,7 @@ pub async fn deep_id_parallel_batch_insert(
                 let insertion_layer = searcher.gen_layer_prf(&prf_seed, &(vector_id))?;
 
                 let (links, update_ep) = searcher
-                    .search_to_insert::<_, SortedNeighborhood<_>>(
-                        &mut store,
-                        &graph,
-                        &query,
-                        insertion_layer,
-                    )
+                    .search_to_insert(&mut store, &graph, &query, insertion_layer)
                     .await?;
 
                 // Trim and extract unstructured vector lists
@@ -227,7 +217,10 @@ pub async fn deep_id_parallel_batch_insert(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{hawkers::plaintext_store::PlaintextStore, hnsw::HnswSearcher};
+    use crate::{
+        hawkers::plaintext_store::PlaintextStore,
+        hnsw::{HnswSearcher, SortedNeighborhood},
+    };
     use aes_prng::AesRng;
     use iris_mpc_common::iris_db::db::IrisDB;
     use rand::SeedableRng;
@@ -286,9 +279,7 @@ mod tests {
         // Check if each inserted iris can be found and matched correctly
         for (_vector_id, iris_code) in irises {
             let query = Arc::new(iris_code);
-            let result = searcher
-                .search::<_, SortedNeighborhood<_>>(&mut store, &graph, &query, 1)
-                .await?;
+            let result = searcher.search(&mut store, &graph, &query, 1).await?;
             assert!(
                 searcher.is_match(&mut store, &[result]).await?,
                 "Match verification failed for an inserted iris"

--- a/iris-mpc-cpu/src/hawkers/ideal_knn_engines.rs
+++ b/iris-mpc-cpu/src/hawkers/ideal_knn_engines.rs
@@ -43,14 +43,41 @@ impl KNNResult {
     }
 }
 
+/// The on-disk serialization format for [`KNNResult`]: plain `u32` serial IDs.
+///
+/// This is the stable file format used by both the generator and the reader.
+/// `IrisVectorId` is intentionally not used here so that the file format stays
+/// compact and backward-compatible (no `{id, version}` objects).
+#[derive(Serialize, Deserialize)]
+pub struct KNNResultU32 {
+    pub node: u32,
+    pub neighbors: Vec<u32>,
+}
+
+impl From<&KNNResult> for KNNResultU32 {
+    fn from(r: &KNNResult) -> Self {
+        KNNResultU32 {
+            node: r.node.serial_id(),
+            neighbors: r.neighbors.iter().map(|v| v.serial_id()).collect(),
+        }
+    }
+}
+
+impl From<KNNResultU32> for KNNResult {
+    fn from(r: KNNResultU32) -> Self {
+        KNNResult {
+            node: IrisVectorId::from_serial_id(r.node),
+            neighbors: r
+                .neighbors
+                .into_iter()
+                .map(IrisVectorId::from_serial_id)
+                .collect(),
+        }
+    }
+}
+
 /// Reads a `Vec<KNNResult>` from a file, skipping the first line (header).
 pub fn read_knn_results_from_file(path: PathBuf) -> std::io::Result<Vec<KNNResult>> {
-    #[derive(Deserialize)]
-    struct KNNResultU32 {
-        node: u32,
-        neighbors: Vec<u32>,
-    }
-
     let file = File::open(path)?;
     let mut lines = BufReader::new(file).lines();
 
@@ -62,15 +89,7 @@ pub fn read_knn_results_from_file(path: PathBuf) -> std::io::Result<Vec<KNNResul
         let line = line?;
         let knn_result_u32: KNNResultU32 = serde_json::from_str(&line)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-        let knn_result = KNNResult {
-            node: IrisVectorId::from_serial_id(knn_result_u32.node),
-            neighbors: knn_result_u32
-                .neighbors
-                .into_iter()
-                .map(IrisVectorId::from_serial_id)
-                .collect(),
-        };
-        results.push(knn_result);
+        results.push(knn_result_u32.into());
     }
     Ok(results)
 }

--- a/iris-mpc-cpu/src/hawkers/ideal_knn_engines.rs
+++ b/iris-mpc-cpu/src/hawkers/ideal_knn_engines.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use clap::ValueEnum;
-use iris_mpc_common::{iris_db::iris::IrisCode, IrisSerialId, IrisVectorId};
+use iris_mpc_common::{iris_db::iris::IrisCode, IrisSerialId};
 use rayon::{
     iter::{IntoParallelIterator, ParallelIterator},
     ThreadPool, ThreadPoolBuilder,
@@ -20,22 +20,24 @@ use crate::hawkers::{
 };
 
 #[derive(Serialize, Deserialize, Clone, Default)]
-pub struct KNNResult {
-    pub node: IrisVectorId,
-    pub neighbors: Vec<IrisVectorId>,
+pub struct KNNResult<V> {
+    pub node: V,
+    pub neighbors: Vec<V>,
 }
 
-impl KNNResult {
-    pub fn map<F>(self, mut f: F) -> KNNResult
+impl<U> KNNResult<U> {
+    pub fn map<V, F>(self, mut f: F) -> KNNResult<V>
     where
-        F: FnMut(IrisVectorId) -> IrisVectorId,
+        F: FnMut(U) -> V,
     {
         KNNResult {
             node: f(self.node),
             neighbors: self.neighbors.into_iter().map(f).collect(),
         }
     }
+}
 
+impl<V> KNNResult<V> {
     pub fn truncate(&mut self, k: usize) {
         assert!(k <= self.neighbors.len(), "k must be <= neighbors.len()");
         self.neighbors.truncate(k);
@@ -43,41 +45,8 @@ impl KNNResult {
     }
 }
 
-/// The on-disk serialization format for [`KNNResult`]: plain `u32` serial IDs.
-///
-/// This is the stable file format used by both the generator and the reader.
-/// `IrisVectorId` is intentionally not used here so that the file format stays
-/// compact and backward-compatible (no `{id, version}` objects).
-#[derive(Serialize, Deserialize)]
-pub struct KNNResultU32 {
-    pub node: u32,
-    pub neighbors: Vec<u32>,
-}
-
-impl From<&KNNResult> for KNNResultU32 {
-    fn from(r: &KNNResult) -> Self {
-        KNNResultU32 {
-            node: r.node.serial_id(),
-            neighbors: r.neighbors.iter().map(|v| v.serial_id()).collect(),
-        }
-    }
-}
-
-impl From<KNNResultU32> for KNNResult {
-    fn from(r: KNNResultU32) -> Self {
-        KNNResult {
-            node: IrisVectorId::from_serial_id(r.node),
-            neighbors: r
-                .neighbors
-                .into_iter()
-                .map(IrisVectorId::from_serial_id)
-                .collect(),
-        }
-    }
-}
-
-/// Reads a `Vec<KNNResult>` from a file, skipping the first line (header).
-pub fn read_knn_results_from_file(path: PathBuf) -> std::io::Result<Vec<KNNResult>> {
+/// Reads a `Vec<KNNResult<u32>>` from a file, skipping the first line (header).
+pub fn read_knn_results_from_file(path: PathBuf) -> std::io::Result<Vec<KNNResult<u32>>> {
     let file = File::open(path)?;
     let mut lines = BufReader::new(file).lines();
 
@@ -87,9 +56,9 @@ pub fn read_knn_results_from_file(path: PathBuf) -> std::io::Result<Vec<KNNResul
     let mut results = Vec::new();
     for line in lines {
         let line = line?;
-        let knn_result_u32: KNNResultU32 = serde_json::from_str(&line)
+        let knn_result: KNNResult<u32> = serde_json::from_str(&line)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-        results.push(knn_result_u32.into());
+        results.push(knn_result);
     }
     Ok(results)
 }
@@ -253,7 +222,7 @@ impl<K: IdealKnn> NaiveKNN<K> {
         self.next_id
     }
 
-    pub fn compute_chunk(&mut self, chunk_size: usize) -> Vec<KNNResult> {
+    pub fn compute_chunk(&mut self, chunk_size: usize) -> Vec<KNNResult<IrisSerialId>> {
         let start = self.next_id as usize;
         let end = (start + chunk_size).min(self.vectors.len() + 1);
         self.next_id = end as IrisSerialId;
@@ -293,10 +262,10 @@ impl<K: IdealKnn> NaiveKNN<K> {
                     });
 
                     KNNResult {
-                        node: IrisVectorId::from_serial_id(i as IrisSerialId),
+                        node: i as IrisSerialId,
                         neighbors: neighbors
                             .into_iter()
-                            .map(|(j, _)| IrisVectorId::from_serial_id(j as IrisSerialId))
+                            .map(|(j, _)| j as IrisSerialId)
                             .collect(),
                     }
                 })
@@ -337,7 +306,7 @@ impl Engine {
         }
     }
 
-    pub fn compute_chunk(&mut self, chunk_size: usize) -> Vec<KNNResult> {
+    pub fn compute_chunk(&mut self, chunk_size: usize) -> Vec<KNNResult<IrisSerialId>> {
         match self {
             Self::Fhd(engine) => engine.compute_chunk(chunk_size),
             Self::Nhd(engine) => engine.compute_chunk(chunk_size),
@@ -372,7 +341,7 @@ impl EngineInt4 {
         }
     }
 
-    pub fn compute_chunk(&mut self, chunk_size: usize) -> Vec<KNNResult> {
+    pub fn compute_chunk(&mut self, chunk_size: usize) -> Vec<KNNResult<IrisSerialId>> {
         match self {
             Self::Int4Dot(engine) => engine.compute_chunk(chunk_size),
         }

--- a/iris-mpc-cpu/src/hawkers/ideal_knn_engines.rs
+++ b/iris-mpc-cpu/src/hawkers/ideal_knn_engines.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use clap::ValueEnum;
-use iris_mpc_common::{iris_db::iris::IrisCode, IrisSerialId};
+use iris_mpc_common::{iris_db::iris::IrisCode, IrisSerialId, IrisVectorId};
 use rayon::{
     iter::{IntoParallelIterator, ParallelIterator},
     ThreadPool, ThreadPoolBuilder,
@@ -20,24 +20,22 @@ use crate::hawkers::{
 };
 
 #[derive(Serialize, Deserialize, Clone, Default)]
-pub struct KNNResult<V> {
-    pub node: V,
-    pub neighbors: Vec<V>,
+pub struct KNNResult {
+    pub node: IrisVectorId,
+    pub neighbors: Vec<IrisVectorId>,
 }
 
-impl<U> KNNResult<U> {
-    pub fn map<V, F>(self, mut f: F) -> KNNResult<V>
+impl KNNResult {
+    pub fn map<F>(self, mut f: F) -> KNNResult
     where
-        F: FnMut(U) -> V,
+        F: FnMut(IrisVectorId) -> IrisVectorId,
     {
         KNNResult {
             node: f(self.node),
             neighbors: self.neighbors.into_iter().map(f).collect(),
         }
     }
-}
 
-impl<V> KNNResult<V> {
     pub fn truncate(&mut self, k: usize) {
         assert!(k <= self.neighbors.len(), "k must be <= neighbors.len()");
         self.neighbors.truncate(k);
@@ -45,8 +43,14 @@ impl<V> KNNResult<V> {
     }
 }
 
-/// Reads a `Vec<KNNResult<u32>>` from a file, skipping the first line (header).
-pub fn read_knn_results_from_file(path: PathBuf) -> std::io::Result<Vec<KNNResult<u32>>> {
+/// Reads a `Vec<KNNResult>` from a file, skipping the first line (header).
+pub fn read_knn_results_from_file(path: PathBuf) -> std::io::Result<Vec<KNNResult>> {
+    #[derive(Deserialize)]
+    struct KNNResultU32 {
+        node: u32,
+        neighbors: Vec<u32>,
+    }
+
     let file = File::open(path)?;
     let mut lines = BufReader::new(file).lines();
 
@@ -56,8 +60,16 @@ pub fn read_knn_results_from_file(path: PathBuf) -> std::io::Result<Vec<KNNResul
     let mut results = Vec::new();
     for line in lines {
         let line = line?;
-        let knn_result: KNNResult<u32> = serde_json::from_str(&line)
+        let knn_result_u32: KNNResultU32 = serde_json::from_str(&line)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        let knn_result = KNNResult {
+            node: IrisVectorId::from_serial_id(knn_result_u32.node),
+            neighbors: knn_result_u32
+                .neighbors
+                .into_iter()
+                .map(IrisVectorId::from_serial_id)
+                .collect(),
+        };
         results.push(knn_result);
     }
     Ok(results)
@@ -222,7 +234,7 @@ impl<K: IdealKnn> NaiveKNN<K> {
         self.next_id
     }
 
-    pub fn compute_chunk(&mut self, chunk_size: usize) -> Vec<KNNResult<IrisSerialId>> {
+    pub fn compute_chunk(&mut self, chunk_size: usize) -> Vec<KNNResult> {
         let start = self.next_id as usize;
         let end = (start + chunk_size).min(self.vectors.len() + 1);
         self.next_id = end as IrisSerialId;
@@ -262,10 +274,10 @@ impl<K: IdealKnn> NaiveKNN<K> {
                     });
 
                     KNNResult {
-                        node: i as IrisSerialId,
+                        node: IrisVectorId::from_serial_id(i as IrisSerialId),
                         neighbors: neighbors
                             .into_iter()
-                            .map(|(j, _)| j as IrisSerialId)
+                            .map(|(j, _)| IrisVectorId::from_serial_id(j as IrisSerialId))
                             .collect(),
                     }
                 })
@@ -306,7 +318,7 @@ impl Engine {
         }
     }
 
-    pub fn compute_chunk(&mut self, chunk_size: usize) -> Vec<KNNResult<IrisSerialId>> {
+    pub fn compute_chunk(&mut self, chunk_size: usize) -> Vec<KNNResult> {
         match self {
             Self::Fhd(engine) => engine.compute_chunk(chunk_size),
             Self::Nhd(engine) => engine.compute_chunk(chunk_size),
@@ -341,7 +353,7 @@ impl EngineInt4 {
         }
     }
 
-    pub fn compute_chunk(&mut self, chunk_size: usize) -> Vec<KNNResult<IrisSerialId>> {
+    pub fn compute_chunk(&mut self, chunk_size: usize) -> Vec<KNNResult> {
         match self {
             Self::Int4Dot(engine) => engine.compute_chunk(chunk_size),
         }
@@ -412,13 +424,18 @@ mod int4_engine_tests {
         assert_eq!(results.len(), n);
         for KNNResult { node, neighbors } in results {
             // Brute-force expected top-k by descending dot (excluding self).
-            let me = &vectors[node as usize - 1];
+            let node_serial = node.serial_id();
+            let me = &vectors[node_serial as usize - 1];
             let mut dists: Vec<(IrisSerialId, i32)> = (1..=n as IrisSerialId)
-                .filter(|j| *j != node)
+                .filter(|j| *j != node_serial)
                 .map(|j| (j, me.dot(&vectors[j as usize - 1])))
                 .collect();
             dists.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
-            let expected: Vec<IrisSerialId> = dists.into_iter().take(k).map(|(j, _)| j).collect();
+            let expected: Vec<IrisVectorId> = dists
+                .into_iter()
+                .take(k)
+                .map(|(j, _)| IrisVectorId::from_serial_id(j))
+                .collect();
             assert_eq!(neighbors, expected, "node {} top-{}", node, k);
         }
     }

--- a/iris-mpc-cpu/src/hawkers/ideal_knn_engines.rs
+++ b/iris-mpc-cpu/src/hawkers/ideal_knn_engines.rs
@@ -412,18 +412,13 @@ mod int4_engine_tests {
         assert_eq!(results.len(), n);
         for KNNResult { node, neighbors } in results {
             // Brute-force expected top-k by descending dot (excluding self).
-            let node_serial = node.serial_id();
-            let me = &vectors[node_serial as usize - 1];
+            let me = &vectors[node as usize - 1];
             let mut dists: Vec<(IrisSerialId, i32)> = (1..=n as IrisSerialId)
-                .filter(|j| *j != node_serial)
+                .filter(|j| *j != node)
                 .map(|j| (j, me.dot(&vectors[j as usize - 1])))
                 .collect();
             dists.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
-            let expected: Vec<IrisVectorId> = dists
-                .into_iter()
-                .take(k)
-                .map(|(j, _)| IrisVectorId::from_serial_id(j))
-                .collect();
+            let expected: Vec<IrisSerialId> = dists.into_iter().take(k).map(|(j, _)| j).collect();
             assert_eq!(neighbors, expected, "node {} top-{}", node, k);
         }
     }

--- a/iris-mpc-cpu/src/hawkers/plaintext_deep_id_store.rs
+++ b/iris-mpc-cpu/src/hawkers/plaintext_deep_id_store.rs
@@ -11,7 +11,7 @@ use crate::{
     hnsw::{
         metrics::ops_counter::Operation::{CompareDistance, EvaluateDistance},
         vector_store::VectorStoreMut,
-        GraphMem, HnswSearcher, SortedNeighborhood, VectorStore,
+        GraphMem, HnswSearcher, VectorStore,
     },
 };
 use aes_prng::AesRng;
@@ -243,7 +243,7 @@ impl PlaintextDeepIDStore {
                 .unwrap_or_else(|| VectorId::from_serial_id(serial_id));
             let insertion_layer = searcher.gen_layer_rng(&mut rng)?;
             let (neighbors, update_ep) = searcher
-                .search_to_insert::<_, SortedNeighborhood<_>>(self, &graph, &query, insertion_layer)
+                .search_to_insert(self, &graph, &query, insertion_layer)
                 .await?;
             searcher
                 .insert_from_search_results(self, &mut graph, query_id, neighbors, update_ep)
@@ -454,6 +454,7 @@ impl VectorStoreMut for SharedPlaintextDeepIDStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::hnsw::SortedNeighborhood;
     use tokio::task::JoinSet;
 
     #[test]

--- a/iris-mpc-cpu/src/hawkers/plaintext_deep_id_store.rs
+++ b/iris-mpc-cpu/src/hawkers/plaintext_deep_id_store.rs
@@ -443,6 +443,15 @@ impl VectorStore for SharedPlaintextDeepIDStore {
         vectors.retain(|v| store.contains(v));
         vectors
     }
+
+    async fn only_valid_entry_points(
+        &mut self,
+        mut entry_points: Vec<(VectorId, usize)>,
+    ) -> Vec<(VectorId, usize)> {
+        let store = self.storage.read().await;
+        entry_points.retain(|(v, _)| store.contains(v));
+        entry_points
+    }
 }
 
 impl VectorStoreMut for SharedPlaintextDeepIDStore {

--- a/iris-mpc-cpu/src/hawkers/plaintext_deep_id_store.rs
+++ b/iris-mpc-cpu/src/hawkers/plaintext_deep_id_store.rs
@@ -311,6 +311,14 @@ impl VectorStore for PlaintextDeepIDStore {
         vectors.retain(|v| self.storage.contains(v));
         vectors
     }
+
+    async fn only_valid_entry_points(
+        &mut self,
+        mut entry_points: Vec<(VectorId, usize)>,
+    ) -> Vec<(VectorId, usize)> {
+        entry_points.retain(|(v, _)| self.storage.contains(v));
+        entry_points
+    }
 }
 
 impl VectorStoreMut for PlaintextDeepIDStore {

--- a/iris-mpc-cpu/src/hawkers/plaintext_deep_id_store.rs
+++ b/iris-mpc-cpu/src/hawkers/plaintext_deep_id_store.rs
@@ -213,8 +213,8 @@ impl PlaintextDeepIDStore {
         rng: &mut R,
         graph_size: usize,
         searcher: &HnswSearcher,
-    ) -> Result<GraphMem<VectorId>> {
-        let mut graph: GraphMem<VectorId> = GraphMem::new();
+    ) -> Result<GraphMem> {
+        let mut graph: GraphMem = GraphMem::new();
         let mut rng = AesRng::from_rng(rng.clone())?;
 
         if graph_size > self.len() {

--- a/iris-mpc-cpu/src/hawkers/plaintext_store.rs
+++ b/iris-mpc-cpu/src/hawkers/plaintext_store.rs
@@ -339,6 +339,15 @@ impl<D: DistanceOps> VectorStore for SharedPlaintextStore<D> {
         vectors.retain(|v| storage.contains(v));
         vectors
     }
+
+    async fn only_valid_entry_points(
+        &mut self,
+        mut entry_points: Vec<(VectorId, usize)>,
+    ) -> Vec<(VectorId, usize)> {
+        let storage = self.storage.read().await;
+        entry_points.retain(|(v, _)| storage.contains(v));
+        entry_points
+    }
 }
 
 impl<D: DistanceOps> VectorStoreMut for SharedPlaintextStore<D> {

--- a/iris-mpc-cpu/src/hawkers/plaintext_store.rs
+++ b/iris-mpc-cpu/src/hawkers/plaintext_store.rs
@@ -196,6 +196,14 @@ impl<D: DistanceOps> VectorStore for PlaintextStore<D> {
         vectors.retain(|v| self.storage.contains(v));
         vectors
     }
+
+    async fn only_valid_entry_points(
+        &mut self,
+        mut entry_points: Vec<(VectorId, usize)>,
+    ) -> Vec<(VectorId, usize)> {
+        entry_points.retain(|(v, _)| self.storage.contains(v));
+        entry_points
+    }
 }
 
 impl<D: DistanceOps> VectorStoreMut for PlaintextStore<D> {

--- a/iris-mpc-cpu/src/hawkers/plaintext_store.rs
+++ b/iris-mpc-cpu/src/hawkers/plaintext_store.rs
@@ -107,7 +107,7 @@ impl<D: DistanceOps> PlaintextStore<D> {
         rng: &mut R,
         graph_size: usize,
         searcher: &HnswSearcher,
-    ) -> Result<GraphMem<VectorId>> {
+    ) -> Result<GraphMem> {
         let mut graph = GraphMem::new();
         let mut rng = AesRng::from_rng(rng.clone())?;
 

--- a/iris-mpc-cpu/src/hawkers/plaintext_store.rs
+++ b/iris-mpc-cpu/src/hawkers/plaintext_store.rs
@@ -7,7 +7,7 @@ use crate::{
     hnsw::{
         metrics::ops_counter::Operation::{CompareDistance, EvaluateDistance},
         vector_store::VectorStoreMut,
-        GraphMem, HnswSearcher, SortedNeighborhood, VectorStore,
+        GraphMem, HnswSearcher, VectorStore,
     },
 };
 use aes_prng::AesRng;
@@ -128,7 +128,7 @@ impl<D: DistanceOps> PlaintextStore<D> {
             let query_id = VectorId::from_serial_id(serial_id);
             let insertion_layer = searcher.gen_layer_rng(&mut rng)?;
             let (neighbors, update_ep) = searcher
-                .search_to_insert::<_, SortedNeighborhood<_>>(self, &graph, &query, insertion_layer)
+                .search_to_insert(self, &graph, &query, insertion_layer)
                 .await?;
             searcher
                 .insert_from_search_results(self, &mut graph, query_id, neighbors, update_ep)
@@ -359,7 +359,7 @@ impl<D: DistanceOps> VectorStoreMut for SharedPlaintextStore<D> {
 mod tests {
     use super::*;
     use crate::hawkers::aby3::aby3_store::FhdOps;
-    use crate::hnsw::HnswSearcher;
+    use crate::hnsw::{HnswSearcher, SortedNeighborhood};
     use aes_prng::AesRng;
     use iris_mpc_common::iris_db::db::IrisDB;
     use itertools::Itertools;

--- a/iris-mpc-cpu/src/hnsw/graph/graph_diff/explicit.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/graph_diff/explicit.rs
@@ -1,13 +1,12 @@
 use std::{
     collections::HashSet,
     fmt::{Display, Formatter, Result},
-    str::FromStr,
 };
 
 use clap::ValueEnum;
+use iris_mpc_common::IrisVectorId;
 
 use super::{jaccard::JaccardState, Differ};
-use crate::hnsw::vector_store::Ref;
 
 #[derive(Debug, Clone, ValueEnum)]
 pub enum SortBy {
@@ -29,22 +28,22 @@ impl Display for SortBy {
 
 /// Contains the explicit differences between two neighborhoods for a single node.
 #[derive(Debug, Clone)]
-pub struct NeighborhoodDiff<V: Ref> {
-    pub only_in_lhs: HashSet<V>,
-    pub only_in_rhs: HashSet<V>,
+pub struct NeighborhoodDiff {
+    pub only_in_lhs: HashSet<IrisVectorId>,
+    pub only_in_rhs: HashSet<IrisVectorId>,
     pub jaccard_state: JaccardState,
 }
 
 #[derive(Debug, Clone)]
-pub struct ExplicitDiff<V: Ref>(pub Vec<LayerDiffResult<V>>);
+pub struct ExplicitDiff(pub Vec<LayerDiffResult>);
 
 #[derive(Debug, Clone)]
-pub struct LayerDiffResult<V: Ref> {
+pub struct LayerDiffResult {
     pub layer_index: usize,
-    pub diffs: Vec<(V, NeighborhoodDiff<V>)>,
+    pub diffs: Vec<(IrisVectorId, NeighborhoodDiff)>,
 }
 
-impl<V: Ref + Display> Display for ExplicitDiff<V> {
+impl Display for ExplicitDiff {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         for layer_result in &self.0 {
             let nonempty_diffs: Vec<_> = layer_result
@@ -85,13 +84,13 @@ impl<V: Ref + Display> Display for ExplicitDiff<V> {
 }
 
 /// A differ that returns the explicit lists of node differences between neighborhoods.
-pub struct ExplicitNeighborhoodDiffer<V: Ref> {
+pub struct ExplicitNeighborhoodDiffer {
     sort_by: SortBy,
-    per_layer_results: Vec<LayerDiffResult<V>>,
-    current_layer_diffs: Vec<(V, NeighborhoodDiff<V>)>,
+    per_layer_results: Vec<LayerDiffResult>,
+    current_layer_diffs: Vec<(IrisVectorId, NeighborhoodDiff)>,
 }
 
-impl<V: Ref> ExplicitNeighborhoodDiffer<V> {
+impl ExplicitNeighborhoodDiffer {
     pub fn new(sort_by: SortBy) -> Self {
         Self {
             sort_by,
@@ -101,14 +100,20 @@ impl<V: Ref> ExplicitNeighborhoodDiffer<V> {
     }
 }
 
-impl<V: Ref + Display + FromStr + Ord> Differ<V> for ExplicitNeighborhoodDiffer<V> {
-    type Output = ExplicitDiff<V>;
+impl Differ for ExplicitNeighborhoodDiffer {
+    type Output = ExplicitDiff;
 
     fn start_layer(&mut self, _layer_index: usize) {
         self.current_layer_diffs.clear();
     }
 
-    fn diff_neighborhood(&mut self, _layer_index: usize, node: &V, lhs: &[V], rhs: &[V]) {
+    fn diff_neighborhood(
+        &mut self,
+        _layer_index: usize,
+        node: &IrisVectorId,
+        lhs: &[IrisVectorId],
+        rhs: &[IrisVectorId],
+    ) {
         let lhs_set: HashSet<_> = lhs.iter().cloned().collect();
         let rhs_set: HashSet<_> = rhs.iter().cloned().collect();
 

--- a/iris-mpc-cpu/src/hnsw/graph/graph_diff/explicit.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/graph_diff/explicit.rs
@@ -130,7 +130,7 @@ impl Differ for ExplicitNeighborhoodDiffer {
             jaccard_state,
         };
 
-        self.current_layer_diffs.push((node.clone(), diff));
+        self.current_layer_diffs.push((*node, diff));
     }
 
     fn end_layer(&mut self, layer_index: usize) {
@@ -141,7 +141,7 @@ impl Differ for ExplicitNeighborhoodDiffer {
                         .sort_by(|a, b| a.1.jaccard_state.compare_as_fractions(&b.1.jaccard_state));
                 }
                 SortBy::Index => {
-                    self.current_layer_diffs.sort_by(|a, b| a.0.cmp(&b.0));
+                    self.current_layer_diffs.sort_by_key(|a| a.0);
                 }
             }
             self.per_layer_results.push(LayerDiffResult {

--- a/iris-mpc-cpu/src/hnsw/graph/graph_diff/jaccard.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/graph_diff/jaccard.rs
@@ -1,6 +1,6 @@
 use super::Differ;
-use crate::hnsw::vector_store::Ref;
-use std::{collections::HashSet, fmt::Display, ops::Add, str::FromStr};
+use iris_mpc_common::IrisVectorId;
+use std::{collections::HashSet, fmt::Display, ops::Add};
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct JaccardState {
@@ -56,14 +56,14 @@ impl Display for JaccardState {
 }
 
 /// A differ that computes detailed Jaccard similarity, including the `n` most dissimilar nodes per layer.
-pub struct DetailedJaccardDiffer<V: Ref> {
+pub struct DetailedJaccardDiffer {
     n: usize,
     graph_state: JaccardState,
-    current_layer_details: Vec<(V, JaccardState)>,
-    per_layer_results: Vec<(JaccardState, Vec<(V, JaccardState)>)>,
+    current_layer_details: Vec<(IrisVectorId, JaccardState)>,
+    per_layer_results: Vec<(JaccardState, Vec<(IrisVectorId, JaccardState)>)>,
 }
 
-impl<V: Ref> DetailedJaccardDiffer<V> {
+impl DetailedJaccardDiffer {
     pub fn new(n: usize) -> Self {
         Self {
             n,
@@ -74,12 +74,15 @@ impl<V: Ref> DetailedJaccardDiffer<V> {
     }
 }
 
-pub struct DetailedJaccardReport<V>(
+pub struct DetailedJaccardReport(
     #[allow(clippy::type_complexity)]
-    pub  (JaccardState, Vec<(JaccardState, Vec<(V, JaccardState)>)>),
+    pub  (
+        JaccardState,
+        Vec<(JaccardState, Vec<(IrisVectorId, JaccardState)>)>,
+    ),
 );
 
-impl<V: Ref + Display> Display for DetailedJaccardReport<V> {
+impl Display for DetailedJaccardReport {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let (graph_state, per_layer_results) = &self.0;
         writeln!(f, "GRAPH aggregate: {}", graph_state)?;
@@ -95,14 +98,20 @@ impl<V: Ref + Display> Display for DetailedJaccardReport<V> {
     }
 }
 
-impl<V: Ref + Display + FromStr + Ord> Differ<V> for DetailedJaccardDiffer<V> {
-    type Output = DetailedJaccardReport<V>;
+impl Differ for DetailedJaccardDiffer {
+    type Output = DetailedJaccardReport;
 
     fn start_layer(&mut self, _layer_index: usize) {
         self.current_layer_details.clear();
     }
 
-    fn diff_neighborhood(&mut self, _layer_index: usize, node: &V, lhs: &[V], rhs: &[V]) {
+    fn diff_neighborhood(
+        &mut self,
+        _layer_index: usize,
+        node: &IrisVectorId,
+        lhs: &[IrisVectorId],
+        rhs: &[IrisVectorId],
+    ) {
         let lhs_set: HashSet<_> = lhs.iter().collect();
         let rhs_set: HashSet<_> = rhs.iter().collect();
         let intersection = lhs_set.intersection(&rhs_set).count();

--- a/iris-mpc-cpu/src/hnsw/graph/graph_diff/jaccard.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/graph_diff/jaccard.rs
@@ -117,7 +117,7 @@ impl Differ for DetailedJaccardDiffer {
         let intersection = lhs_set.intersection(&rhs_set).count();
         let union = lhs_set.union(&rhs_set).count();
         let node_state = JaccardState::new(intersection, union);
-        self.current_layer_details.push((node.clone(), node_state));
+        self.current_layer_details.push((*node, node_state));
     }
 
     fn end_layer(&mut self, _layer_index: usize) {

--- a/iris-mpc-cpu/src/hnsw/graph/graph_diff/mod.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/graph_diff/mod.rs
@@ -1,7 +1,6 @@
+use crate::hnsw::GraphMem;
+use iris_mpc_common::IrisVectorId;
 use std::fmt::Display;
-use std::str::FromStr;
-
-use crate::hnsw::{vector_store::Ref, GraphMem};
 
 pub mod explicit;
 pub mod jaccard;
@@ -11,7 +10,7 @@ pub mod node_equiv;
 ///
 /// A `Differ` implementation can maintain internal state and update it as the
 /// `run_diff` function traverses the layers and nodes of the graphs.
-pub trait Differ<V: Ref + Display + FromStr + Ord> {
+pub trait Differ {
     /// The final output type of the diffing operation.
     type Output: Display;
 
@@ -22,7 +21,13 @@ pub trait Differ<V: Ref + Display + FromStr + Ord> {
     fn start_layer(&mut self, _layer_index: usize) {}
 
     /// Called for each node that exists in both the `lhs` and `rhs` layer.
-    fn diff_neighborhood(&mut self, layer_index: usize, node: &V, lhs: &[V], rhs: &[V]);
+    fn diff_neighborhood(
+        &mut self,
+        layer_index: usize,
+        node: &IrisVectorId,
+        lhs: &[IrisVectorId],
+        rhs: &[IrisVectorId],
+    );
 
     /// Called after traversing each layer.
     fn end_layer(&mut self, _layer_index: usize) {}
@@ -35,10 +40,9 @@ pub trait Differ<V: Ref + Display + FromStr + Ord> {
 ///
 /// It's recommended to run `ensure_node_equivalence` before using this function
 /// to ensure the graphs have a comparable structure.
-pub fn run_diff<V, D>(lhs: &GraphMem<V>, rhs: &GraphMem<V>, mut differ: D) -> D::Output
+pub fn run_diff<D>(lhs: &GraphMem, rhs: &GraphMem, mut differ: D) -> D::Output
 where
-    V: Ref + Display + FromStr + Ord,
-    D: Differ<V>,
+    D: Differ,
 {
     differ.start_graph();
 

--- a/iris-mpc-cpu/src/hnsw/graph/graph_diff/node_equiv.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/graph_diff/node_equiv.rs
@@ -46,7 +46,7 @@ pub fn ensure_node_equivalence(lhs: &GraphMem, rhs: &GraphMem) -> Result<(), Nod
         if let Some(missing_node) = lhs_nodes.difference(&rhs_nodes).next() {
             return Err(NodeEquivalenceError::NodeMissingInRhs {
                 layer_index: i,
-                node: missing_node.clone(),
+                node: *missing_node,
             });
         }
 
@@ -54,7 +54,7 @@ pub fn ensure_node_equivalence(lhs: &GraphMem, rhs: &GraphMem) -> Result<(), Nod
         if let Some(missing_node) = rhs_nodes.difference(&lhs_nodes).next() {
             return Err(NodeEquivalenceError::NodeMissingInLhs {
                 layer_index: i,
-                node: missing_node.clone(),
+                node: *missing_node,
             });
         }
     }

--- a/iris-mpc-cpu/src/hnsw/graph/graph_diff/node_equiv.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/graph_diff/node_equiv.rs
@@ -1,19 +1,23 @@
 use std::collections::HashSet;
-use std::fmt::Display;
-use std::str::FromStr;
 
-use crate::hnsw::vector_store::Ref;
 use crate::hnsw::GraphMem;
+use iris_mpc_common::IrisVectorId;
 
 /// Describes how the node and layer structure of two graphs are not equivalent.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum NodeEquivalenceError<V> {
+pub enum NodeEquivalenceError {
     /// The graphs have a different number of layers.
     LayerCountMismatch { lhs_count: usize, rhs_count: usize },
     /// A node was found in the left-hand graph's layer that was not in the right's.
-    NodeMissingInRhs { layer_index: usize, node: V },
+    NodeMissingInRhs {
+        layer_index: usize,
+        node: IrisVectorId,
+    },
     /// A node was found in the right-hand graph's layer that was not in the left's.
-    NodeMissingInLhs { layer_index: usize, node: V },
+    NodeMissingInLhs {
+        layer_index: usize,
+        node: IrisVectorId,
+    },
 }
 
 /// Diffs the node and layer structure of two graphs.
@@ -24,10 +28,7 @@ pub enum NodeEquivalenceError<V> {
 /// # Returns
 /// - `Ok(())` if the graphs are equivalent in their node and layer structure.
 /// - `Err(NodeEquivalenceError)` if they are not, with a reason for the failure.
-pub fn ensure_node_equivalence<V: Ref + Display + FromStr + Ord>(
-    lhs: &GraphMem<V>,
-    rhs: &GraphMem<V>,
-) -> Result<(), NodeEquivalenceError<V>> {
+pub fn ensure_node_equivalence(lhs: &GraphMem, rhs: &GraphMem) -> Result<(), NodeEquivalenceError> {
     // First, check if the number of layers is the same.
     if lhs.layers.len() != rhs.layers.len() {
         return Err(NodeEquivalenceError::LayerCountMismatch {

--- a/iris-mpc-cpu/src/hnsw/graph/graph_store.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/graph_store.rs
@@ -24,7 +24,7 @@ pub struct GraphCheckpointRow {
 #[derive(sqlx::FromRow, Debug, Clone, PartialEq, Eq)]
 pub struct GraphMutationRow {
     pub modification_id: i64,
-    /// Bincode-serialized `BothEyes<Vec<GraphMutation<VectorId>>>` (mutations for both eyes)
+    /// Bincode-serialized `BothEyes<Vec<GraphMutation>>` (mutations for both eyes)
     pub serialized_mutations: Vec<u8>,
 }
 
@@ -35,8 +35,8 @@ pub struct GraphPg<V: VectorStore> {
 }
 
 impl GraphMutationRow {
-    pub fn deserialize_mutations(&self) -> Result<BothEyes<Vec<GraphMutation<IrisVectorId>>>> {
-        let both_eyes: BothEyes<Vec<GraphMutation<IrisVectorId>>> =
+    pub fn deserialize_mutations(&self) -> Result<BothEyes<Vec<GraphMutation>>> {
+        let both_eyes: BothEyes<Vec<GraphMutation>> =
             bincode::deserialize(&self.serialized_mutations)?;
         Ok(both_eyes)
     }
@@ -839,7 +839,7 @@ mod tests {
                 update_ep: UpdateEntryPoint::SetUnique { layer: 0 },
             }],
         };
-        let both: BothEyes<Vec<GraphMutation<IrisVectorId>>> =
+        let both: BothEyes<Vec<GraphMutation>> =
             [vec![plan_left.clone()], vec![plan_right.clone()]];
         let payload = bincode::serialize(&both)?;
 

--- a/iris-mpc-cpu/src/hnsw/graph/graph_store.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/graph_store.rs
@@ -3,7 +3,7 @@ use crate::{
     hnsw::{graph::GraphMutation, VectorStore},
 };
 use eyre::{eyre, Result};
-use iris_mpc_common::{postgres::PostgresClient, IrisVectorId};
+use iris_mpc_common::postgres::PostgresClient;
 use serde::{de::DeserializeOwned, Serialize};
 use sqlx::{types::Json, Postgres, Row, Transaction};
 use std::{marker::PhantomData, ops::DerefMut};
@@ -559,6 +559,7 @@ pub mod test_utils {
 mod tests {
     use super::{test_utils::TestGraphPg, *};
     use crate::hawkers::plaintext_store::PlaintextStore;
+    use iris_mpc_common::IrisVectorId;
     use tokio;
 
     #[tokio::test]
@@ -823,7 +824,7 @@ mod tests {
 
         let store = TestGraphPg::<PlaintextStore>::new().await?;
 
-        let plan_left = GraphMutation::<IrisVectorId> {
+        let plan_left = GraphMutation {
             seq_no: 1,
             ops: vec![MutationOp::AddNode {
                 id: IrisVectorId::from_serial_id(1),
@@ -831,7 +832,7 @@ mod tests {
                 update_ep: UpdateEntryPoint::SetUnique { layer: 0 },
             }],
         };
-        let plan_right = GraphMutation::<IrisVectorId> {
+        let plan_right = GraphMutation {
             seq_no: 1,
             ops: vec![MutationOp::AddNode {
                 id: IrisVectorId::from_serial_id(2),

--- a/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
@@ -13,7 +13,6 @@ use crate::{
             mutation::{EdgeType, UnstampedMutation},
             GraphMutation, MutationOp, UpdateEntryPoint,
         },
-        searcher::LayerMode,
         HnswSearcher,
     },
 };
@@ -52,13 +51,8 @@ pub struct EntryPoint {
 pub struct GraphMem {
     /// Entry points for HNSW search.
     ///
-    /// If the graph is built by a searcher in `LinearScan` mode, this list will contain all nodes assigned
-    /// to an `insertion_level >= max_graph_layer`. The searcher uses `get_temporary_entry_point`
-    /// while no such node exists.
-    ///
-    /// If the graph is built by a searcher in `Standard` or `Bounded` mode this list
-    /// will contain a single entry point at any given time, which corresponds to a node
-    /// in the highest layer of the graph.
+    /// This list contains all nodes assigned to an `insertion_level >= max_graph_layer`.
+    /// The searcher uses `get_temporary_entry_point` while no such node exists.
     pub entry_points: Vec<EntryPoint>,
 
     /// The layers of the hierarchical graph. The nodes of each layer are a
@@ -561,30 +555,14 @@ where
     let mut nodes_for_nonzero_layers: Vec<Vec<(IrisVectorId, K::Vector)>> =
         nonzero_layers_map.into_values().collect();
 
-    let entry_points = match searcher.layer_mode {
-        LayerMode::Standard { max_graph_layer } => {
-            if let Some(max_layer) = max_graph_layer {
-                nodes_for_nonzero_layers.truncate(max_layer);
-            }
-            once(&vectors_with_ids)
-                .chain(nodes_for_nonzero_layers.iter())
-                .last()
-                .unwrap_or(&vec![])
-                .first()
-                .map(|(v, _)| vec![(*v, nodes_for_nonzero_layers.len())])
-                .unwrap_or_default()
-        }
-        LayerMode::LinearScan { max_graph_layer } => {
-            let entry_points = nodes_for_nonzero_layers
-                .get(max_graph_layer)
-                .unwrap_or(&vec![])
-                .iter()
-                .map(|(v, _)| (*v, max_graph_layer))
-                .collect();
-            nodes_for_nonzero_layers.truncate(max_graph_layer);
-            entry_points
-        }
-    };
+    let max_graph_layer = searcher.max_graph_layer;
+    let entry_points = nodes_for_nonzero_layers
+        .get(max_graph_layer)
+        .unwrap_or(&vec![])
+        .iter()
+        .map(|(v, _)| (*v, max_graph_layer))
+        .collect();
+    nodes_for_nonzero_layers.truncate(max_graph_layer);
 
     let nonzero_layers = nodes_for_nonzero_layers
         .into_iter()
@@ -1084,7 +1062,11 @@ mod tests {
     async fn test_from_another() -> Result<()> {
         let mut vector_store = PlaintextStore::<FhdOps>::new();
         let mut graph_store = GraphMem::new();
-        let searcher = HnswSearcher::new_with_test_parameters();
+        let mut searcher = HnswSearcher::new_with_test_parameters();
+        // Bump layer density so enough nodes roll onto the entry-point layer
+        // (max_graph_layer + 1) for the entry-point migration checks below.
+        searcher.layer_distribution =
+            crate::hnsw::searcher::LayerDistribution::new_geometric_from_M(2);
         let mut rng = AesRng::seed_from_u64(0_u64);
 
         let mut point_ids_map: HashMap<IrisVectorId, IrisVectorId> = HashMap::new();

--- a/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
@@ -573,19 +573,11 @@ where
         .into_iter()
         .enumerate()
         .map(|(i, layer_data)| {
-            let (vector_ids, vectors): (Vec<IrisVectorId>, Vec<K::Vector>) =
-                layer_data.into_iter().unzip();
-            let n = vectors.len();
-            let k = searcher.params.get_M_max(i + 1).min(n - 1);
-
-            let mut engine = NaiveKNN::<K>::init(knn_proto.clone(), vectors, k, 1);
-            let results = engine
-                .compute_chunk(n)
-                .into_iter()
-                // remap from engine 1-based indices to original vector ids
-                .map(|result| result.map(|i| vector_ids[(i as usize) - 1]))
-                .collect::<Vec<_>>();
-            Layer::from_knn_results(results, n)
+            Layer::ideal_from_data::<K>(
+                layer_data,
+                searcher.params.get_M_max(i + 1),
+                knn_proto.clone(),
+            )
         });
 
     Ok(GraphMem::from_precomputed(
@@ -968,6 +960,13 @@ mod tests {
             distance2: &Self::DistanceRef,
         ) -> Result<bool> {
             Ok(*distance1 < *distance2)
+        }
+
+        async fn only_valid_entry_points(
+            &mut self,
+            entry_points: Vec<(VectorId, usize)>,
+        ) -> Vec<(VectorId, usize)> {
+            entry_points
         }
     }
 

--- a/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
@@ -21,7 +21,6 @@ use crate::{
 use eyre::Result;
 use iris_mpc_common::{iris_db::iris::IrisCode, IrisVectorId};
 use itertools::{izip, Itertools};
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use serde::{
     ser::{SerializeMap, SerializeStruct, Serializer},
     Deserialize, Serialize,
@@ -1404,7 +1403,6 @@ mod tests {
     #[test]
     fn next_seq_no_is_one_past_last_and_does_not_mutate() {
         use crate::hnsw::GraphMem;
-        use iris_mpc_common::IrisVectorId;
         let mut graph = GraphMem::new();
         assert_eq!(graph.last_update_seq_no, 0);
         assert_eq!(graph.next_sequence_number(), 1);

--- a/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
@@ -20,6 +20,7 @@ use crate::{
 use eyre::Result;
 use iris_mpc_common::{iris_db::iris::IrisCode, IrisVectorId};
 use itertools::{izip, Itertools};
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use serde::{
     ser::{SerializeMap, SerializeStruct, Serializer},
     Deserialize, Serialize,
@@ -531,6 +532,10 @@ where
         for result in results.iter_mut() {
             result.truncate(searcher.params.get_M_max(0));
         }
+        let results = results
+            .into_par_iter()
+            .map(|result| result.map(IrisVectorId::from_serial_id))
+            .collect::<Vec<_>>();
         Layer::from_knn_results(results, vectors.len())
     };
 
@@ -577,17 +582,8 @@ where
             let results = engine
                 .compute_chunk(n)
                 .into_iter()
-                .map(|result| {
-                    // remap from engine 1-based indices to original vector ids
-                    let node_idx = result.node.serial_id() as usize;
-                    let node = vector_ids[node_idx - 1];
-                    let neighbors: Vec<IrisVectorId> = result
-                        .neighbors
-                        .into_iter()
-                        .map(|neighbor_vid| vector_ids[(neighbor_vid.serial_id() as usize) - 1])
-                        .collect();
-                    KNNResult { node, neighbors }
-                })
+                // remap from engine 1-based indices to original vector ids
+                .map(|result| result.map(|i| vector_ids[(i as usize) - 1]))
                 .collect::<Vec<_>>();
             Layer::from_knn_results(results, n)
         });
@@ -785,7 +781,7 @@ impl Layer {
         &self.links
     }
 
-    fn from_knn_results(results: Vec<KNNResult>, n: usize) -> Self {
+    fn from_knn_results(results: Vec<KNNResult<IrisVectorId>>, n: usize) -> Self {
         let mut ret = Layer::new();
         for KNNResult { node, neighbors } in results.into_iter().take(n) {
             ret.set_links(node, neighbors);
@@ -811,17 +807,8 @@ impl Layer {
         let results = engine
             .compute_chunk(n)
             .into_iter()
-            .map(|result| {
-                // remap from engine 1-based indices to original vector ids
-                let node_idx = result.node.serial_id() as usize;
-                let node = vector_ids[node_idx - 1];
-                let neighbors: Vec<IrisVectorId> = result
-                    .neighbors
-                    .into_iter()
-                    .map(|neighbor_vid| vector_ids[(neighbor_vid.serial_id() as usize) - 1])
-                    .collect();
-                KNNResult { node, neighbors }
-            })
+            // remap from engine 1-based indices to original vector ids
+            .map(|result| result.map(|i| vector_ids[(i as usize) - 1]))
             .collect::<Vec<_>>();
 
         Layer::from_knn_results(results, n)

--- a/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
@@ -168,17 +168,13 @@ impl GraphMem {
             .iter()
             .enumerate()
             .rfind(|(_lc, layer)| !layer.links.is_empty())
-            .and_then(|(lc, layer)| layer.links.keys().min().map(|x| (x.clone(), lc)))
+            .and_then(|(lc, layer)| layer.links.keys().min().map(|x| (*x, lc)))
     }
 
     /// Gets the list of entry points.
     /// If this list is empty in LinearScan mode, `get_temporary_entry_point` may be used instead.
     pub fn get_entry_points(&self) -> Option<Vec<IrisVectorId>> {
-        let v: Vec<_> = self
-            .entry_points
-            .iter()
-            .map(|ep| ep.point.clone())
-            .collect();
+        let v: Vec<_> = self.entry_points.iter().map(|ep| ep.point).collect();
         if v.is_empty() {
             None
         } else {
@@ -225,13 +221,13 @@ impl GraphMem {
                                 self.layers.resize(*layer + 1, Layer::new());
                             }
                             self.entry_points = vec![EntryPoint {
-                                point: id.clone(),
+                                point: *id,
                                 layer: *layer,
                             }];
                         }
                         UpdateEntryPoint::Append { layer } => {
                             self.entry_points.push(EntryPoint {
-                                point: id.clone(),
+                                point: *id,
                                 layer: *layer,
                             });
                         }
@@ -399,9 +395,7 @@ impl GraphMem {
     }
 
     pub async fn get_first_entry_point(&self) -> Option<(IrisVectorId, usize)> {
-        self.entry_points
-            .first()
-            .map(|ep| (ep.point.clone(), ep.layer))
+        self.entry_points.first().map(|ep| (ep.point, ep.layer))
     }
 
     pub async fn init_entry_points(&mut self, points: Vec<IrisVectorId>, layer: usize) {
@@ -696,7 +690,7 @@ impl Layer {
     }
 
     pub fn insert_node(&mut self, id: &IrisVectorId, neighbors: Vec<IrisVectorId>) {
-        self.set_links(id.clone(), neighbors.clone());
+        self.set_links(*id, neighbors.clone());
     }
 
     /// Insert `id` as an incoming edge into each target's neighbor list,
@@ -710,7 +704,7 @@ impl Layer {
                 if let Err(pos) = target_links.binary_search(node) {
                     self.set_hash
                         .remove_unordered_set(target, target_links.iter());
-                    target_links.insert(pos, node.clone());
+                    target_links.insert(pos, *node);
                     self.set_hash.add_unordered_set(target, target_links.iter());
                 }
             }
@@ -748,10 +742,10 @@ impl Layer {
             for neighbor in neighbors {
                 if let Some(neighbor_links) = self.links.get_mut(&neighbor) {
                     self.set_hash
-                        .remove_unordered_set(&neighbor, neighbor_links.iter());
+                        .remove_unordered_set(neighbor, neighbor_links.iter());
                     neighbor_links.retain(|x| x != id);
                     self.set_hash
-                        .add_unordered_set(&neighbor, neighbor_links.iter());
+                        .add_unordered_set(neighbor, neighbor_links.iter());
                 }
             }
         }
@@ -913,7 +907,7 @@ where
         .entry_points
         .iter()
         .map(|ep| EntryPoint {
-            point: vector_map(ep.point.clone()),
+            point: vector_map(ep.point),
             layer: ep.layer,
         })
         .collect();
@@ -945,7 +939,7 @@ mod tests {
         hawkers::{aby3::aby3_store::FhdOps, plaintext_store::PlaintextStore},
         hnsw::{
             graph::layered_graph::migrate, vector_store::VectorStoreMut, GraphMem, HnswSearcher,
-            SortedNeighborhood, VectorStore,
+            VectorStore,
         },
     };
     use aes_prng::AesRng;
@@ -1041,12 +1035,7 @@ mod tests {
             let query = Arc::new(raw_query);
             let insertion_layer = searcher.gen_layer_rng(&mut rng)?;
             let (neighbors, update_ep) = searcher
-                .search_to_insert::<_, SortedNeighborhood<_>>(
-                    &mut vector_store,
-                    &graph_store,
-                    &query,
-                    insertion_layer,
-                )
+                .search_to_insert(&mut vector_store, &graph_store, &query, insertion_layer)
                 .await?;
             let inserted = vector_store.insert(&query).await;
             searcher
@@ -1104,12 +1093,7 @@ mod tests {
             let query = Arc::new(raw_query);
             let insertion_layer = searcher.gen_layer_rng(&mut rng)?;
             let (neighbors, update_ep) = searcher
-                .search_to_insert::<_, SortedNeighborhood<_>>(
-                    &mut vector_store,
-                    &graph_store,
-                    &query,
-                    insertion_layer,
-                )
+                .search_to_insert(&mut vector_store, &graph_store, &query, insertion_layer)
                 .await?;
             let inserted = vector_store.insert(&query).await;
             searcher

--- a/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
@@ -14,7 +14,6 @@ use crate::{
             GraphMutation, MutationOp, UpdateEntryPoint,
         },
         searcher::LayerMode,
-        vector_store::Ref,
         HnswSearcher,
     },
 };
@@ -32,7 +31,6 @@ use std::{
     fmt::Display,
     iter::once,
     path::PathBuf,
-    str::FromStr,
     sync::Arc,
 };
 use tokio::sync::RwLock;
@@ -42,9 +40,9 @@ use tracing::warn;
 /// This is a vector reference along with the layer of the graph at which
 /// search begins.
 #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
-pub struct EntryPoint<VectorRef> {
+pub struct EntryPoint {
     /// The vector reference of the entry point
-    pub point: VectorRef,
+    pub point: IrisVectorId,
 
     /// The layer at which HNSW search begins
     pub layer: usize,
@@ -52,8 +50,7 @@ pub struct EntryPoint<VectorRef> {
 
 /// An in-memory implementation of an HNSW hierarchical graph.
 #[derive(Default, PartialEq, Eq, Debug, Serialize, Deserialize)]
-#[serde(bound = "V: Ref + Display + FromStr")]
-pub struct GraphMem<V: Ref + Display + FromStr + Ord> {
+pub struct GraphMem {
     /// Entry points for HNSW search.
     ///
     /// If the graph is built by a searcher in `LinearScan` mode, this list will contain all nodes assigned
@@ -63,12 +60,12 @@ pub struct GraphMem<V: Ref + Display + FromStr + Ord> {
     /// If the graph is built by a searcher in `Standard` or `Bounded` mode this list
     /// will contain a single entry point at any given time, which corresponds to a node
     /// in the highest layer of the graph.
-    pub entry_points: Vec<EntryPoint<V>>,
+    pub entry_points: Vec<EntryPoint>,
 
     /// The layers of the hierarchical graph. The nodes of each layer are a
     /// subset of the nodes of the previous layer, and graph neighborhoods in
     /// each layer represent approximate nearest neighbors within that layer.
-    pub layers: Vec<Layer<V>>,
+    pub layers: Vec<Layer>,
 
     /// The sequence number of the most recently applied `GraphMutation`. `0`
     /// means no mutation has been applied. Advanced by `insert_apply` on
@@ -76,7 +73,7 @@ pub struct GraphMem<V: Ref + Display + FromStr + Ord> {
     pub last_update_seq_no: u64,
 }
 
-impl Display for GraphMem<IrisVectorId> {
+impl Display for GraphMem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "GraphMem")?;
         let eps_str = self
@@ -93,7 +90,7 @@ impl Display for GraphMem<IrisVectorId> {
     }
 }
 
-impl Display for Layer<IrisVectorId> {
+impl Display for Layer {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut links = self
             .links
@@ -109,7 +106,7 @@ impl Display for Layer<IrisVectorId> {
     }
 }
 
-impl<V: Ref + Display + FromStr + Ord> Clone for GraphMem<V> {
+impl Clone for GraphMem {
     fn clone(&self) -> Self {
         GraphMem {
             entry_points: self.entry_points.clone(),
@@ -119,7 +116,7 @@ impl<V: Ref + Display + FromStr + Ord> Clone for GraphMem<V> {
     }
 }
 
-impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
+impl GraphMem {
     pub fn new() -> Self {
         GraphMem {
             entry_points: vec![],
@@ -138,7 +135,7 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
         Arc::new(RwLock::new(self))
     }
 
-    pub fn from_precomputed(entry_points: Vec<(V, usize)>, layers: Vec<Layer<V>>) -> Self {
+    pub fn from_precomputed(entry_points: Vec<(IrisVectorId, usize)>, layers: Vec<Layer>) -> Self {
         GraphMem {
             entry_points: entry_points
                 .into_iter()
@@ -152,7 +149,7 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
         }
     }
 
-    pub fn get_layers(&self) -> Vec<Layer<V>> {
+    pub fn get_layers(&self) -> Vec<Layer> {
         self.layers.clone()
     }
 
@@ -167,7 +164,7 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
     ///
     /// This is intended to be used in LinearScan mode while the entry_points
     /// list empty.
-    pub fn get_temporary_entry_point(&self) -> Option<(V, usize)> {
+    pub fn get_temporary_entry_point(&self) -> Option<(IrisVectorId, usize)> {
         self.layers
             .iter()
             .enumerate()
@@ -177,7 +174,7 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
 
     /// Gets the list of entry points.
     /// If this list is empty in LinearScan mode, `get_temporary_entry_point` may be used instead.
-    pub fn get_entry_points(&self) -> Option<Vec<V>> {
+    pub fn get_entry_points(&self) -> Option<Vec<IrisVectorId>> {
         let v: Vec<_> = self
             .entry_points
             .iter()
@@ -199,7 +196,7 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
     /// `self.last_update_seq_no`; otherwise the call returns `Err` without
     /// touching the graph. On success `self.last_update_seq_no` advances to
     /// `mutation.seq_no`.
-    pub fn insert_apply(&mut self, mutation: &GraphMutation<V>) -> Result<()> {
+    pub fn insert_apply(&mut self, mutation: &GraphMutation) -> Result<()> {
         if mutation.seq_no <= self.last_update_seq_no {
             return Err(eyre::eyre!(
                 "GraphMem::insert_apply: mutation seq_no {} is not strictly greater than \
@@ -386,7 +383,7 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
     /// that already carry a sequence number (replayed from a WAL or checkpoint)
     /// go through `insert_apply`/`insert_apply_all` instead, where the strict
     /// monotonicity check guards the externally-supplied `seq_no`.
-    pub fn apply_new(&mut self, mutation: UnstampedMutation<V>) -> Result<GraphMutation<V>> {
+    pub fn apply_new(&mut self, mutation: UnstampedMutation) -> Result<GraphMutation> {
         let stamped = GraphMutation {
             seq_no: self.next_sequence_number(),
             ops: mutation.ops,
@@ -395,34 +392,34 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
         Ok(stamped)
     }
 
-    pub fn insert_apply_all(&mut self, mutations: &[GraphMutation<V>]) -> Result<()> {
+    pub fn insert_apply_all(&mut self, mutations: &[GraphMutation]) -> Result<()> {
         for m in mutations {
             self.insert_apply(m)?;
         }
         Ok(())
     }
 
-    pub async fn get_first_entry_point(&self) -> Option<(V, usize)> {
+    pub async fn get_first_entry_point(&self) -> Option<(IrisVectorId, usize)> {
         self.entry_points
             .first()
             .map(|ep| (ep.point.clone(), ep.layer))
     }
 
-    pub async fn init_entry_points(&mut self, points: Vec<V>, layer: usize) {
+    pub async fn init_entry_points(&mut self, points: Vec<IrisVectorId>, layer: usize) {
         self.entry_points = points
             .into_iter()
             .map(|point| EntryPoint { point, layer })
             .collect()
     }
 
-    pub async fn add_entry_point(&mut self, point: V, layer: usize) {
+    pub async fn add_entry_point(&mut self, point: IrisVectorId, layer: usize) {
         if let Some(previous) = self.entry_points.first() {
             assert!(previous.layer == layer, "add_entry_point: layer mismatch");
         }
         self.entry_points.push(EntryPoint { point, layer });
     }
 
-    pub async fn set_unique_entry_point(&mut self, point: V, layer: usize) {
+    pub async fn set_unique_entry_point(&mut self, point: IrisVectorId, layer: usize) {
         if let Some(previous) = self.entry_points.first() {
             assert!(
                 previous.layer < layer,
@@ -437,13 +434,13 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
         self.entry_points = vec![EntryPoint { point, layer }];
     }
 
-    pub async fn get_links(&self, base: &V, lc: usize) -> &[V] {
+    pub async fn get_links(&self, base: &IrisVectorId, lc: usize) -> &[IrisVectorId] {
         let layer = &self.layers[lc];
         layer.get_links(base).unwrap_or(&[])
     }
 
     /// Set the neighbors of vertex `base` at layer `lc` to `links`.
-    pub async fn set_links(&mut self, base: V, links: Vec<V>, lc: usize) {
+    pub async fn set_links(&mut self, base: IrisVectorId, links: Vec<IrisVectorId>, lc: usize) {
         if self.layers.len() < lc + 1 {
             self.layers.resize(lc + 1, Layer::new());
         }
@@ -468,7 +465,7 @@ impl<V: Ref + Display + FromStr + Ord> GraphMem<V> {
     }
 }
 
-impl GraphMem<IrisVectorId> {
+impl GraphMem {
     /// Builds an idealized GraphMem, where all nearest-neighborhoods are exact.
     ///
     /// Layer 0 is built directly from a file (which generally is expensive to produce).
@@ -537,7 +534,7 @@ fn ideal_graph_from_vectors<K>(
     searcher: &HnswSearcher,
     prf_seed: [u8; 16],
     knn_proto: K,
-) -> Result<GraphMem<IrisVectorId>>
+) -> Result<GraphMem>
 where
     K: IdealKnn,
     K::Vector: Clone,
@@ -547,10 +544,6 @@ where
         for result in results.iter_mut() {
             result.truncate(searcher.params.get_M_max(0));
         }
-        let results = results
-            .into_par_iter()
-            .map(|result| result.map(IrisVectorId::from_serial_id))
-            .collect::<Vec<_>>();
         Layer::from_knn_results(results, vectors.len())
     };
 
@@ -604,11 +597,28 @@ where
         .into_iter()
         .enumerate()
         .map(|(i, layer_data)| {
-            Layer::ideal_from_data::<K>(
-                layer_data,
-                searcher.params.get_M_max(i + 1),
-                knn_proto.clone(),
-            )
+            let (vector_ids, vectors): (Vec<IrisVectorId>, Vec<K::Vector>) =
+                layer_data.into_iter().unzip();
+            let n = vectors.len();
+            let k = searcher.params.get_M_max(i + 1).min(n - 1);
+
+            let mut engine = NaiveKNN::<K>::init(knn_proto.clone(), vectors, k, 1);
+            let results = engine
+                .compute_chunk(n)
+                .into_iter()
+                .map(|result| {
+                    // remap from engine 1-based indices to original vector ids
+                    let node_idx = result.node.serial_id() as usize;
+                    let node = vector_ids[node_idx - 1];
+                    let neighbors: Vec<IrisVectorId> = result
+                        .neighbors
+                        .into_iter()
+                        .map(|neighbor_vid| vector_ids[(neighbor_vid.serial_id() as usize) - 1])
+                        .collect();
+                    KNNResult { node, neighbors }
+                })
+                .collect::<Vec<_>>();
+            Layer::from_knn_results(results, n)
         });
 
     Ok(GraphMem::from_precomputed(
@@ -618,23 +628,19 @@ where
 }
 
 #[derive(PartialEq, Eq, Default, Debug, Deserialize)]
-#[serde(bound = "V: Ref + Display + FromStr")]
-pub struct Layer<V: Ref + Display + FromStr + Ord> {
+pub struct Layer {
     /// Map a base vector to its neighbors.
-    pub links: HashMap<V, Vec<V>>,
+    pub links: HashMap<IrisVectorId, Vec<IrisVectorId>>,
     /// A checksum of the layer's links, used for state verification.
     /// This hash is updated whenever links are modified.
     set_hash: SetHash,
 }
 
-struct SortedLinks<'a, V: Ord> {
-    links: &'a HashMap<V, Vec<V>>,
+struct SortedLinks<'a> {
+    links: &'a HashMap<IrisVectorId, Vec<IrisVectorId>>,
 }
 
-impl<'a, V> Serialize for SortedLinks<'a, V>
-where
-    V: Serialize + Ord,
-{
+impl<'a> Serialize for SortedLinks<'a> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -650,10 +656,7 @@ where
     }
 }
 
-impl<V> Serialize for Layer<V>
-where
-    V: Ref + Display + FromStr + Ord + Serialize,
-{
+impl Serialize for Layer {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -665,7 +668,7 @@ where
     }
 }
 
-impl<V: Ref + Display + FromStr + Ord> Clone for Layer<V> {
+impl Clone for Layer {
     fn clone(&self) -> Self {
         Layer {
             links: self.links.clone(),
@@ -674,7 +677,7 @@ impl<V: Ref + Display + FromStr + Ord> Clone for Layer<V> {
     }
 }
 
-impl<V: Ref + Display + FromStr + Ord> Layer<V> {
+impl Layer {
     pub fn new() -> Self {
         Layer {
             links: HashMap::new(),
@@ -682,7 +685,7 @@ impl<V: Ref + Display + FromStr + Ord> Layer<V> {
         }
     }
 
-    pub fn get_links(&self, from: &V) -> Option<&[V]> {
+    pub fn get_links(&self, from: &IrisVectorId) -> Option<&[IrisVectorId]> {
         self.links.get(from).map(|v| v.as_slice())
     }
 
@@ -693,7 +696,7 @@ impl<V: Ref + Display + FromStr + Ord> Layer<V> {
         self.set_hash.checksum()
     }
 
-    pub fn insert_node(&mut self, id: &V, neighbors: Vec<V>) {
+    pub fn insert_node(&mut self, id: &IrisVectorId, neighbors: Vec<IrisVectorId>) {
         self.set_links(id.clone(), neighbors.clone());
     }
 
@@ -702,7 +705,7 @@ impl<V: Ref + Display + FromStr + Ord> Layer<V> {
     /// this layer are silently skipped (callers that need to log the missing
     /// case should check `get_links(target)` first). Idempotent: if `id` is
     /// already present in a target's list, that target is left unchanged.
-    pub fn link_node_to_neighbors(&mut self, node: &V, neighbors: Vec<V>) {
+    pub fn link_node_to_neighbors(&mut self, node: &IrisVectorId, neighbors: Vec<IrisVectorId>) {
         for target in &neighbors {
             if let Some(target_links) = self.links.get_mut(target) {
                 if let Err(pos) = target_links.binary_search(node) {
@@ -719,7 +722,7 @@ impl<V: Ref + Display + FromStr + Ord> Layer<V> {
     /// No-op if `id` is not present in this layer (callers that need to log
     /// the missing case should check `get_links(id)` first). Idempotent:
     /// existing entries are not duplicated.
-    pub fn link_neighbors_to_node(&mut self, node: &V, neighbors: Vec<V>) {
+    pub fn link_neighbors_to_node(&mut self, node: &IrisVectorId, neighbors: Vec<IrisVectorId>) {
         let Some(node_links) = self.links.get_mut(node) else {
             return;
         };
@@ -733,7 +736,7 @@ impl<V: Ref + Display + FromStr + Ord> Layer<V> {
     }
 
     /// Remove a node from the graph and clean up all backlinks from its neighbors.
-    pub fn remove_node(&mut self, id: &V) {
+    pub fn remove_node(&mut self, id: &IrisVectorId) {
         // Remove the node's links and get its neighbors
         if let Some(neighbors) = self.links.remove(id) {
             // Update set_hash for removed node
@@ -758,7 +761,11 @@ impl<V: Ref + Display + FromStr + Ord> Layer<V> {
     /// Remove `id` from each target's neighbor list, where `target` ranges over
     /// `to_remove`. Targets that don't exist in this layer are silently skipped
     /// (the caller's apply path is responsible for any logging).
-    pub fn unlink_node_from_neighbors(&mut self, node: &V, neighbors: Vec<V>) {
+    pub fn unlink_node_from_neighbors(
+        &mut self,
+        node: &IrisVectorId,
+        neighbors: Vec<IrisVectorId>,
+    ) {
         for target in &neighbors {
             if let Some(target_links) = self.links.get_mut(target) {
                 self.set_hash
@@ -773,7 +780,11 @@ impl<V: Ref + Display + FromStr + Ord> Layer<V> {
     /// if `id` is not present in this layer (callers that need to log the
     /// missing case should check `get_links(id)` first). The removal is
     /// unidirectional: the targets' own link lists are not modified.
-    pub fn unlink_neighbors_from_node(&mut self, node: &V, neighbors: Vec<V>) {
+    pub fn unlink_neighbors_from_node(
+        &mut self,
+        node: &IrisVectorId,
+        neighbors: Vec<IrisVectorId>,
+    ) {
         let Some(node_links) = self.links.get_mut(node) else {
             return;
         };
@@ -782,7 +793,7 @@ impl<V: Ref + Display + FromStr + Ord> Layer<V> {
         self.set_hash.add_unordered_set(node, node_links.iter());
     }
 
-    pub fn set_links(&mut self, from: V, links: Vec<V>) {
+    pub fn set_links(&mut self, from: IrisVectorId, links: Vec<IrisVectorId>) {
         use std::collections::hash_map::Entry;
         match self.links.entry(from) {
             Entry::Occupied(mut e) => {
@@ -799,11 +810,11 @@ impl<V: Ref + Display + FromStr + Ord> Layer<V> {
         }
     }
 
-    pub fn get_links_map(&self) -> &HashMap<V, Vec<V>> {
+    pub fn get_links_map(&self) -> &HashMap<IrisVectorId, Vec<IrisVectorId>> {
         &self.links
     }
 
-    fn from_knn_results(results: Vec<KNNResult<V>>, n: usize) -> Self {
+    fn from_knn_results(results: Vec<KNNResult>, n: usize) -> Self {
         let mut ret = Layer::new();
         for KNNResult { node, neighbors } in results.into_iter().take(n) {
             ret.set_links(node, neighbors);
@@ -811,19 +822,35 @@ impl<V: Ref + Display + FromStr + Ord> Layer<V> {
         ret
     }
 
-    /// Constructs a Layer from `(vector_ref, K::Vector)` pairs by brute-force
+    /// Constructs a Layer from `(vector_id, K::Vector)` pairs by brute-force
     /// top-k KNN using the supplied [`IdealKnn`] implementation.
-    pub fn ideal_from_data<K: IdealKnn>(data: Vec<(V, K::Vector)>, k: usize, knn: K) -> Self {
-        let (vector_refs, vectors): (Vec<V>, Vec<K::Vector>) = data.into_iter().unzip();
+    pub fn ideal_from_data<K: IdealKnn>(
+        data: Vec<(IrisVectorId, K::Vector)>,
+        k: usize,
+        knn: K,
+    ) -> Self {
+        let (vector_ids, vectors): (Vec<IrisVectorId>, Vec<K::Vector>) = data.into_iter().unzip();
         let n = vectors.len();
+        if n == 0 {
+            return Layer::new();
+        }
         let k = k.min(n - 1);
 
         let mut engine = NaiveKNN::<K>::init(knn, vectors, k, 1);
         let results = engine
             .compute_chunk(n)
             .into_iter()
-            // remap from engine 1-based indices to original vector ids
-            .map(|result| result.map(|i| vector_refs[(i - 1) as usize].clone()))
+            .map(|result| {
+                // remap from engine 1-based indices to original vector ids
+                let node_idx = result.node.serial_id() as usize;
+                let node = vector_ids[node_idx - 1];
+                let neighbors: Vec<IrisVectorId> = result
+                    .neighbors
+                    .into_iter()
+                    .map(|neighbor_vid| vector_ids[(neighbor_vid.serial_id() as usize) - 1])
+                    .collect();
+                KNNResult { node, neighbors }
+            })
             .collect::<Vec<_>>();
 
         Layer::from_knn_results(results, n)
@@ -832,7 +859,7 @@ impl<V: Ref + Display + FromStr + Ord> Layer<V> {
     /// Layer constructor for iris codes — kept for backward compatibility;
     /// delegates to [`Layer::ideal_from_data`].
     pub fn ideal_from_irises(
-        iris_data: Vec<(V, IrisCode)>,
+        iris_data: Vec<(IrisVectorId, IrisCode)>,
         k: usize,
         echoice: EngineChoice,
     ) -> Self {
@@ -854,7 +881,10 @@ impl<V: Ref + Display + FromStr + Ord> Layer<V> {
     /// Layer constructor for deep-ID Int4 vectors — kept for backward
     /// compatibility; delegates to [`Layer::ideal_from_data`].
     pub fn ideal_from_int4_vectors(
-        data: Vec<(V, crate::hawkers::plaintext_deep_id_store::Int4Vector)>,
+        data: Vec<(
+            IrisVectorId,
+            crate::hawkers::plaintext_deep_id_store::Int4Vector,
+        )>,
         k: usize,
         echoice: crate::hawkers::ideal_knn_engines::EngineChoiceInt4,
     ) -> Self {
@@ -875,11 +905,9 @@ impl<V: Ref + Display + FromStr + Ord> Layer<V> {
 /// vertices or distances is changed, but not the underlying values. For
 /// example:
 /// - vector ids are re-mapped to remove blank entries left by deletions
-pub fn migrate<U, V, VecMap>(graph: GraphMem<U>, vector_map: VecMap) -> GraphMem<V>
+pub fn migrate<VecMap>(graph: GraphMem, vector_map: VecMap) -> GraphMem
 where
-    U: Ref + Display + FromStr + Ord,
-    V: Ref + Display + FromStr + Ord,
-    VecMap: Fn(U) -> V + Copy,
+    VecMap: Fn(IrisVectorId) -> IrisVectorId + Copy,
 {
     let last_update_seq_no = graph.last_update_seq_no;
     let new_entry_point = graph
@@ -903,7 +931,7 @@ where
         })
         .collect();
 
-    GraphMem::<V> {
+    GraphMem {
         entry_points: new_entry_point,
         layers: new_layers,
         last_update_seq_no,
@@ -1033,7 +1061,7 @@ mod tests {
                 .await?;
         }
 
-        let different_graph_store: GraphMem<VectorId> = migrate(graph_store.clone(), |v| {
+        let different_graph_store: GraphMem = migrate(graph_store.clone(), |v| {
             VectorId::from_0_index(v.index() * 2)
         });
         assert_ne!(graph_store, different_graph_store);
@@ -1071,7 +1099,7 @@ mod tests {
         let searcher = HnswSearcher::new_with_test_parameters();
         let mut rng = AesRng::seed_from_u64(0_u64);
 
-        let mut point_ids_map: HashMap<VectorId, usize> = HashMap::new();
+        let mut point_ids_map: HashMap<IrisVectorId, IrisVectorId> = HashMap::new();
 
         for raw_query in IrisDB::new_random_rng(20, &mut rng).db {
             let query = Arc::new(raw_query);
@@ -1095,10 +1123,10 @@ mod tests {
                 )
                 .await?;
 
-            point_ids_map.insert(inserted, rng.next_u32() as usize);
+            point_ids_map.insert(inserted, IrisVectorId::from_serial_id(rng.next_u32()));
         }
 
-        let new_graph_store: GraphMem<usize> = migrate(graph_store.clone(), |v| point_ids_map[&v]);
+        let new_graph_store: GraphMem = migrate(graph_store.clone(), |v| point_ids_map[&v]);
 
         let (entry_point, layer) = graph_store.get_first_entry_point().await.unwrap();
         let (new_entry_point, new_layer) = new_graph_store.get_first_entry_point().await.unwrap();
@@ -1119,8 +1147,8 @@ mod tests {
                 reason = "Iteration is for assertions against a parallel data structure, compared entry by entry."
             )]
             for (point_id, queue) in links.iter() {
-                let new_point_id = &point_ids_map[point_id];
-                let new_queue_vec = new_links[new_point_id].to_vec();
+                let new_point_id = point_ids_map[point_id];
+                let new_queue_vec = new_links[&new_point_id].to_vec();
                 for (neighbor_id, new_neighbor_id) in queue.iter().zip(new_queue_vec) {
                     assert_eq!(point_ids_map[neighbor_id], new_neighbor_id);
                 }
@@ -1134,7 +1162,7 @@ mod tests {
 
     #[test]
     fn add_edges_outgoing_writes_only_to_id_list() {
-        let mut graph = GraphMem::<IrisVectorId>::new();
+        let mut graph = GraphMem::new();
         let a = IrisVectorId::from_serial_id(1);
         let b = IrisVectorId::from_serial_id(2);
         let c = IrisVectorId::from_serial_id(3);
@@ -1185,7 +1213,7 @@ mod tests {
 
     #[test]
     fn add_edges_incoming_writes_only_to_target_lists() {
-        let mut graph = GraphMem::<IrisVectorId>::new();
+        let mut graph = GraphMem::new();
         let a = IrisVectorId::from_serial_id(1);
         let b = IrisVectorId::from_serial_id(2);
         let c = IrisVectorId::from_serial_id(3);
@@ -1232,7 +1260,7 @@ mod tests {
 
     #[test]
     fn add_edges_bidirectional_writes_both_sides() {
-        let mut graph = GraphMem::<IrisVectorId>::new();
+        let mut graph = GraphMem::new();
         let a = IrisVectorId::from_serial_id(1);
         let b = IrisVectorId::from_serial_id(2);
         let c = IrisVectorId::from_serial_id(3);
@@ -1276,7 +1304,7 @@ mod tests {
 
     #[test]
     fn remove_edges_outgoing_only_modifies_id_list() {
-        let mut graph = GraphMem::<IrisVectorId>::new();
+        let mut graph = GraphMem::new();
         let a = IrisVectorId::from_serial_id(1);
         let b = IrisVectorId::from_serial_id(2);
         let c = IrisVectorId::from_serial_id(3);
@@ -1340,7 +1368,7 @@ mod tests {
     fn two_phase_apply_edges_before_node_in_vec_still_works() {
         // Pass 1 should apply AddNode before pass 2 applies AddEdges, regardless
         // of their order in the input Vec.
-        let mut graph = GraphMem::<IrisVectorId>::new();
+        let mut graph = GraphMem::new();
         let a = IrisVectorId::from_serial_id(1);
         let b = IrisVectorId::from_serial_id(2);
         graph
@@ -1377,7 +1405,7 @@ mod tests {
     fn next_seq_no_is_one_past_last_and_does_not_mutate() {
         use crate::hnsw::GraphMem;
         use iris_mpc_common::IrisVectorId;
-        let mut graph = GraphMem::<IrisVectorId>::new();
+        let mut graph = GraphMem::new();
         assert_eq!(graph.last_update_seq_no, 0);
         assert_eq!(graph.next_sequence_number(), 1);
         assert_eq!(graph.next_sequence_number(), 1, "peek must not mutate");
@@ -1388,9 +1416,9 @@ mod tests {
 
     #[test]
     fn insert_apply_advances_last_update_seq_no_on_success() {
-        let mut graph = GraphMem::<IrisVectorId>::new();
+        let mut graph = GraphMem::new();
         let a = IrisVectorId::from_serial_id(1);
-        let mutation = GraphMutation::<IrisVectorId> {
+        let mutation = GraphMutation {
             seq_no: 1,
             ops: vec![MutationOp::AddNode {
                 id: a,
@@ -1406,9 +1434,9 @@ mod tests {
 
     #[test]
     fn insert_apply_rejects_seq_no_equal_to_last_update_seq_no() {
-        let mut graph = GraphMem::<IrisVectorId>::new();
+        let mut graph = GraphMem::new();
         graph.last_update_seq_no = 5;
-        let mutation = GraphMutation::<IrisVectorId> {
+        let mutation = GraphMutation {
             seq_no: 5,
             ops: vec![MutationOp::AddNode {
                 id: IrisVectorId::from_serial_id(1),
@@ -1427,9 +1455,9 @@ mod tests {
 
     #[test]
     fn insert_apply_rejects_seq_no_below_last_update_seq_no() {
-        let mut graph = GraphMem::<IrisVectorId>::new();
+        let mut graph = GraphMem::new();
         graph.last_update_seq_no = 10;
-        let mutation = GraphMutation::<IrisVectorId> {
+        let mutation = GraphMutation {
             seq_no: 9,
             ops: vec![MutationOp::AddNode {
                 id: IrisVectorId::from_serial_id(1),
@@ -1444,11 +1472,11 @@ mod tests {
 
     #[test]
     fn insert_apply_all_short_circuits_on_first_violation() {
-        let mut graph = GraphMem::<IrisVectorId>::new();
+        let mut graph = GraphMem::new();
         let a = IrisVectorId::from_serial_id(1);
         let b = IrisVectorId::from_serial_id(2);
         let mutations = vec![
-            GraphMutation::<IrisVectorId> {
+            GraphMutation {
                 seq_no: 1,
                 ops: vec![MutationOp::AddNode {
                     id: a,
@@ -1457,7 +1485,7 @@ mod tests {
                 }],
             },
             // Equal seq_no — should fail.
-            GraphMutation::<IrisVectorId> {
+            GraphMutation {
                 seq_no: 1,
                 ops: vec![MutationOp::AddNode {
                     id: b,

--- a/iris-mpc-cpu/src/hnsw/graph/mutation.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/mutation.rs
@@ -1,9 +1,10 @@
+use iris_mpc_common::IrisVectorId;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct GraphMutation<V: Ord> {
+pub struct GraphMutation {
     pub seq_no: u64,
-    pub ops: Vec<MutationOp<V>>,
+    pub ops: Vec<MutationOp>,
 }
 
 /// A graph mutation that has not yet been assigned a sequence number.
@@ -15,8 +16,8 @@ pub struct GraphMutation<V: Ord> {
 /// number can never be minted in-process without immediately advancing the
 /// graph.
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
-pub struct UnstampedMutation<V: Ord> {
-    pub ops: Vec<MutationOp<V>>,
+pub struct UnstampedMutation {
+    pub ops: Vec<MutationOp>,
 }
 
 // NOTE: if a new version of any mutation is needed (ex: InsertNodeV2) such that
@@ -29,32 +30,32 @@ pub struct UnstampedMutation<V: Ord> {
 //
 /// Represents a diff to apply to an existing graph.
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum MutationOp<Vector: Ord> {
+pub enum MutationOp {
     AddNode {
-        id: Vector,
+        id: IrisVectorId,
         /// Number of real graph layers this node is included in. The node will
         /// be present in layers `0..height`.
         height: usize,
         update_ep: UpdateEntryPoint,
     },
     RemoveNode {
-        id: Vector,
+        id: IrisVectorId,
     },
     AddEdges {
-        base: Vector,
-        neighbors: Vec<Vector>,
+        base: IrisVectorId,
+        neighbors: Vec<IrisVectorId>,
         layer: usize,
         edge_type: EdgeType,
     },
     RemoveEdges {
-        base: Vector,
-        neighbors: Vec<Vector>,
+        base: IrisVectorId,
+        neighbors: Vec<IrisVectorId>,
         layer: usize,
         edge_type: EdgeType,
     },
 }
 
-impl<V: std::fmt::Debug + Ord> std::fmt::Debug for MutationOp<V> {
+impl std::fmt::Debug for MutationOp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::RemoveNode { id } => f.debug_struct("RemoveNode").field("id", id).finish(),
@@ -94,13 +95,13 @@ impl<V: std::fmt::Debug + Ord> std::fmt::Debug for MutationOp<V> {
     }
 }
 
-impl<V: Clone + Ord> UnstampedMutation<V> {
+impl UnstampedMutation {
     /// Subset of `updated_neighborhoods` restricted to neighborhoods that
     /// may have *grown* — i.e. those affected by `AddEdges` ops in this
     /// mutation. Used as the candidate set for batch compaction. The
     /// returned Vec is the raw walk and may contain duplicates; callers
     /// fold into a set to dedup.
-    pub fn expanded_neighborhoods(&self) -> Vec<(V, usize)> {
+    pub fn expanded_neighborhoods(&self) -> Vec<(IrisVectorId, usize)> {
         let mut out = Vec::new();
         for op in &self.ops {
             if let MutationOp::AddEdges {
@@ -128,7 +129,7 @@ impl<V: Clone + Ord> UnstampedMutation<V> {
     /// edge set was modified is a candidate for stale-reference cleanup.
     /// The returned Vec is the raw walk and may contain duplicates; callers
     /// fold into a set to dedup.
-    pub fn updated_neighborhoods(&self) -> Vec<(V, usize)> {
+    pub fn updated_neighborhoods(&self) -> Vec<(IrisVectorId, usize)> {
         let mut out = Vec::new();
         for op in &self.ops {
             match op {
@@ -195,6 +196,11 @@ pub enum UpdateEntryPoint {
 #[cfg(test)]
 mod tests {
     use crate::hnsw::graph::layered_graph::Layer;
+    use iris_mpc_common::IrisVectorId;
+
+    fn vid(n: u32) -> IrisVectorId {
+        IrisVectorId::from_serial_id(n)
+    }
 
     // ── InsertNode ────────────────────────────────────────────────────────────
 
@@ -202,17 +208,20 @@ mod tests {
     #[test]
     fn insert_node_sets_exact_links() {
         let mut layer = Layer::new();
-        layer.insert_node(&1i32, vec![2, 3, 4]);
-        assert_eq!(layer.get_links(&1), Some([2, 3, 4].as_slice()));
+        layer.insert_node(&vid(1), vec![vid(2), vid(3), vid(4)]);
+        assert_eq!(
+            layer.get_links(&vid(1)),
+            Some([vid(2), vid(3), vid(4)].as_slice())
+        );
     }
 
     /// A second InsertNode on the same id replaces the link list entirely.
     #[test]
     fn insert_node_replaces_existing_links() {
         let mut layer = Layer::new();
-        layer.insert_node(&1i32, vec![2, 3]);
-        layer.insert_node(&1i32, vec![4, 5]);
-        assert_eq!(layer.get_links(&1), Some([4, 5].as_slice()));
+        layer.insert_node(&vid(1), vec![vid(2), vid(3)]);
+        layer.insert_node(&vid(1), vec![vid(4), vid(5)]);
+        assert_eq!(layer.get_links(&vid(1)), Some([vid(4), vid(5)].as_slice()));
     }
 
     // ── AddNeighbors ─────────────────────────────────────────────────────────
@@ -221,11 +230,11 @@ mod tests {
     #[test]
     fn add_neighbors_inserts_id_into_existing_nodes() {
         let mut layer = Layer::new();
-        layer.insert_node(&10i32, vec![]);
-        layer.insert_node(&20i32, vec![]);
-        layer.link_node_to_neighbors(&5, vec![10, 20]);
-        assert_eq!(layer.get_links(&10), Some([5].as_slice()));
-        assert_eq!(layer.get_links(&20), Some([5].as_slice()));
+        layer.insert_node(&vid(10), vec![]);
+        layer.insert_node(&vid(20), vec![]);
+        layer.link_node_to_neighbors(&vid(5), vec![vid(10), vid(20)]);
+        assert_eq!(layer.get_links(&vid(10)), Some([vid(5)].as_slice()));
+        assert_eq!(layer.get_links(&vid(20)), Some([vid(5)].as_slice()));
     }
 
     /// Repeated calls with the same id are idempotent — no duplicate links.
@@ -233,10 +242,10 @@ mod tests {
     #[test]
     fn add_neighbors_is_idempotent() {
         let mut layer = Layer::new();
-        layer.insert_node(&10i32, vec![]);
-        layer.link_node_to_neighbors(&5, vec![10]);
-        layer.link_node_to_neighbors(&5, vec![10]);
-        assert_eq!(layer.get_links(&10), Some([5].as_slice()));
+        layer.insert_node(&vid(10), vec![]);
+        layer.link_node_to_neighbors(&vid(5), vec![vid(10)]);
+        layer.link_node_to_neighbors(&vid(5), vec![vid(10)]);
+        assert_eq!(layer.get_links(&vid(10)), Some([vid(5)].as_slice()));
     }
 
     /// Links remain sorted after multiple add_neighbor calls in arbitrary order.
@@ -245,11 +254,14 @@ mod tests {
     #[test]
     fn add_neighbors_maintains_sorted_order() {
         let mut layer = Layer::new();
-        layer.insert_node(&10i32, vec![]);
-        layer.link_node_to_neighbors(&7, vec![10]);
-        layer.link_node_to_neighbors(&3, vec![10]);
-        layer.link_node_to_neighbors(&5, vec![10]);
-        assert_eq!(layer.get_links(&10), Some([3, 5, 7].as_slice()));
+        layer.insert_node(&vid(10), vec![]);
+        layer.link_node_to_neighbors(&vid(7), vec![vid(10)]);
+        layer.link_node_to_neighbors(&vid(3), vec![vid(10)]);
+        layer.link_node_to_neighbors(&vid(5), vec![vid(10)]);
+        assert_eq!(
+            layer.get_links(&vid(10)),
+            Some([vid(3), vid(5), vid(7)].as_slice())
+        );
     }
 
     /// add_neighbor silently skips neighborhood nodes that don't exist.
@@ -257,8 +269,8 @@ mod tests {
     #[test]
     fn add_neighbors_skips_nonexistent_nodes() {
         let mut layer = Layer::new();
-        layer.link_node_to_neighbors(&1i32, vec![99]); // node 99 was never inserted
-        assert!(layer.get_links(&99).is_none());
+        layer.link_node_to_neighbors(&vid(1), vec![vid(99)]); // node 99 was never inserted
+        assert!(layer.get_links(&vid(99)).is_none());
     }
 
     // ── RemoveNeighbors ───────────────────────────────────────────────────────
@@ -267,9 +279,9 @@ mod tests {
     #[test]
     fn remove_neighbors_removes_specified_only() {
         let mut layer = Layer::new();
-        layer.insert_node(&1i32, vec![2, 3, 4, 5]);
-        layer.unlink_neighbors_from_node(&1, vec![2, 4]);
-        assert_eq!(layer.get_links(&1), Some([3, 5].as_slice()));
+        layer.insert_node(&vid(1), vec![vid(2), vid(3), vid(4), vid(5)]);
+        layer.unlink_neighbors_from_node(&vid(1), vec![vid(2), vid(4)]);
+        assert_eq!(layer.get_links(&vid(1)), Some([vid(3), vid(5)].as_slice()));
     }
 
     /// Removal is unidirectional: only the target node's list is modified.
@@ -278,18 +290,18 @@ mod tests {
     #[test]
     fn remove_neighbors_is_unidirectional() {
         let mut layer = Layer::new();
-        layer.insert_node(&1i32, vec![2, 3]);
-        layer.insert_node(&2i32, vec![1, 3]);
-        layer.unlink_neighbors_from_node(&1, vec![2]);
-        assert_eq!(layer.get_links(&1), Some([3].as_slice()));
-        assert_eq!(layer.get_links(&2), Some([1, 3].as_slice()));
+        layer.insert_node(&vid(1), vec![vid(2), vid(3)]);
+        layer.insert_node(&vid(2), vec![vid(1), vid(3)]);
+        layer.unlink_neighbors_from_node(&vid(1), vec![vid(2)]);
+        assert_eq!(layer.get_links(&vid(1)), Some([vid(3)].as_slice()));
+        assert_eq!(layer.get_links(&vid(2)), Some([vid(1), vid(3)].as_slice()));
     }
 
     /// remove_neighbors on a node that doesn't exist is a no-op, not a panic.
     #[test]
     fn remove_neighbors_on_nonexistent_node_is_noop() {
         let mut layer = Layer::new();
-        layer.unlink_neighbors_from_node(&99i32, vec![1, 2]); // should not panic
+        layer.unlink_neighbors_from_node(&vid(99), vec![vid(1), vid(2)]); // should not panic
     }
 
     // ── WAL replay sequences ──────────────────────────────────────────────────
@@ -301,20 +313,29 @@ mod tests {
     #[test]
     fn wal_replay_insert_then_backlinks() {
         let mut layer = Layer::new();
-        layer.insert_node(&10i32, vec![20, 30]);
-        layer.insert_node(&20i32, vec![10, 30]);
-        layer.insert_node(&30i32, vec![10, 20]);
+        layer.insert_node(&vid(10), vec![vid(20), vid(30)]);
+        layer.insert_node(&vid(20), vec![vid(10), vid(30)]);
+        layer.insert_node(&vid(30), vec![vid(10), vid(20)]);
 
         // New node 40 inserted with forward links to 10 and 20
-        layer.insert_node(&40, vec![10, 20]);
+        layer.insert_node(&vid(40), vec![vid(10), vid(20)]);
         // Backlinks: 10 and 20 each gain 40 as a neighbor
-        layer.link_node_to_neighbors(&40, vec![10, 20]);
+        layer.link_node_to_neighbors(&vid(40), vec![vid(10), vid(20)]);
 
-        assert_eq!(layer.get_links(&40), Some([10, 20].as_slice()));
-        assert_eq!(layer.get_links(&10).unwrap(), &[20, 30, 40]);
-        assert_eq!(layer.get_links(&20).unwrap(), &[10, 30, 40]);
+        assert_eq!(
+            layer.get_links(&vid(40)),
+            Some([vid(10), vid(20)].as_slice())
+        );
+        assert_eq!(
+            layer.get_links(&vid(10)).unwrap(),
+            &[vid(20), vid(30), vid(40)]
+        );
+        assert_eq!(
+            layer.get_links(&vid(20)).unwrap(),
+            &[vid(10), vid(30), vid(40)]
+        );
         // 30 was not in the backlink set — untouched
-        assert_eq!(layer.get_links(&30).unwrap(), &[10, 20]);
+        assert_eq!(layer.get_links(&vid(30)).unwrap(), &[vid(10), vid(20)]);
     }
 
     /// Replays a full mutation group: insert + backlinks + compaction (RemoveNeighbors).
@@ -322,37 +343,41 @@ mod tests {
     #[test]
     fn wal_replay_insert_backlinks_then_compact() {
         let mut layer = Layer::new();
-        layer.insert_node(&1i32, vec![2, 3]);
-        layer.insert_node(&2i32, vec![1, 3]);
-        layer.insert_node(&3i32, vec![1, 2]);
+        layer.insert_node(&vid(1), vec![vid(2), vid(3)]);
+        layer.insert_node(&vid(2), vec![vid(1), vid(3)]);
+        layer.insert_node(&vid(3), vec![vid(1), vid(2)]);
 
         // Insert node 4 with forward links [1, 2]
-        layer.insert_node(&4, vec![1, 2]);
+        layer.insert_node(&vid(4), vec![vid(1), vid(2)]);
         // Backlinks into 1 and 2
-        layer.link_node_to_neighbors(&4, vec![1, 2]);
+        layer.link_node_to_neighbors(&vid(4), vec![vid(1), vid(2)]);
         // Compaction: node 2 now exceeds link limit, prune neighbor 3
-        layer.unlink_neighbors_from_node(&2, vec![3]);
+        layer.unlink_neighbors_from_node(&vid(2), vec![vid(3)]);
 
-        assert_eq!(layer.get_links(&4), Some([1, 2].as_slice()));
-        assert_eq!(layer.get_links(&1).unwrap(), &[2, 3, 4]);
-        assert_eq!(layer.get_links(&2).unwrap(), &[1, 4]);
+        assert_eq!(layer.get_links(&vid(4)), Some([vid(1), vid(2)].as_slice()));
+        assert_eq!(layer.get_links(&vid(1)).unwrap(), &[vid(2), vid(3), vid(4)]);
+        assert_eq!(layer.get_links(&vid(2)).unwrap(), &[vid(1), vid(4)]);
         // unidirectional pruning — 3 still links back to 2
-        assert_eq!(layer.get_links(&3).unwrap(), &[1, 2]);
+        assert_eq!(layer.get_links(&vid(3)).unwrap(), &[vid(1), vid(2)]);
     }
 
     // ── expanded_neighborhoods ────────────────────────────────────────────────
 
     use super::{EdgeType, MutationOp, UnstampedMutation, UpdateEntryPoint};
 
+    fn mk_vector_id(id: u32) -> IrisVectorId {
+        IrisVectorId::from_serial_id(id)
+    }
+
     fn mk_add_edges(
-        base: i32,
-        neighbors: Vec<i32>,
+        base: u32,
+        neighbors: Vec<u32>,
         layer: usize,
         edge_type: EdgeType,
-    ) -> MutationOp<i32> {
+    ) -> MutationOp {
         MutationOp::AddEdges {
-            base,
-            neighbors,
+            base: mk_vector_id(base),
+            neighbors: neighbors.into_iter().map(mk_vector_id).collect(),
             layer,
             edge_type,
         }
@@ -365,7 +390,14 @@ mod tests {
         };
         let mut got = mutation.expanded_neighborhoods();
         got.sort();
-        assert_eq!(got, vec![(1, 0), (2, 0), (3, 0)]);
+        assert_eq!(
+            got,
+            vec![
+                (mk_vector_id(1), 0),
+                (mk_vector_id(2), 0),
+                (mk_vector_id(3), 0)
+            ]
+        );
     }
 
     #[test]
@@ -373,7 +405,10 @@ mod tests {
         let mutation = UnstampedMutation {
             ops: vec![mk_add_edges(1, vec![2, 3], 1, EdgeType::Base)],
         };
-        assert_eq!(mutation.expanded_neighborhoods(), vec![(1, 1)]);
+        assert_eq!(
+            mutation.expanded_neighborhoods(),
+            vec![(mk_vector_id(1), 1)]
+        );
     }
 
     #[test]
@@ -383,7 +418,7 @@ mod tests {
         };
         let mut got = mutation.expanded_neighborhoods();
         got.sort();
-        assert_eq!(got, vec![(2, 2), (3, 2)]);
+        assert_eq!(got, vec![(mk_vector_id(2), 2), (mk_vector_id(3), 2)]);
     }
 
     #[test]
@@ -391,14 +426,16 @@ mod tests {
         let mutation = UnstampedMutation {
             ops: vec![
                 MutationOp::AddNode {
-                    id: 1,
+                    id: mk_vector_id(1),
                     height: 1,
                     update_ep: UpdateEntryPoint::False,
                 },
-                MutationOp::RemoveNode { id: 2 },
+                MutationOp::RemoveNode {
+                    id: mk_vector_id(2),
+                },
                 MutationOp::RemoveEdges {
-                    base: 3,
-                    neighbors: vec![4, 5],
+                    base: mk_vector_id(3),
+                    neighbors: vec![mk_vector_id(4), mk_vector_id(5)],
                     layer: 0,
                     edge_type: EdgeType::All,
                 },
@@ -407,7 +444,7 @@ mod tests {
         };
         let mut got = mutation.expanded_neighborhoods();
         got.sort();
-        assert_eq!(got, vec![(6, 0), (7, 0)]);
+        assert_eq!(got, vec![(mk_vector_id(6), 0), (mk_vector_id(7), 0)]);
     }
 
     // ── updated_neighborhoods ─────────────────────────────────────────────────
@@ -417,14 +454,14 @@ mod tests {
         let mutation = UnstampedMutation {
             ops: vec![
                 MutationOp::RemoveEdges {
-                    base: 1,
-                    neighbors: vec![2, 3],
+                    base: mk_vector_id(1),
+                    neighbors: vec![mk_vector_id(2), mk_vector_id(3)],
                     layer: 0,
                     edge_type: EdgeType::All,
                 },
                 MutationOp::AddEdges {
-                    base: 10,
-                    neighbors: vec![11],
+                    base: mk_vector_id(10),
+                    neighbors: vec![mk_vector_id(11)],
                     layer: 1,
                     edge_type: EdgeType::Base,
                 },
@@ -432,7 +469,15 @@ mod tests {
         };
         let mut got = mutation.updated_neighborhoods();
         got.sort();
-        assert_eq!(got, vec![(1, 0), (2, 0), (3, 0), (10, 1)]);
+        assert_eq!(
+            got,
+            vec![
+                (mk_vector_id(1), 0),
+                (mk_vector_id(2), 0),
+                (mk_vector_id(3), 0),
+                (mk_vector_id(10), 1)
+            ]
+        );
     }
 
     #[test]
@@ -440,14 +485,14 @@ mod tests {
         let mutation = UnstampedMutation {
             ops: vec![
                 MutationOp::RemoveEdges {
-                    base: 1,
-                    neighbors: vec![2, 3],
+                    base: mk_vector_id(1),
+                    neighbors: vec![mk_vector_id(2), mk_vector_id(3)],
                     layer: 0,
                     edge_type: EdgeType::Base,
                 },
                 MutationOp::RemoveEdges {
-                    base: 5,
-                    neighbors: vec![6, 7],
+                    base: mk_vector_id(5),
+                    neighbors: vec![mk_vector_id(6), mk_vector_id(7)],
                     layer: 0,
                     edge_type: EdgeType::Neighbors,
                 },
@@ -455,7 +500,14 @@ mod tests {
         };
         let mut got = mutation.updated_neighborhoods();
         got.sort();
-        assert_eq!(got, vec![(1, 0), (6, 0), (7, 0)]);
+        assert_eq!(
+            got,
+            vec![
+                (mk_vector_id(1), 0),
+                (mk_vector_id(6), 0),
+                (mk_vector_id(7), 0)
+            ]
+        );
     }
 
     #[test]
@@ -463,11 +515,13 @@ mod tests {
         let mutation = UnstampedMutation {
             ops: vec![
                 MutationOp::AddNode {
-                    id: 1,
+                    id: mk_vector_id(1),
                     height: 1,
                     update_ep: UpdateEntryPoint::False,
                 },
-                MutationOp::RemoveNode { id: 2 },
+                MutationOp::RemoveNode {
+                    id: mk_vector_id(2),
+                },
             ],
         };
         assert!(mutation.updated_neighborhoods().is_empty());

--- a/iris-mpc-cpu/src/hnsw/graph/mutation.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/mutation.rs
@@ -112,11 +112,11 @@ impl UnstampedMutation {
             } = op
             {
                 if matches!(edge_type, EdgeType::Base | EdgeType::All) {
-                    out.push((base.clone(), *layer));
+                    out.push((*base, *layer));
                 }
                 if matches!(edge_type, EdgeType::Neighbors | EdgeType::All) {
                     for n in neighbors {
-                        out.push((n.clone(), *layer));
+                        out.push((*n, *layer));
                     }
                 }
             }
@@ -146,11 +146,11 @@ impl UnstampedMutation {
                     edge_type,
                 } => {
                     if matches!(edge_type, EdgeType::Base | EdgeType::All) {
-                        out.push((base.clone(), *layer));
+                        out.push((*base, *layer));
                     }
                     if matches!(edge_type, EdgeType::Neighbors | EdgeType::All) {
                         for n in neighbors {
-                            out.push((n.clone(), *layer));
+                            out.push((*n, *layer));
                         }
                     }
                 }

--- a/iris-mpc-cpu/src/hnsw/graph/neighborhood.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/neighborhood.rs
@@ -156,7 +156,7 @@ impl<V: VectorStore> SortedNeighborhood<V> {
     }
 
     /// Appends `vals` to the neighborhood, applies quicksort and truncates to length `k`.
-    /// Expected bandwitdh: loglinear in `|self.edges| + |vals|`, but `|vals| log |self.edges|` for small `|vals|`.
+    /// Expected bandwidth: loglinear in `|self.edges| + |vals|`, but `|vals| log |self.edges|` for small `|vals|`.
     /// Expected rounds: logarithmic in `|self.edges| + |vals|`.
     /// Consult quicksort implementation for details on performance.
     pub async fn insert_batch_and_trim(

--- a/iris-mpc-cpu/src/hnsw/graph/neighborhood.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/neighborhood.rs
@@ -5,80 +5,15 @@
 
 use crate::hnsw::{
     sorting::{
-        batcher::partial_batcher_network, quickselect::run_quickselect_with_store,
-        quicksort::apply_quicksort, swap_network::apply_swap_network,
+        batcher::partial_batcher_network, quicksort::apply_quicksort,
+        swap_network::apply_swap_network,
     },
     VectorStore,
 };
-use delegate::delegate;
 use eyre::Result;
 use iris_mpc_common::vector_id::VectorId;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
-
-/// Trait that captures the requirements for an HNSW candidate list container/data-structure.
-/// Implementers should ensure the following post-condition for calls to `trim` methods:
-/// - The elements in the container are the smallest `container.length` ones among all insertions.
-/// - The last element in the container is the largest one.
-#[allow(async_fn_in_trait)]
-pub trait Neighborhood<V: VectorStore>:
-    Send + Sync + Clone + AsRef<[(VectorId, V::DistanceRef)]> + Into<WrappedNeighborhood<V>>
-{
-    fn new() -> Self;
-
-    fn len(&self) -> usize {
-        self.as_ref().len()
-    }
-
-    fn is_empty(&self) -> bool {
-        self.as_ref().is_empty()
-    }
-
-    fn from_singleton(element: (VectorId, V::DistanceRef)) -> Self;
-
-    fn edge_ids(&self) -> Vec<VectorId> {
-        self.as_ref().iter().map(|(v, _)| *v).collect::<Vec<_>>()
-    }
-
-    /// Inserts a batch of elements into the neighborhood and applies the necessary
-    /// changes to ensure the neighborhood invariant holds
-    /// Note that in general maintaining the invariant may incur significant overhead.
-    /// Consult implementer for performance specs
-    async fn insert_batch_and_trim(
-        &mut self,
-        store: &mut V,
-        vals: &[(VectorId, V::DistanceRef)],
-        k: usize,
-    ) -> Result<()>;
-
-    /// Apply the invariant-maintaining algorithm
-    /// Note that in general maintaining the invariant may incur significant overhead.
-    /// Consult implementer for performance specs.
-    async fn trim(&mut self, store: &mut V, k: usize) -> Result<()> {
-        self.insert_batch_and_trim(store, &[], k).await
-    }
-
-    /// Inserts a single element into the neighborhood.
-    /// By default calls batched version with size 1.
-    /// Note that in general maintaining the invariant may incur significant overhead.
-    /// Consult implementer for performance specs.
-    async fn insert_and_trim(
-        &mut self,
-        store: &mut V,
-        to: VectorId,
-        dist: V::DistanceRef,
-        k: usize,
-    ) -> Result<()> {
-        self.insert_batch_and_trim(store, &[(to, dist)], k).await
-    }
-
-    /// Returns matching records in the neighborhood.
-    /// No specific order should be assumed.
-    async fn matches(&self, store: &mut V) -> Result<Vec<(VectorId, V::DistanceRef)>>;
-
-    /// Returns the node with maximum distance in the neighborhood
-    fn get_furthest(&self) -> Option<&(VectorId, V::DistanceRef)>;
-}
 
 /// SortedNeighborhood maintains a collection of distance-weighted oriented
 /// graph edges for an HNSW graph which are stored in increasing order of edge
@@ -178,29 +113,53 @@ impl<V: VectorStore> AsRef<[(VectorId, V::DistanceRef)]> for SortedNeighborhood<
     }
 }
 
-#[allow(async_fn_in_trait)]
-impl<V: VectorStore> Neighborhood<V> for SortedNeighborhood<V> {
-    /// Insert the element `to` with distance `dist` into the list, maintaining
-    /// the ascending order.
-    ///
-    /// Calls the `VectorStore` to find the insertion index.
-    fn new() -> Self {
+impl<V: VectorStore> SortedNeighborhood<V> {
+    pub fn new() -> Self {
         Self {
             edges: Default::default(),
         }
     }
 
-    fn from_singleton(element: (VectorId, V::DistanceRef)) -> Self {
+    pub fn len(&self) -> usize {
+        self.edges.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.edges.is_empty()
+    }
+
+    pub fn from_singleton(element: (VectorId, V::DistanceRef)) -> Self {
         SortedNeighborhood {
             edges: vec![element],
         }
+    }
+
+    pub fn edge_ids(&self) -> Vec<VectorId> {
+        self.edges.iter().map(|(v, _)| *v).collect::<Vec<_>>()
+    }
+
+    /// Apply the invariant-maintaining algorithm so the elements are the
+    /// smallest `k` ones among all insertions, with the last element largest.
+    pub async fn trim(&mut self, store: &mut V, k: usize) -> Result<()> {
+        self.insert_batch_and_trim(store, &[], k).await
+    }
+
+    /// Inserts a single element into the neighborhood and trims to length `k`.
+    pub async fn insert_and_trim(
+        &mut self,
+        store: &mut V,
+        to: VectorId,
+        dist: V::DistanceRef,
+        k: usize,
+    ) -> Result<()> {
+        self.insert_batch_and_trim(store, &[(to, dist)], k).await
     }
 
     /// Appends `vals` to the neighborhood, applies quicksort and truncates to length `k`.
     /// Expected bandwitdh: loglinear in `|self.edges| + |vals|`, but `|vals| log |self.edges|` for small `|vals|`.
     /// Expected rounds: logarithmic in `|self.edges| + |vals|`.
     /// Consult quicksort implementation for details on performance.
-    async fn insert_batch_and_trim(
+    pub async fn insert_batch_and_trim(
         &mut self,
         store: &mut V,
         vals: &[(VectorId, V::DistanceRef)],
@@ -220,12 +179,12 @@ impl<V: VectorStore> Neighborhood<V> for SortedNeighborhood<V> {
         Ok(())
     }
 
-    fn get_furthest(&self) -> Option<&(VectorId, V::DistanceRef)> {
+    pub fn get_furthest(&self) -> Option<&(VectorId, V::DistanceRef)> {
         self.edges.last()
     }
     /// Count the neighbors that match according to `store.is_match`.
     /// The nearest `count` elements are matches and the rest are non-matches.
-    async fn matches(&self, store: &mut V) -> Result<Vec<(VectorId, V::DistanceRef)>> {
+    pub async fn matches(&self, store: &mut V) -> Result<Vec<(VectorId, V::DistanceRef)>> {
         let mut left = 0;
         let mut right = self.edges.len();
 
@@ -243,161 +202,6 @@ impl<V: VectorStore> Neighborhood<V> for SortedNeighborhood<V> {
     }
 }
 
-pub struct UnsortedNeighborhood<V: VectorStore> {
-    /// List of distance-weighted directed edges, specified as tuples
-    /// `(target, weight)`
-    pub edges: Vec<(VectorId, V::DistanceRef)>,
-}
-
-impl<V: VectorStore> Clone for UnsortedNeighborhood<V>
-where
-    VectorId: Clone,
-    V::DistanceRef: Clone,
-{
-    fn clone(&self) -> Self {
-        UnsortedNeighborhood {
-            edges: self.edges.clone(),
-        }
-    }
-}
-
-impl<V: VectorStore> UnsortedNeighborhood<V> {
-    async fn quickselect(&mut self, store: &mut V, k: usize) -> Result<()> {
-        assert!(0 < k && k <= self.edges.len());
-        let values = self
-            .edges
-            .iter()
-            .map(|(_, dist)| dist.clone())
-            .collect::<Vec<_>>();
-        // Get the permutation which describes the partitioned sequence
-        let indices = run_quickselect_with_store(store, &values, k).await?;
-        self.edges = indices
-            .into_iter()
-            .take(k) // truncate to smallest k
-            .map(|i| self.edges[i].clone())
-            .collect::<Vec<_>>();
-        Ok(())
-    }
-}
-
-impl<V: VectorStore> AsRef<[(VectorId, V::DistanceRef)]> for UnsortedNeighborhood<V> {
-    fn as_ref(&self) -> &[(VectorId, V::DistanceRef)] {
-        &self.edges
-    }
-}
-
-impl<V: VectorStore> Neighborhood<V> for UnsortedNeighborhood<V> {
-    fn new() -> Self {
-        Self {
-            edges: Default::default(),
-        }
-    }
-
-    fn from_singleton(element: (VectorId, V::DistanceRef)) -> Self {
-        UnsortedNeighborhood {
-            edges: vec![element],
-        }
-    }
-
-    /// Appends `vals` to the neighborhood, applies quickselect and truncates to length k.
-    /// Expected bandwitdh: linear in `|self.edges| + |vals|`
-    /// Expected rounds: logarithmic in `|self.edges| + |vals|`
-    async fn insert_batch_and_trim(
-        &mut self,
-        store: &mut V,
-        vals: &[(VectorId, V::DistanceRef)],
-        k: usize,
-    ) -> Result<()> {
-        debug!(batch_size = vals.len(), "Insert batch into neighborhood");
-        self.edges.extend(vals.to_vec());
-
-        // TODO: this case can be optimized if needed
-        let k = k.min(self.edges.len());
-
-        if k == 0 {
-            self.edges.clear();
-        } else {
-            self.quickselect(store, k).await?;
-        }
-        Ok(())
-    }
-
-    fn get_furthest(&self) -> Option<&(VectorId, V::DistanceRef)> {
-        self.edges.last()
-    }
-
-    /// Count the neighbors that match according to `store.is_match`.
-    async fn matches(&self, store: &mut V) -> Result<Vec<(VectorId, V::DistanceRef)>> {
-        let distances = self
-            .edges
-            .iter()
-            .map(|(_, dist)| dist.clone())
-            .collect::<Vec<_>>();
-        let results = store.is_match_batch(&distances).await?;
-        Ok(self
-            .edges
-            .iter()
-            .enumerate()
-            .filter_map(|(i, (v, d))| {
-                if results[i] {
-                    Some((*v, d.clone()))
-                } else {
-                    None
-                }
-            })
-            .collect())
-    }
-}
-
-/// Datatype which covers all used implementers of Neighborhood
-#[allow(dead_code)]
-pub enum WrappedNeighborhood<V: VectorStore> {
-    Sorted(SortedNeighborhood<V>),
-    Unsorted(UnsortedNeighborhood<V>),
-}
-
-impl<V: VectorStore> From<SortedNeighborhood<V>> for WrappedNeighborhood<V> {
-    fn from(value: SortedNeighborhood<V>) -> Self {
-        Self::Sorted(value)
-    }
-}
-
-impl<V: VectorStore> From<UnsortedNeighborhood<V>> for WrappedNeighborhood<V> {
-    fn from(value: UnsortedNeighborhood<V>) -> Self {
-        Self::Unsorted(value)
-    }
-}
-
-#[allow(dead_code)]
-impl<V: VectorStore> WrappedNeighborhood<V> {
-    delegate! {
-        to match self {
-            WrappedNeighborhood::Sorted(nb) => nb,
-            WrappedNeighborhood::Unsorted(nb) => nb,
-        } {
-            async fn insert_batch_and_trim(
-                &mut self,
-                store: &mut V,
-                vals: &[(VectorId, V::DistanceRef)],
-                k: usize,
-            ) -> Result<()>;
-
-            async fn matches(&self, store: &mut V) -> Result<Vec<(VectorId, V::DistanceRef)>>;
-
-            fn get_furthest(&self) -> Option<&(VectorId, V::DistanceRef)>;
-        }
-    }
-}
-
-impl<V: VectorStore> AsRef<[(VectorId, V::DistanceRef)]> for WrappedNeighborhood<V> {
-    fn as_ref(&self) -> &[(VectorId, V::DistanceRef)] {
-        match self {
-            WrappedNeighborhood::Sorted(nb) => nb.as_ref(),
-            WrappedNeighborhood::Unsorted(nb) => nb.as_ref(),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -407,10 +211,10 @@ mod tests {
     use iris_mpc_common::{iris_db::iris::IrisCode, IrisVectorId};
     use rand::thread_rng;
 
-    async fn insert_batch_store_and_nbhd<N: Neighborhood<PlaintextStore>>(
+    async fn insert_batch_store_and_nbhd(
         query: Arc<IrisCode>,
         store: &mut PlaintextStore,
-        nbhd: &mut N,
+        nbhd: &mut SortedNeighborhood<PlaintextStore>,
         irises: &[Arc<IrisCode>],
     ) -> Result<()> {
         let mut pairs = Vec::new();
@@ -426,11 +230,12 @@ mod tests {
         Ok(())
     }
 
-    async fn test_neighborhood_generic<N: Neighborhood<PlaintextStore>>() -> Result<()> {
+    #[tokio::test]
+    async fn test_sorted_neighborhood() -> Result<()> {
         let mut rng = thread_rng();
         let mut store = PlaintextStore::new();
         let query = Arc::new(IrisCode::random_rng(&mut rng));
-        let mut nbhd = N::new();
+        let mut nbhd = SortedNeighborhood::<PlaintextStore>::new();
 
         let randos = (0..3)
             .map(|_| Arc::new(IrisCode::random_rng(&mut rng)))
@@ -483,19 +288,5 @@ mod tests {
         assert!(nbhd.get_furthest().is_none());
 
         Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_sorted_neighborhood() {
-        test_neighborhood_generic::<SortedNeighborhood<PlaintextStore>>()
-            .await
-            .unwrap();
-    }
-
-    #[tokio::test]
-    async fn test_unsorted_neighborhood() {
-        test_neighborhood_generic::<UnsortedNeighborhood<PlaintextStore>>()
-            .await
-            .unwrap();
     }
 }

--- a/iris-mpc-cpu/src/hnsw/graph/test_utils.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/test_utils.rs
@@ -100,7 +100,7 @@ impl DbContext {
     /// Upload a BothEyes graph to S3 and record it in genesis_graph_checkpoint.
     pub async fn store_checkpoint(
         &self,
-        graph: &BothEyes<GraphMem<VectorId>>,
+        graph: &BothEyes<GraphMem>,
         last_indexed_iris_id: i64,
         last_indexed_modification_id: i64,
         graph_mutation_id: Option<i64>,
@@ -136,10 +136,7 @@ impl DbContext {
     }
 
     /// Create a checkpoint from a graph in memory: get required metadata and upload to S3 and update databases.
-    pub async fn make_checkpoint_from_graph(
-        &self,
-        graph: &BothEyes<GraphMem<VectorId>>,
-    ) -> Result<()> {
+    pub async fn make_checkpoint_from_graph(&self, graph: &BothEyes<GraphMem>) -> Result<()> {
         let graph_mutation_id = self.graph_pg.get_max_hawk_graph_mutation_id().await?;
         let last_indexed_iris_id: i64 = self
             .graph_pg
@@ -197,10 +194,10 @@ impl DbContext {
     /// Reconstruct the current graph state by:
     ///   1. Downloading the latest checkpoint from S3
     ///   2. Applying all hawk_graph_mutations written after that checkpoint
-    pub async fn get_both_eyes(&self) -> Result<BothEyes<GraphMem<VectorId>>> {
+    pub async fn get_both_eyes(&self) -> Result<BothEyes<GraphMem>> {
         let checkpoint_row = self.graph_pg.get_latest_genesis_graph_checkpoint().await?;
 
-        let mut graph: BothEyes<GraphMem<VectorId>> = match checkpoint_row {
+        let mut graph: BothEyes<GraphMem> = match checkpoint_row {
             None => [GraphMem::new(), GraphMem::new()],
             Some(ref row) => {
                 let state = GraphCheckpointState {
@@ -274,7 +271,7 @@ impl DbContext {
             println!("{:#?}", stored_graph);
         }
         let data = tokio::fs::read(path).await?;
-        let loaded_graph: BothEyes<GraphMem<VectorId>> = bincode::deserialize(&data)?;
+        let loaded_graph: BothEyes<GraphMem> = bincode::deserialize(&data)?;
         if dbg {
             println!("loaded graph:");
             println!("{:#?}", loaded_graph);
@@ -345,7 +342,7 @@ impl DbContext {
     /// the test database is initially empty and some data is needed to
     /// test the backup and restore commands.
     /// The graph isn't actually random - the RNG uses the same seed.
-    pub async fn store_random_graph(&self) -> Result<BothEyes<GraphMem<VectorId>>> {
+    pub async fn store_random_graph(&self) -> Result<BothEyes<GraphMem>> {
         const NUM_RANDOM_IRIS_CODES: usize = 10;
         let rng = &mut AesRng::seed_from_u64(0_u64);
         let mut vector_store = PlaintextStore::<FhdOps>::new();
@@ -374,7 +371,7 @@ impl DbContext {
         };
 
         // Build the graph topology as mutations, then apply to an in-memory graph
-        let mut left_graph = GraphMem::<VectorId>::new();
+        let mut left_graph = GraphMem::new();
 
         // Set entry point via InsertNode with SetUnique
         let ep_mutation = MutationOp::AddNode {
@@ -428,7 +425,7 @@ impl DbContext {
     }
 }
 
-async fn deserialize_graph(path: &Path) -> Result<BothEyes<GraphMem<VectorId>>> {
+async fn deserialize_graph(path: &Path) -> Result<BothEyes<GraphMem>> {
     let data = tokio::fs::read(path).await?;
     Ok(bincode::deserialize(&data)?)
 }

--- a/iris-mpc-cpu/src/hnsw/graph/test_utils.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/test_utils.rs
@@ -18,7 +18,6 @@ use crate::{
                 run_diff,
             },
             mutation::EdgeType,
-            neighborhood::Neighborhood,
             GraphMutation, MutationOp, UpdateEntryPoint,
         },
         vector_store::{VectorStore, VectorStoreMut},

--- a/iris-mpc-cpu/src/hnsw/graph/test_utils.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/test_utils.rs
@@ -37,7 +37,6 @@ use clap::ValueEnum;
 use eyre::Result;
 use iris_mpc_common::iris_db::db::IrisDB;
 use iris_mpc_common::postgres::{AccessMode, PostgresClient};
-use iris_mpc_common::vector_id::VectorId;
 use iris_mpc_store::{Store, StoredIrisRef};
 use itertools::Itertools;
 use rand::SeedableRng;

--- a/iris-mpc-cpu/src/hnsw/metrics/ops_counter.rs
+++ b/iris-mpc-cpu/src/hnsw/metrics/ops_counter.rs
@@ -79,7 +79,7 @@ impl OpCountersLayer {
     }
 }
 
-impl<S: Subscriber> Layer<S> for OpCountersLayer {
+impl<S: Subscriber> tracing_subscriber::Layer<S> for OpCountersLayer {
     fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
         let mut visitor = OpVisitor::default();
         event.record(&mut visitor);

--- a/iris-mpc-cpu/src/hnsw/metrics/ops_counter.rs
+++ b/iris-mpc-cpu/src/hnsw/metrics/ops_counter.rs
@@ -11,7 +11,7 @@ use tracing::{
     span::{Attributes, Id},
     Event, Subscriber,
 };
-use tracing_subscriber::layer::{Context, Layer};
+use tracing_subscriber::layer::Context;
 
 #[derive(Debug, Clone, Copy)]
 pub enum Operation {

--- a/iris-mpc-cpu/src/hnsw/mod.rs
+++ b/iris-mpc-cpu/src/hnsw/mod.rs
@@ -15,5 +15,5 @@ pub mod sorting;
 pub mod vector_store;
 
 pub use graph::{layered_graph::GraphMem, neighborhood::SortedNeighborhood};
-pub use searcher::{HnswParams, HnswSearcher, LayerDistribution};
+pub use searcher::{HnswParams, HnswSearcher, LayerDistribution, LINEAR_SCAN_MAX_GRAPH_LAYER};
 pub use vector_store::VectorStore;

--- a/iris-mpc-cpu/src/hnsw/searcher.rs
+++ b/iris-mpc-cpu/src/hnsw/searcher.rs
@@ -40,6 +40,13 @@ use tracing::{debug, instrument, trace_span, Instrument};
 /// search, used by the `HnswParams` struct.
 pub const N_PARAM_LAYERS: usize = 5;
 
+/// Maximum graph layer for node insertion used by Hawk Main's HNSW searcher.
+/// Entry points live in this top layer and search begins with a linear scan
+/// over them. Shared by every searcher that mirrors Hawk Main — genesis, the
+/// e2e bootstrap, the test-parameter constructor, and the tooling defaults —
+/// so they stay in lockstep with the live path.
+pub const LINEAR_SCAN_MAX_GRAPH_LAYER: usize = 1;
+
 /// Scaling parameter to determine the frequency of neighborhood compaction
 /// operations for large graph neighborhoods.  When a neighborhood reaches
 /// size greater than M_limit in some layer, the neighborhood is trimmed
@@ -184,30 +191,6 @@ impl HnswParams {
     }
 }
 
-/// Struct specifies how layers are handled by an `HnswSearcher`.`
-#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
-pub enum LayerMode {
-    /// Standard operation: maintains single entry point and updates it when a
-    /// new node is inserted as the first item in a new highest layer.
-    ///
-    /// Graph search starts at the unique entry point.
-    Standard {
-        /// Maximum layer for node insertion, if any
-        max_graph_layer: Option<usize>,
-    },
-    /// Nodes are inserted at up to a maximum layer height, and any node which
-    /// would be inserted at a higher layer than this is added to an ongoing
-    /// list of entry points.
-    ///
-    /// Graph search starts in the top layer, at a node of minimal distance from
-    /// the query among the entry points, calculated by a direct linear scan of
-    /// the entry points list.
-    LinearScan {
-        /// Maximum layer for node insertion
-        max_graph_layer: usize,
-    },
-}
-
 /// Struct specifies the probability distribution used to generate insertion
 /// layers for new nodes in an HNSW graph.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -276,8 +259,10 @@ pub struct HnswSearcher {
     /// Parameters specifying the behavior of HNSW search in different layers.
     pub params: HnswParams,
 
-    /// Operation mode for managing construction and search of graph layers.
-    pub layer_mode: LayerMode,
+    /// Maximum layer for node insertion. Nodes that would be inserted at a
+    /// higher layer are instead added to the entry point list; graph search
+    /// begins with a linear scan over those entry points in this top layer.
+    pub max_graph_layer: usize,
 
     /// Statistical distribution for layer selection
     pub layer_distribution: LayerDistribution,
@@ -313,19 +298,6 @@ pub fn build_layer_updates<V: Clone + Ord>(
 #[allow(non_snake_case)]
 impl HnswSearcher {
     /// Construct an HnswSearcher with specified parameters, constructed to use
-    /// a unique graph entry point in the dynamic top graph layer.
-    pub fn new_standard(ef_constr: usize, ef_search: usize, M: usize) -> Self {
-        Self {
-            params: HnswParams::new(ef_constr, ef_search, M),
-            layer_mode: LayerMode::Standard {
-                max_graph_layer: None,
-            },
-            layer_distribution: LayerDistribution::new_geometric_from_M(M),
-            fixed_layer_search_batch_size: None,
-        }
-    }
-
-    /// Construct an HnswSearcher with specified parameters, constructed to use
     /// linear scan over a set of entry points at a capped maximum graph layer.
     pub fn new_linear_scan(
         ef_constr: usize,
@@ -335,7 +307,7 @@ impl HnswSearcher {
     ) -> Self {
         Self {
             params: HnswParams::new(ef_constr, ef_search, M),
-            layer_mode: LayerMode::LinearScan { max_graph_layer },
+            max_graph_layer,
             layer_distribution: LayerDistribution::new_geometric_from_M(M),
             fixed_layer_search_batch_size: None,
         }
@@ -350,7 +322,7 @@ impl HnswSearcher {
     /// applicable" default value.
     pub fn new_with_test_parameters() -> Self {
         let (ef_constr, ef_search, M) = (64, 32, 32);
-        Self::new_standard(ef_constr, ef_search, M)
+        Self::new_linear_scan(ef_constr, ef_search, M, LINEAR_SCAN_MAX_GRAPH_LAYER)
     }
 
     /// Choose a random insertion layer from the configured distribution,
@@ -404,82 +376,56 @@ impl HnswSearcher {
         query: &V::QueryRef,
         insertion_layer: usize,
     ) -> Result<(SortedNeighborhood<V>, usize, usize, UpdateEntryPoint)> {
-        match self.layer_mode {
-            LayerMode::Standard { max_graph_layer } => {
-                let ep = graph.get_first_entry_point().await;
-                let (W, layer) = self.init_nbhd_from_ep(store, ep, query).await?;
+        let max_graph_layer = self.max_graph_layer;
 
-                // Layers are 0-indexed, so number of graph layers is one greater than the entry point layer
-                // if an entry point is present, and otherwise 0.
-                let n_layers = layer.map(|l| l + 1).unwrap_or(0);
+        // Get all valid entry points
+        let (ep_vectors, ep_layers): (Vec<_>, Vec<_>) = graph
+            .entry_points
+            .iter()
+            .map(|ep| (ep.point, ep.layer))
+            .unzip();
+        let ep_vectors = store.only_valid_vectors(ep_vectors).await;
+        metrics::gauge!("entry_points_count").set(ep_vectors.len() as f64);
 
-                // If maximum graph layer is specified, truncate insertion layer
-                let bounded_insertion_layer =
-                    insertion_layer.min(max_graph_layer.unwrap_or(usize::MAX));
+        // TODO when updating entry points, should check for invalid vectors and remove
 
-                // Set new entry point if layer is greater than entry point layer, or no entry point available.
-                let update_ep = if layer.map(|l| bounded_insertion_layer > l).unwrap_or(true) {
-                    UpdateEntryPoint::SetUnique {
-                        layer: bounded_insertion_layer,
-                    }
-                } else {
-                    UpdateEntryPoint::False
-                };
-
-                Ok((W, n_layers, bounded_insertion_layer, update_ep))
-            }
-            LayerMode::LinearScan { max_graph_layer } => {
-                // Get all valid entry points
-                let (ep_vectors, ep_layers): (Vec<_>, Vec<_>) = graph
-                    .entry_points
-                    .iter()
-                    .map(|ep| (ep.point, ep.layer))
-                    .unzip();
-                let ep_vectors = store.only_valid_vectors(ep_vectors).await;
-                metrics::gauge!("entry_points_count").set(ep_vectors.len() as f64);
-
-                // TODO when updating entry points, should check for invalid vectors and remove
-
-                // Verify all entry points are at the max graph layer
-                if !ep_layers.into_iter().all(|l| l == max_graph_layer) {
-                    bail!("Found entry point in invalid graph layer for linear scan functionality");
-                }
-
-                let (W, n_layers) = if ep_vectors.is_empty() {
-                    let ep = graph.get_temporary_entry_point();
-                    let (W, layer) = self.init_nbhd_from_ep(store, ep, query).await?;
-
-                    // Layers are 0-indexed, so number of graph layers is one greater than the entry point layer
-                    // if an entry point is present, and otherwise 0.
-                    let n_layers = layer.map(|l| l + 1).unwrap_or(0);
-
-                    (W, n_layers)
-                } else {
-                    let nearest_point =
-                        Self::linear_search_min_distance(store, query, ep_vectors).await?;
-                    let W = SortedNeighborhood::from_singleton(nearest_point);
-
-                    // Entry points are in layer `max_graph_layer`, so number of layers is one more since layers are 0-indexed.
-                    let n_layers = max_graph_layer + 1;
-
-                    (W, n_layers)
-                };
-
-                // Truncate insertion layer at max graph layer.
-                let bounded_insertion_layer = insertion_layer.min(max_graph_layer);
-
-                // Add query to entry points set if target insertion layer is greater than the max graph layer
-                let update_ep = if insertion_layer > max_graph_layer {
-                    UpdateEntryPoint::Append {
-                        layer: max_graph_layer,
-                    }
-                } else {
-                    UpdateEntryPoint::False
-                };
-
-                Ok((W, n_layers, bounded_insertion_layer, update_ep))
-            }
+        // Verify all entry points are at the max graph layer
+        if !ep_layers.into_iter().all(|l| l == max_graph_layer) {
+            bail!("Found entry point in invalid graph layer for linear scan functionality");
         }
+
+        let (W, n_layers) = if ep_vectors.is_empty() {
+            let ep = graph.get_temporary_entry_point();
+            let (W, layer) = self.init_nbhd_from_ep(store, ep, query).await?;
+
+            // Layers are 0-indexed, so number of graph layers is one greater than the entry point layer
+            // if an entry point is present, and otherwise 0.
+            let n_layers = layer.map(|l| l + 1).unwrap_or(0);
+
+            (W, n_layers)
+        } else {
+            let nearest_point = Self::linear_search_min_distance(store, query, ep_vectors).await?;
+            let W = SortedNeighborhood::from_singleton(nearest_point);
+
+            // Entry points are in layer `max_graph_layer`, so number of layers is one more since layers are 0-indexed.
+            let n_layers = max_graph_layer + 1;
+
+            (W, n_layers)
+        };
+
+        // Truncate insertion layer at max graph layer.
+        let bounded_insertion_layer = insertion_layer.min(max_graph_layer);
+
+        // Add query to entry points set if target insertion layer is greater than the max graph layer
+        let update_ep = if insertion_layer > max_graph_layer {
+            UpdateEntryPoint::Append {
+                layer: max_graph_layer,
+            }
+        } else {
+            UpdateEntryPoint::False
+        };
+
+        Ok((W, n_layers, bounded_insertion_layer, update_ep))
     }
 
     /// For a specified entry point, returns an initialized singleton candidate
@@ -1452,9 +1398,9 @@ impl HnswSearcher {
     /// set `query` as the index entry point.
     ///
     /// Note that the `insertion_layer` input does not have any pre-conditions
-    /// on it. The `layer_mode` field of `HnswSearcher` may modify the insertion
-    /// layer before operation, e.g. by truncating to a maximum layer height.
-    /// This step is handled internally.
+    /// on it. The `max_graph_layer` field of `HnswSearcher` may modify the
+    /// insertion layer before operation, by truncating to the maximum layer
+    /// height. This step is handled internally.
     #[instrument(
         level = "trace",
         target = "searcher::network",
@@ -1799,22 +1745,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_hnsw_db_default() -> Result<()> {
-        let db = HnswSearcher::new_standard(64, 32, 32);
-
-        hnsw_db_helper(db, 0).await
-    }
-
-    #[tokio::test]
     async fn test_hnsw_db_linear_scan() -> Result<()> {
-        let db = HnswSearcher::new_linear_scan(64, 32, 32, 1);
+        let db = HnswSearcher::new_linear_scan(64, 32, 32, LINEAR_SCAN_MAX_GRAPH_LAYER);
 
         hnsw_db_helper(db, 0).await
     }
 
     #[tokio::test]
     async fn test_hnsw_db_linear_scan_m() -> Result<()> {
-        let mut db = HnswSearcher::new_linear_scan(64, 32, 32, 1);
+        let mut db = HnswSearcher::new_linear_scan(64, 32, 32, LINEAR_SCAN_MAX_GRAPH_LAYER);
         // Ensure upper layers get exercised well
         db.layer_distribution = LayerDistribution::new_geometric_from_M(4);
 
@@ -1826,50 +1765,10 @@ mod tests {
         let mut rng = AesRng::seed_from_u64(42);
         let iris_db = IrisDB::new_random_rng(10, &mut rng);
 
-        let mut queries = iris_db.db.into_iter().map(Arc::new);
-        // Duplicate queries for the linear mode tests
-        let mut queries_copy = queries.clone();
-
-        // Default mode
-        let searcher_default = HnswSearcher::new_with_test_parameters();
-        let vector_store_default = &mut PlaintextStore::<FhdOps>::new();
-        let graph_store_default = &mut GraphMem::new();
-
-        for (insertion_layer, expected_nb_len, expected_update_ep) in [
-            (0, 1, UpdateEntryPoint::SetUnique { layer: 0 }),
-            (0, 1, UpdateEntryPoint::False),
-            (1, 2, UpdateEntryPoint::SetUnique { layer: 1 }),
-            (1, 2, UpdateEntryPoint::False),
-            (2, 3, UpdateEntryPoint::SetUnique { layer: 2 }),
-            (2, 3, UpdateEntryPoint::False),
-        ] {
-            let query = queries.next().unwrap();
-
-            let (neighbors, update_ep) = searcher_default
-                .search_to_insert(
-                    vector_store_default,
-                    graph_store_default,
-                    &query,
-                    insertion_layer,
-                )
-                .await?;
-
-            assert_eq!(neighbors.len(), expected_nb_len);
-            assert_eq!(update_ep, expected_update_ep);
-
-            searcher_default
-                .insert(
-                    vector_store_default,
-                    graph_store_default,
-                    &query,
-                    insertion_layer,
-                )
-                .await?;
-        }
+        let mut queries_copy = iris_db.db.into_iter().map(Arc::new);
 
         // Linear-scan mode
-        let mut searcher_linear = HnswSearcher::new_with_test_parameters();
-        searcher_linear.layer_mode = LayerMode::LinearScan { max_graph_layer: 1 };
+        let searcher_linear = HnswSearcher::new_with_test_parameters();
         let vector_store_linear = &mut PlaintextStore::<FhdOps>::new();
         let graph_store_linear = &mut GraphMem::new();
 

--- a/iris-mpc-cpu/src/hnsw/searcher.rs
+++ b/iris-mpc-cpu/src/hnsw/searcher.rs
@@ -11,7 +11,7 @@ use super::{
 use crate::hnsw::{
     graph::{
         mutation::{EdgeType, GraphMutation, UnstampedMutation},
-        neighborhood::Neighborhood,
+        neighborhood::SortedNeighborhood,
         MutationOp, UpdateEntryPoint,
     },
     metrics::ops_counter::Operation,
@@ -208,12 +208,6 @@ pub enum LayerMode {
     },
 }
 
-#[derive(Clone, Debug, Deserialize)]
-pub enum NeighborhoodMode {
-    Sorted,
-    Unsorted,
-}
-
 /// Struct specifies the probability distribution used to generate insertion
 /// layers for new nodes in an HNSW graph.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -268,8 +262,8 @@ impl LayerDistribution {
 ///
 /// Evaluation and comparison of vector distances are delegated to an implementor of the
 /// `VectorStore` trait, and management of the hierarchical graph is delegated to a `GraphMem`
-/// struct. Queries and updates to the active neighbor candidate list are delegated to an implementor
-/// of the `Neighborhood` trait.
+/// struct. Queries and updates to the active neighbor candidate list use the
+/// `SortedNeighborhood` candidate-list container.
 ///
 /// Graph search in this implementation is optimized to reduce the number of sequential distance
 /// evaluation and distance comparison operations, because we use SMPC protocols to implement these
@@ -403,13 +397,13 @@ impl HnswSearcher {
     /// - Enum designating how to handle entry point update
     #[allow(non_snake_case)]
     #[instrument(level = "trace", target = "searcher::cpu_time", skip_all)]
-    async fn search_init<V: VectorStore, N: Neighborhood<V>>(
+    async fn search_init<V: VectorStore>(
         &self,
         store: &mut V,
         graph: &GraphMem,
         query: &V::QueryRef,
         insertion_layer: usize,
-    ) -> Result<(N, usize, usize, UpdateEntryPoint)> {
+    ) -> Result<(SortedNeighborhood<V>, usize, usize, UpdateEntryPoint)> {
         match self.layer_mode {
             LayerMode::Standard { max_graph_layer } => {
                 let ep = graph.get_first_entry_point().await;
@@ -463,7 +457,7 @@ impl HnswSearcher {
                 } else {
                     let nearest_point =
                         Self::linear_search_min_distance(store, query, ep_vectors).await?;
-                    let W = N::from_singleton(nearest_point);
+                    let W = SortedNeighborhood::from_singleton(nearest_point);
 
                     // Entry points are in layer `max_graph_layer`, so number of layers is one more since layers are 0-indexed.
                     let n_layers = max_graph_layer + 1;
@@ -494,19 +488,19 @@ impl HnswSearcher {
     ///
     /// If `ep` is specified as `None` (no entry point available), then returns
     /// an empty neighborhood and `None` for its layer.
-    async fn init_nbhd_from_ep<V: VectorStore, N: Neighborhood<V>>(
+    async fn init_nbhd_from_ep<V: VectorStore>(
         &self,
         store: &mut V,
         ep: Option<(VectorId, usize)>,
         query: &V::QueryRef,
-    ) -> Result<(N, Option<usize>)> {
+    ) -> Result<(SortedNeighborhood<V>, Option<usize>)> {
         if let Some((entry_point, layer)) = ep {
             let distance = store.eval_distance(query, &entry_point).await?;
 
-            let W = N::from_singleton((entry_point, distance));
+            let W = SortedNeighborhood::from_singleton((entry_point, distance));
             Ok((W, Some(layer)))
         } else {
-            Ok((N::new(), None))
+            Ok((SortedNeighborhood::new(), None))
         }
     }
 
@@ -520,11 +514,11 @@ impl HnswSearcher {
         fields(event_type = Operation::LayerSearch.id()),
         skip(store, graph, q, W))]
     #[allow(non_snake_case)]
-    async fn search_layer<V: VectorStore, N: Neighborhood<V>>(
+    async fn search_layer<V: VectorStore>(
         store: &mut V,
         graph: &GraphMem,
         q: &V::QueryRef,
-        W: &mut N,
+        W: &mut SortedNeighborhood<V>,
         ef: usize,
         lc: usize,
         fixed_batch_size: Option<usize>,
@@ -536,7 +530,7 @@ impl HnswSearcher {
             1 => {
                 let start = W.as_ref().first().ok_or(eyre!("W cannot be empty"))?;
                 let nearest = Self::layer_search_greedy(store, graph, q, start, lc).await?;
-                *W = N::from_singleton(nearest);
+                *W = SortedNeighborhood::from_singleton(nearest);
             }
             2..32 => {
                 Self::layer_search_std(store, graph, q, W, ef, lc).await?;
@@ -560,11 +554,11 @@ impl HnswSearcher {
     /// neighbors inspected, which is recorded in an additional `HashSet` of
     /// vector ids.
     #[instrument(level = "debug", skip(store, graph, q, W))]
-    async fn layer_search_std<V: VectorStore, N: Neighborhood<V>>(
+    async fn layer_search_std<V: VectorStore>(
         store: &mut V,
         graph: &GraphMem,
         q: &V::QueryRef,
-        W: &mut N,
+        W: &mut SortedNeighborhood<V>,
         ef: usize,
         lc: usize,
     ) -> Result<()> {
@@ -653,7 +647,7 @@ impl HnswSearcher {
     /// First, as `W` is initially filled up to size `ef`, the entire neighborhoods
     /// of nodes are inserted into `W` via a batched insertion operation
     /// such as a low-depth sorting network. (This functionality is provided
-    /// by `neighborhood::insert_batch`.) This continues
+    /// by `SortedNeighborhood::insert_batch_and_trim`.) This continues
     /// until `W` has reached size `ef`, so that additional insertions will
     /// result in truncation of farthest elements.
     ///
@@ -707,11 +701,11 @@ impl HnswSearcher {
     /// returns.
     #[allow(dead_code)]
     #[instrument(level = "debug", skip(store, graph, q, W))]
-    async fn layer_search_batched<V: VectorStore, N: Neighborhood<V>>(
+    async fn layer_search_batched<V: VectorStore>(
         store: &mut V,
         graph: &GraphMem,
         q: &V::QueryRef,
-        W: &mut N,
+        W: &mut SortedNeighborhood<V>,
         ef: usize,
         lc: usize,
     ) -> Result<()> {
@@ -955,7 +949,7 @@ impl HnswSearcher {
     /// neighborhood from which the main search can proceed.  Once neighbors are
     /// chosen, the distances between all new neighbors and the search query are
     /// evaluated as a batch, and the nodes are organized into a candidate
-    /// neighborhood. The specifics of this organization depend on the generic parameter `N`.
+    /// neighborhood.
     ///
     /// Once `W` has size `ef`, the second phase of graph traversal starts. In
     /// this phase, batches of unopened elements of `W` are opened and
@@ -993,11 +987,11 @@ impl HnswSearcher {
     /// not allow batching of distance evaluation, which has become a
     /// significant latency bottleneck in practice.
     #[instrument(level = "debug", skip(store, graph, q, W))]
-    async fn layer_search_batched_v2<V: VectorStore, N: Neighborhood<V>>(
+    async fn layer_search_batched_v2<V: VectorStore>(
         store: &mut V,
         graph: &GraphMem,
         q: &V::QueryRef,
-        W: &mut N,
+        W: &mut SortedNeighborhood<V>,
         ef: usize,
         lc: usize,
         fixed_batch_size: Option<usize>,
@@ -1388,16 +1382,16 @@ impl HnswSearcher {
     /// value for `ef` at layer 0 only, and `ef = 1` (greedy search) for all higher layers.
     #[allow(non_snake_case)]
     #[instrument(level = "trace", target = "searcher::network", skip_all)]
-    pub async fn search<V: VectorStore, N: Neighborhood<V>>(
+    pub async fn search<V: VectorStore>(
         &self,
         store: &mut V,
         graph: &GraphMem,
         query: &V::QueryRef,
         k: usize,
-    ) -> Result<N> {
+    ) -> Result<SortedNeighborhood<V>> {
         // insertion layer doesn't matter here because set_ep is ignored
         let init_start = std::time::Instant::now();
-        let (mut W, n_layers, _, _) = self.search_init::<_, N>(store, graph, query, 0).await?;
+        let (mut W, n_layers, _, _) = self.search_init(store, graph, query, 0).await?;
         metrics::histogram!("search_init_duration").record(init_start.elapsed().as_secs_f64());
 
         // Search from the top layer down to layer 0
@@ -1425,7 +1419,7 @@ impl HnswSearcher {
     /// Insert `query` into the HNSW index represented by `store` and `graph`.
     /// Return a `VectorId` representing the inserted vector.
     #[instrument(level = "trace", skip_all, target = "searcher::network")]
-    pub async fn insert<V: VectorStoreMut, N: Neighborhood<V>>(
+    pub async fn insert<V: VectorStoreMut>(
         &self,
         store: &mut V,
         graph: &mut GraphMem,
@@ -1433,7 +1427,7 @@ impl HnswSearcher {
         insertion_layer: usize,
     ) -> Result<VectorId> {
         let (neighbors, update_ep) = self
-            .search_to_insert::<_, N>(store, graph, query, insertion_layer)
+            .search_to_insert(store, graph, query, insertion_layer)
             .await?;
         let inserted = store.insert(query).await;
         self.insert_from_search_results(store, graph, inserted, neighbors, update_ep)
@@ -1467,18 +1461,18 @@ impl HnswSearcher {
         skip(self, store, graph, query)
     )]
     #[allow(non_snake_case)]
-    pub async fn search_to_insert<V: VectorStore, N: Neighborhood<V>>(
+    pub async fn search_to_insert<V: VectorStore>(
         &self,
         store: &mut V,
         graph: &GraphMem,
         query: &V::QueryRef,
         insertion_layer: usize,
-    ) -> Result<(Vec<N>, UpdateEntryPoint)> {
+    ) -> Result<(Vec<SortedNeighborhood<V>>, UpdateEntryPoint)> {
         // Initialize candidate neighborhood, index of highest search layer,
         // finalized layer of node insertion, and entry point update outcome.
         let init_start = std::time::Instant::now();
         let (mut W, n_layers, insertion_layer, update_ep) = self
-            .search_init::<_, N>(store, graph, query, insertion_layer)
+            .search_init(store, graph, query, insertion_layer)
             .await?;
         metrics::histogram!("search_init_duration").record(init_start.elapsed().as_secs_f64());
 
@@ -1519,7 +1513,7 @@ impl HnswSearcher {
         // If query is to be inserted at a new highest layer as a new entry
         // point, insert additional empty neighborhoods for any new layers
         for _ in links.len()..insertion_layer + 1 {
-            links.push(N::new());
+            links.push(SortedNeighborhood::new());
         }
 
         assert_eq!(links.len(), insertion_layer + 1);
@@ -1651,12 +1645,12 @@ impl HnswSearcher {
         target = "searcher::cpu_time",
         skip(self, store, graph, inserted_vector, links)
     )]
-    pub async fn insert_from_search_results<V: VectorStore, N: Neighborhood<V>>(
+    pub async fn insert_from_search_results<V: VectorStore>(
         &self,
         store: &mut V,
         graph: &mut GraphMem,
         inserted_vector: VectorId,
-        links: Vec<N>,
+        links: Vec<SortedNeighborhood<V>>,
         update_ep: UpdateEntryPoint,
     ) -> Result<()> {
         // Trim and extract unstructured vector lists.
@@ -1708,10 +1702,10 @@ impl HnswSearcher {
         Ok(())
     }
 
-    pub async fn is_match<V: VectorStore, N: Neighborhood<V>>(
+    pub async fn is_match<V: VectorStore>(
         &self,
         store: &mut V,
-        neighbors: &[N],
+        neighbors: &[SortedNeighborhood<V>],
     ) -> Result<bool> {
         match neighbors.first() {
             None => Ok(false),
@@ -1719,10 +1713,10 @@ impl HnswSearcher {
         }
     }
 
-    pub async fn matches<V: VectorStore, N: Neighborhood<V>>(
+    pub async fn matches<V: VectorStore>(
         &self,
         store: &mut V,
-        neighbors: &[N],
+        neighbors: &[SortedNeighborhood<V>],
     ) -> Result<Vec<(VectorId, V::DistanceRef)>> {
         match neighbors.first() {
             None => Ok(vec![]),
@@ -1741,7 +1735,7 @@ mod tests {
     use super::*;
     use crate::{
         hawkers::{aby3::aby3_store::FhdOps, plaintext_store::PlaintextStore},
-        hnsw::{GraphMem, SortedNeighborhood},
+        hnsw::GraphMem,
     };
     use aes_prng::AesRng;
     use iris_mpc_common::{
@@ -1766,12 +1760,7 @@ mod tests {
         for query in queries1.iter() {
             let insertion_layer = db.gen_layer_rng(rng)?;
             let (neighbors, update_ep) = db
-                .search_to_insert::<_, SortedNeighborhood<PlaintextStore>>(
-                    vector_store,
-                    graph_store,
-                    query,
-                    insertion_layer,
-                )
+                .search_to_insert(vector_store, graph_store, query, insertion_layer)
                 .await?;
             assert!(!db.is_match(vector_store, &neighbors).await?);
 
@@ -1796,20 +1785,13 @@ mod tests {
         // Insert the codes with helper function
         for query in queries2.iter() {
             let insertion_layer = db.gen_layer_rng(rng)?;
-            db.insert::<_, SortedNeighborhood<_>>(
-                vector_store,
-                graph_store,
-                query,
-                insertion_layer,
-            )
-            .await?;
+            db.insert(vector_store, graph_store, query, insertion_layer)
+                .await?;
         }
 
         // Search for the same codes and find matches.
         for query in queries1.iter().chain(queries2.iter()) {
-            let neighbors = db
-                .search::<_, SortedNeighborhood<_>>(vector_store, graph_store, query, 1)
-                .await?;
+            let neighbors = db.search(vector_store, graph_store, query, 1).await?;
             assert!(db.is_match(vector_store, &[neighbors]).await?);
         }
 
@@ -1864,7 +1846,7 @@ mod tests {
             let query = queries.next().unwrap();
 
             let (neighbors, update_ep) = searcher_default
-                .search_to_insert::<_, SortedNeighborhood<PlaintextStore>>(
+                .search_to_insert(
                     vector_store_default,
                     graph_store_default,
                     &query,
@@ -1876,7 +1858,7 @@ mod tests {
             assert_eq!(update_ep, expected_update_ep);
 
             searcher_default
-                .insert::<_, SortedNeighborhood<_>>(
+                .insert(
                     vector_store_default,
                     graph_store_default,
                     &query,
@@ -1903,7 +1885,7 @@ mod tests {
             let query = queries_copy.next().unwrap();
 
             let (neighbors, update_ep) = searcher_linear
-                .search_to_insert::<_, SortedNeighborhood<PlaintextStore>>(
+                .search_to_insert(
                     vector_store_linear,
                     graph_store_linear,
                     &query,
@@ -1915,7 +1897,7 @@ mod tests {
             assert_eq!(update_ep, expected_update_ep);
 
             searcher_linear
-                .insert::<_, SortedNeighborhood<_>>(
+                .insert(
                     vector_store_linear,
                     graph_store_linear,
                     &query,

--- a/iris-mpc-cpu/src/hnsw/searcher.rs
+++ b/iris-mpc-cpu/src/hnsw/searcher.rs
@@ -379,12 +379,13 @@ impl HnswSearcher {
         let max_graph_layer = self.max_graph_layer;
 
         // Get all valid entry points
-        let (ep_vectors, ep_layers): (Vec<_>, Vec<_>) = graph
+        let entry_points: Vec<_> = graph
             .entry_points
             .iter()
             .map(|ep| (ep.point, ep.layer))
-            .unzip();
-        let ep_vectors = store.only_valid_vectors(ep_vectors).await;
+            .collect();
+        let entry_points = store.only_valid_entry_points(entry_points).await;
+        let (ep_vectors, ep_layers): (Vec<VectorId>, Vec<usize>) = entry_points.into_iter().unzip();
         metrics::gauge!("entry_points_count").set(ep_vectors.len() as f64);
 
         // TODO when updating entry points, should check for invalid vectors and remove

--- a/iris-mpc-cpu/src/hnsw/searcher.rs
+++ b/iris-mpc-cpu/src/hnsw/searcher.rs
@@ -295,8 +295,8 @@ pub struct HnswSearcher {
 
 /// A list of graph mutations representing state updates for insertion of new nodes
 /// into the HNSW graph.
-pub type ConnectPlan<Vector> = GraphMutation<Vector>;
-pub type ConnectPlanV = ConnectPlan<VectorId>;
+pub type ConnectPlan = GraphMutation;
+pub type ConnectPlanV = ConnectPlan;
 
 /// Represents a graph update of a single node's neighborhood in a graph, given
 /// by a tuple `(update_layer, update_vector, new_neighborhood)`.
@@ -406,7 +406,7 @@ impl HnswSearcher {
     async fn search_init<V: VectorStore, N: Neighborhood<V>>(
         &self,
         store: &mut V,
-        graph: &GraphMem<VectorId>,
+        graph: &GraphMem,
         query: &V::QueryRef,
         insertion_layer: usize,
     ) -> Result<(N, usize, usize, UpdateEntryPoint)> {
@@ -522,7 +522,7 @@ impl HnswSearcher {
     #[allow(non_snake_case)]
     async fn search_layer<V: VectorStore, N: Neighborhood<V>>(
         store: &mut V,
-        graph: &GraphMem<VectorId>,
+        graph: &GraphMem,
         q: &V::QueryRef,
         W: &mut N,
         ef: usize,
@@ -562,7 +562,7 @@ impl HnswSearcher {
     #[instrument(level = "debug", skip(store, graph, q, W))]
     async fn layer_search_std<V: VectorStore, N: Neighborhood<V>>(
         store: &mut V,
-        graph: &GraphMem<VectorId>,
+        graph: &GraphMem,
         q: &V::QueryRef,
         W: &mut N,
         ef: usize,
@@ -709,7 +709,7 @@ impl HnswSearcher {
     #[instrument(level = "debug", skip(store, graph, q, W))]
     async fn layer_search_batched<V: VectorStore, N: Neighborhood<V>>(
         store: &mut V,
-        graph: &GraphMem<VectorId>,
+        graph: &GraphMem,
         q: &V::QueryRef,
         W: &mut N,
         ef: usize,
@@ -995,7 +995,7 @@ impl HnswSearcher {
     #[instrument(level = "debug", skip(store, graph, q, W))]
     async fn layer_search_batched_v2<V: VectorStore, N: Neighborhood<V>>(
         store: &mut V,
-        graph: &GraphMem<VectorId>,
+        graph: &GraphMem,
         q: &V::QueryRef,
         W: &mut N,
         ef: usize,
@@ -1229,7 +1229,7 @@ impl HnswSearcher {
     #[instrument(level = "debug", skip(store, graph, q, start))]
     async fn layer_search_greedy<V: VectorStore>(
         store: &mut V,
-        graph: &GraphMem<VectorId>,
+        graph: &GraphMem,
         q: &V::QueryRef,
         start: &(VectorId, V::DistanceRef),
         lc: usize,
@@ -1305,7 +1305,7 @@ impl HnswSearcher {
     #[instrument(level = "trace", target = "searcher::network", skip_all)]
     async fn open_node<V: VectorStore>(
         store: &mut V,
-        graph: &GraphMem<VectorId>,
+        graph: &GraphMem,
         node: &VectorId,
         lc: usize,
         query: &V::QueryRef,
@@ -1341,7 +1341,7 @@ impl HnswSearcher {
     #[allow(clippy::type_complexity)]
     async fn open_nodes_batch<V: VectorStore>(
         store: &mut V,
-        graph: &GraphMem<VectorId>,
+        graph: &GraphMem,
         nodes: &[VectorId],
         lc: usize,
         query: &V::QueryRef,
@@ -1391,7 +1391,7 @@ impl HnswSearcher {
     pub async fn search<V: VectorStore, N: Neighborhood<V>>(
         &self,
         store: &mut V,
-        graph: &GraphMem<VectorId>,
+        graph: &GraphMem,
         query: &V::QueryRef,
         k: usize,
     ) -> Result<N> {
@@ -1428,7 +1428,7 @@ impl HnswSearcher {
     pub async fn insert<V: VectorStoreMut, N: Neighborhood<V>>(
         &self,
         store: &mut V,
-        graph: &mut GraphMem<VectorId>,
+        graph: &mut GraphMem,
         query: &V::QueryRef,
         insertion_layer: usize,
     ) -> Result<VectorId> {
@@ -1470,7 +1470,7 @@ impl HnswSearcher {
     pub async fn search_to_insert<V: VectorStore, N: Neighborhood<V>>(
         &self,
         store: &mut V,
-        graph: &GraphMem<VectorId>,
+        graph: &GraphMem,
         query: &V::QueryRef,
         insertion_layer: usize,
     ) -> Result<(Vec<N>, UpdateEntryPoint)> {
@@ -1541,9 +1541,9 @@ impl HnswSearcher {
     pub async fn compact_batch<V: VectorStore>(
         &self,
         store: &mut V,
-        graph: &GraphMem<VectorId>,
+        graph: &GraphMem,
         candidates: &BTreeSet<(VectorId, usize)>,
-    ) -> Result<Vec<MutationOp<VectorId>>> {
+    ) -> Result<Vec<MutationOp>> {
         // Read the current neighborhood for each candidate; keep only those
         // exceeding M_limit on their layer.
         let mut oversized: Vec<(VectorId, usize, Vec<VectorId>)> = Vec::new();
@@ -1613,9 +1613,9 @@ impl HnswSearcher {
     pub async fn prune_invalid_links<V: VectorStore>(
         &self,
         store: &mut V,
-        graph: &GraphMem<VectorId>,
+        graph: &GraphMem,
         candidates: &BTreeSet<(VectorId, usize)>,
-    ) -> Result<Vec<MutationOp<VectorId>>> {
+    ) -> Result<Vec<MutationOp>> {
         let mut ops = Vec::new();
         for (id, layer) in candidates {
             let current_links = graph.get_links(id, *layer).await.to_vec();
@@ -1654,7 +1654,7 @@ impl HnswSearcher {
     pub async fn insert_from_search_results<V: VectorStore, N: Neighborhood<V>>(
         &self,
         store: &mut V,
-        graph: &mut GraphMem<VectorId>,
+        graph: &mut GraphMem,
         inserted_vector: VectorId,
         links: Vec<N>,
         update_ep: UpdateEntryPoint,
@@ -1670,7 +1670,7 @@ impl HnswSearcher {
         // Build the AddNode + per-layer AddEdges mutation, apply it, then run
         // the same post-apply prune + compaction the batched path uses.
         let height = links_unstructured.len();
-        let mut ops: Vec<MutationOp<VectorId>> = vec![MutationOp::AddNode {
+        let mut ops: Vec<MutationOp> = vec![MutationOp::AddNode {
             id: inserted_vector,
             height,
             update_ep,
@@ -1934,7 +1934,7 @@ mod tests {
     #[tokio::test]
     async fn prune_invalid_links_emits_remove_edges_for_stale_refs() -> Result<()> {
         let mut store = PlaintextStore::<FhdOps>::new();
-        let mut graph: GraphMem<VectorId> = GraphMem::new();
+        let mut graph: GraphMem = GraphMem::new();
         let searcher = HnswSearcher::new_with_test_parameters();
 
         // Real, inserted vector.
@@ -1992,7 +1992,7 @@ mod tests {
     #[tokio::test]
     async fn prune_invalid_links_noop_when_all_valid() -> Result<()> {
         let mut store = PlaintextStore::<FhdOps>::new();
-        let mut graph: GraphMem<VectorId> = GraphMem::new();
+        let mut graph: GraphMem = GraphMem::new();
         let searcher = HnswSearcher::new_with_test_parameters();
 
         let a = store.insert(&Arc::new(IrisCode::default())).await;
@@ -2031,7 +2031,7 @@ mod tests {
     #[tokio::test]
     async fn compact_batch_emits_remove_edges_for_oversized() -> Result<()> {
         let mut store = PlaintextStore::<FhdOps>::new();
-        let mut graph: GraphMem<VectorId> = GraphMem::new();
+        let mut graph: GraphMem = GraphMem::new();
         let searcher = HnswSearcher::new_with_test_parameters();
 
         // Seed a base vector and enough neighbors to exceed M_limit at layer 0.
@@ -2108,7 +2108,7 @@ mod tests {
         use std::sync::Arc;
 
         let mut store = PlaintextStore::<FhdOps>::new();
-        let mut graph: GraphMem<VectorId> = GraphMem::new();
+        let mut graph: GraphMem = GraphMem::new();
         let searcher = HnswSearcher::new_with_test_parameters();
 
         let a = store.insert(&Arc::new(IrisCode::default())).await;

--- a/iris-mpc-cpu/src/hnsw/vector_store.rs
+++ b/iris-mpc-cpu/src/hnsw/vector_store.rs
@@ -72,6 +72,14 @@ pub trait VectorStore: Debug {
         vectors
     }
 
+    /// Retain entrypoints (vector id, layer) whose vector id is valid
+    async fn only_valid_entry_points(
+        &mut self,
+        entry_points: Vec<(VectorId, usize)>,
+    ) -> Vec<(VectorId, usize)> {
+        entry_points
+    }
+
     /// Evaluate the distance between pairs of (query, vector), in batch.
     /// The default implementation is a loop over `eval_distance`.
     /// Override for more efficient batch distance evaluations.

--- a/iris-mpc-cpu/src/hnsw/vector_store.rs
+++ b/iris-mpc-cpu/src/hnsw/vector_store.rs
@@ -76,9 +76,7 @@ pub trait VectorStore: Debug {
     async fn only_valid_entry_points(
         &mut self,
         entry_points: Vec<(VectorId, usize)>,
-    ) -> Vec<(VectorId, usize)> {
-        entry_points
-    }
+    ) -> Vec<(VectorId, usize)>;
 
     /// Evaluate the distance between pairs of (query, vector), in batch.
     /// The default implementation is a loop over `eval_distance`.

--- a/iris-mpc-cpu/src/py_bindings/hnsw.rs
+++ b/iris-mpc-cpu/src/py_bindings/hnsw.rs
@@ -13,7 +13,7 @@ pub fn search(
     query: IrisCode,
     searcher: &HnswSearcher,
     vector: &mut PlaintextStore,
-    graph: &mut GraphMem<VectorId>,
+    graph: &mut GraphMem,
 ) -> (VectorId, f64) {
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -34,7 +34,7 @@ pub fn insert(
     iris: IrisCode,
     searcher: &HnswSearcher,
     vector: &mut PlaintextStore,
-    graph: &mut GraphMem<VectorId>,
+    graph: &mut GraphMem,
 ) -> VectorId {
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -56,7 +56,7 @@ pub fn insert(
 pub fn insert_uniform_random(
     searcher: &HnswSearcher,
     vector: &mut PlaintextStore,
-    graph: &mut GraphMem<VectorId>,
+    graph: &mut GraphMem,
 ) -> VectorId {
     let mut rng = ThreadRng::default();
     let raw_query = IrisCode::random_rng(&mut rng);
@@ -68,7 +68,7 @@ pub fn fill_uniform_random(
     num: usize,
     searcher: &HnswSearcher,
     vector: &mut PlaintextStore,
-    graph: &mut GraphMem<VectorId>,
+    graph: &mut GraphMem,
 ) {
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -97,7 +97,7 @@ pub fn fill_from_ndjson_file(
     limit: Option<usize>,
     searcher: &HnswSearcher,
     vector: &mut PlaintextStore,
-    graph: &mut GraphMem<VectorId>,
+    graph: &mut GraphMem,
 ) {
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()

--- a/iris-mpc-cpu/src/py_bindings/hnsw.rs
+++ b/iris-mpc-cpu/src/py_bindings/hnsw.rs
@@ -47,7 +47,7 @@ pub fn insert(
         let query = Arc::new(iris);
         let insertion_layer = searcher.gen_layer_rng(&mut rng).unwrap();
         searcher
-            .insert::<_, SortedNeighborhood<_>>(vector, graph, &query, insertion_layer)
+            .insert(vector, graph, &query, insertion_layer)
             .await
             .unwrap()
     })
@@ -82,7 +82,7 @@ pub fn fill_uniform_random(
             let query = Arc::new(IrisCode::random_rng(&mut rng));
             let insertion_layer = searcher.gen_layer_rng(&mut rng).unwrap();
             searcher
-                .insert::<_, SortedNeighborhood<_>>(vector, graph, &query, insertion_layer)
+                .insert(vector, graph, &query, insertion_layer)
                 .await
                 .unwrap();
             if idx % 100 == 99 {
@@ -115,7 +115,7 @@ pub fn fill_from_ndjson_file(
             let query = Arc::new(raw_query);
             let insertion_layer = searcher.gen_layer_rng(&mut rng).unwrap();
             searcher
-                .insert::<_, SortedNeighborhood<_>>(vector, graph, &query, insertion_layer)
+                .insert(vector, graph, &query, insertion_layer)
                 .await
                 .unwrap();
         }

--- a/iris-mpc-cpu/src/utils/cli.rs
+++ b/iris-mpc-cpu/src/utils/cli.rs
@@ -12,7 +12,7 @@ use serde::Deserialize;
 use crate::{
     hawkers::plaintext_deep_id_store::Int4Vector,
     hnsw::{
-        searcher::{LayerDistribution, LayerMode, N_PARAM_LAYERS},
+        searcher::{LayerDistribution, N_PARAM_LAYERS},
         GraphMem, HnswParams, HnswSearcher,
     },
     utils::serialization::{
@@ -119,7 +119,7 @@ impl LoadGraphConfig {
 #[allow(non_snake_case)]
 pub struct SearcherConfig {
     pub params: SearcherParams,
-    pub layer_mode: LayerMode,
+    pub max_graph_layer: usize,
     pub layer_distribution: Option<LayerDistribution>,
     #[serde(default)]
     pub fixed_layer_search_batch_size: Option<usize>,
@@ -130,7 +130,6 @@ impl TryFrom<&SearcherConfig> for HnswSearcher {
 
     fn try_from(value: &SearcherConfig) -> Result<Self> {
         let params: HnswParams = (&value.params).try_into()?;
-        let layer_mode = value.layer_mode.clone();
         let layer_distribution = value
             .layer_distribution
             .clone()
@@ -138,7 +137,7 @@ impl TryFrom<&SearcherConfig> for HnswSearcher {
 
         Ok(HnswSearcher {
             params,
-            layer_mode,
+            max_graph_layer: value.max_graph_layer,
             layer_distribution,
             fixed_layer_search_batch_size: value.fixed_layer_search_batch_size,
         })

--- a/iris-mpc-cpu/src/utils/cli.rs
+++ b/iris-mpc-cpu/src/utils/cli.rs
@@ -106,7 +106,7 @@ pub struct LoadGraphConfig {
 }
 
 impl LoadGraphConfig {
-    pub fn read_graph_from_file(&self) -> Result<GraphMem<IrisVectorId>> {
+    pub fn read_graph_from_file(&self) -> Result<GraphMem> {
         let format = self.format.unwrap_or(GraphFormat::Current);
         super::serialization::graph::read_graph_from_file(&self.path, format)
     }

--- a/iris-mpc-cpu/src/utils/cli.rs
+++ b/iris-mpc-cpu/src/utils/cli.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use eyre::{bail, eyre, OptionExt, Result};
-use iris_mpc_common::{iris_db::iris::IrisCode, IrisVectorId};
+use iris_mpc_common::iris_db::iris::IrisCode;
 use rand::{rngs::StdRng, RngCore, SeedableRng};
 use serde::Deserialize;
 

--- a/iris-mpc-cpu/src/utils/serialization/graph.rs
+++ b/iris-mpc-cpu/src/utils/serialization/graph.rs
@@ -141,19 +141,14 @@ impl TryFrom<i32> for GraphFormat {
 
 /// Designated method for reading a `GraphMem`. Currently goes through the
 /// `GraphV4` serialization type.
-pub fn read_graph_current<R: std::io::Read>(
-    reader: &mut R,
-) -> eyre::Result<GraphMem<IrisVectorId>> {
+pub fn read_graph_current<R: std::io::Read>(reader: &mut R) -> eyre::Result<GraphMem> {
     let data = bincode::deserialize_from::<_, GraphV4>(reader)?.into();
     Ok(data)
 }
 
 /// Designated method for writing a `GraphMem`. Currently goes through the
 /// `GraphV4` serialization type.
-pub fn write_graph_current<W: std::io::Write>(
-    writer: &mut W,
-    data: GraphMem<IrisVectorId>,
-) -> Result<()> {
+pub fn write_graph_current<W: std::io::Write>(writer: &mut W, data: GraphMem) -> Result<()> {
     bincode::serialize_into::<_, GraphV4>(writer, &(data.into()))?;
     Ok(())
 }
@@ -163,8 +158,8 @@ pub fn write_graph_current<W: std::io::Write>(
 ///
 /// _Provided for compatibility only_ -- please prefer use of stable serialization
 /// formats.
-pub fn read_graph_raw<R: std::io::Read>(reader: &mut R) -> Result<GraphMem<IrisVectorId>> {
-    let data = bincode::deserialize_from::<_, GraphMem<IrisVectorId>>(reader)?;
+pub fn read_graph_raw<R: std::io::Read>(reader: &mut R) -> Result<GraphMem> {
+    let data = bincode::deserialize_from::<_, GraphMem>(reader)?;
     Ok(data)
 }
 
@@ -173,19 +168,13 @@ pub fn read_graph_raw<R: std::io::Read>(reader: &mut R) -> Result<GraphMem<IrisV
 ///
 /// _Provided for compatibility only_ -- please prefer use of stable serialization
 /// formats.
-pub fn write_graph_raw<W: std::io::Write>(
-    writer: &mut W,
-    data: GraphMem<IrisVectorId>,
-) -> Result<()> {
-    bincode::serialize_into::<_, GraphMem<IrisVectorId>>(writer, &data)?;
+pub fn write_graph_raw<W: std::io::Write>(writer: &mut W, data: GraphMem) -> Result<()> {
+    bincode::serialize_into::<_, GraphMem>(writer, &data)?;
     Ok(())
 }
 
 /// Read a `GraphMem` with a specified serialization format.
-pub fn read_graph<R: std::io::Read>(
-    reader: &mut R,
-    format: GraphFormat,
-) -> Result<GraphMem<IrisVectorId>> {
+pub fn read_graph<R: std::io::Read>(reader: &mut R, format: GraphFormat) -> Result<GraphMem> {
     match format {
         GraphFormat::Current => read_graph_current(reader),
         GraphFormat::V4 => {
@@ -213,10 +202,7 @@ pub fn read_graph<R: std::io::Read>(
 }
 
 /// Read a `GraphMem` from file with a specified serialization format.
-pub fn read_graph_from_file<P: AsRef<Path>>(
-    path: P,
-    format: GraphFormat,
-) -> Result<GraphMem<IrisVectorId>> {
+pub fn read_graph_from_file<P: AsRef<Path>>(path: P, format: GraphFormat) -> Result<GraphMem> {
     let file = File::open(path)?;
     let mut reader = BufReader::new(file);
     read_graph(&mut reader, format)
@@ -225,7 +211,7 @@ pub fn read_graph_from_file<P: AsRef<Path>>(
 /// Read a graph from file with unknown serialization format.  Returns deserialization
 /// results using the most recent graph format for which deserialization is successful,
 /// or an `Err` result if no graph format is valid.
-pub fn try_read_graph_from_file<P: AsRef<Path>>(path: P) -> Result<GraphMem<IrisVectorId>> {
+pub fn try_read_graph_from_file<P: AsRef<Path>>(path: P) -> Result<GraphMem> {
     let data = std::fs::read(&path)?;
 
     for format in ALL_CONCRETE_GRAPH_FORMATS {
@@ -258,7 +244,7 @@ pub fn check_valid_graph_formats(data: &[u8]) -> Vec<GraphFormat> {
 
 /// Write a `GraphMem` to file using the `GraphFormat::Current` serialization
 /// format, currently `GraphV4`.
-pub fn write_graph_to_file<P: AsRef<Path>>(path: P, data: GraphMem<IrisVectorId>) -> Result<()> {
+pub fn write_graph_to_file<P: AsRef<Path>>(path: P, data: GraphMem) -> Result<()> {
     let file = File::create(path)?;
     let mut writer = BufWriter::new(file);
     write_graph_current(&mut writer, data)
@@ -276,9 +262,7 @@ fn read_pair<R: std::io::Read + ?Sized, G: for<'a> Deserialize<'a>>(
 
 /// Designated method for reading a pair of `GraphMem` structs. Currently goes
 /// through the `GraphV4` serialization type.
-pub fn read_graph_pair_current<R: std::io::Read + ?Sized>(
-    reader: &mut R,
-) -> Result<[GraphMem<IrisVectorId>; 2]> {
+pub fn read_graph_pair_current<R: std::io::Read + ?Sized>(reader: &mut R) -> Result<[GraphMem; 2]> {
     let data = read_pair::<_, GraphV4>(reader)?.map(|graph| graph.into());
     Ok(data)
 }
@@ -287,7 +271,7 @@ pub fn read_graph_pair_current<R: std::io::Read + ?Sized>(
 /// through the `GraphV4` serialization type.
 pub fn write_graph_pair_current<W: std::io::Write>(
     writer: &mut W,
-    data: [GraphMem<IrisVectorId>; 2],
+    data: [GraphMem; 2],
 ) -> Result<()> {
     let data = data.map(|graph| graph.into());
     bincode::serialize_into::<_, [GraphV4; 2]>(writer, &data)?;
@@ -299,10 +283,8 @@ pub fn write_graph_pair_current<W: std::io::Write>(
 ///
 /// _Provided for compatibility only_ -- please prefer use of stable serialization
 /// formats.
-pub fn read_graph_pair_raw<R: std::io::Read + ?Sized>(
-    reader: &mut R,
-) -> Result<[GraphMem<IrisVectorId>; 2]> {
-    let data = read_pair::<_, GraphMem<IrisVectorId>>(reader)?;
+pub fn read_graph_pair_raw<R: std::io::Read + ?Sized>(reader: &mut R) -> Result<[GraphMem; 2]> {
+    let data = read_pair::<_, GraphMem>(reader)?;
     Ok(data)
 }
 
@@ -311,11 +293,8 @@ pub fn read_graph_pair_raw<R: std::io::Read + ?Sized>(
 ///
 /// _Provided for compatibility only_ -- please prefer use of stable serialization
 /// formats.
-pub fn write_graph_pair_raw<W: std::io::Write>(
-    writer: &mut W,
-    data: [GraphMem<IrisVectorId>; 2],
-) -> Result<()> {
-    bincode::serialize_into::<_, [GraphMem<IrisVectorId>; 2]>(writer, &data)?;
+pub fn write_graph_pair_raw<W: std::io::Write>(writer: &mut W, data: [GraphMem; 2]) -> Result<()> {
+    bincode::serialize_into::<_, [GraphMem; 2]>(writer, &data)?;
     Ok(())
 }
 
@@ -323,7 +302,7 @@ pub fn write_graph_pair_raw<W: std::io::Write>(
 pub fn read_graph_pair<R: std::io::Read + ?Sized>(
     reader: &mut R,
     format: GraphFormat,
-) -> Result<[GraphMem<IrisVectorId>; 2]> {
+) -> Result<[GraphMem; 2]> {
     match format {
         GraphFormat::Current => read_graph_pair_current(reader),
         GraphFormat::V4 => {
@@ -355,7 +334,7 @@ pub fn read_graph_pair<R: std::io::Read + ?Sized>(
 pub fn read_graph_pair_from_file<P: AsRef<Path>>(
     path: P,
     format: GraphFormat,
-) -> Result<[GraphMem<IrisVectorId>; 2]> {
+) -> Result<[GraphMem; 2]> {
     let file = File::open(path)?;
     let mut reader = BufReader::new(file);
     read_graph_pair(&mut reader, format)
@@ -365,9 +344,7 @@ pub fn read_graph_pair_from_file<P: AsRef<Path>>(
 /// deserialization results using the most recent graph format for which
 /// deserialization is successful, or an `Err` result if no graph format is
 /// valid.
-pub fn try_read_graph_pair_from_file<P: AsRef<Path>>(
-    path: P,
-) -> Result<[GraphMem<IrisVectorId>; 2]> {
+pub fn try_read_graph_pair_from_file<P: AsRef<Path>>(path: P) -> Result<[GraphMem; 2]> {
     let data = std::fs::read(&path)?;
 
     for format in ALL_CONCRETE_GRAPH_FORMATS {
@@ -400,10 +377,7 @@ pub fn check_valid_graph_pair_formats(data: &[u8]) -> Vec<GraphFormat> {
 
 /// Write a pair of `GraphMem` structs to file using the `GraphFormat::Current`
 /// graph serialization format, currently `GraphV4`.
-pub fn write_graph_pair_to_file<P: AsRef<Path>>(
-    path: P,
-    data: [GraphMem<IrisVectorId>; 2],
-) -> Result<()> {
+pub fn write_graph_pair_to_file<P: AsRef<Path>>(path: P, data: [GraphMem; 2]) -> Result<()> {
     let file = File::create(path)?;
     let mut writer = BufWriter::new(file);
     write_graph_pair_current(&mut writer, data)
@@ -418,7 +392,7 @@ impl From<graph_v0::PointId> for IrisVectorId {
     }
 }
 
-impl From<graph_v0::EntryPoint> for layered_graph::EntryPoint<IrisVectorId> {
+impl From<graph_v0::EntryPoint> for layered_graph::EntryPoint {
     fn from(value: graph_v0::EntryPoint) -> Self {
         layered_graph::EntryPoint {
             point: value.point.into(),
@@ -427,7 +401,7 @@ impl From<graph_v0::EntryPoint> for layered_graph::EntryPoint<IrisVectorId> {
     }
 }
 
-impl From<graph_v0::Layer> for Layer<IrisVectorId> {
+impl From<graph_v0::Layer> for Layer {
     fn from(value: graph_v0::Layer) -> Self {
         let mut layer = Layer::new();
         for (point_id, edges) in value.links.into_iter() {
@@ -440,7 +414,7 @@ impl From<graph_v0::Layer> for Layer<IrisVectorId> {
     }
 }
 
-impl From<graph_v0::GraphV0> for GraphMem<IrisVectorId> {
+impl From<graph_v0::GraphV0> for GraphMem {
     fn from(value: GraphV0) -> Self {
         GraphMem {
             entry_points: value
@@ -462,7 +436,7 @@ impl From<graph_v1::VectorId> for IrisVectorId {
     }
 }
 
-impl From<graph_v1::EntryPoint> for layered_graph::EntryPoint<IrisVectorId> {
+impl From<graph_v1::EntryPoint> for layered_graph::EntryPoint {
     fn from(value: graph_v1::EntryPoint) -> Self {
         layered_graph::EntryPoint {
             point: value.point.into(),
@@ -471,7 +445,7 @@ impl From<graph_v1::EntryPoint> for layered_graph::EntryPoint<IrisVectorId> {
     }
 }
 
-impl From<graph_v1::Layer> for Layer<IrisVectorId> {
+impl From<graph_v1::Layer> for Layer {
     fn from(value: graph_v1::Layer) -> Self {
         let mut layer = Layer::new();
         for (v, nb) in value.links.into_iter() {
@@ -486,7 +460,7 @@ impl From<graph_v1::Layer> for Layer<IrisVectorId> {
     }
 }
 
-impl From<graph_v1::GraphV1> for GraphMem<IrisVectorId> {
+impl From<graph_v1::GraphV1> for GraphMem {
     fn from(value: GraphV1) -> Self {
         GraphMem {
             entry_points: value
@@ -508,7 +482,7 @@ impl From<graph_v2::VectorId> for IrisVectorId {
     }
 }
 
-impl From<graph_v2::EntryPoint> for layered_graph::EntryPoint<IrisVectorId> {
+impl From<graph_v2::EntryPoint> for layered_graph::EntryPoint {
     fn from(value: graph_v2::EntryPoint) -> Self {
         layered_graph::EntryPoint {
             point: value.point.into(),
@@ -517,7 +491,7 @@ impl From<graph_v2::EntryPoint> for layered_graph::EntryPoint<IrisVectorId> {
     }
 }
 
-impl From<graph_v2::Layer> for Layer<IrisVectorId> {
+impl From<graph_v2::Layer> for Layer {
     fn from(value: graph_v2::Layer) -> Self {
         let mut layer = Layer::new();
 
@@ -530,7 +504,7 @@ impl From<graph_v2::Layer> for Layer<IrisVectorId> {
     }
 }
 
-impl From<graph_v2::GraphV2> for GraphMem<IrisVectorId> {
+impl From<graph_v2::GraphV2> for GraphMem {
     fn from(value: graph_v2::GraphV2) -> Self {
         GraphMem {
             // GraphMem uses a Vec<EntryPoint>, V2 uses Option<EntryPoint>.
@@ -553,7 +527,7 @@ impl From<graph_v3::VectorId> for IrisVectorId {
     }
 }
 
-impl From<graph_v3::EntryPoint> for layered_graph::EntryPoint<IrisVectorId> {
+impl From<graph_v3::EntryPoint> for layered_graph::EntryPoint {
     fn from(value: graph_v3::EntryPoint) -> Self {
         layered_graph::EntryPoint {
             point: value.point.into(),
@@ -562,7 +536,7 @@ impl From<graph_v3::EntryPoint> for layered_graph::EntryPoint<IrisVectorId> {
     }
 }
 
-impl From<graph_v3::Layer> for Layer<IrisVectorId> {
+impl From<graph_v3::Layer> for Layer {
     fn from(value: graph_v3::Layer) -> Self {
         let mut layer = Layer::new();
         for (v, nb) in value.links.into_iter() {
@@ -572,7 +546,7 @@ impl From<graph_v3::Layer> for Layer<IrisVectorId> {
     }
 }
 
-impl From<graph_v3::GraphV3> for GraphMem<IrisVectorId> {
+impl From<graph_v3::GraphV3> for GraphMem {
     fn from(value: graph_v3::GraphV3) -> Self {
         GraphMem {
             // V3 uses a Vec<EntryPoint>, which matches GraphMem
@@ -591,7 +565,7 @@ impl From<graph_v4::VectorId> for IrisVectorId {
     }
 }
 
-impl From<graph_v4::EntryPoint> for layered_graph::EntryPoint<IrisVectorId> {
+impl From<graph_v4::EntryPoint> for layered_graph::EntryPoint {
     fn from(value: graph_v4::EntryPoint) -> Self {
         layered_graph::EntryPoint {
             point: value.point.into(),
@@ -600,7 +574,7 @@ impl From<graph_v4::EntryPoint> for layered_graph::EntryPoint<IrisVectorId> {
     }
 }
 
-impl From<graph_v4::Layer> for Layer<IrisVectorId> {
+impl From<graph_v4::Layer> for Layer {
     fn from(value: graph_v4::Layer) -> Self {
         let mut layer = Layer::new();
         for (v, nb) in value.links.into_iter() {
@@ -610,7 +584,7 @@ impl From<graph_v4::Layer> for Layer<IrisVectorId> {
     }
 }
 
-impl From<graph_v4::GraphV4> for GraphMem<IrisVectorId> {
+impl From<graph_v4::GraphV4> for GraphMem {
     fn from(value: graph_v4::GraphV4) -> Self {
         GraphMem {
             entry_points: value.entry_points.into_iter().map(|e| e.into()).collect(),
@@ -631,8 +605,8 @@ impl From<IrisVectorId> for graph_v4::VectorId {
     }
 }
 
-impl From<layered_graph::EntryPoint<IrisVectorId>> for graph_v4::EntryPoint {
-    fn from(value: layered_graph::EntryPoint<IrisVectorId>) -> Self {
+impl From<layered_graph::EntryPoint> for graph_v4::EntryPoint {
+    fn from(value: layered_graph::EntryPoint) -> Self {
         graph_v4::EntryPoint {
             point: value.point.into(),
             layer: value.layer,
@@ -640,8 +614,8 @@ impl From<layered_graph::EntryPoint<IrisVectorId>> for graph_v4::EntryPoint {
     }
 }
 
-impl From<Layer<IrisVectorId>> for graph_v4::Layer {
-    fn from(value: Layer<IrisVectorId>) -> Self {
+impl From<Layer> for graph_v4::Layer {
+    fn from(value: Layer) -> Self {
         let set_hash = value.checksum();
         graph_v4::Layer {
             links: value
@@ -659,8 +633,8 @@ impl From<Layer<IrisVectorId>> for graph_v4::Layer {
     }
 }
 
-impl From<GraphMem<IrisVectorId>> for graph_v4::GraphV4 {
-    fn from(value: GraphMem<IrisVectorId>) -> Self {
+impl From<GraphMem> for graph_v4::GraphV4 {
+    fn from(value: GraphMem) -> Self {
         graph_v4::GraphV4 {
             entry_points: value.entry_points.into_iter().map(|ep| ep.into()).collect(),
             layers: value.layers.into_iter().map(|layer| layer.into()).collect(),
@@ -686,7 +660,7 @@ impl From<GraphMem<IrisVectorId>> for graph_v4::GraphV4 {
 pub fn read_graph_pair_streaming<R: std::io::Read + ?Sized>(
     reader: &mut R,
     format: GraphFormat,
-) -> Result<[GraphMem<IrisVectorId>; 2]> {
+) -> Result<[GraphMem; 2]> {
     match format {
         GraphFormat::Current | GraphFormat::V4 => Ok([
             read_graph_v4_streaming(reader)?,
@@ -704,11 +678,9 @@ pub fn read_graph_pair_streaming<R: std::io::Read + ?Sized>(
 ///
 /// Reads `entry_points`, then deserialises each `Layer` individually via
 /// [`read_hashed_layer_streaming`], then reads `last_update_seq_no`.  Each
-/// layer is converted to [`Layer<IrisVectorId>`] and appended before the
+/// layer is converted to [`Layer`] and appended before the
 /// next layer is read, so no two full-graph copies coexist.
-fn read_graph_v4_streaming<R: std::io::Read + ?Sized>(
-    reader: &mut R,
-) -> Result<GraphMem<IrisVectorId>> {
+fn read_graph_v4_streaming<R: std::io::Read + ?Sized>(reader: &mut R) -> Result<GraphMem> {
     let entry_points: Vec<graph_v4::EntryPoint> = bincode::deserialize_from(&mut *reader)
         .map_err(|e| eyre::eyre!("v4 streaming entry_points: {e}"))?;
 
@@ -739,9 +711,7 @@ fn read_graph_v4_streaming<R: std::io::Read + ?Sized>(
 /// V3 differs from V4 only in having `entry_point` (same binary layout) and
 /// no `last_update_seq_no` field.  Layers share the same on-wire layout as
 /// V4 (see [`read_hashed_layer_streaming`]).
-fn read_graph_v3_streaming<R: std::io::Read + ?Sized>(
-    reader: &mut R,
-) -> Result<GraphMem<IrisVectorId>> {
+fn read_graph_v3_streaming<R: std::io::Read + ?Sized>(reader: &mut R) -> Result<GraphMem> {
     // Field name is `entry_point` in GraphV3 vs `entry_points` in GraphV4,
     // but bincode uses positional encoding so the bytes are identical.
     let entry_points: Vec<graph_v3::EntryPoint> = bincode::deserialize_from(&mut *reader)
@@ -767,7 +737,7 @@ fn read_graph_v3_streaming<R: std::io::Read + ?Sized>(
     })
 }
 
-/// Deserialise one layer entry-by-entry into [`Layer<IrisVectorId>`].
+/// Deserialise one layer entry-by-entry into [`Layer`].
 ///
 /// Works for both V3 and V4 layers because their on-wire layout is
 /// identical: both store `HashMap<{u32, i16}, Vec<{u32, i16}>>`
@@ -777,9 +747,7 @@ fn read_graph_v3_streaming<R: std::io::Read + ?Sized>(
 ///
 /// The serialised `set_hash` is read and discarded; [`Layer::set_links`]
 /// recomputes it incrementally as each edge list is inserted.
-fn read_hashed_layer_streaming<R: std::io::Read + ?Sized>(
-    reader: &mut R,
-) -> Result<Layer<IrisVectorId>> {
+fn read_hashed_layer_streaming<R: std::io::Read + ?Sized>(reader: &mut R) -> Result<Layer> {
     // HashMap bincode layout: u64 count + count × (key, value)
     let link_count: u64 =
         bincode::deserialize_from(&mut *reader).map_err(|e| eyre::eyre!("link_count: {e}"))?;
@@ -814,7 +782,7 @@ mod tests {
     /// Multi-node layer inserted out of key order, so `HashMap` iteration order
     /// is overwhelmingly unlikely to coincide with sorted order — i.e. the test
     /// actually exercises the link sorting.
-    fn sample_graph() -> GraphMem<IrisVectorId> {
+    fn sample_graph() -> GraphMem {
         let v = IrisVectorId::from_serial_id;
         let mut layer = Layer::new();
         for &n in &[7u32, 3, 9, 1, 5, 8, 2, 6, 4] {

--- a/iris-mpc-cpu/tests/counter_subscriber.rs
+++ b/iris-mpc-cpu/tests/counter_subscriber.rs
@@ -14,7 +14,7 @@
 
 use aes_prng::AesRng;
 use eyre::Result;
-use iris_mpc_common::{iris_db::iris::IrisCode, vector_id::VectorId};
+use iris_mpc_common::iris_db::iris::IrisCode;
 use iris_mpc_cpu::{
     hawkers::plaintext_store::PlaintextStore,
     hnsw::{

--- a/iris-mpc-cpu/tests/counter_subscriber.rs
+++ b/iris-mpc-cpu/tests/counter_subscriber.rs
@@ -168,7 +168,7 @@ async fn init_hnsw(
 ) -> Result<(
     HnswSearcher,
     PlaintextStore,
-    GraphMem<VectorId>,
+    GraphMem,
     Arc<IrisCode>,
     Arc<IrisCode>,
 )> {
@@ -183,7 +183,7 @@ async fn init_hnsw(
 async fn hnsw_search_queries_seq(
     searcher: &HnswSearcher,
     vector_store: &mut PlaintextStore,
-    graph_store: &mut GraphMem<VectorId>,
+    graph_store: &mut GraphMem,
     query1: Arc<IrisCode>,
     query2: Arc<IrisCode>,
 ) -> Result<()> {
@@ -199,7 +199,7 @@ async fn hnsw_search_queries_seq(
 async fn hnsw_search_queries_par(
     searcher: &HnswSearcher,
     vector_store: &mut PlaintextStore,
-    graph_store: &mut GraphMem<VectorId>,
+    graph_store: &mut GraphMem,
     query1: Arc<IrisCode>,
     query2: Arc<IrisCode>,
 ) {

--- a/iris-mpc-cpu/tests/counter_subscriber.rs
+++ b/iris-mpc-cpu/tests/counter_subscriber.rs
@@ -18,7 +18,6 @@ use iris_mpc_common::iris_db::iris::IrisCode;
 use iris_mpc_cpu::{
     hawkers::plaintext_store::PlaintextStore,
     hnsw::{
-        graph::neighborhood::SortedNeighborhood,
         metrics::ops_counter::{
             OpCountersLayer, Operation, ParamCounterRef, ParamVertexOpeningsCounter, StaticCounter,
         },
@@ -188,9 +187,7 @@ async fn hnsw_search_queries_seq(
     query2: Arc<IrisCode>,
 ) -> Result<()> {
     for q in [query1, query2].into_iter() {
-        searcher
-            .search::<_, SortedNeighborhood<PlaintextStore>>(vector_store, graph_store, &q, 1)
-            .await?;
+        searcher.search(vector_store, graph_store, &q, 1).await?;
     }
 
     Ok(())
@@ -210,12 +207,7 @@ async fn hnsw_search_queries_par(
         let graph_store = graph_store.clone();
         jobs.spawn(async move {
             searcher
-                .search::<_, SortedNeighborhood<PlaintextStore>>(
-                    &mut vector_store,
-                    &graph_store,
-                    &q,
-                    1,
-                )
+                .search(&mut vector_store, &graph_store, &q, 1)
                 .await?;
 
             Ok(())

--- a/iris-mpc-cpu/tests/deep_id_neighborhoods_format.rs
+++ b/iris-mpc-cpu/tests/deep_id_neighborhoods_format.rs
@@ -6,7 +6,7 @@ use std::io::Write;
 
 use aes_prng::AesRng;
 use iris_mpc_cpu::hawkers::ideal_knn_engines::{
-    read_knn_results_from_file, EngineChoiceInt4, EngineInt4, KNNResult,
+    read_knn_results_from_file, EngineChoiceInt4, EngineInt4,
 };
 use iris_mpc_cpu::hawkers::plaintext_deep_id_store::Int4Vector;
 use rand::SeedableRng;
@@ -21,7 +21,7 @@ fn int4_neighborhoods_file_is_consumable_and_contiguous() {
 
     // Compute neighborhoods exactly as the binary does (engine path).
     let mut engine = EngineInt4::init(EngineChoiceInt4::NaiveInt4Dot, vectors, k, 1);
-    let results: Vec<KNNResult> = engine.compute_chunk(n);
+    let results = engine.compute_chunk(n);
 
     // Write a results file: a header line (ignored by the consumer) + body lines.
     let dir = tempdir().unwrap();
@@ -29,13 +29,8 @@ fn int4_neighborhoods_file_is_consumable_and_contiguous() {
     {
         let mut f = std::fs::File::create(&path).unwrap();
         writeln!(f, "{{\"some\":\"header the consumer skips\"}}").unwrap();
-        // First, serialize the nodes as u32 values for the test file
-        for (i, _) in results.iter().enumerate() {
-            let json = serde_json::json!({
-                "node": (i + 1) as u32,
-                "neighbors": results[i].neighbors.iter().map(|v| v.serial_id()).collect::<Vec<_>>()
-            });
-            writeln!(f, "{}", json).unwrap();
+        for r in &results {
+            writeln!(f, "{}", serde_json::to_string(r).unwrap()).unwrap();
         }
     }
 
@@ -45,7 +40,7 @@ fn int4_neighborhoods_file_is_consumable_and_contiguous() {
 
     // Node ids must be the contiguous 1..=N sequence (the consumer zips
     // sorted ids against vectors loaded in file order).
-    let mut nodes: Vec<u32> = parsed.iter().map(|r| r.node.serial_id()).collect();
+    let mut nodes: Vec<u32> = parsed.iter().map(|r| r.node).collect();
     nodes.sort_unstable();
     let expected: Vec<u32> = (1..=n as u32).collect();
     assert_eq!(nodes, expected, "node ids form 1..=N");
@@ -53,9 +48,9 @@ fn int4_neighborhoods_file_is_consumable_and_contiguous() {
     // Each neighborhood has k entries, all in range and excluding self.
     for r in &parsed {
         assert_eq!(r.neighbors.len(), k);
-        for nb in &r.neighbors {
-            assert!((1..=n as u32).contains(&nb.serial_id()));
-            assert_ne!(*nb, r.node, "self must be excluded");
+        for &nb in &r.neighbors {
+            assert!((1..=n as u32).contains(&nb));
+            assert_ne!(nb, r.node, "self must be excluded");
         }
     }
 }

--- a/iris-mpc-cpu/tests/deep_id_neighborhoods_format.rs
+++ b/iris-mpc-cpu/tests/deep_id_neighborhoods_format.rs
@@ -21,7 +21,7 @@ fn int4_neighborhoods_file_is_consumable_and_contiguous() {
 
     // Compute neighborhoods exactly as the binary does (engine path).
     let mut engine = EngineInt4::init(EngineChoiceInt4::NaiveInt4Dot, vectors, k, 1);
-    let results: Vec<KNNResult<u32>> = engine.compute_chunk(n);
+    let results: Vec<KNNResult> = engine.compute_chunk(n);
 
     // Write a results file: a header line (ignored by the consumer) + body lines.
     let dir = tempdir().unwrap();
@@ -29,8 +29,13 @@ fn int4_neighborhoods_file_is_consumable_and_contiguous() {
     {
         let mut f = std::fs::File::create(&path).unwrap();
         writeln!(f, "{{\"some\":\"header the consumer skips\"}}").unwrap();
-        for r in &results {
-            writeln!(f, "{}", serde_json::to_string(r).unwrap()).unwrap();
+        // First, serialize the nodes as u32 values for the test file
+        for (i, _) in results.iter().enumerate() {
+            let json = serde_json::json!({
+                "node": (i + 1) as u32,
+                "neighbors": results[i].neighbors.iter().map(|v| v.serial_id()).collect::<Vec<_>>()
+            });
+            writeln!(f, "{}", json).unwrap();
         }
     }
 
@@ -40,7 +45,7 @@ fn int4_neighborhoods_file_is_consumable_and_contiguous() {
 
     // Node ids must be the contiguous 1..=N sequence (the consumer zips
     // sorted ids against vectors loaded in file order).
-    let mut nodes: Vec<u32> = parsed.iter().map(|r| r.node).collect();
+    let mut nodes: Vec<u32> = parsed.iter().map(|r| r.node.serial_id()).collect();
     nodes.sort_unstable();
     let expected: Vec<u32> = (1..=n as u32).collect();
     assert_eq!(nodes, expected, "node ids form 1..=N");
@@ -48,9 +53,9 @@ fn int4_neighborhoods_file_is_consumable_and_contiguous() {
     // Each neighborhood has k entries, all in range and excluding self.
     for r in &parsed {
         assert_eq!(r.neighbors.len(), k);
-        for &nb in &r.neighbors {
-            assert!((1..=n as u32).contains(&nb));
-            assert_ne!(nb, r.node, "self must be excluded");
+        for nb in &r.neighbors {
+            assert!((1..=n as u32).contains(&nb.serial_id()));
+            assert_ne!(*nb, r.node, "self must be excluded");
         }
     }
 }

--- a/iris-mpc-cpu/tests/e2e.rs
+++ b/iris-mpc-cpu/tests/e2e.rs
@@ -60,7 +60,7 @@ async fn create_graph_from_plain_dbs(
     left_db: &IrisDB,
     right_db: &IrisDB,
     searcher: &HnswSearcher,
-) -> Result<([GraphMem<VectorId>; 2], [Aby3SharedIrises; 2])> {
+) -> Result<([GraphMem; 2], [Aby3SharedIrises; 2])> {
     let mut rng = StdRng::seed_from_u64(DB_RNG_SEED);
     let left_points: HashMap<VectorId, Arc<IrisCode>> = left_db
         .db
@@ -103,8 +103,8 @@ async fn create_graph_from_plain_dbs(
     assert_eq!(Some(DB_SIZE), left_graph_max_id);
     assert_eq!(Some(DB_SIZE), right_graph_max_id);
 
-    let left_mpc_graph: GraphMem<VectorId> = left_graph;
-    let right_mpc_graph: GraphMem<VectorId> = right_graph;
+    let left_mpc_graph: GraphMem = left_graph;
+    let right_mpc_graph: GraphMem = right_graph;
 
     let mut left_shared_irises = HashMap::new();
     let mut right_shared_irises = HashMap::new();

--- a/iris-mpc-cpu/tests/e2e.rs
+++ b/iris-mpc-cpu/tests/e2e.rs
@@ -15,7 +15,7 @@ use iris_mpc_cpu::{
         plaintext_store::PlaintextStore,
         shared_irises::SharedIrises,
     },
-    hnsw::{GraphMem, HnswSearcher, LayerDistribution},
+    hnsw::{GraphMem, HnswSearcher, LayerDistribution, LINEAR_SCAN_MAX_GRAPH_LAYER},
     protocol::shared_iris::GaloisRingSharedIris,
 };
 use rand::{rngs::StdRng, SeedableRng};
@@ -38,8 +38,6 @@ const MAX_RESET_UPDATES_PER_BATCH: usize = 3;
 const HNSW_EF_CONSTR: usize = 320;
 const HNSW_M: usize = 256;
 const HNSW_EF_SEARCH: usize = 256;
-// Must match HawkActor's LINEAR_SCAN_MAX_GRAPH_LAYER (hawk_main.rs).
-const LINEAR_SCAN_MAX_GRAPH_LAYER: usize = 1;
 const HNSW_LAYER_DENSITY: usize = 20;
 
 const UNIQUENESS_REQUEST_PARALLELISM: usize = 4;

--- a/iris-mpc-cpu/tests/streaming_s3_integration.rs
+++ b/iris-mpc-cpu/tests/streaming_s3_integration.rs
@@ -308,7 +308,7 @@ async fn v3_graph_pair_streams_to_graphmem() -> Result<()> {
         *blake3::hash(&bytes).as_bytes()
     };
 
-    // Stream-download V3 bytes → `[GraphMem<IrisVectorId>; 2]`.
+    // Stream-download V3 bytes → `[GraphMem; 2]`.
     let download =
         stream_download_and_deserialize_graph_pair(&client, &bucket, key, GraphFormat::V3).await;
     cleanup_bucket(&client, &bucket).await;
@@ -318,7 +318,7 @@ async fn v3_graph_pair_streams_to_graphmem() -> Result<()> {
     assert_eq!(hash, expected_hash, "BLAKE3 hash mismatch");
 
     // Reference: standard `.into()` conversion on the original in-memory pair.
-    let expected: [GraphMem<IrisVectorId>; 2] = pair.map(|g| g.into());
+    let expected: [GraphMem; 2] = pair.map(|g| g.into());
 
     for i in 0..2 {
         assert_eq!(
@@ -422,7 +422,7 @@ async fn v4_graph_pair_streams_to_graphmem_seq_no_preserved() -> Result<()> {
         return Err(e);
     }
 
-    // Stream-download V4 bytes → `[GraphMem<IrisVectorId>; 2]`.
+    // Stream-download V4 bytes → `[GraphMem; 2]`.
     let download =
         stream_download_and_deserialize_graph_pair(&client, &bucket, key, GraphFormat::V4).await;
     cleanup_bucket(&client, &bucket).await;
@@ -432,7 +432,7 @@ async fn v4_graph_pair_streams_to_graphmem_seq_no_preserved() -> Result<()> {
     assert_eq!(hash, expected_hash, "BLAKE3 hash mismatch");
 
     // Reference: standard `.into()` conversion on the original in-memory pair.
-    let expected: [GraphMem<IrisVectorId>; 2] = pair.map(|g| g.into());
+    let expected: [GraphMem; 2] = pair.map(|g| g.into());
 
     for i in 0..2 {
         assert_eq!(

--- a/iris-mpc-cpu/tests/streaming_s3_integration.rs
+++ b/iris-mpc-cpu/tests/streaming_s3_integration.rs
@@ -18,7 +18,6 @@ use aws_sdk_s3::{
     Client as S3Client, Config,
 };
 use eyre::{eyre, Result};
-use iris_mpc_common::IrisVectorId;
 use iris_mpc_cpu::{
     graph_checkpoint::{
         stream_download_and_deserialize_graph_pair, stream_download_and_deserialize_with,

--- a/iris-mpc-py/src/py_hnsw/pyclasses/graph_store.rs
+++ b/iris-mpc-py/src/py_hnsw/pyclasses/graph_store.rs
@@ -4,7 +4,7 @@ use pyo3::{exceptions::PyIOError, prelude::*};
 
 #[pyclass]
 #[derive(Clone, Default)]
-pub struct PyGraphStore(pub GraphMem<IrisVectorId>);
+pub struct PyGraphStore(pub GraphMem);
 
 #[pymethods]
 impl PyGraphStore {

--- a/iris-mpc-py/src/py_hnsw/pyclasses/hnsw_searcher.rs
+++ b/iris-mpc-py/src/py_hnsw/pyclasses/hnsw_searcher.rs
@@ -1,6 +1,8 @@
 use super::{graph_store::PyGraphStore, iris_code::PyIrisCode, plaintext_store::PyPlaintextStore};
 use iris_mpc_cpu::{
-    hnsw::searcher::{HnswParams, HnswSearcher, LayerDistribution, LayerMode, N_PARAM_LAYERS},
+    hnsw::searcher::{
+        HnswParams, HnswSearcher, LayerDistribution, LINEAR_SCAN_MAX_GRAPH_LAYER, N_PARAM_LAYERS,
+    },
     py_bindings,
     utils::serialization::{read_json, write_json},
 };
@@ -21,24 +23,31 @@ impl Default for PyHnswSearcher {
 impl PyHnswSearcher {
     #[new]
     pub fn new(M: usize, ef_constr: usize, ef_search: usize) -> Self {
-        Self::new_standard(ef_constr, ef_search, M)
+        Self::new_linear_scan(M, ef_constr, ef_search, LINEAR_SCAN_MAX_GRAPH_LAYER)
     }
 
     #[staticmethod]
-    pub fn new_standard(M: usize, ef_constr: usize, ef_search: usize) -> Self {
-        Self(HnswSearcher::new_standard(ef_constr, ef_search, M))
+    pub fn new_linear_scan(
+        M: usize,
+        ef_constr: usize,
+        ef_search: usize,
+        max_graph_layer: usize,
+    ) -> Self {
+        Self(HnswSearcher::new_linear_scan(
+            ef_constr,
+            ef_search,
+            M,
+            max_graph_layer,
+        ))
     }
 
     #[staticmethod]
     pub fn new_uniform(M: usize, ef: usize) -> Self {
         let params = HnswParams::new_uniform(ef, M);
-        let layer_mode = LayerMode::Standard {
-            max_graph_layer: None,
-        };
         let layer_distribution = LayerDistribution::new_geometric_from_M(M);
         Self(HnswSearcher {
             params,
-            layer_mode,
+            max_graph_layer: LINEAR_SCAN_MAX_GRAPH_LAYER,
             layer_distribution,
             fixed_layer_search_batch_size: None,
         })
@@ -65,13 +74,10 @@ impl PyHnswSearcher {
             ef_constr_insert,
             ef_search,
         };
-        let layer_mode = LayerMode::Standard {
-            max_graph_layer: None,
-        };
         let layer_distribution = LayerDistribution::Geometric { layer_probability };
         Self(HnswSearcher {
             params,
-            layer_mode,
+            max_graph_layer: LINEAR_SCAN_MAX_GRAPH_LAYER,
             layer_distribution,
             fixed_layer_search_batch_size: None,
         })

--- a/iris-mpc-upgrade-hawk/tests/utils/mpc_node.rs
+++ b/iris-mpc-upgrade-hawk/tests/utils/mpc_node.rs
@@ -105,14 +105,14 @@ impl MpcNodes {
     pub async fn assert_s3_checkpoint_graphs(
         &self,
         configs: &HawkConfigs,
-        expected_graphs: &BothEyes<GraphMem<IrisVectorId>>,
+        expected_graphs: &BothEyes<GraphMem>,
     ) -> Result<()> {
         for (i, (node, config)) in self.nodes.iter().zip(configs.iter()).enumerate() {
             let aws_clients = get_aws_clients(config).await?;
             let checkpoint_state = get_latest_checkpoint_state(&node.cpu_stores.graph)
                 .await?
                 .ok_or_else(|| eyre::eyre!("No checkpoint found for node {}", i))?;
-            let s3_graphs: BothEyes<GraphMem<IrisVectorId>> = download_graph_checkpoint(
+            let s3_graphs: BothEyes<GraphMem> = download_graph_checkpoint(
                 &aws_clients.checkpoint_s3_client,
                 &config.graph_checkpoint_bucket_name,
                 &checkpoint_state,

--- a/iris-mpc/tests/utils/cpu_node.rs
+++ b/iris-mpc/tests/utils/cpu_node.rs
@@ -118,11 +118,11 @@ impl DbStores {
     /// digest of its bincode serialisation.
     ///
     /// This mirrors exactly what the sidecar does in `terminal.rs`:
-    /// `bincode::serialize_into(writer, &graph)` where `graph: BothEyes<GraphMem<VectorId>>`.
+    /// `bincode::serialize_into(writer, &graph)` where `graph: BothEyes<GraphMem>`.
     /// Use this to build a reference hash for `CpuNodes::assert_checkpoint_hashes_match_reference`.
     pub async fn compute_reference_hash(&self) -> eyre::Result<[u8; 32]> {
         let rows = self.graph.get_hawk_graph_mutations_after(None).await?;
-        let mut graph_pair: [GraphMem<IrisVectorId>; 2] = [GraphMem::new(), GraphMem::new()];
+        let mut graph_pair: [GraphMem; 2] = [GraphMem::new(), GraphMem::new()];
         for row in &rows {
             let [left_muts, right_muts] = row.deserialize_mutations()?;
             graph_pair[0].insert_apply_all(&left_muts)?;
@@ -346,7 +346,7 @@ impl CpuNode {
     ///
     /// 1. Query `MAX(modification_id)` from `hawk_graph_mutations`.
     /// 2. Read all `hawk_graph_mutations` rows up to that id.
-    /// 3. Replay mutations into `[GraphMem<IrisVectorId>; 2]` (left + right eye).
+    /// 3. Replay mutations into `[GraphMem; 2]` (left + right eye).
     /// 4. Serialize according to `format`:
     ///    - `Current` → `bincode::serialize(&[GraphMem; 2])` (sidecar wire format).
     ///    - `V3`      → deterministic custom encoding via `write_graph_v3` (no `seq_no`).
@@ -376,8 +376,8 @@ impl CpuNode {
             .get_hawk_graph_mutations(Some(last_modification_id))
             .await?;
 
-        let mut left_graph = GraphMem::<IrisVectorId>::new();
-        let mut right_graph = GraphMem::<IrisVectorId>::new();
+        let mut left_graph = GraphMem::new();
+        let mut right_graph = GraphMem::new();
         for row in &mutation_rows {
             let both_eyes = row.deserialize_mutations()?;
             left_graph.insert_apply_all(&both_eyes[0])?;
@@ -387,13 +387,13 @@ impl CpuNode {
         let bytes: Vec<u8> = match &format {
             GraphFormat::Current => {
                 // bincode-serialised [GraphMem; 2] — matches the sidecar wire format.
-                let graph_pair: [GraphMem<IrisVectorId>; 2] = [left_graph, right_graph];
+                let graph_pair: [GraphMem; 2] = [left_graph, right_graph];
                 bincode::serialize(&graph_pair)?
             }
             GraphFormat::V3 => {
                 // Convert GraphMem → GraphV3 by copying entry_points and layers,
                 // dropping the seq_no field that is absent in the V3 format.
-                let to_v3 = |g: GraphMem<IrisVectorId>| -> graph_v3::GraphV3 {
+                let to_v3 = |g: GraphMem| -> graph_v3::GraphV3 {
                     let vec_id = |v: &IrisVectorId| graph_v3::VectorId {
                         id: v.serial_id(),
                         version: v.version_id(),

--- a/iris-mpc/tests/utils/wal_builder.rs
+++ b/iris-mpc/tests/utils/wal_builder.rs
@@ -52,7 +52,7 @@ impl ModificationStatus {
 /// Use [`set_persisted`] / [`set_status`] to override individual modifications.
 #[derive(Default)]
 pub struct WalMutationBuilder {
-    entries: HashMap<i64, GraphMutation<IrisVectorId>>,
+    entries: HashMap<i64, GraphMutation>,
     persisted: HashMap<i64, bool>,
     status: HashMap<i64, ModificationStatus>,
     processed: usize,
@@ -168,7 +168,7 @@ impl WalMutationBuilder {
         for m in mutations {
             let modification_id = m.seq_no as _;
             let m = vec![m];
-            let both_eyes: BothEyes<Vec<GraphMutation<IrisVectorId>>> = [m.clone(), m];
+            let both_eyes: BothEyes<Vec<GraphMutation>> = [m.clone(), m];
             let bytes = bincode::serialize(&both_eyes)?;
             graph
                 .upsert_hawk_graph_mutations(&mut tx, modification_id, &bytes)


### PR DESCRIPTION
As an intermediate step to `GraphV5`, which will use half the space (an enormous savings at scale), concretize `GraphMJem`. In this PR, `GraphMem` becomes concrete over `VectorId` and in the future it will be changed to `SerialId`.

As part of this effort, also remove support for unsorted neighborhoods and "single" entrypoints. 

The last 2 commits to remove support for unsorted neighborhoods and "single" entrypoints were reviewed already when being merged into `sw/concretize_graph_mem`. Changes to `main` necessitated cherry-picking onto a new branch. 