### PR TITLE
Unify IrisVectorId and VectorId naming conventions

### DIFF
--- a/docs/request-lifecycle.md
+++ b/docs/request-lifecycle.md
@@ -77,7 +77,7 @@ for del_id in del_ids {
 ## Serial ID Mapping Summary
 
 ```
-Client IrisSerialId (1-based)
+Client SerialId (1-based)
   ↓ request_enqueuer: IdentityDeletionRequest { serial_id }
 Server process_identity_deletion:
   ↓ push_deletion_request(serial_id - 1)   →  0-based index
@@ -88,5 +88,5 @@ ServerJobResult.deleted_ids = [0-based indices]
   ↓ job.rs: serial_id = idx + 1
 IdentityDeletionResult { serial_id }   →  back to 1-based
   ↓ SNS → SQS
-Client is_correlation: parent.IrisSerialId == result.serial_id
+Client is_correlation: parent.SerialId == result.serial_id
 ```

--- a/docs/shared-irises-and-vector-id.md
+++ b/docs/shared-irises-and-vector-id.md
@@ -5,7 +5,7 @@
 **File:** `iris-mpc-common/src/vector_id.rs`
 
 ```rust
-pub type SerialId = u32;    // re-exported as IrisSerialId
+pub type SerialId = u32;    // re-exported as SerialId
 pub type VersionId = i16;
 
 pub struct VectorId {
@@ -20,7 +20,7 @@ Key methods:
 - `next_version()` — same serial_id, version + 1
 - `serial_id()` → u32, `version_id()` → i16, `index()` → u32 (serial_id)
 
-**Important:** `IrisSerialId = SerialId = u32` (re-exported in `iris-mpc-common/src/lib.rs:33`).
+**Important:** `SerialId = SerialId = u32` (re-exported in `iris-mpc-common/src/lib.rs:33`).
 
 The 0-based index used in `BatchQuery.deletion_requests_indices` maps to serial_id via `index + 1`.
 

--- a/docs/shared-irises-and-vector-id.md
+++ b/docs/shared-irises-and-vector-id.md
@@ -5,7 +5,7 @@
 **File:** `iris-mpc-common/src/vector_id.rs`
 
 ```rust
-pub type SerialId = u32;    // re-exported as SerialId
+pub type SerialId = u32;
 pub type VersionId = i16;
 
 pub struct VectorId {
@@ -19,8 +19,6 @@ Key methods:
 - `from_0_index(index: u32)` — serial_id = index + 1, version = 0
 - `next_version()` — same serial_id, version + 1
 - `serial_id()` → u32, `version_id()` → i16, `index()` → u32 (serial_id)
-
-**Important:** `SerialId = SerialId = u32` (re-exported in `iris-mpc-common/src/lib.rs:33`).
 
 The 0-based index used in `BatchQuery.deletion_requests_indices` maps to serial_id via `index + 1`.
 

--- a/iris-mpc-bins/bin/iris-mpc-cpu/communication_stats.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/communication_stats.rs
@@ -46,7 +46,7 @@ use ampc_actor_utils::{
 use async_trait::async_trait;
 use clap::Parser;
 use eyre::Result;
-use iris_mpc_common::{job::JobSubmissionHandle, vector_id::VectorId};
+use iris_mpc_common::{job::JobSubmissionHandle, VectorId};
 use iris_mpc_cpu::{
     execution::{
         hawk_main::{

--- a/iris-mpc-bins/bin/iris-mpc-cpu/construct_graph_ptxt.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/construct_graph_ptxt.rs
@@ -2,7 +2,7 @@ use std::{iter::once, path::PathBuf, sync::Arc};
 
 use clap::Parser;
 use eyre::{bail, Result};
-use iris_mpc_common::{iris_db::iris::IrisCode, IrisVectorId};
+use iris_mpc_common::{iris_db::iris::IrisCode, VectorId};
 use itertools::{chain, Itertools};
 use serde::Deserialize;
 
@@ -161,7 +161,7 @@ fn load_existing_graph(graph_spec: Option<LoadGraphConfig>) -> Result<(GraphMem,
 
 #[allow(non_snake_case)]
 async fn build_iris_graph<D: DistanceOps>(
-    irises: Vec<(IrisVectorId, IrisCode)>,
+    irises: Vec<(VectorId, IrisCode)>,
     graph_spec: Option<LoadGraphConfig>,
     distance_fn: DistanceMode,
     searcher: &HnswSearcher,
@@ -255,7 +255,7 @@ async fn build_iris_graph<D: DistanceOps>(
 }
 
 async fn build_deep_id_graph(
-    vectors: Vec<(IrisVectorId, Int4Vector)>,
+    vectors: Vec<(VectorId, Int4Vector)>,
     threshold: i32,
     graph_spec: Option<LoadGraphConfig>,
     searcher: &HnswSearcher,
@@ -370,7 +370,7 @@ async fn main() -> Result<()> {
             let irises: Vec<_> = irises_
                 .into_iter()
                 .enumerate()
-                .map(|(idx, code)| (IrisVectorId::from_0_index(idx as u32), code))
+                .map(|(idx, code)| (VectorId::from_0_index(idx as u32), code))
                 .collect();
             if irises.is_empty() {
                 bail!("Iris DB is empty");
@@ -409,7 +409,7 @@ async fn main() -> Result<()> {
             let vectors: Vec<_> = vectors_
                 .into_iter()
                 .enumerate()
-                .map(|(idx, v)| (IrisVectorId::from_0_index(idx as u32), v))
+                .map(|(idx, v)| (VectorId::from_0_index(idx as u32), v))
                 .collect();
             if vectors.is_empty() {
                 bail!("Deep-ID DB is empty");

--- a/iris-mpc-bins/bin/iris-mpc-cpu/db_sanity_check.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/db_sanity_check.rs
@@ -8,7 +8,7 @@ use iris_mpc_common::{
         REAUTH_MESSAGE_TYPE, RECOVERY_UPDATE_MESSAGE_TYPE, RESET_UPDATE_MESSAGE_TYPE,
     },
     postgres::{AccessMode, PostgresClient},
-    vector_id::VectorId,
+    VectorId,
 };
 use iris_mpc_cpu::{
     execution::hawk_main::{BothEyes, LEFT, RIGHT},

--- a/iris-mpc-bins/bin/iris-mpc-cpu/generate_ideal_graph.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/generate_ideal_graph.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use eyre::Result;
-use iris_mpc_common::IrisVectorId;
+use iris_mpc_common::VectorId;
 use iris_mpc_cpu::hawkers::aby3::aby3_store::{DistanceOps, FhdOps, NhdOps};
 use iris_mpc_cpu::hawkers::ideal_knn_engines::{EngineChoice, EngineChoiceInt4};
 use iris_mpc_cpu::hawkers::plaintext_deep_id_store::{Int4Vector, PlaintextDeepIDStore};
@@ -114,7 +114,7 @@ async fn run_sanity_check_iris<D: DistanceOps>(
     store.distance_mode = echoice.distance_mode();
 
     for (i, iris) in irises.into_iter().enumerate() {
-        store.insert_with_id(IrisVectorId::from_serial_id((i as u32) + 1), Arc::new(iris));
+        store.insert_with_id(VectorId::from_serial_id((i as u32) + 1), Arc::new(iris));
     }
 
     let sample_iris = store.storage.get_vector(&sample).cloned().unwrap();
@@ -192,7 +192,7 @@ async fn run_sanity_check_deep_id(
 
     let mut store = PlaintextDeepIDStore::new(threshold);
     for (i, v) in vectors.into_iter().enumerate() {
-        store.insert_with_id(IrisVectorId::from_serial_id((i as u32) + 1), Arc::new(v));
+        store.insert_with_id(VectorId::from_serial_id((i as u32) + 1), Arc::new(v));
     }
 
     let sample_vec = Arc::new(store.storage.get_vector(&sample).cloned().unwrap());
@@ -202,7 +202,7 @@ async fn run_sanity_check_deep_id(
             .get_links(&sample)
             .unwrap_or_else(|| panic!("{}", lc));
 
-        let mut dists: Vec<(IrisVectorId, i32)> = Vec::new();
+        let mut dists: Vec<(VectorId, i32)> = Vec::new();
         for k in graph.layers[lc].links.keys() {
             if *k != sample {
                 let dist = store.eval_distance(&sample_vec, k).await.unwrap();

--- a/iris-mpc-bins/bin/iris-mpc-cpu/generate_ideal_neighborhoods.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/generate_ideal_neighborhoods.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use clap::Parser;
-use iris_mpc_common::{iris_db::iris::IrisCode, vector_id::SerialId};
+use iris_mpc_common::{iris_db::iris::IrisCode, SerialId};
 use iris_mpc_cpu::{
     hawkers::ideal_knn_engines::{Engine, EngineInt4, EngineKind, KNNResult},
     utils::serialization::{

--- a/iris-mpc-bins/bin/iris-mpc-cpu/init_test_dbs.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/init_test_dbs.rs
@@ -4,7 +4,7 @@ use aws_sdk_s3::config::Region as S3Region;
 use aws_sdk_s3::Client as S3Client;
 use clap::Parser;
 use eyre::Result;
-use iris_mpc_common::{iris_db::iris::IrisCode, vector_id::SerialId, IrisVectorId};
+use iris_mpc_common::{iris_db::iris::IrisCode, SerialId, VectorId};
 use iris_mpc_cpu::{
     execution::hawk_main::STORE_IDS,
     hawkers::aby3::aby3_store::FhdOps,
@@ -393,7 +393,7 @@ async fn main() -> Result<()> {
                 }
                 let query = Arc::new(raw_query.iris_code);
 
-                let inserted_id = IrisVectorId::from_serial_id(serial_id);
+                let inserted_id = VectorId::from_serial_id(serial_id);
                 vector_store.insert_with_id(inserted_id, query.clone());
 
                 let insertion_layer = searcher.gen_layer_prf(&prf_seed, &(inserted_id, side))?;

--- a/iris-mpc-bins/bin/iris-mpc-upgrade-hawk/iris_mpc_hawk_genesis.rs
+++ b/iris-mpc-bins/bin/iris-mpc-upgrade-hawk/iris_mpc_hawk_genesis.rs
@@ -2,9 +2,7 @@
 
 use clap::Parser;
 use eyre::{bail, Result};
-use iris_mpc_common::{
-    config::Config, helpers::numactl, tracing::initialize_tracing, IrisSerialId,
-};
+use iris_mpc_common::{config::Config, helpers::numactl, tracing::initialize_tracing, SerialId};
 use iris_mpc_cpu::{genesis::BatchSizeConfig, graph_checkpoint::PruningMode};
 use iris_mpc_upgrade_hawk::genesis::{exec, ExecutionArgs};
 
@@ -123,7 +121,7 @@ fn parse_args() -> Result<ExecutionArgs> {
         bail!("--max-height argument is required.");
     }
     let max_indexation_height_arg = args.max_indexation_height.as_ref().unwrap();
-    let max_indexation_id: IrisSerialId = max_indexation_height_arg.parse().map_err(|_| {
+    let max_indexation_id: SerialId = max_indexation_height_arg.parse().map_err(|_| {
         eprintln!(
             "Error: --max-height argument must be a valid u32. Value: {}",
             max_indexation_height_arg

--- a/iris-mpc-common/src/helpers/inmemory_store.rs
+++ b/iris-mpc-common/src/helpers/inmemory_store.rs
@@ -1,4 +1,4 @@
-use crate::vector_id::VectorId;
+use crate::VectorId;
 
 /// A helper trait encapsulating the functionality to add iris codes to some
 /// form of in-memory store.

--- a/iris-mpc-common/src/lib.rs
+++ b/iris-mpc-common/src/lib.rs
@@ -30,6 +30,6 @@ pub type IrisCodeDbSlice<'a> = (&'a [u16], &'a [u16]);
 
 pub use ampc_secret_sharing::galois;
 pub use ampc_secret_sharing::id;
-pub use vector_id::SerialId as IrisSerialId;
-pub use vector_id::VectorId as IrisVectorId;
-pub use vector_id::VersionId as IrisVersionId;
+pub use vector_id::SerialId;
+pub use vector_id::VectorId;
+pub use vector_id::VersionId;

--- a/iris-mpc-common/src/test.rs
+++ b/iris-mpc-common/src/test.rs
@@ -14,8 +14,7 @@ use crate::{
         iris::{IrisCode, IrisCodeArray},
     },
     job::{BatchQuery, JobSubmissionHandle, ServerJobResult},
-    vector_id::VectorId,
-    IRIS_CODE_LENGTH,
+    VectorId, IRIS_CODE_LENGTH,
 };
 use eyre::Result;
 use itertools::izip;

--- a/iris-mpc-cpu/benches/dot.rs
+++ b/iris-mpc-cpu/benches/dot.rs
@@ -6,7 +6,7 @@ use iris_mpc_common::galois_engine::degree4::{rotation_aware_trick_dot_padded, I
 use iris_mpc_common::{
     iris_db::iris::IrisCode, IRIS_CODE_LENGTH, MASK_CODE_LENGTH, PRE_PROC_IRIS_CODE_LENGTH,
 };
-use iris_mpc_common::{IrisVectorId, ROTATIONS};
+use iris_mpc_common::{VectorId, ROTATIONS};
 use iris_mpc_cpu::execution::hawk_main::iris_worker::init_workers;
 use iris_mpc_cpu::hawkers::shared_irises::SharedIrises;
 use iris_mpc_cpu::protocol::{
@@ -632,7 +632,7 @@ pub fn bench_worker_pool(c: &mut Criterion) {
     let num_iris_codes = iris_codes.len();
     let dist = Uniform::new(0, num_iris_codes);
 
-    let points_map: HashMap<IrisVectorId, Arc<GaloisRingSharedIris>> = HashMap::new();
+    let points_map: HashMap<VectorId, Arc<GaloisRingSharedIris>> = HashMap::new();
     let shared_irises = SharedIrises::new(
         points_map,
         Arc::new(GaloisRingSharedIris::default_for_party(0)),
@@ -642,7 +642,7 @@ pub fn bench_worker_pool(c: &mut Criterion) {
 
     // similar to numa_realloc
     for (idx, iris) in iris_codes.iter().enumerate() {
-        pool.insert(IrisVectorId::from_0_index(idx as u32), iris.clone())
+        pool.insert(VectorId::from_0_index(idx as u32), iris.clone())
             .unwrap();
     }
 
@@ -665,7 +665,7 @@ pub fn bench_worker_pool(c: &mut Criterion) {
                         let mut b = vec![];
                         for _ in 0..nearest_neighbors {
                             let idx = dist.sample(rng);
-                            b.push(IrisVectorId::from_0_index(idx as u32));
+                            b.push(VectorId::from_0_index(idx as u32));
                         }
                         (iris_codes[a].clone(), b)
                     },

--- a/iris-mpc-cpu/benches/set_hash.rs
+++ b/iris-mpc-cpu/benches/set_hash.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use iris_mpc_common::vector_id::VectorId;
+use iris_mpc_common::VectorId;
 use iris_mpc_cpu::execution::hawk_main::state_check::SetHash;
 
 /// Benchmark that repeatedly calls insert on SharedIrises.

--- a/iris-mpc-cpu/src/analysis/accuracy.rs
+++ b/iris-mpc-cpu/src/analysis/accuracy.rs
@@ -15,7 +15,7 @@ use crate::{
 use eyre::{bail, eyre, Result};
 use iris_mpc_common::{
     iris_db::iris::{IrisCode, IrisMutationFamily},
-    IrisSerialId, IrisVectorId as VectorId,
+    SerialId, VectorId,
 };
 use itertools::{izip, Itertools};
 use rand::{rngs::StdRng, seq::SliceRandom};
@@ -69,7 +69,7 @@ impl AnalysisConfig {
 /// Struct to hold a single search result for analysis.
 #[derive(Debug, Serialize)]
 pub struct AnalysisResult {
-    id: IrisSerialId,
+    id: SerialId,
     mutation: f64,
     rotation: isize,
     found: bool,
@@ -230,7 +230,7 @@ pub fn process_results(config: &AnalysisConfig, results: Vec<AnalysisResult>) ->
         }
         "histogram" => {
             // Option 2: For each rotation amount, output a histogram of "minimum mutation amount for which match was not found in search results"
-            let mut min_failure_map: HashMap<(IrisSerialId, isize), usize> = HashMap::new();
+            let mut min_failure_map: HashMap<(SerialId, isize), usize> = HashMap::new();
 
             for res in results.iter() {
                 let mutation_key = (res.mutation * PRECISION).floor() as usize;

--- a/iris-mpc-cpu/src/analysis/accuracy_deep_id.rs
+++ b/iris-mpc-cpu/src/analysis/accuracy_deep_id.rs
@@ -18,7 +18,7 @@ use crate::{
     },
 };
 use eyre::{bail, eyre, Result};
-use iris_mpc_common::{IrisSerialId, IrisVectorId as VectorId};
+use iris_mpc_common::{SerialId, VectorId};
 use itertools::Itertools;
 use rand::{rngs::StdRng, seq::SliceRandom, Rng};
 use serde::{Deserialize, Serialize};
@@ -214,7 +214,7 @@ pub fn perturb_nibbles<R: Rng>(v: &Int4Vector, p: f64, rng: &mut R) -> Int4Vecto
 
 #[derive(Debug, Serialize)]
 pub struct AnalysisResult {
-    id: IrisSerialId,
+    id: SerialId,
     noise_level: f64,
     found: bool,
 }
@@ -360,7 +360,7 @@ pub fn process_results(config: &AnalysisConfig, results: Vec<AnalysisResult>) ->
             }
         }
         "histogram" => {
-            let mut min_failure_map: HashMap<IrisSerialId, usize> = HashMap::new();
+            let mut min_failure_map: HashMap<SerialId, usize> = HashMap::new();
             for res in results.iter() {
                 let key = (res.noise_level * PRECISION).floor() as usize;
                 if !res.found {

--- a/iris-mpc-cpu/src/checkpoint_protocol/hasher.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/hasher.rs
@@ -34,7 +34,7 @@ impl GraphHasher for Blake3GraphHasher {
 mod tests {
     use super::*;
     use crate::hnsw::graph::layered_graph::{EntryPoint, GraphMem, Layer};
-    use iris_mpc_common::vector_id::VectorId;
+    use iris_mpc_common::VectorId;
 
     fn vid(i: u32) -> VectorId {
         VectorId::from_0_index(i)

--- a/iris-mpc-cpu/src/checkpoint_protocol/materializer.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/materializer.rs
@@ -123,10 +123,10 @@ mod tests {
     use crate::hnsw::graph::layered_graph::GraphMem;
     use crate::hnsw::graph::mutation::{GraphMutation, MutationOp, UpdateEntryPoint};
     use futures::{stream, StreamExt};
-    use iris_mpc_common::IrisVectorId;
+    use iris_mpc_common::VectorId;
 
-    fn vid(n: u32) -> IrisVectorId {
-        IrisVectorId::from_serial_id(n)
+    fn vid(n: u32) -> VectorId {
+        VectorId::from_serial_id(n)
     }
 
     // Use `n` itself as the seq_no — every test below picks node ids that

--- a/iris-mpc-cpu/src/checkpoint_protocol/store.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/store.rs
@@ -76,7 +76,7 @@ mod tests {
         mutation::{GraphMutation, MutationOp},
     };
     use futures::TryStreamExt;
-    use iris_mpc_common::vector_id::VectorId;
+    use iris_mpc_common::VectorId;
 
     fn vid(n: u32) -> VectorId {
         VectorId::from_serial_id(n)

--- a/iris-mpc-cpu/src/checkpoint_protocol/terminal.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/terminal.rs
@@ -189,10 +189,10 @@ impl TerminalAction for InstallAsServing {
 mod tests {
     use super::*;
     use crate::hnsw::graph::mutation::{GraphMutation, MutationOp, UpdateEntryPoint};
-    use iris_mpc_common::IrisVectorId;
+    use iris_mpc_common::VectorId;
 
-    fn vid(n: u32) -> IrisVectorId {
-        IrisVectorId::from_serial_id(n)
+    fn vid(n: u32) -> VectorId {
+        VectorId::from_serial_id(n)
     }
 
     fn cp_meta() -> CheckpointMeta {

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -102,7 +102,7 @@ use iris_mpc_common::{
         REAUTH_MESSAGE_TYPE, RECOVERY_CHECK_MESSAGE_TYPE, RESET_CHECK_MESSAGE_TYPE,
         UNIQUENESS_MESSAGE_TYPE,
     },
-    vector_id::VectorId,
+    VectorId,
 };
 use iris_mpc_common::{
     helpers::sync::{Modification, ModificationKey},

--- a/iris-mpc-cpu/src/execution/hawk_main/identity_update.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/identity_update.rs
@@ -7,7 +7,7 @@ use super::{
 };
 use crate::execution::hawk_main::{iris_worker::QueryId, search::SearchIds};
 use eyre::Result;
-use iris_mpc_common::vector_id::VectorId;
+use iris_mpc_common::VectorId;
 
 pub struct IdentityUpdateRequests {
     pub vector_ids: Vec<VectorId>,

--- a/iris-mpc-cpu/src/execution/hawk_main/insert.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/insert.rs
@@ -11,7 +11,7 @@ use crate::hnsw::{
 use super::VecRequests;
 
 use eyre::{bail, Result};
-use iris_mpc_common::vector_id::VectorId;
+use iris_mpc_common::VectorId;
 use itertools::izip;
 use std::collections::BTreeSet;
 

--- a/iris-mpc-cpu/src/execution/hawk_main/iris_worker.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/iris_worker.rs
@@ -18,7 +18,7 @@ use eyre::Result;
 use futures::future::{try_join_all, BoxFuture};
 use iris_mpc_common::{
     galois_engine::degree4::{GaloisRingIrisCodeShare, GaloisRingTrimmedMaskCodeShare},
-    vector_id::VectorId,
+    VectorId,
 };
 use itertools::{izip, Itertools};
 use std::{

--- a/iris-mpc-cpu/src/execution/hawk_main/search.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/search.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 use eyre::{OptionExt, Result};
 use iris_mpc_common::iris_db::iris::Threshold;
-use iris_mpc_common::vector_id::VectorId;
+use iris_mpc_common::VectorId;
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};

--- a/iris-mpc-cpu/src/execution/hawk_main/state_check.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/state_check.rs
@@ -1,7 +1,7 @@
 use ampc_secret_sharing::RingElement;
 use eyre::{bail, eyre, Result};
 use futures::join;
-use iris_mpc_common::vector_id::VectorId;
+use iris_mpc_common::VectorId;
 use serde::{Deserialize, Serialize};
 use siphasher::sip::SipHasher13;
 use std::{

--- a/iris-mpc-cpu/src/execution/hawk_main/worker_pool_initializer.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/worker_pool_initializer.rs
@@ -16,7 +16,7 @@ use async_trait::async_trait;
 use eyre::Result;
 use iris_mpc_common::config::Config;
 use iris_mpc_common::helpers::inmemory_store::InMemoryStore;
-use iris_mpc_common::vector_id::VectorId;
+use iris_mpc_common::VectorId;
 use iris_mpc_store::loader::load_iris_db;
 use iris_mpc_store::Store;
 use itertools::izip;

--- a/iris-mpc-cpu/src/genesis/batch_generator.rs
+++ b/iris-mpc-cpu/src/genesis/batch_generator.rs
@@ -8,7 +8,7 @@ use crate::{
     protocol::shared_iris::ArcIris,
 };
 use eyre::Result;
-use iris_mpc_common::{vector_id::VectorId, IrisSerialId};
+use iris_mpc_common::{SerialId, VectorId};
 use std::{fmt, future::Future, iter::Peekable, ops::RangeInclusive};
 
 /// A batch for upstream indexation.
@@ -78,22 +78,22 @@ pub struct BatchGenerator {
     batch_size: BatchSize,
 
     // Set of Iris serial identifiers to exclude from indexing.
-    exclusions: Vec<IrisSerialId>,
+    exclusions: Vec<SerialId>,
 
     // Range of Iris serial identifiers to be indexed.
-    range: RangeInclusive<IrisSerialId>,
+    range: RangeInclusive<SerialId>,
 
     // Iterator over range of Iris serial identifiers to be indexed.
-    range_iter: Peekable<RangeInclusive<IrisSerialId>>,
+    range_iter: Peekable<RangeInclusive<SerialId>>,
 }
 
 /// Constructor.
 impl BatchGenerator {
     pub fn new(
-        start_id: IrisSerialId,
-        end_id: IrisSerialId,
+        start_id: SerialId,
+        end_id: SerialId,
         batch_size: BatchSize,
-        exclusions: Vec<IrisSerialId>,
+        exclusions: Vec<SerialId>,
     ) -> Self {
         let range = start_id..=end_id;
 
@@ -140,7 +140,7 @@ pub trait BatchIterator {
     ///
     fn next_batch(
         &mut self,
-        last_indexed_id: IrisSerialId,
+        last_indexed_id: SerialId,
         registries: &BothEyes<VectorIdRegistryRef>,
         worker_pools: &BothEyes<impl IrisWorkerPool>,
     ) -> impl Future<Output = Result<Option<Batch>, IndexationError>> + Send;
@@ -207,7 +207,7 @@ impl fmt::Display for BatchSize {
 /// Methods.
 impl Batch {
     // Returns Iris serial id of batch's last element.
-    pub fn id_end(&self) -> IrisSerialId {
+    pub fn id_end(&self) -> SerialId {
         self.vector_ids_to_persist
             .last()
             .map(|id| id.serial_id())
@@ -215,7 +215,7 @@ impl Batch {
     }
 
     // Returns Iris serial id of batch's first element.
-    pub fn id_start(&self) -> IrisSerialId {
+    pub fn id_start(&self) -> SerialId {
         self.vector_ids_to_persist
             .first()
             .map(|id| id.serial_id())
@@ -223,7 +223,7 @@ impl Batch {
     }
 
     // Returns serial identifiers within batch.
-    pub fn serial_ids(&self) -> Vec<IrisSerialId> {
+    pub fn serial_ids(&self) -> Vec<SerialId> {
         self.vector_ids.iter().map(|id| id.serial_id()).collect()
     }
 
@@ -238,8 +238,8 @@ impl BatchGenerator {
     /// Returns next batch of Iris serial identifiers to be indexed.
     fn next_identifiers(
         &mut self,
-        last_indexed_id: IrisSerialId,
-    ) -> Option<(Vec<IrisSerialId>, Vec<IrisSerialId>)> {
+        last_indexed_id: SerialId,
+    ) -> Option<(Vec<SerialId>, Vec<SerialId>)> {
         // Escape if exhausted.
         if self.range_iter.peek().is_none() {
             tracing::info!(
@@ -253,8 +253,8 @@ impl BatchGenerator {
         let batch_size_max = self.batch_size.next_max(last_indexed_id);
 
         // Construct next batch.
-        let mut identifiers = Vec::<IrisSerialId>::new();
-        let mut identifiers_for_copying = Vec::<IrisSerialId>::new();
+        let mut identifiers = Vec::<SerialId>::new();
+        let mut identifiers_for_copying = Vec::<SerialId>::new();
         while self.range_iter.peek().is_some() && identifiers.len() < batch_size_max {
             let next_id = self.range_iter.by_ref().next().unwrap();
             identifiers_for_copying.push(next_id);
@@ -283,7 +283,7 @@ impl BatchIterator for BatchGenerator {
     // Returns next batch of Iris data to be indexed or None if exhausted.
     async fn next_batch(
         &mut self,
-        last_indexed_id: IrisSerialId,
+        last_indexed_id: SerialId,
         registries: &BothEyes<VectorIdRegistryRef>,
         worker_pools: &BothEyes<impl IrisWorkerPool>,
     ) -> Result<Option<Batch>, IndexationError> {
@@ -355,7 +355,7 @@ impl BatchSize {
     /// Dynamically computes size of next batch to be indexed.
     #[allow(non_snake_case)]
     pub fn get_dynamic_size(
-        last_indexed_id: IrisSerialId,
+        last_indexed_id: SerialId,
         error_correction: usize,
         hnsw_M: usize,
     ) -> usize {
@@ -376,7 +376,7 @@ impl BatchSize {
 
     /// Calculates maximum size of next batch to be indexed.
     #[allow(non_snake_case)]
-    fn next_max(&self, last_indexed_id: IrisSerialId) -> usize {
+    fn next_max(&self, last_indexed_id: SerialId) -> usize {
         match self {
             BatchSize::Static(size) => {
                 tracing::info!(
@@ -419,12 +419,12 @@ mod tests {
     use rand::{Rng, SeedableRng};
 
     const BATCH_SIZE_ERROR_RATE: usize = 128;
-    const EXCLUSIONS: [IrisSerialId; 9] = [3, 7, 12, 15, 22, 30, 70, 84, 92];
+    const EXCLUSIONS: [SerialId; 9] = [3, 7, 12, 15, 22, 30, 70, 84, 92];
     const HNSW_PARAM_M: usize = 256;
-    const INDEXATION_END_ID: IrisSerialId = 100;
-    const INDEXATION_END_ID_MAX: IrisSerialId = 15_000_000;
-    const INDEXATION_START_ID: IrisSerialId = 1;
-    const LAST_INDEXED_IDS: [(IrisSerialId, usize); 10] = [
+    const INDEXATION_END_ID: SerialId = 100;
+    const INDEXATION_END_ID_MAX: SerialId = 15_000_000;
+    const INDEXATION_START_ID: SerialId = 1;
+    const LAST_INDEXED_IDS: [(SerialId, usize); 10] = [
         (0, 1),
         (2312177, 71),
         (6983790, 214),
@@ -456,7 +456,7 @@ mod tests {
     }
 
     impl BatchGenerator {
-        fn new_0(batch_size: BatchSize, exclusions: Vec<IrisSerialId>) -> Self {
+        fn new_0(batch_size: BatchSize, exclusions: Vec<SerialId>) -> Self {
             Self::new(
                 INDEXATION_START_ID,
                 INDEXATION_END_ID,
@@ -505,10 +505,10 @@ mod tests {
     }
 
     // Returns a random ordered set of last indexed identifiers.
-    fn get_last_indexed_identifiers() -> Vec<IrisSerialId> {
+    fn get_last_indexed_identifiers() -> Vec<SerialId> {
         let mut rng = rand::thread_rng();
         let mut random_vec: Vec<u32> = (0..10)
-            .map(|_| rng.gen_range(2 as IrisSerialId..=INDEXATION_END_ID_MAX as IrisSerialId))
+            .map(|_| rng.gen_range(2 as SerialId..=INDEXATION_END_ID_MAX as SerialId))
             .collect();
         random_vec.sort();
         random_vec.insert(0, 0);
@@ -567,7 +567,7 @@ mod tests {
     fn test_next_identifiers_1() {
         let mut batch_id: usize = 0;
         let mut generator = BatchGenerator::new_1();
-        let mut last_indexed_id = 0 as IrisSerialId;
+        let mut last_indexed_id = 0 as SerialId;
 
         while let Some((identifiers, identifiers_for_indexation)) =
             generator.next_identifiers(last_indexed_id)
@@ -575,7 +575,7 @@ mod tests {
             batch_id += 1;
             assert_eq!(identifiers.len(), STATIC_BATCH_SIZE_10);
             assert_eq!(identifiers_for_indexation.len(), STATIC_BATCH_SIZE_10);
-            last_indexed_id += identifiers.len() as IrisSerialId;
+            last_indexed_id += identifiers.len() as SerialId;
         }
         assert_eq!(batch_id, 10);
     }
@@ -585,7 +585,7 @@ mod tests {
     fn test_next_identifiers_2() {
         let mut batch_id: usize = 0;
         let mut generator = BatchGenerator::new_2();
-        let mut last_indexed_id = 0 as IrisSerialId;
+        let mut last_indexed_id = 0 as SerialId;
 
         while let Some((identifiers, identifiers_for_indexation)) =
             generator.next_identifiers(last_indexed_id)
@@ -603,10 +603,10 @@ mod tests {
     fn test_next_identifiers_for_indexation_with_exclusions() {
         let mut batch_id: usize = 0;
         let mut generator = BatchGenerator::new_4();
-        let mut last_indexed_id = 0 as IrisSerialId;
+        let mut last_indexed_id = 0 as SerialId;
 
-        let mut all_identifiers: Vec<IrisSerialId> = vec![];
-        let mut all_identifiers_for_indexation: Vec<IrisSerialId> = vec![];
+        let mut all_identifiers: Vec<SerialId> = vec![];
+        let mut all_identifiers_for_indexation: Vec<SerialId> = vec![];
 
         while let Some((identifiers, identifiers_for_indexation)) =
             generator.next_identifiers(last_indexed_id)
@@ -630,14 +630,14 @@ mod tests {
     async fn test_next_batch_1() -> Result<()> {
         let mut generator = BatchGenerator::new_1();
         let (registries, workers, _) = get_test_stores();
-        let mut last_indexed_id = 0 as IrisSerialId;
+        let mut last_indexed_id = 0 as SerialId;
 
         while let Some(batch) = generator
             .next_batch(last_indexed_id, &registries, &workers)
             .await?
         {
             assert_eq!(batch.size(), 10);
-            last_indexed_id += batch.size() as IrisSerialId;
+            last_indexed_id += batch.size() as SerialId;
         }
 
         Ok(())
@@ -650,7 +650,7 @@ mod tests {
         let mut batch_id = 0;
         let mut generator = BatchGenerator::new_2();
         let (registries, workers, _) = get_test_stores();
-        let mut last_indexed_id = 0 as IrisSerialId;
+        let mut last_indexed_id = 0 as SerialId;
 
         while let Some(batch) = generator
             .next_batch(last_indexed_id, &registries, &workers)
@@ -670,7 +670,7 @@ mod tests {
         let mut batches = Vec::new();
         let mut generator = BatchGenerator::new_4();
         let (registries, workers, _) = get_test_stores();
-        let mut last_indexed_id = 0 as IrisSerialId;
+        let mut last_indexed_id = 0 as SerialId;
 
         while let Some(batch) = generator
             .next_batch(last_indexed_id, &registries, &workers)

--- a/iris-mpc-cpu/src/genesis/hawk_job.rs
+++ b/iris-mpc-cpu/src/genesis/hawk_job.rs
@@ -6,7 +6,7 @@ use crate::{
     protocol::shared_iris::ArcIris,
 };
 use eyre::Result;
-use iris_mpc_common::{helpers::sync::Modification, IrisSerialId, IrisVectorId};
+use iris_mpc_common::{helpers::sync::Modification, SerialId, VectorId};
 use std::{
     fmt,
     sync::{atomic::AtomicU8, Arc},
@@ -42,10 +42,10 @@ pub enum JobRequest {
         batch_id: usize,
 
         // Incoming batch of iris identifiers for subsequent correlation.
-        vector_ids: Vec<IrisVectorId>,
+        vector_ids: Vec<VectorId>,
 
         /// Iris data for persistence.
-        vector_ids_to_persist: Vec<IrisVectorId>,
+        vector_ids_to_persist: Vec<VectorId>,
 
         /// HNSW indexation queries over both eyes.
         queries: Aby3BatchQueryRef,
@@ -91,15 +91,15 @@ pub enum JobResult {
         batch_id: usize,
 
         /// Set of Iris identifiers being indexed.
-        vector_ids: Vec<IrisVectorId>,
+        vector_ids: Vec<VectorId>,
 
         /// Vector ids for persistence
-        vector_ids_to_persist: Vec<IrisVectorId>,
+        vector_ids_to_persist: Vec<VectorId>,
 
         /// Iris serial id of batch's first element.
-        first_serial_id: IrisSerialId,
+        first_serial_id: SerialId,
         /// Iris serial id of batch's last element.
-        last_serial_id: IrisSerialId,
+        last_serial_id: SerialId,
         done_tx: sync::oneshot::Sender<()>,
     },
     Modification {
@@ -107,7 +107,7 @@ pub enum JobResult {
         modification_id: i64,
 
         /// Vector id for persistence.
-        vector_id_to_persist: IrisVectorId,
+        vector_id_to_persist: VectorId,
 
         done_tx: sync::oneshot::Sender<()>,
     },
@@ -127,8 +127,8 @@ pub enum JobResult {
 impl JobResult {
     pub(crate) fn new_batch_result(
         batch_id: usize,
-        vector_ids: Vec<IrisVectorId>,
-        vector_ids_to_persist: Vec<IrisVectorId>,
+        vector_ids: Vec<VectorId>,
+        vector_ids_to_persist: Vec<VectorId>,
         done_tx: sync::oneshot::Sender<()>,
     ) -> Self {
         let first_serial_id = vector_ids_to_persist.first().unwrap().serial_id();
@@ -146,7 +146,7 @@ impl JobResult {
 
     pub(crate) fn new_modification_result(
         modification_id: i64,
-        vector_id_to_persist: IrisVectorId,
+        vector_id_to_persist: VectorId,
         done_tx: sync::oneshot::Sender<()>,
     ) -> Self {
         Self::Modification {

--- a/iris-mpc-cpu/src/genesis/plaintext.rs
+++ b/iris-mpc-cpu/src/genesis/plaintext.rs
@@ -21,7 +21,7 @@ use iris_mpc_common::{
         RESET_UPDATE_MESSAGE_TYPE,
     },
     iris_db::iris::IrisCode,
-    IrisSerialId, IrisVectorId, IrisVersionId,
+    SerialId, VectorId, VersionId,
 };
 use itertools::izip;
 use rand::{thread_rng, Rng};
@@ -38,17 +38,17 @@ use crate::{
 };
 
 /// Represents irises db table, mapping serial ids to version, and left and right iris codes.
-pub type IrisesTable = HashMap<IrisSerialId, (IrisVersionId, IrisCode, IrisCode)>;
+pub type IrisesTable = HashMap<SerialId, (VersionId, IrisCode, IrisCode)>;
 
 /// Represents modifications db table, mapping modification ids to tuples of serial id,
 /// request type, completion flag, and persisted flag.
-pub type ModificationsTable = HashMap<i64, (IrisSerialId, String, bool, bool)>;
+pub type ModificationsTable = HashMap<i64, (SerialId, String, bool, bool)>;
 
 /// Represents a left/right pair of plaintext in-memory HNSW graphs.
 pub type PlaintextGraphs = BothEyes<GraphMem>;
 
 /// List of serial ids to treat as deleted enrollments in the source iris database.
-pub type GenesisDeletions = Vec<IrisSerialId>;
+pub type GenesisDeletions = Vec<SerialId>;
 
 /// Plaintext representation of global state of genesis indexer.
 #[derive(Default, Clone)]
@@ -85,7 +85,7 @@ pub struct GenesisDstDbState {
 /// Database entries for the PersistentState table.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct PersistentState {
-    pub last_indexed_iris_id: Option<IrisSerialId>,
+    pub last_indexed_iris_id: Option<SerialId>,
 
     pub last_indexed_modification_id: Option<i64>,
 }
@@ -105,7 +105,7 @@ pub struct GenesisConfig {
 /// Logical CLI arguments for genesis process.
 #[derive(Debug, Clone)]
 pub struct GenesisArgs {
-    pub max_indexation_id: IrisSerialId,
+    pub max_indexation_id: SerialId,
 
     pub batch_size_config: BatchSizeConfig,
 
@@ -162,7 +162,7 @@ pub async fn run_plaintext_genesis(mut state: GenesisState) -> Result<GenesisSta
         reason = "HashMap keys are primary key for insertion, so result is independent of insertion ordering."
     )]
     for (serial_id, (version, left_iris, right_iris)) in state.src_db.irises.iter() {
-        let vector_id = IrisVectorId::new(*serial_id, *version);
+        let vector_id = VectorId::new(*serial_id, *version);
         left_store
             .insert_at(&vector_id, &Arc::new(left_iris.clone()))
             .await?;
@@ -219,7 +219,7 @@ pub async fn run_plaintext_genesis(mut state: GenesisState) -> Result<GenesisSta
                     .get(&serial_id)
                     .map(|(version, left_iris, right_iris)| {
                         (
-                            IrisVectorId::new(serial_id, *version),
+                            VectorId::new(serial_id, *version),
                             left_iris.clone(),
                             right_iris.clone(),
                         )
@@ -298,7 +298,7 @@ pub async fn run_plaintext_genesis(mut state: GenesisState) -> Result<GenesisSta
     // Generate and process batches until we've reached the target indexation id
     while id < target_id {
         // 1. Generate new batch
-        let mut batch: Vec<(IrisSerialId, bool)> = Vec::new(); // Iris serial id, whether it should be indexed
+        let mut batch: Vec<(SerialId, bool)> = Vec::new(); // Iris serial id, whether it should be indexed
         let mut n_to_index = 0;
         while n_to_index < batch_size && id < target_id {
             id += 1;
@@ -324,7 +324,7 @@ pub async fn run_plaintext_genesis(mut state: GenesisState) -> Result<GenesisSta
                 .get(cur_id)
                 .ok_or_eyre("Expected iris id missing")?
                 .clone();
-            let vector_id = IrisVectorId::new(*cur_id, version);
+            let vector_id = VectorId::new(*cur_id, version);
             ids.push(Some(vector_id));
 
             // Initial search and construct insert plans
@@ -398,7 +398,7 @@ mod tests {
         let irises_right = IrisDB::new_random_rng(n_src_enrollments, &mut rng).db;
         let src_db_irises: HashMap<_, _> = izip!(irises_left, irises_right)
             .enumerate()
-            .map(|(id, (left, right))| (id as IrisSerialId, (0, left, right)))
+            .map(|(id, (left, right))| (id as SerialId, (0, left, right)))
             .collect();
 
         GenesisState {
@@ -435,7 +435,7 @@ mod tests {
     fn apply_modification(
         state: &mut GenesisState,
         id: i64,
-        serial_id: IrisSerialId,
+        serial_id: SerialId,
         request_type: &str,
     ) {
         let mut rng = thread_rng();
@@ -454,7 +454,7 @@ mod tests {
     fn add_modification(
         state: &mut GenesisState,
         id: i64,
-        serial_id: IrisSerialId,
+        serial_id: SerialId,
         request_type: &str,
         completed: bool,
         persisted: bool,

--- a/iris-mpc-cpu/src/genesis/state_accessor.rs
+++ b/iris-mpc-cpu/src/genesis/state_accessor.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use aws_sdk_s3::Client as S3_Client;
 use eyre::Result;
-use iris_mpc_common::{config::Config, helpers::sync::Modification, IrisSerialId};
+use iris_mpc_common::{config::Config, helpers::sync::Modification, SerialId};
 use iris_mpc_store::Store;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use sqlx::{Postgres, Transaction};
@@ -37,12 +37,12 @@ pub const STATE_KEY_LAST_INDEXED_MODIFICATION_ID: &str = "last_indexed_modificat
 pub async fn get_iris_deletions(
     config: &Config,
     s3_client: &S3_Client,
-    max_indexation_id: IrisSerialId,
-) -> Result<Vec<IrisSerialId>, IndexationError> {
+    max_indexation_id: SerialId,
+) -> Result<Vec<SerialId>, IndexationError> {
     // Struct for deserialization.
     #[derive(Serialize, Deserialize, Debug, Clone)]
     struct S3Object {
-        deleted_serial_ids: Vec<IrisSerialId>,
+        deleted_serial_ids: Vec<SerialId>,
     }
 
     // Set bucket and key based on environment
@@ -132,7 +132,7 @@ pub async fn get_iris_modifications(
 ///
 pub async fn get_last_indexed_iris_id(
     graph_store: Arc<GraphPg<Aby3Store<HawkOps>>>,
-) -> Result<IrisSerialId> {
+) -> Result<SerialId> {
     get_state_element(graph_store, STATE_KEY_LAST_INDEXED_IRIS_ID).await
 }
 
@@ -180,7 +180,7 @@ async fn get_state_element<T: DeserializeOwned + Default>(
 ///
 pub async fn set_last_indexed_iris_id(
     tx: &mut Transaction<'_, Postgres>,
-    value: IrisSerialId,
+    value: SerialId,
 ) -> Result<(), IndexationError> {
     set_state_element(tx, STATE_KEY_LAST_INDEXED_IRIS_ID, &value).await
 }

--- a/iris-mpc-cpu/src/genesis/state_sync.rs
+++ b/iris-mpc-cpu/src/genesis/state_sync.rs
@@ -1,6 +1,6 @@
 use super::BatchSizeConfig;
 use eyre::{ensure, Result};
-use iris_mpc_common::{config::CommonConfig, helpers::sync::Modification, IrisSerialId};
+use iris_mpc_common::{config::CommonConfig, helpers::sync::Modification, SerialId};
 use serde::{Deserialize, Serialize};
 
 /// Encapsulates common Genesis specific configuration information. This is a network level type.
@@ -10,13 +10,13 @@ pub struct Config {
     pub batch_size_config: BatchSizeConfig,
 
     // Set of identifiers of Iris's to be excluded from indexation.
-    pub excluded_serial_ids: Vec<IrisSerialId>,
+    pub excluded_serial_ids: Vec<SerialId>,
 
     // Identifier of last Iris serial ID to have been indexed.
-    pub last_indexed_id: IrisSerialId,
+    pub last_indexed_id: SerialId,
 
     // Identifier of the last Iris serial ID to be indexed.
-    pub max_indexation_id: IrisSerialId,
+    pub max_indexation_id: SerialId,
 
     // Identifier of the last modification ID to be indexed.
     pub max_modification_id: i64,
@@ -33,9 +33,9 @@ impl Config {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         batch_size_config: BatchSizeConfig,
-        excluded_serial_ids: Vec<IrisSerialId>,
-        last_indexed_id: IrisSerialId,
-        max_indexation_id: IrisSerialId,
+        excluded_serial_ids: Vec<SerialId>,
+        last_indexed_id: SerialId,
+        max_indexation_id: SerialId,
         max_modification_id: i64,
         max_modification_persisted_id: i64,
         modifications: Vec<Modification>,

--- a/iris-mpc-cpu/src/genesis/utils/errors.rs
+++ b/iris-mpc-cpu/src/genesis/utils/errors.rs
@@ -1,4 +1,4 @@
-use iris_mpc_common::IrisSerialId;
+use iris_mpc_common::SerialId;
 use thiserror::Error;
 
 // Encpasulates a non-exhaustive set of errors raised during indexation.
@@ -32,7 +32,7 @@ pub enum IndexationError {
     IndexationHeightMismatch,
 
     #[error("Failed to fetch Iris with given serial ID: {0}")]
-    MissingSerialId(IrisSerialId),
+    MissingSerialId(SerialId),
 
     #[error("Failed to persist genesis Graph indexation state element {0} to PostgreSQL dB: {1}")]
     PersistIndexationStateElement(String, String),

--- a/iris-mpc-cpu/src/graph_checkpoint/data.rs
+++ b/iris-mpc-cpu/src/graph_checkpoint/data.rs
@@ -1,6 +1,6 @@
 use crate::hnsw::graph::graph_store::GraphCheckpointRow;
 use eyre::eyre;
-use iris_mpc_common::IrisSerialId;
+use iris_mpc_common::SerialId;
 use serde::{Deserialize, Serialize};
 use std::{fmt::Display, str::FromStr};
 
@@ -54,7 +54,7 @@ pub struct GraphCheckpointState {
     /// S3 key where the checkpoint is stored
     pub s3_key: String,
     /// Last iris serial ID included in this checkpoint
-    pub last_indexed_iris_id: IrisSerialId,
+    pub last_indexed_iris_id: SerialId,
     /// Last modification ID included in this checkpoint
     pub last_indexed_modification_id: i64,
     /// Last graph mutation ID included in this checkpoint (optional)
@@ -82,7 +82,7 @@ impl GraphCheckpointState {
 impl TryFrom<GraphCheckpointRow> for GraphCheckpointState {
     type Error = eyre::Error;
     fn try_from(value: GraphCheckpointRow) -> Result<Self, Self::Error> {
-        let last_indexed_iris_id: IrisSerialId =
+        let last_indexed_iris_id: SerialId =
             value.last_indexed_iris_id.try_into().map_err(|_| {
                 eyre!(
                     "Invalid last_indexed_iris_id for checkpoint: {}",

--- a/iris-mpc-cpu/src/graph_checkpoint/s3_client/mod.rs
+++ b/iris-mpc-cpu/src/graph_checkpoint/s3_client/mod.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 use crate::graph_checkpoint::data::*;
-use iris_mpc_common::IrisSerialId;
+use iris_mpc_common::SerialId;
 pub use multipart::*;
 pub use streaming::*;
 pub use streaming_download::*;
@@ -33,7 +33,7 @@ pub async fn upload_graph_checkpoint(
     party_id: usize,
     graph_mem: &BothEyes<GraphRef>,
     s3_client: &S3Client,
-    last_indexed_iris_id: IrisSerialId,
+    last_indexed_iris_id: SerialId,
     last_indexed_modification_id: i64,
     graph_mutation_id: Option<i64>,
     is_archival: bool,
@@ -72,7 +72,7 @@ pub async fn upload_graph_checkpoint_plaintext(
     party_id: usize,
     graph_mem: &BothEyes<GraphMem>,
     s3_client: &S3Client,
-    last_indexed_iris_id: IrisSerialId,
+    last_indexed_iris_id: SerialId,
     last_indexed_modification_id: i64,
     graph_mutation_id: Option<i64>,
     is_archival: bool,
@@ -107,7 +107,7 @@ async fn _upload_graph_checkpoint(
     bucket: &str,
     party_id: usize,
     s3_client: &S3Client,
-    last_indexed_iris_id: IrisSerialId,
+    last_indexed_iris_id: SerialId,
     last_indexed_modification_id: i64,
     graph_mutation_id: Option<i64>,
     is_archival: bool,

--- a/iris-mpc-cpu/src/graph_checkpoint/synchronize.rs
+++ b/iris-mpc-cpu/src/graph_checkpoint/synchronize.rs
@@ -182,7 +182,7 @@ pub fn apply_graph_mutations(
 mod tests {
     use super::*;
     use crate::hnsw::graph::mutation::{MutationOp, UpdateEntryPoint};
-    use iris_mpc_common::IrisVectorId;
+    use iris_mpc_common::VectorId;
 
     // ── helpers ───────────────────────────────────────────────────────────────
 
@@ -205,13 +205,13 @@ mod tests {
     }
 
     /// Construct a `VectorId` from a plain serial id for use in tests.
-    fn vid(id: u32) -> IrisVectorId {
-        IrisVectorId::from_serial_id(id)
+    fn vid(id: u32) -> VectorId {
+        VectorId::from_serial_id(id)
     }
 
     /// A minimal `AddNode` mutation that adds the node to layer 0 without
     /// updating entry points. Uses a static counter to assign incrementing seq_no.
-    fn add_node(id: IrisVectorId) -> GraphMutation {
+    fn add_node(id: VectorId) -> GraphMutation {
         use std::sync::atomic::{AtomicU64, Ordering};
         static SEQ_COUNTER: AtomicU64 = AtomicU64::new(1);
 

--- a/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
@@ -29,7 +29,7 @@ use crate::{
 };
 use ampc_secret_sharing::shares::{vecshare_bittranspose::Transpose64, VecShare};
 use eyre::{bail, OptionExt, Result};
-use iris_mpc_common::{iris_db::iris::Threshold, vector_id::VectorId};
+use iris_mpc_common::{iris_db::iris::Threshold, VectorId};
 use itertools::{izip, Itertools};
 use rand_distr::{Distribution, Standard};
 use static_assertions::const_assert;

--- a/iris-mpc-cpu/src/hawkers/aby3/test_utils.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3/test_utils.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, path::Path, sync::Arc};
 use aes_prng::AesRng;
 use eyre::{bail, Result};
 use futures::future::join_all;
-use iris_mpc_common::{iris_db::db::IrisDB, vector_id::VectorId};
+use iris_mpc_common::{iris_db::db::IrisDB, VectorId};
 use rand::{CryptoRng, RngCore, SeedableRng};
 use tokio::{sync::Mutex, task::JoinHandle};
 

--- a/iris-mpc-cpu/src/hawkers/build_plaintext.rs
+++ b/iris-mpc-cpu/src/hawkers/build_plaintext.rs
@@ -29,7 +29,7 @@
 use std::sync::Arc;
 
 use eyre::Result;
-use iris_mpc_common::{iris_db::iris::IrisCode, IrisVectorId};
+use iris_mpc_common::{iris_db::iris::IrisCode, VectorId};
 use itertools::Itertools;
 use tokio::task::JoinSet;
 use tracing::info;
@@ -47,7 +47,7 @@ const REPORTING_INTERVAL: usize = 1000;
 pub async fn plaintext_parallel_batch_insert<D: DistanceOps>(
     graph: GraphMem,
     mut store: SharedPlaintextStore<D>,
-    irises: Vec<(IrisVectorId, IrisCode)>,
+    irises: Vec<(VectorId, IrisCode)>,
     searcher: &HnswSearcher,
     batch_size: usize,
     prf_seed: &[u8; 16],
@@ -132,7 +132,7 @@ pub async fn plaintext_parallel_batch_insert<D: DistanceOps>(
 pub async fn deep_id_parallel_batch_insert(
     graph: GraphMem,
     mut store: SharedPlaintextDeepIDStore,
-    vectors: Vec<(IrisVectorId, Int4Vector)>,
+    vectors: Vec<(VectorId, Int4Vector)>,
     searcher: &HnswSearcher,
     batch_size: usize,
     prf_seed: &[u8; 16],
@@ -232,7 +232,7 @@ mod tests {
         HnswSearcher,
         GraphMem,
         SharedPlaintextStore,
-        Vec<(IrisVectorId, IrisCode)>,
+        Vec<(VectorId, IrisCode)>,
         [u8; 16],
     )> {
         let mut rng = AesRng::seed_from_u64(0_u64);
@@ -249,12 +249,12 @@ mod tests {
 
         let irises_to_insert = IrisDB::new_random_rng(to_insert, &mut rng).db;
 
-        let irises: Vec<(IrisVectorId, IrisCode)> = irises_to_insert
+        let irises: Vec<(VectorId, IrisCode)> = irises_to_insert
             .into_iter()
             .enumerate()
             .map(|(id, iris_code)| {
                 (
-                    IrisVectorId::from_serial_id((id + database_size + 1).try_into().unwrap()),
+                    VectorId::from_serial_id((id + database_size + 1).try_into().unwrap()),
                     iris_code,
                 )
             })
@@ -266,7 +266,7 @@ mod tests {
     async fn check_results(
         mut store: SharedPlaintextStore,
         graph: GraphMem,
-        irises: Vec<(IrisVectorId, IrisCode)>,
+        irises: Vec<(VectorId, IrisCode)>,
         searcher: &HnswSearcher,
         expected_total_size: usize,
     ) -> Result<()> {
@@ -345,10 +345,10 @@ mod tests {
         let shared_store: SharedPlaintextDeepIDStore = store.into();
 
         // Build the to-insert batch with explicit ids past the seeded range.
-        let to_insert_vectors: Vec<(IrisVectorId, Int4Vector)> = (0..to_insert)
+        let to_insert_vectors: Vec<(VectorId, Int4Vector)> = (0..to_insert)
             .map(|i| {
                 (
-                    IrisVectorId::from_serial_id((i + database_size + 1).try_into().unwrap()),
+                    VectorId::from_serial_id((i + database_size + 1).try_into().unwrap()),
                     Int4Vector::random(&mut rng),
                 )
             })

--- a/iris-mpc-cpu/src/hawkers/ideal_knn_engines.rs
+++ b/iris-mpc-cpu/src/hawkers/ideal_knn_engines.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use clap::ValueEnum;
-use iris_mpc_common::{iris_db::iris::IrisCode, IrisSerialId};
+use iris_mpc_common::{iris_db::iris::IrisCode, SerialId};
 use rayon::{
     iter::{IntoParallelIterator, ParallelIterator},
     ThreadPool, ThreadPoolBuilder,
@@ -200,12 +200,12 @@ pub struct NaiveKNN<K: IdealKnn> {
     knn: K,
     vectors: Vec<K::Vector>,
     k: usize,
-    next_id: IrisSerialId,
+    next_id: SerialId,
     pool: ThreadPool,
 }
 
 impl<K: IdealKnn> NaiveKNN<K> {
-    pub fn init(knn: K, vectors: Vec<K::Vector>, k: usize, next_id: IrisSerialId) -> Self {
+    pub fn init(knn: K, vectors: Vec<K::Vector>, k: usize, next_id: SerialId) -> Self {
         // The chunk loop indexes `self.vectors[i - 1]` for `i in next_id..end`,
         // so a starting id of 0 would underflow.
         assert!(next_id >= 1, "next_id must be >= 1 (1-based serial ids)");
@@ -218,14 +218,14 @@ impl<K: IdealKnn> NaiveKNN<K> {
         }
     }
 
-    pub fn next_id(&self) -> IrisSerialId {
+    pub fn next_id(&self) -> SerialId {
         self.next_id
     }
 
-    pub fn compute_chunk(&mut self, chunk_size: usize) -> Vec<KNNResult<IrisSerialId>> {
+    pub fn compute_chunk(&mut self, chunk_size: usize) -> Vec<KNNResult<SerialId>> {
         let start = self.next_id as usize;
         let end = (start + chunk_size).min(self.vectors.len() + 1);
-        self.next_id = end as IrisSerialId;
+        self.next_id = end as SerialId;
 
         let k = self.k;
         let knn = &self.knn;
@@ -262,11 +262,8 @@ impl<K: IdealKnn> NaiveKNN<K> {
                     });
 
                     KNNResult {
-                        node: i as IrisSerialId,
-                        neighbors: neighbors
-                            .into_iter()
-                            .map(|(j, _)| j as IrisSerialId)
-                            .collect(),
+                        node: i as SerialId,
+                        neighbors: neighbors.into_iter().map(|(j, _)| j as SerialId).collect(),
                     }
                 })
                 .collect::<Vec<_>>()
@@ -282,12 +279,7 @@ pub enum Engine {
 }
 
 impl Engine {
-    pub fn init(
-        which: EngineChoice,
-        irises: Vec<IrisCode>,
-        k: usize,
-        next_id: IrisSerialId,
-    ) -> Self {
+    pub fn init(which: EngineChoice, irises: Vec<IrisCode>, k: usize, next_id: SerialId) -> Self {
         assert!(k < irises.len());
         let distance_mode = which.distance_mode();
         match which {
@@ -306,7 +298,7 @@ impl Engine {
         }
     }
 
-    pub fn compute_chunk(&mut self, chunk_size: usize) -> Vec<KNNResult<IrisSerialId>> {
+    pub fn compute_chunk(&mut self, chunk_size: usize) -> Vec<KNNResult<SerialId>> {
         match self {
             Self::Fhd(engine) => engine.compute_chunk(chunk_size),
             Self::Nhd(engine) => engine.compute_chunk(chunk_size),
@@ -314,7 +306,7 @@ impl Engine {
     }
 
     /// Next id to process
-    pub fn next_id(&self) -> IrisSerialId {
+    pub fn next_id(&self) -> SerialId {
         match self {
             Self::Fhd(engine) => engine.next_id(),
             Self::Nhd(engine) => engine.next_id(),
@@ -331,7 +323,7 @@ impl EngineInt4 {
         which: EngineChoiceInt4,
         vectors: Vec<Int4Vector>,
         k: usize,
-        next_id: IrisSerialId,
+        next_id: SerialId,
     ) -> Self {
         assert!(k < vectors.len());
         match which {
@@ -341,13 +333,13 @@ impl EngineInt4 {
         }
     }
 
-    pub fn compute_chunk(&mut self, chunk_size: usize) -> Vec<KNNResult<IrisSerialId>> {
+    pub fn compute_chunk(&mut self, chunk_size: usize) -> Vec<KNNResult<SerialId>> {
         match self {
             Self::Int4Dot(engine) => engine.compute_chunk(chunk_size),
         }
     }
 
-    pub fn next_id(&self) -> IrisSerialId {
+    pub fn next_id(&self) -> SerialId {
         match self {
             Self::Int4Dot(engine) => engine.next_id(),
         }
@@ -413,12 +405,12 @@ mod int4_engine_tests {
         for KNNResult { node, neighbors } in results {
             // Brute-force expected top-k by descending dot (excluding self).
             let me = &vectors[node as usize - 1];
-            let mut dists: Vec<(IrisSerialId, i32)> = (1..=n as IrisSerialId)
+            let mut dists: Vec<(SerialId, i32)> = (1..=n as SerialId)
                 .filter(|j| *j != node)
                 .map(|j| (j, me.dot(&vectors[j as usize - 1])))
                 .collect();
             dists.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
-            let expected: Vec<IrisSerialId> = dists.into_iter().take(k).map(|(j, _)| j).collect();
+            let expected: Vec<SerialId> = dists.into_iter().take(k).map(|(j, _)| j).collect();
             assert_eq!(neighbors, expected, "node {} top-{}", node, k);
         }
     }

--- a/iris-mpc-cpu/src/hawkers/plaintext_deep_id_store.rs
+++ b/iris-mpc-cpu/src/hawkers/plaintext_deep_id_store.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 use aes_prng::AesRng;
 use eyre::{bail, Result};
-use iris_mpc_common::vector_id::VectorId;
+use iris_mpc_common::VectorId;
 use rand::{CryptoRng, Rng, RngCore, SeedableRng};
 use serde::{Deserialize, Serialize};
 use serde_big_array::BigArray;

--- a/iris-mpc-cpu/src/hawkers/plaintext_store.rs
+++ b/iris-mpc-cpu/src/hawkers/plaintext_store.rs
@@ -13,7 +13,7 @@ use crate::{
 use aes_prng::AesRng;
 use iris_mpc_common::{
     iris_db::{db::IrisDB, iris::IrisCode},
-    vector_id::VectorId,
+    VectorId,
 };
 use rand::{CryptoRng, RngCore, SeedableRng};
 use serde::{Deserialize, Serialize};

--- a/iris-mpc-cpu/src/hawkers/shared_irises.rs
+++ b/iris-mpc-cpu/src/hawkers/shared_irises.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
-use iris_mpc_common::vector_id::{SerialId, VectorId, VersionId};
+use iris_mpc_common::{SerialId, VectorId, VersionId};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};

--- a/iris-mpc-cpu/src/hnsw/graph/graph_diff/explicit.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/graph_diff/explicit.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use clap::ValueEnum;
-use iris_mpc_common::IrisVectorId;
+use iris_mpc_common::VectorId;
 
 use super::{jaccard::JaccardState, Differ};
 
@@ -29,8 +29,8 @@ impl Display for SortBy {
 /// Contains the explicit differences between two neighborhoods for a single node.
 #[derive(Debug, Clone)]
 pub struct NeighborhoodDiff {
-    pub only_in_lhs: HashSet<IrisVectorId>,
-    pub only_in_rhs: HashSet<IrisVectorId>,
+    pub only_in_lhs: HashSet<VectorId>,
+    pub only_in_rhs: HashSet<VectorId>,
     pub jaccard_state: JaccardState,
 }
 
@@ -40,7 +40,7 @@ pub struct ExplicitDiff(pub Vec<LayerDiffResult>);
 #[derive(Debug, Clone)]
 pub struct LayerDiffResult {
     pub layer_index: usize,
-    pub diffs: Vec<(IrisVectorId, NeighborhoodDiff)>,
+    pub diffs: Vec<(VectorId, NeighborhoodDiff)>,
 }
 
 impl Display for ExplicitDiff {
@@ -87,7 +87,7 @@ impl Display for ExplicitDiff {
 pub struct ExplicitNeighborhoodDiffer {
     sort_by: SortBy,
     per_layer_results: Vec<LayerDiffResult>,
-    current_layer_diffs: Vec<(IrisVectorId, NeighborhoodDiff)>,
+    current_layer_diffs: Vec<(VectorId, NeighborhoodDiff)>,
 }
 
 impl ExplicitNeighborhoodDiffer {
@@ -110,9 +110,9 @@ impl Differ for ExplicitNeighborhoodDiffer {
     fn diff_neighborhood(
         &mut self,
         _layer_index: usize,
-        node: &IrisVectorId,
-        lhs: &[IrisVectorId],
-        rhs: &[IrisVectorId],
+        node: &VectorId,
+        lhs: &[VectorId],
+        rhs: &[VectorId],
     ) {
         let lhs_set: HashSet<_> = lhs.iter().cloned().collect();
         let rhs_set: HashSet<_> = rhs.iter().cloned().collect();

--- a/iris-mpc-cpu/src/hnsw/graph/graph_diff/jaccard.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/graph_diff/jaccard.rs
@@ -1,5 +1,5 @@
 use super::Differ;
-use iris_mpc_common::IrisVectorId;
+use iris_mpc_common::VectorId;
 use std::{collections::HashSet, fmt::Display, ops::Add};
 
 #[derive(Debug, Default, Clone, Copy)]
@@ -59,8 +59,8 @@ impl Display for JaccardState {
 pub struct DetailedJaccardDiffer {
     n: usize,
     graph_state: JaccardState,
-    current_layer_details: Vec<(IrisVectorId, JaccardState)>,
-    per_layer_results: Vec<(JaccardState, Vec<(IrisVectorId, JaccardState)>)>,
+    current_layer_details: Vec<(VectorId, JaccardState)>,
+    per_layer_results: Vec<(JaccardState, Vec<(VectorId, JaccardState)>)>,
 }
 
 impl DetailedJaccardDiffer {
@@ -78,7 +78,7 @@ pub struct DetailedJaccardReport(
     #[allow(clippy::type_complexity)]
     pub  (
         JaccardState,
-        Vec<(JaccardState, Vec<(IrisVectorId, JaccardState)>)>,
+        Vec<(JaccardState, Vec<(VectorId, JaccardState)>)>,
     ),
 );
 
@@ -108,9 +108,9 @@ impl Differ for DetailedJaccardDiffer {
     fn diff_neighborhood(
         &mut self,
         _layer_index: usize,
-        node: &IrisVectorId,
-        lhs: &[IrisVectorId],
-        rhs: &[IrisVectorId],
+        node: &VectorId,
+        lhs: &[VectorId],
+        rhs: &[VectorId],
     ) {
         let lhs_set: HashSet<_> = lhs.iter().collect();
         let rhs_set: HashSet<_> = rhs.iter().collect();

--- a/iris-mpc-cpu/src/hnsw/graph/graph_diff/mod.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/graph_diff/mod.rs
@@ -1,5 +1,5 @@
 use crate::hnsw::GraphMem;
-use iris_mpc_common::IrisVectorId;
+use iris_mpc_common::VectorId;
 use std::fmt::Display;
 
 pub mod explicit;
@@ -24,9 +24,9 @@ pub trait Differ {
     fn diff_neighborhood(
         &mut self,
         layer_index: usize,
-        node: &IrisVectorId,
-        lhs: &[IrisVectorId],
-        rhs: &[IrisVectorId],
+        node: &VectorId,
+        lhs: &[VectorId],
+        rhs: &[VectorId],
     );
 
     /// Called after traversing each layer.

--- a/iris-mpc-cpu/src/hnsw/graph/graph_diff/node_equiv.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/graph_diff/node_equiv.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use crate::hnsw::GraphMem;
-use iris_mpc_common::IrisVectorId;
+use iris_mpc_common::VectorId;
 
 /// Describes how the node and layer structure of two graphs are not equivalent.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -9,15 +9,9 @@ pub enum NodeEquivalenceError {
     /// The graphs have a different number of layers.
     LayerCountMismatch { lhs_count: usize, rhs_count: usize },
     /// A node was found in the left-hand graph's layer that was not in the right's.
-    NodeMissingInRhs {
-        layer_index: usize,
-        node: IrisVectorId,
-    },
+    NodeMissingInRhs { layer_index: usize, node: VectorId },
     /// A node was found in the right-hand graph's layer that was not in the left's.
-    NodeMissingInLhs {
-        layer_index: usize,
-        node: IrisVectorId,
-    },
+    NodeMissingInLhs { layer_index: usize, node: VectorId },
 }
 
 /// Diffs the node and layer structure of two graphs.

--- a/iris-mpc-cpu/src/hnsw/graph/graph_store.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/graph_store.rs
@@ -559,7 +559,7 @@ pub mod test_utils {
 mod tests {
     use super::{test_utils::TestGraphPg, *};
     use crate::hawkers::plaintext_store::PlaintextStore;
-    use iris_mpc_common::IrisVectorId;
+    use iris_mpc_common::VectorId;
     use tokio;
 
     #[tokio::test]
@@ -827,7 +827,7 @@ mod tests {
         let plan_left = GraphMutation {
             seq_no: 1,
             ops: vec![MutationOp::AddNode {
-                id: IrisVectorId::from_serial_id(1),
+                id: VectorId::from_serial_id(1),
                 height: 1,
                 update_ep: UpdateEntryPoint::SetUnique { layer: 0 },
             }],
@@ -835,7 +835,7 @@ mod tests {
         let plan_right = GraphMutation {
             seq_no: 1,
             ops: vec![MutationOp::AddNode {
-                id: IrisVectorId::from_serial_id(2),
+                id: VectorId::from_serial_id(2),
                 height: 1,
                 update_ep: UpdateEntryPoint::SetUnique { layer: 0 },
             }],

--- a/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 use eyre::Result;
-use iris_mpc_common::{iris_db::iris::IrisCode, IrisVectorId};
+use iris_mpc_common::{iris_db::iris::IrisCode, VectorId};
 use itertools::{izip, Itertools};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use serde::{
@@ -41,7 +41,7 @@ use tracing::warn;
 #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct EntryPoint {
     /// The vector reference of the entry point
-    pub point: IrisVectorId,
+    pub point: VectorId,
 
     /// The layer at which HNSW search begins
     pub layer: usize,
@@ -129,7 +129,7 @@ impl GraphMem {
         Arc::new(RwLock::new(self))
     }
 
-    pub fn from_precomputed(entry_points: Vec<(IrisVectorId, usize)>, layers: Vec<Layer>) -> Self {
+    pub fn from_precomputed(entry_points: Vec<(VectorId, usize)>, layers: Vec<Layer>) -> Self {
         GraphMem {
             entry_points: entry_points
                 .into_iter()
@@ -158,7 +158,7 @@ impl GraphMem {
     ///
     /// This is intended to be used in LinearScan mode while the entry_points
     /// list empty.
-    pub fn get_temporary_entry_point(&self) -> Option<(IrisVectorId, usize)> {
+    pub fn get_temporary_entry_point(&self) -> Option<(VectorId, usize)> {
         self.layers
             .iter()
             .enumerate()
@@ -168,7 +168,7 @@ impl GraphMem {
 
     /// Gets the list of entry points.
     /// If this list is empty in LinearScan mode, `get_temporary_entry_point` may be used instead.
-    pub fn get_entry_points(&self) -> Option<Vec<IrisVectorId>> {
+    pub fn get_entry_points(&self) -> Option<Vec<VectorId>> {
         let v: Vec<_> = self.entry_points.iter().map(|ep| ep.point).collect();
         if v.is_empty() {
             None
@@ -389,25 +389,25 @@ impl GraphMem {
         Ok(())
     }
 
-    pub async fn get_first_entry_point(&self) -> Option<(IrisVectorId, usize)> {
+    pub async fn get_first_entry_point(&self) -> Option<(VectorId, usize)> {
         self.entry_points.first().map(|ep| (ep.point, ep.layer))
     }
 
-    pub async fn init_entry_points(&mut self, points: Vec<IrisVectorId>, layer: usize) {
+    pub async fn init_entry_points(&mut self, points: Vec<VectorId>, layer: usize) {
         self.entry_points = points
             .into_iter()
             .map(|point| EntryPoint { point, layer })
             .collect()
     }
 
-    pub async fn add_entry_point(&mut self, point: IrisVectorId, layer: usize) {
+    pub async fn add_entry_point(&mut self, point: VectorId, layer: usize) {
         if let Some(previous) = self.entry_points.first() {
             assert!(previous.layer == layer, "add_entry_point: layer mismatch");
         }
         self.entry_points.push(EntryPoint { point, layer });
     }
 
-    pub async fn set_unique_entry_point(&mut self, point: IrisVectorId, layer: usize) {
+    pub async fn set_unique_entry_point(&mut self, point: VectorId, layer: usize) {
         if let Some(previous) = self.entry_points.first() {
             assert!(
                 previous.layer < layer,
@@ -422,13 +422,13 @@ impl GraphMem {
         self.entry_points = vec![EntryPoint { point, layer }];
     }
 
-    pub async fn get_links(&self, base: &IrisVectorId, lc: usize) -> &[IrisVectorId] {
+    pub async fn get_links(&self, base: &VectorId, lc: usize) -> &[VectorId] {
         let layer = &self.layers[lc];
         layer.get_links(base).unwrap_or(&[])
     }
 
     /// Set the neighbors of vertex `base` at layer `lc` to `links`.
-    pub async fn set_links(&mut self, base: IrisVectorId, links: Vec<IrisVectorId>, lc: usize) {
+    pub async fn set_links(&mut self, base: VectorId, links: Vec<VectorId>, lc: usize) {
         if self.layers.len() < lc + 1 {
             self.layers.resize(lc + 1, Layer::new());
         }
@@ -534,19 +534,19 @@ where
         }
         let results = results
             .into_par_iter()
-            .map(|result| result.map(IrisVectorId::from_serial_id))
+            .map(|result| result.map(VectorId::from_serial_id))
             .collect::<Vec<_>>();
         Layer::from_knn_results(results, vectors.len())
     };
 
-    let vectors_with_ids: Vec<(IrisVectorId, K::Vector)> = izip!(
+    let vectors_with_ids: Vec<(VectorId, K::Vector)> = izip!(
         zero_layer.links.keys().cloned().sorted(),
         vectors.into_iter(),
     )
     .collect();
 
     // Collect nodes into layers they are inserted into (for layers > 0)
-    let mut nonzero_layers_map: BTreeMap<usize, Vec<(IrisVectorId, K::Vector)>> = BTreeMap::new();
+    let mut nonzero_layers_map: BTreeMap<usize, Vec<(VectorId, K::Vector)>> = BTreeMap::new();
     for (vector_id, v) in vectors_with_ids.iter() {
         let layer = searcher.gen_layer_prf(&prf_seed, vector_id)?;
         for l in 1..=layer {
@@ -557,7 +557,7 @@ where
         }
     }
 
-    let mut nodes_for_nonzero_layers: Vec<Vec<(IrisVectorId, K::Vector)>> =
+    let mut nodes_for_nonzero_layers: Vec<Vec<(VectorId, K::Vector)>> =
         nonzero_layers_map.into_values().collect();
 
     let max_graph_layer = searcher.max_graph_layer;
@@ -589,14 +589,14 @@ where
 #[derive(PartialEq, Eq, Default, Debug, Deserialize)]
 pub struct Layer {
     /// Map a base vector to its neighbors.
-    pub links: HashMap<IrisVectorId, Vec<IrisVectorId>>,
+    pub links: HashMap<VectorId, Vec<VectorId>>,
     /// A checksum of the layer's links, used for state verification.
     /// This hash is updated whenever links are modified.
     set_hash: SetHash,
 }
 
 struct SortedLinks<'a> {
-    links: &'a HashMap<IrisVectorId, Vec<IrisVectorId>>,
+    links: &'a HashMap<VectorId, Vec<VectorId>>,
 }
 
 impl<'a> Serialize for SortedLinks<'a> {
@@ -644,7 +644,7 @@ impl Layer {
         }
     }
 
-    pub fn get_links(&self, from: &IrisVectorId) -> Option<&[IrisVectorId]> {
+    pub fn get_links(&self, from: &VectorId) -> Option<&[VectorId]> {
         self.links.get(from).map(|v| v.as_slice())
     }
 
@@ -655,7 +655,7 @@ impl Layer {
         self.set_hash.checksum()
     }
 
-    pub fn insert_node(&mut self, id: &IrisVectorId, neighbors: Vec<IrisVectorId>) {
+    pub fn insert_node(&mut self, id: &VectorId, neighbors: Vec<VectorId>) {
         self.set_links(*id, neighbors.clone());
     }
 
@@ -664,7 +664,7 @@ impl Layer {
     /// this layer are silently skipped (callers that need to log the missing
     /// case should check `get_links(target)` first). Idempotent: if `id` is
     /// already present in a target's list, that target is left unchanged.
-    pub fn link_node_to_neighbors(&mut self, node: &IrisVectorId, neighbors: Vec<IrisVectorId>) {
+    pub fn link_node_to_neighbors(&mut self, node: &VectorId, neighbors: Vec<VectorId>) {
         for target in &neighbors {
             if let Some(target_links) = self.links.get_mut(target) {
                 if let Err(pos) = target_links.binary_search(node) {
@@ -681,7 +681,7 @@ impl Layer {
     /// No-op if `id` is not present in this layer (callers that need to log
     /// the missing case should check `get_links(id)` first). Idempotent:
     /// existing entries are not duplicated.
-    pub fn link_neighbors_to_node(&mut self, node: &IrisVectorId, neighbors: Vec<IrisVectorId>) {
+    pub fn link_neighbors_to_node(&mut self, node: &VectorId, neighbors: Vec<VectorId>) {
         let Some(node_links) = self.links.get_mut(node) else {
             return;
         };
@@ -695,7 +695,7 @@ impl Layer {
     }
 
     /// Remove a node from the graph and clean up all backlinks from its neighbors.
-    pub fn remove_node(&mut self, id: &IrisVectorId) {
+    pub fn remove_node(&mut self, id: &VectorId) {
         // Remove the node's links and get its neighbors
         if let Some(neighbors) = self.links.remove(id) {
             // Update set_hash for removed node
@@ -720,11 +720,7 @@ impl Layer {
     /// Remove `id` from each target's neighbor list, where `target` ranges over
     /// `to_remove`. Targets that don't exist in this layer are silently skipped
     /// (the caller's apply path is responsible for any logging).
-    pub fn unlink_node_from_neighbors(
-        &mut self,
-        node: &IrisVectorId,
-        neighbors: Vec<IrisVectorId>,
-    ) {
+    pub fn unlink_node_from_neighbors(&mut self, node: &VectorId, neighbors: Vec<VectorId>) {
         for target in &neighbors {
             if let Some(target_links) = self.links.get_mut(target) {
                 self.set_hash
@@ -739,11 +735,7 @@ impl Layer {
     /// if `id` is not present in this layer (callers that need to log the
     /// missing case should check `get_links(id)` first). The removal is
     /// unidirectional: the targets' own link lists are not modified.
-    pub fn unlink_neighbors_from_node(
-        &mut self,
-        node: &IrisVectorId,
-        neighbors: Vec<IrisVectorId>,
-    ) {
+    pub fn unlink_neighbors_from_node(&mut self, node: &VectorId, neighbors: Vec<VectorId>) {
         let Some(node_links) = self.links.get_mut(node) else {
             return;
         };
@@ -752,7 +744,7 @@ impl Layer {
         self.set_hash.add_unordered_set(node, node_links.iter());
     }
 
-    pub fn set_links(&mut self, from: IrisVectorId, links: Vec<IrisVectorId>) {
+    pub fn set_links(&mut self, from: VectorId, links: Vec<VectorId>) {
         use std::collections::hash_map::Entry;
         match self.links.entry(from) {
             Entry::Occupied(mut e) => {
@@ -769,11 +761,11 @@ impl Layer {
         }
     }
 
-    pub fn get_links_map(&self) -> &HashMap<IrisVectorId, Vec<IrisVectorId>> {
+    pub fn get_links_map(&self) -> &HashMap<VectorId, Vec<VectorId>> {
         &self.links
     }
 
-    fn from_knn_results(results: Vec<KNNResult<IrisVectorId>>, n: usize) -> Self {
+    fn from_knn_results(results: Vec<KNNResult<VectorId>>, n: usize) -> Self {
         let mut ret = Layer::new();
         for KNNResult { node, neighbors } in results.into_iter().take(n) {
             ret.set_links(node, neighbors);
@@ -784,11 +776,11 @@ impl Layer {
     /// Constructs a Layer from `(vector_id, K::Vector)` pairs by brute-force
     /// top-k KNN using the supplied [`IdealKnn`] implementation.
     pub fn ideal_from_data<K: IdealKnn>(
-        data: Vec<(IrisVectorId, K::Vector)>,
+        data: Vec<(VectorId, K::Vector)>,
         k: usize,
         knn: K,
     ) -> Self {
-        let (vector_ids, vectors): (Vec<IrisVectorId>, Vec<K::Vector>) = data.into_iter().unzip();
+        let (vector_ids, vectors): (Vec<VectorId>, Vec<K::Vector>) = data.into_iter().unzip();
         let n = vectors.len();
         if n == 0 {
             return Layer::new();
@@ -809,7 +801,7 @@ impl Layer {
     /// Layer constructor for iris codes — kept for backward compatibility;
     /// delegates to [`Layer::ideal_from_data`].
     pub fn ideal_from_irises(
-        iris_data: Vec<(IrisVectorId, IrisCode)>,
+        iris_data: Vec<(VectorId, IrisCode)>,
         k: usize,
         echoice: EngineChoice,
     ) -> Self {
@@ -832,7 +824,7 @@ impl Layer {
     /// compatibility; delegates to [`Layer::ideal_from_data`].
     pub fn ideal_from_int4_vectors(
         data: Vec<(
-            IrisVectorId,
+            VectorId,
             crate::hawkers::plaintext_deep_id_store::Int4Vector,
         )>,
         k: usize,
@@ -857,7 +849,7 @@ impl Layer {
 /// - vector ids are re-mapped to remove blank entries left by deletions
 pub fn migrate<VecMap>(graph: GraphMem, vector_map: VecMap) -> GraphMem
 where
-    VecMap: Fn(IrisVectorId) -> IrisVectorId + Copy,
+    VecMap: Fn(VectorId) -> VectorId + Copy,
 {
     let last_update_seq_no = graph.last_update_seq_no;
     let new_entry_point = graph
@@ -901,7 +893,7 @@ mod tests {
     };
     use aes_prng::AesRng;
     use eyre::Result;
-    use iris_mpc_common::{iris_db::db::IrisDB, vector_id::VectorId, IrisVectorId};
+    use iris_mpc_common::{iris_db::db::IrisDB, VectorId};
 
     use rand::{RngCore, SeedableRng};
 
@@ -1026,11 +1018,11 @@ mod tests {
         let mut layer_a = super::Layer::new();
         let mut layer_b = super::Layer::new();
 
-        let v1 = IrisVectorId::from_serial_id(1);
-        let v2 = IrisVectorId::from_serial_id(2);
-        let v3 = IrisVectorId::from_serial_id(3);
-        let v4 = IrisVectorId::from_serial_id(4);
-        let v5 = IrisVectorId::from_serial_id(5);
+        let v1 = VectorId::from_serial_id(1);
+        let v2 = VectorId::from_serial_id(2);
+        let v3 = VectorId::from_serial_id(3);
+        let v4 = VectorId::from_serial_id(4);
+        let v5 = VectorId::from_serial_id(5);
 
         layer_a.set_links(v1, vec![v2, v3]);
         layer_a.set_links(v4, vec![v5]);
@@ -1055,7 +1047,7 @@ mod tests {
             crate::hnsw::searcher::LayerDistribution::new_geometric_from_M(2);
         let mut rng = AesRng::seed_from_u64(0_u64);
 
-        let mut point_ids_map: HashMap<IrisVectorId, IrisVectorId> = HashMap::new();
+        let mut point_ids_map: HashMap<VectorId, VectorId> = HashMap::new();
 
         for raw_query in IrisDB::new_random_rng(20, &mut rng).db {
             let query = Arc::new(raw_query);
@@ -1074,7 +1066,7 @@ mod tests {
                 )
                 .await?;
 
-            point_ids_map.insert(inserted, IrisVectorId::from_serial_id(rng.next_u32()));
+            point_ids_map.insert(inserted, VectorId::from_serial_id(rng.next_u32()));
         }
 
         let new_graph_store: GraphMem = migrate(graph_store.clone(), |v| point_ids_map[&v]);
@@ -1114,9 +1106,9 @@ mod tests {
     #[test]
     fn add_edges_outgoing_writes_only_to_id_list() {
         let mut graph = GraphMem::new();
-        let a = IrisVectorId::from_serial_id(1);
-        let b = IrisVectorId::from_serial_id(2);
-        let c = IrisVectorId::from_serial_id(3);
+        let a = VectorId::from_serial_id(1);
+        let b = VectorId::from_serial_id(2);
+        let c = VectorId::from_serial_id(3);
         // Seed: a, b, c all exist at layer 0 with no edges.
         graph
             .insert_apply(&GraphMutation {
@@ -1152,22 +1144,16 @@ mod tests {
             })
             .unwrap();
         assert_eq!(graph.layers[0].get_links(&a).unwrap(), &[b, c]);
-        assert_eq!(
-            graph.layers[0].get_links(&b).unwrap(),
-            &[] as &[IrisVectorId]
-        );
-        assert_eq!(
-            graph.layers[0].get_links(&c).unwrap(),
-            &[] as &[IrisVectorId]
-        );
+        assert_eq!(graph.layers[0].get_links(&b).unwrap(), &[] as &[VectorId]);
+        assert_eq!(graph.layers[0].get_links(&c).unwrap(), &[] as &[VectorId]);
     }
 
     #[test]
     fn add_edges_incoming_writes_only_to_target_lists() {
         let mut graph = GraphMem::new();
-        let a = IrisVectorId::from_serial_id(1);
-        let b = IrisVectorId::from_serial_id(2);
-        let c = IrisVectorId::from_serial_id(3);
+        let a = VectorId::from_serial_id(1);
+        let b = VectorId::from_serial_id(2);
+        let c = VectorId::from_serial_id(3);
         graph
             .insert_apply(&GraphMutation {
                 seq_no: 1,
@@ -1201,10 +1187,7 @@ mod tests {
                 }],
             })
             .unwrap();
-        assert_eq!(
-            graph.layers[0].get_links(&a).unwrap(),
-            &[] as &[IrisVectorId]
-        );
+        assert_eq!(graph.layers[0].get_links(&a).unwrap(), &[] as &[VectorId]);
         assert_eq!(graph.layers[0].get_links(&b).unwrap(), &[a]);
         assert_eq!(graph.layers[0].get_links(&c).unwrap(), &[a]);
     }
@@ -1212,9 +1195,9 @@ mod tests {
     #[test]
     fn add_edges_bidirectional_writes_both_sides() {
         let mut graph = GraphMem::new();
-        let a = IrisVectorId::from_serial_id(1);
-        let b = IrisVectorId::from_serial_id(2);
-        let c = IrisVectorId::from_serial_id(3);
+        let a = VectorId::from_serial_id(1);
+        let b = VectorId::from_serial_id(2);
+        let c = VectorId::from_serial_id(3);
         graph
             .insert_apply(&GraphMutation {
                 seq_no: 1,
@@ -1256,9 +1239,9 @@ mod tests {
     #[test]
     fn remove_edges_outgoing_only_modifies_id_list() {
         let mut graph = GraphMem::new();
-        let a = IrisVectorId::from_serial_id(1);
-        let b = IrisVectorId::from_serial_id(2);
-        let c = IrisVectorId::from_serial_id(3);
+        let a = VectorId::from_serial_id(1);
+        let b = VectorId::from_serial_id(2);
+        let c = VectorId::from_serial_id(3);
         graph
             .insert_apply(&GraphMutation {
                 seq_no: 1,
@@ -1320,8 +1303,8 @@ mod tests {
         // Pass 1 should apply AddNode before pass 2 applies AddEdges, regardless
         // of their order in the input Vec.
         let mut graph = GraphMem::new();
-        let a = IrisVectorId::from_serial_id(1);
-        let b = IrisVectorId::from_serial_id(2);
+        let a = VectorId::from_serial_id(1);
+        let b = VectorId::from_serial_id(2);
         graph
             .insert_apply(&GraphMutation {
                 seq_no: 1,
@@ -1367,7 +1350,7 @@ mod tests {
     #[test]
     fn insert_apply_advances_last_update_seq_no_on_success() {
         let mut graph = GraphMem::new();
-        let a = IrisVectorId::from_serial_id(1);
+        let a = VectorId::from_serial_id(1);
         let mutation = GraphMutation {
             seq_no: 1,
             ops: vec![MutationOp::AddNode {
@@ -1389,7 +1372,7 @@ mod tests {
         let mutation = GraphMutation {
             seq_no: 5,
             ops: vec![MutationOp::AddNode {
-                id: IrisVectorId::from_serial_id(1),
+                id: VectorId::from_serial_id(1),
                 height: 1,
                 update_ep: UpdateEntryPoint::SetUnique { layer: 0 },
             }],
@@ -1410,7 +1393,7 @@ mod tests {
         let mutation = GraphMutation {
             seq_no: 9,
             ops: vec![MutationOp::AddNode {
-                id: IrisVectorId::from_serial_id(1),
+                id: VectorId::from_serial_id(1),
                 height: 1,
                 update_ep: UpdateEntryPoint::SetUnique { layer: 0 },
             }],
@@ -1423,8 +1406,8 @@ mod tests {
     #[test]
     fn insert_apply_all_short_circuits_on_first_violation() {
         let mut graph = GraphMem::new();
-        let a = IrisVectorId::from_serial_id(1);
-        let b = IrisVectorId::from_serial_id(2);
+        let a = VectorId::from_serial_id(1);
+        let b = VectorId::from_serial_id(2);
         let mutations = vec![
             GraphMutation {
                 seq_no: 1,
@@ -1472,10 +1455,10 @@ mod int4_layer_tests {
         let k = 3_usize;
         let vectors: Vec<Int4Vector> = (0..n).map(|_| Int4Vector::random(&mut rng)).collect();
 
-        let data: Vec<(IrisVectorId, Int4Vector)> = vectors
+        let data: Vec<(VectorId, Int4Vector)> = vectors
             .iter()
             .enumerate()
-            .map(|(i, v)| (IrisVectorId::from_serial_id((i + 1) as u32), v.clone()))
+            .map(|(i, v)| (VectorId::from_serial_id((i + 1) as u32), v.clone()))
             .collect();
 
         let layer = Layer::ideal_from_int4_vectors(data, k, EngineChoiceInt4::NaiveInt4Dot);
@@ -1487,17 +1470,17 @@ mod int4_layer_tests {
         for (key, neighbors) in layer.get_links_map() {
             let me_idx = key.serial_id() as usize - 1;
             let me = &vectors[me_idx];
-            let mut dists: Vec<(IrisVectorId, i32)> = (0..n)
+            let mut dists: Vec<(VectorId, i32)> = (0..n)
                 .filter(|j| *j != me_idx)
                 .map(|j| {
                     (
-                        IrisVectorId::from_serial_id((j + 1) as u32),
+                        VectorId::from_serial_id((j + 1) as u32),
                         me.dot(&vectors[j]),
                     )
                 })
                 .collect();
             dists.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.serial_id().cmp(&b.0.serial_id())));
-            let expected: Vec<IrisVectorId> = dists.into_iter().take(k).map(|(j, _)| j).collect();
+            let expected: Vec<VectorId> = dists.into_iter().take(k).map(|(j, _)| j).collect();
             assert_eq!(neighbors, &expected, "key {key}");
         }
     }

--- a/iris-mpc-cpu/src/hnsw/graph/mutation.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/mutation.rs
@@ -1,4 +1,4 @@
-use iris_mpc_common::IrisVectorId;
+use iris_mpc_common::VectorId;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -32,24 +32,24 @@ pub struct UnstampedMutation {
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MutationOp {
     AddNode {
-        id: IrisVectorId,
+        id: VectorId,
         /// Number of real graph layers this node is included in. The node will
         /// be present in layers `0..height`.
         height: usize,
         update_ep: UpdateEntryPoint,
     },
     RemoveNode {
-        id: IrisVectorId,
+        id: VectorId,
     },
     AddEdges {
-        base: IrisVectorId,
-        neighbors: Vec<IrisVectorId>,
+        base: VectorId,
+        neighbors: Vec<VectorId>,
         layer: usize,
         edge_type: EdgeType,
     },
     RemoveEdges {
-        base: IrisVectorId,
-        neighbors: Vec<IrisVectorId>,
+        base: VectorId,
+        neighbors: Vec<VectorId>,
         layer: usize,
         edge_type: EdgeType,
     },
@@ -101,7 +101,7 @@ impl UnstampedMutation {
     /// mutation. Used as the candidate set for batch compaction. The
     /// returned Vec is the raw walk and may contain duplicates; callers
     /// fold into a set to dedup.
-    pub fn expanded_neighborhoods(&self) -> Vec<(IrisVectorId, usize)> {
+    pub fn expanded_neighborhoods(&self) -> Vec<(VectorId, usize)> {
         let mut out = Vec::new();
         for op in &self.ops {
             if let MutationOp::AddEdges {
@@ -129,7 +129,7 @@ impl UnstampedMutation {
     /// edge set was modified is a candidate for stale-reference cleanup.
     /// The returned Vec is the raw walk and may contain duplicates; callers
     /// fold into a set to dedup.
-    pub fn updated_neighborhoods(&self) -> Vec<(IrisVectorId, usize)> {
+    pub fn updated_neighborhoods(&self) -> Vec<(VectorId, usize)> {
         let mut out = Vec::new();
         for op in &self.ops {
             match op {
@@ -196,10 +196,10 @@ pub enum UpdateEntryPoint {
 #[cfg(test)]
 mod tests {
     use crate::hnsw::graph::layered_graph::Layer;
-    use iris_mpc_common::IrisVectorId;
+    use iris_mpc_common::VectorId;
 
-    fn vid(n: u32) -> IrisVectorId {
-        IrisVectorId::from_serial_id(n)
+    fn vid(n: u32) -> VectorId {
+        VectorId::from_serial_id(n)
     }
 
     // ── InsertNode ────────────────────────────────────────────────────────────
@@ -365,8 +365,8 @@ mod tests {
 
     use super::{EdgeType, MutationOp, UnstampedMutation, UpdateEntryPoint};
 
-    fn mk_vector_id(id: u32) -> IrisVectorId {
-        IrisVectorId::from_serial_id(id)
+    fn mk_vector_id(id: u32) -> VectorId {
+        VectorId::from_serial_id(id)
     }
 
     fn mk_add_edges(

--- a/iris-mpc-cpu/src/hnsw/graph/neighborhood.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/neighborhood.rs
@@ -11,7 +11,7 @@ use crate::hnsw::{
     VectorStore,
 };
 use eyre::Result;
-use iris_mpc_common::vector_id::VectorId;
+use iris_mpc_common::VectorId;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 
@@ -208,7 +208,7 @@ mod tests {
 
     use super::*;
     use crate::{hawkers::plaintext_store::PlaintextStore, hnsw::vector_store::VectorStoreMut};
-    use iris_mpc_common::{iris_db::iris::IrisCode, IrisVectorId};
+    use iris_mpc_common::{iris_db::iris::IrisCode, VectorId};
     use rand::thread_rng;
 
     async fn insert_batch_store_and_nbhd(
@@ -278,7 +278,7 @@ mod tests {
 
         // The furthest element should be the earliest inserted match
         let furthest = nbhd.get_furthest().unwrap();
-        assert_eq!(furthest.0, IrisVectorId::from_serial_id(4));
+        assert_eq!(furthest.0, VectorId::from_serial_id(4));
 
         // This should clear
         nbhd.insert_batch_and_trim(&mut store, &[], 0).await?;

--- a/iris-mpc-cpu/src/hnsw/searcher.rs
+++ b/iris-mpc-cpu/src/hnsw/searcher.rs
@@ -23,7 +23,7 @@ use crate::hnsw::GraphMem;
 use aes_prng::AesRng;
 use ampc_actor_utils::fast_metrics::FastHistogram;
 use eyre::{bail, eyre, OptionExt, Result};
-use iris_mpc_common::vector_id::VectorId;
+use iris_mpc_common::VectorId;
 use itertools::{izip, Itertools};
 use rand::{RngCore, SeedableRng};
 use rand_distr::{Distribution, Geometric};
@@ -1687,7 +1687,7 @@ mod tests {
     use aes_prng::AesRng;
     use iris_mpc_common::{
         iris_db::{db::IrisDB, iris::IrisCode},
-        vector_id::VectorId,
+        VectorId,
     };
     use rand::SeedableRng;
     use tokio;

--- a/iris-mpc-cpu/src/hnsw/sorting/quicksort.rs
+++ b/iris-mpc-cpu/src/hnsw/sorting/quicksort.rs
@@ -1,5 +1,5 @@
 use eyre::{bail, OptionExt, Result};
-use iris_mpc_common::vector_id::VectorId;
+use iris_mpc_common::VectorId;
 use itertools::izip;
 
 use crate::hnsw::VectorStore;

--- a/iris-mpc-cpu/src/hnsw/sorting/swap_network.rs
+++ b/iris-mpc-cpu/src/hnsw/sorting/swap_network.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use ampc_secret_sharing::shares::{bit::Bit, vecshare_bittranspose::Transpose64, VecShare};
 use eyre::{eyre, Result};
-use iris_mpc_common::vector_id::VectorId;
+use iris_mpc_common::VectorId;
 use itertools::{EitherOrBoth, Itertools};
 use rand_distr::{Distribution, Standard};
 

--- a/iris-mpc-cpu/src/hnsw/vector_store.rs
+++ b/iris-mpc-cpu/src/hnsw/vector_store.rs
@@ -1,5 +1,5 @@
 use eyre::{bail, OptionExt, Result};
-use iris_mpc_common::IrisVectorId as VectorId;
+use iris_mpc_common::VectorId;
 use itertools::izip;
 use serde::Serialize;
 use std::{fmt::Debug, hash::Hash};

--- a/iris-mpc-cpu/src/py_bindings/hnsw.rs
+++ b/iris-mpc-cpu/src/py_bindings/hnsw.rs
@@ -4,7 +4,7 @@ use crate::{
     hawkers::plaintext_store::PlaintextStore,
     hnsw::{GraphMem, HnswSearcher},
 };
-use iris_mpc_common::{iris_db::iris::IrisCode, vector_id::VectorId};
+use iris_mpc_common::{iris_db::iris::IrisCode, VectorId};
 use rand::rngs::ThreadRng;
 use std::path::Path;
 use std::sync::Arc;

--- a/iris-mpc-cpu/src/utils/serialization/graph.rs
+++ b/iris-mpc-cpu/src/utils/serialization/graph.rs
@@ -7,7 +7,7 @@ use std::{
 
 use clap::ValueEnum;
 use eyre::{bail, Result};
-use iris_mpc_common::IrisVectorId;
+use iris_mpc_common::VectorId;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -385,10 +385,10 @@ pub fn write_graph_pair_to_file<P: AsRef<Path>>(path: P, data: [GraphMem; 2]) ->
 
 /* --------------- Conversion GraphV0 -> GraphMem ------------------- */
 
-impl From<graph_v0::PointId> for IrisVectorId {
+impl From<graph_v0::PointId> for VectorId {
     fn from(value: graph_v0::PointId) -> Self {
         // The V0 format only stores a u32 ID. We assume version 0.
-        IrisVectorId::new(value.0, 0)
+        VectorId::new(value.0, 0)
     }
 }
 
@@ -430,9 +430,9 @@ impl From<graph_v0::GraphV0> for GraphMem {
 
 /* --------------- Conversion GraphV1 -> GraphMem ------------------- */
 
-impl From<graph_v1::VectorId> for IrisVectorId {
+impl From<graph_v1::VectorId> for VectorId {
     fn from(value: graph_v1::VectorId) -> Self {
-        IrisVectorId::new(value.0, 0)
+        VectorId::new(value.0, 0)
     }
 }
 
@@ -450,10 +450,8 @@ impl From<graph_v1::Layer> for Layer {
         let mut layer = Layer::new();
         for (v, nb) in value.links.into_iter() {
             layer.set_links(
-                IrisVectorId::new(v.0, 1),
-                nb.0.into_iter()
-                    .map(|x| IrisVectorId::new(x.0, 1))
-                    .collect(),
+                VectorId::new(v.0, 1),
+                nb.0.into_iter().map(|x| VectorId::new(x.0, 1)).collect(),
             );
         }
         layer
@@ -476,9 +474,9 @@ impl From<graph_v1::GraphV1> for GraphMem {
 
 /* --------------- Conversion GraphV2 -> GraphMem ------------------- */
 
-impl From<graph_v2::VectorId> for IrisVectorId {
+impl From<graph_v2::VectorId> for VectorId {
     fn from(value: graph_v2::VectorId) -> Self {
-        IrisVectorId::new(value.id, value.version)
+        VectorId::new(value.id, value.version)
     }
 }
 
@@ -521,9 +519,9 @@ impl From<graph_v2::GraphV2> for GraphMem {
 
 /* --------------- Conversion GraphV3 -> GraphMem ------------------- */
 
-impl From<graph_v3::VectorId> for IrisVectorId {
+impl From<graph_v3::VectorId> for VectorId {
     fn from(value: graph_v3::VectorId) -> Self {
-        IrisVectorId::new(value.id, value.version)
+        VectorId::new(value.id, value.version)
     }
 }
 
@@ -559,9 +557,9 @@ impl From<graph_v3::GraphV3> for GraphMem {
 
 /* --------------- Conversion GraphV4 -> GraphMem ------------------- */
 
-impl From<graph_v4::VectorId> for IrisVectorId {
+impl From<graph_v4::VectorId> for VectorId {
     fn from(value: graph_v4::VectorId) -> Self {
-        IrisVectorId::new(value.id, value.version)
+        VectorId::new(value.id, value.version)
     }
 }
 
@@ -596,8 +594,8 @@ impl From<graph_v4::GraphV4> for GraphMem {
 
 /* --------------- Conversion GraphMem -> GraphV4 ------------------- */
 
-impl From<IrisVectorId> for graph_v4::VectorId {
-    fn from(value: IrisVectorId) -> Self {
+impl From<VectorId> for graph_v4::VectorId {
+    fn from(value: VectorId) -> Self {
         graph_v4::VectorId {
             id: value.serial_id(),
             version: value.version_id(),
@@ -783,7 +781,7 @@ mod tests {
     /// is overwhelmingly unlikely to coincide with sorted order — i.e. the test
     /// actually exercises the link sorting.
     fn sample_graph() -> GraphMem {
-        let v = IrisVectorId::from_serial_id;
+        let v = VectorId::from_serial_id;
         let mut layer = Layer::new();
         for &n in &[7u32, 3, 9, 1, 5, 8, 2, 6, 4] {
             layer.set_links(v(n), vec![v(n + 1), v(n + 2)]);

--- a/iris-mpc-cpu/src/utils/serialization/iris_ndjson.rs
+++ b/iris-mpc-cpu/src/utils/serialization/iris_ndjson.rs
@@ -9,7 +9,7 @@ use clap::ValueEnum;
 use eyre::Result;
 use iris_mpc_common::{
     iris_db::iris::{IrisCode, IrisCodeArray},
-    IrisVectorId,
+    VectorId,
 };
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
@@ -118,7 +118,7 @@ impl PlaintextStore {
         // Iterate over each deserialized object
         let mut vector = PlaintextStore::new();
         for (idx, iris) in stream_iterator.enumerate() {
-            let id = IrisVectorId::from_0_index(idx as u32);
+            let id = VectorId::from_0_index(idx as u32);
             vector.insert_with_id(id, Arc::new(iris));
         }
 

--- a/iris-mpc-cpu/tests/e2e.rs
+++ b/iris-mpc-cpu/tests/e2e.rs
@@ -6,7 +6,7 @@ use iris_mpc_common::{
     iris_db::{db::IrisDB, iris::IrisCode},
     job::{BatchMetadata, BatchQuery, JobSubmissionHandle, ServerJobResult},
     test::{generate_full_test_db, prepare_batch, E2ETemplate, TestCaseGenerator},
-    vector_id::VectorId,
+    VectorId,
 };
 use iris_mpc_cpu::{
     execution::hawk_main::{HawkActor, HawkArgs, HawkHandle, HawkMutation},

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -50,7 +50,7 @@ use iris_mpc_common::{
     },
     iris_db::get_dummy_shares_for_deletion,
     job::{JobSubmissionHandle, ServerJobResult},
-    vector_id::VectorId,
+    VectorId,
 };
 use iris_mpc_cpu::shares::{
     share::{DistanceShare, Share},

--- a/iris-mpc-py/src/py_hnsw/pyclasses/graph_store.rs
+++ b/iris-mpc-py/src/py_hnsw/pyclasses/graph_store.rs
@@ -1,4 +1,4 @@
-use iris_mpc_common::IrisVectorId;
+use iris_mpc_common::VectorId;
 use iris_mpc_cpu::{hnsw::graph::layered_graph::GraphMem, utils::serialization::graph};
 use pyo3::{exceptions::PyIOError, prelude::*};
 
@@ -38,8 +38,7 @@ impl PyGraphStore {
     }
 
     pub fn get_links(&self, vector_id: u32, layer_index: usize) -> PyResult<Option<Vec<u32>>> {
-        let raw_ret =
-            self.0.layers[layer_index].get_links(&IrisVectorId::from_serial_id(vector_id));
+        let raw_ret = self.0.layers[layer_index].get_links(&VectorId::from_serial_id(vector_id));
         Ok(raw_ret.map(|neighborhood| neighborhood.iter().map(|nb| nb.serial_id()).collect()))
     }
 }

--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -20,7 +20,7 @@ use iris_mpc_common::{
     },
     iris_db::iris::IrisCode,
     postgres::PostgresClient,
-    vector_id::{SerialId, VectorId},
+    SerialId, VectorId,
 };
 use itertools::izip;
 use rand::{rngs::StdRng, Rng, SeedableRng};

--- a/iris-mpc-store/src/s3_importer.rs
+++ b/iris-mpc-store/src/s3_importer.rs
@@ -6,7 +6,7 @@ use aws_sdk_s3::{config::Builder as S3ConfigBuilder, Client as S3Client};
 use aws_sdk_s3::{primitives::ByteStream, Client};
 use eyre::{bail, eyre, Result};
 use futures::{stream, StreamExt};
-use iris_mpc_common::{vector_id::VectorId, IRIS_CODE_LENGTH, MASK_CODE_LENGTH};
+use iris_mpc_common::{VectorId, IRIS_CODE_LENGTH, MASK_CODE_LENGTH};
 use std::{mem, sync::Arc, time::Duration};
 use tokio::{io::AsyncReadExt, sync::mpsc::Sender};
 

--- a/iris-mpc-upgrade-hawk/src/genesis/graph_checkpoint.rs
+++ b/iris-mpc-upgrade-hawk/src/genesis/graph_checkpoint.rs
@@ -1,6 +1,6 @@
 use aws_sdk_s3::Client as S3Client;
 use eyre::{bail, Result};
-use iris_mpc_common::IrisSerialId;
+use iris_mpc_common::SerialId;
 use iris_mpc_cpu::execution::hawk_main::{BothEyes, GraphRef, HawkOps};
 use iris_mpc_cpu::genesis::state_accessor::set_last_indexed_iris_id;
 use iris_mpc_cpu::graph_checkpoint::{upload_graph_checkpoint, GraphCheckpointState};
@@ -61,7 +61,7 @@ pub async fn maybe_rollback_iris_db(
     graph_checkpoint: &GraphCheckpointState,
     graph_store: &GraphPg<Aby3Store<HawkOps>>,
     iris_store: &IrisStore,
-    last_indexed_id: IrisSerialId,
+    last_indexed_id: SerialId,
     last_indexed_modification_id: i64,
 ) -> Result<()> {
     if last_indexed_modification_id != graph_checkpoint.last_indexed_modification_id {

--- a/iris-mpc-upgrade-hawk/src/genesis/mod.rs
+++ b/iris-mpc-upgrade-hawk/src/genesis/mod.rs
@@ -19,7 +19,7 @@ use iris_mpc_common::{
     config::{CommonConfig, Config, ENV_PROD, ENV_STAGE},
     helpers::{smpc_request, sync::Modification},
     postgres::{AccessMode, PostgresClient},
-    IrisSerialId,
+    SerialId,
 };
 pub use iris_mpc_cpu::genesis::BatchSizeConfig;
 use iris_mpc_cpu::{
@@ -72,7 +72,7 @@ const DEFAULT_REGION: &str = "eu-north-1";
 #[derive(Debug, Clone)]
 pub struct ExecutionArgs {
     // Serial identifier of maximum indexed Iris.
-    pub max_indexation_id: IrisSerialId,
+    pub max_indexation_id: SerialId,
 
     // Batch size configuration (static or dynamic with cap).
     pub batch_size_config: BatchSizeConfig,
@@ -112,10 +112,10 @@ struct ExecutionContextInfo {
     config: Config,
 
     // Serial idenitifer of last indexed Iris.
-    last_indexed_id: IrisSerialId,
+    last_indexed_id: SerialId,
 
     // Set identifiers of Iris's to be excluded from indexation.
-    excluded_serial_ids: Vec<IrisSerialId>,
+    excluded_serial_ids: Vec<SerialId>,
 
     // Set of modifications to be applied.
     modifications: Vec<Modification>,
@@ -133,8 +133,8 @@ impl ExecutionContextInfo {
     fn new(
         args: &ExecutionArgs,
         config: &Config,
-        last_indexed_id: IrisSerialId,
-        excluded_serial_ids: Vec<IrisSerialId>,
+        last_indexed_id: SerialId,
+        excluded_serial_ids: Vec<SerialId>,
         modifications: Vec<Modification>,
         max_modification_indexed_id: i64,
         max_modification_persist_id: i64,
@@ -1498,8 +1498,8 @@ fn validate_config(config: &Config) -> Result<()> {
 async fn validate_consistency_of_stores(
     config: &Config,
     iris_store: &IrisStore,
-    max_indexation_id: IrisSerialId,
-    last_indexed_id: IrisSerialId,
+    max_indexation_id: SerialId,
+    last_indexed_id: SerialId,
 ) -> Result<()> {
     // Bail if last indexed id exceeds max indexation id
     if last_indexed_id > max_indexation_id {

--- a/iris-mpc-upgrade-hawk/tests/utils/mpc_node.rs
+++ b/iris-mpc-upgrade-hawk/tests/utils/mpc_node.rs
@@ -10,7 +10,7 @@ use eyre::{bail, Result};
 use iris_mpc_common::{
     config::Config,
     postgres::{AccessMode, PostgresClient},
-    IrisSerialId, IrisVectorId,
+    SerialId, VectorId,
 };
 use iris_mpc_cpu::{
     execution::hawk_main::BothEyes,
@@ -285,7 +285,7 @@ impl MpcNode {
         let dummy_code = vec![0u16; IRIS_CODE_LENGTH];
         let dummy_mask = vec![0u16; MASK_CODE_LENGTH];
 
-        let (irises, vector_ids): (Vec<StoredIrisRef>, Vec<IrisVectorId>) = (1..=count)
+        let (irises, vector_ids): (Vec<StoredIrisRef>, Vec<VectorId>) = (1..=count)
             .map(|i| {
                 let iris_id = starting_id + i;
                 (
@@ -296,7 +296,7 @@ impl MpcNode {
                         right_code: &dummy_code,
                         right_mask: &dummy_mask,
                     },
-                    IrisVectorId::new(iris_id as u32, 500),
+                    VectorId::new(iris_id as u32, 500),
                 )
             })
             .collect();
@@ -325,7 +325,7 @@ impl MpcNode {
     /// Deletes the most recent  genesis graph checkpoint from this node's CPU store only.
     pub async fn delete_cpu_checkpoint(&self) -> Result<()> {
         sqlx::query(
-            "DELETE FROM genesis_graph_checkpoint 
+            "DELETE FROM genesis_graph_checkpoint
          WHERE id = (SELECT id FROM genesis_graph_checkpoint ORDER BY id DESC LIMIT 1)",
         )
         .execute(self.cpu_stores.graph.pool())
@@ -407,9 +407,9 @@ impl MpcNode {
 #[derive(Default, Clone)]
 pub struct DbAssertions {
     pub num_irises: Option<usize>,
-    pub vector_ids: Option<Vec<IrisVectorId>>,
+    pub vector_ids: Option<Vec<VectorId>>,
     pub num_modifications: Option<usize>,
-    pub last_indexed_iris_id: Option<IrisSerialId>,
+    pub last_indexed_iris_id: Option<SerialId>,
     pub last_indexed_modification_id: Option<i64>,
 }
 
@@ -423,7 +423,7 @@ impl DbAssertions {
         self
     }
 
-    pub fn assert_vector_ids(mut self, vector_ids: Vec<IrisVectorId>) -> Self {
+    pub fn assert_vector_ids(mut self, vector_ids: Vec<VectorId>) -> Self {
         self.vector_ids = Some(vector_ids);
         self
     }
@@ -433,7 +433,7 @@ impl DbAssertions {
         self
     }
 
-    pub fn assert_last_indexed_iris_id(mut self, id: IrisSerialId) -> Self {
+    pub fn assert_last_indexed_iris_id(mut self, id: SerialId) -> Self {
         self.last_indexed_iris_id = Some(id);
         self
     }
@@ -494,7 +494,7 @@ pub mod db_ops {
     use std::ops::DerefMut;
 
     use eyre::Result;
-    use iris_mpc_common::{helpers::sync::Modification, IrisVectorId};
+    use iris_mpc_common::{helpers::sync::Modification, VectorId};
     use iris_mpc_store::Store;
     use sqlx::{Postgres, Transaction};
 
@@ -516,7 +516,7 @@ pub mod db_ops {
         Ok(())
     }
 
-    pub async fn get_iris_vector_ids(store: &Store) -> Result<Vec<IrisVectorId>> {
+    pub async fn get_iris_vector_ids(store: &Store) -> Result<Vec<VectorId>> {
         let ids: Vec<(i64, i16)> = sqlx::query_as(
             r#"
             SELECT
@@ -531,7 +531,7 @@ pub mod db_ops {
 
         let ids = ids
             .into_iter()
-            .map(|(serial_id, version)| IrisVectorId::new(serial_id as u32, version))
+            .map(|(serial_id, version)| VectorId::new(serial_id as u32, version))
             .collect();
 
         Ok(ids)

--- a/iris-mpc-upgrade-hawk/tests/utils/plaintext_genesis.rs
+++ b/iris-mpc-upgrade-hawk/tests/utils/plaintext_genesis.rs
@@ -3,9 +3,7 @@ use crate::utils::{
     IrisCodePair,
 };
 use eyre::{bail, OptionExt, Result};
-use iris_mpc_common::{
-    config::Config, iris_db::iris::IrisCode, IrisSerialId, IrisVectorId, IrisVersionId,
-};
+use iris_mpc_common::{config::Config, iris_db::iris::IrisCode, SerialId, VectorId, VersionId};
 use iris_mpc_cpu::{
     genesis::plaintext::{
         run_plaintext_genesis, GenesisArgs, GenesisConfig, GenesisDstDbState, GenesisSrcDbState,
@@ -70,7 +68,7 @@ async fn simulate_genesis(
 fn construct_initial_genesis_state(
     genesis_config: GenesisConfig,
     genesis_args: GenesisArgs,
-    input: HashMap<IrisSerialId, (IrisVersionId, IrisCode, IrisCode)>,
+    input: HashMap<SerialId, (VersionId, IrisCode, IrisCode)>,
     s3_deletions: Vec<u32>,
 ) -> GenesisState {
     GenesisState {
@@ -153,10 +151,10 @@ pub fn init_plaintext_config(config: &Config) -> GenesisConfig {
     }
 }
 
-pub fn get_vector_ids(irises: &IrisesTable) -> Vec<IrisVectorId> {
+pub fn get_vector_ids(irises: &IrisesTable) -> Vec<VectorId> {
     let mut ids: Vec<_> = irises
         .iter()
-        .map(|(serial_id, data)| IrisVectorId::new(*serial_id, data.0))
+        .map(|(serial_id, data)| VectorId::new(*serial_id, data.0))
         .collect();
     ids.sort_by_key(|id| id.serial_id());
     ids

--- a/iris-mpc-upgrade-hawk/tests/utils/s3_deletions.rs
+++ b/iris-mpc-upgrade-hawk/tests/utils/s3_deletions.rs
@@ -1,12 +1,12 @@
 use aws_sdk_s3::{primitives::ByteStream as S3_ByteStream, Client as S3_Client};
 use eyre::{eyre, Result};
 use iris_mpc::services::aws::clients::AwsClients;
-use iris_mpc_common::{config::Config, IrisSerialId};
+use iris_mpc_common::{config::Config, SerialId};
 use serde::Serialize;
 
 /// Uploads to an AWS S3 bucket a set of serial identifiers marked as deleted.
 pub async fn upload_iris_deletions(
-    data: &Vec<IrisSerialId>,
+    data: &Vec<SerialId>,
     s3: &S3_Client,
     environment: &str,
 ) -> Result<()> {
@@ -54,7 +54,7 @@ pub async fn get_aws_clients(config: &Config) -> Result<AwsClients> {
 // Struct for S3 serialization.
 #[derive(Serialize, Debug, Clone)]
 pub struct IrisDeletionsForS3 {
-    pub deleted_serial_ids: Vec<IrisSerialId>,
+    pub deleted_serial_ids: Vec<SerialId>,
 }
 
 /// AWS S3 bucket for iris deletions.

--- a/iris-mpc-utils/src/aws/ops.rs
+++ b/iris-mpc-utils/src/aws/ops.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-use iris_mpc_common::IrisSerialId;
+use iris_mpc_common::SerialId;
 use iris_mpc_cpu::execution::hawk_main::BothEyes;
 
 use super::{
@@ -13,13 +13,10 @@ use crate::{constants::N_PARTIES, irises::GaloisRingSharedIrisForUpload};
 
 impl AwsClient {
     /// Uploads Iris serial identifiers marked for deletion.
-    pub async fn s3_upload_iris_deletions(
-        &self,
-        data: &[IrisSerialId],
-    ) -> Result<(), AwsClientError> {
+    pub async fn s3_upload_iris_deletions(&self, data: &[SerialId]) -> Result<(), AwsClientError> {
         #[derive(Serialize)]
         struct S3Data<'a> {
-            deleted_serial_ids: &'a [IrisSerialId],
+            deleted_serial_ids: &'a [SerialId],
         }
 
         let data = S3Data {

--- a/iris-mpc-utils/src/client/mod.rs
+++ b/iris-mpc-utils/src/client/mod.rs
@@ -8,7 +8,7 @@ use futures::StreamExt;
 use iris_mpc_cpu::execution::hawk_main::BothEyes;
 use rand::rngs::StdRng;
 
-use iris_mpc_common::{helpers::smpc_request, IrisSerialId};
+use iris_mpc_common::{helpers::smpc_request, SerialId};
 use tokio::time::{sleep, timeout, Instant};
 use uuid::Uuid;
 
@@ -209,7 +209,7 @@ impl ServiceClient {
 
         for (item_idx, opts) in batch.iter().enumerate() {
             // Resolve parent serial ID from labels or use provided ID.
-            let parent_serial_id: Option<IrisSerialId> = match opts.get_parent() {
+            let parent_serial_id: Option<SerialId> = match opts.get_parent() {
                 Some(Parent::Id(id)) => Some(id),
                 Some(Parent::Label(label)) => {
                     if let Some(&serial_id) = self.state.uniqueness_labels.get(label.as_str()) {
@@ -428,11 +428,11 @@ impl std::fmt::Display for ErrorBits {
 
 // Holds the cross-batch state needed while processing requests and responses.
 struct ExecState {
-    uniqueness_labels: HashMap<String, IrisSerialId>,
+    uniqueness_labels: HashMap<String, SerialId>,
     signup_id_to_labels: HashMap<Uuid, String>,
     outstanding_requests: HashMap<Uuid, typeset::RequestInfo>,
-    outstanding_deletions: HashMap<IrisSerialId, typeset::RequestInfo>,
-    live_serial_ids: HashSet<IrisSerialId>,
+    outstanding_deletions: HashMap<SerialId, typeset::RequestInfo>,
+    live_serial_ids: HashSet<SerialId>,
     error_bits: ErrorBits,
 }
 

--- a/iris-mpc-utils/src/client/options/types.rs
+++ b/iris-mpc-utils/src/client/options/types.rs
@@ -6,7 +6,7 @@ use serde::{
     Deserialize, Serialize,
 };
 
-use iris_mpc_common::IrisSerialId;
+use iris_mpc_common::SerialId;
 use iris_mpc_cpu::utils::serialization::iris_ndjson::IrisSelection;
 use uuid::Uuid;
 
@@ -77,7 +77,7 @@ pub enum Parent {
     /// A label referring to a Uniqueness request whose serial ID is not yet known.
     Label(String),
     /// A known Iris serial ID; no dependency resolution needed.
-    Id(IrisSerialId),
+    Id(SerialId),
 }
 
 impl Serialize for Parent {
@@ -149,7 +149,7 @@ pub enum RequestBatchOptions {
         batch_size: usize,
 
         // A known serial identifier that allows response correlation to be bypassed.
-        known_iris_serial_id: Option<IrisSerialId>,
+        known_iris_serial_id: Option<SerialId>,
     },
     /// Used to make large heterogenerous batches with minimal configuration
     Random {
@@ -175,7 +175,7 @@ impl RequestBatchOptions {
         batch_kind: &str,
         batch_count: usize,
         batch_size: usize,
-        known_iris_serial_id: Option<IrisSerialId>,
+        known_iris_serial_id: Option<SerialId>,
     ) -> Self {
         Self::Simple {
             batch_count,
@@ -366,7 +366,7 @@ impl RequestOptions {
     pub fn make_request(
         &self,
         info: RequestInfo,
-        parent_serial_id: Option<IrisSerialId>,
+        parent_serial_id: Option<SerialId>,
     ) -> Result<Request, String> {
         let corr_uuid = Uuid::new_v4();
 

--- a/iris-mpc-utils/src/client/typeset/data/request.rs
+++ b/iris-mpc-utils/src/client/typeset/data/request.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use serde::{Deserialize, Serialize};
 use uuid;
 
-use iris_mpc_common::IrisSerialId;
+use iris_mpc_common::SerialId;
 
 use super::{IrisPairDescriptor, RequestInfo};
 
@@ -14,7 +14,7 @@ pub enum Request {
         // Standard request information.
         info: RequestInfo,
         // Serial ID of associated uniqueness request (always known at creation).
-        parent: IrisSerialId,
+        parent: SerialId,
     },
     Reauthorization {
         // Standard request information.
@@ -22,7 +22,7 @@ pub enum Request {
         // Associated Iris pair descriptor ... used to build deterministic graphs.
         iris_pair: Option<IrisPairDescriptor>,
         // Serial ID of associated uniqueness request (always known at creation).
-        parent: IrisSerialId,
+        parent: SerialId,
         // Operation identifier.
         reauth_id: uuid::Uuid,
     },
@@ -48,7 +48,7 @@ pub enum Request {
         // Associated Iris pair descriptor ... used to build deterministic graphs.
         iris_pair: Option<IrisPairDescriptor>,
         // Serial ID of associated uniqueness request (always known at creation).
-        parent: IrisSerialId,
+        parent: SerialId,
         // Operation identifier.
         reset_id: uuid::Uuid,
     },
@@ -58,7 +58,7 @@ pub enum Request {
         // Associated Iris pair descriptor ... used to build deterministic graphs.
         iris_pair: Option<IrisPairDescriptor>,
         // Serial ID of associated uniqueness request (always known at creation).
-        parent: IrisSerialId,
+        parent: SerialId,
         // Operation identifier.
         recovery_id: uuid::Uuid,
     },
@@ -133,7 +133,7 @@ impl Request {
             Self::Uniqueness { .. } => "Uniqueness",
         };
         let label = self.info().label();
-        let serial_id: Option<IrisSerialId> = match self {
+        let serial_id: Option<SerialId> = match self {
             Self::IdentityDeletion { parent, .. }
             | Self::Reauthorization { parent, .. }
             | Self::ResetUpdate { parent, .. }

--- a/iris-mpc-utils/src/pgres/ops.rs
+++ b/iris-mpc-utils/src/pgres/ops.rs
@@ -1,5 +1,5 @@
 use eyre::Result;
-use iris_mpc_common::{helpers::sync::Modification, IrisVectorId};
+use iris_mpc_common::{helpers::sync::Modification, VectorId};
 use iris_mpc_store::Store;
 use sqlx::{Postgres, Transaction};
 use std::ops::DerefMut;
@@ -23,7 +23,7 @@ pub async fn increment_iris_version(
 }
 
 /// Returns set of an Iris's versions - historical plus present.
-pub async fn get_iris_vector_ids(store: &Store) -> Result<Vec<IrisVectorId>> {
+pub async fn get_iris_vector_ids(store: &Store) -> Result<Vec<VectorId>> {
     let ids: Vec<(i64, i16)> = sqlx::query_as(
         r#"
             SELECT
@@ -38,7 +38,7 @@ pub async fn get_iris_vector_ids(store: &Store) -> Result<Vec<IrisVectorId>> {
 
     let ids = ids
         .into_iter()
-        .map(|(serial_id, version)| IrisVectorId::new(serial_id as u32, version))
+        .map(|(serial_id, version)| VectorId::new(serial_id as u32, version))
         .collect();
 
     Ok(ids)

--- a/iris-mpc/tests/utils/cpu_node.rs
+++ b/iris-mpc/tests/utils/cpu_node.rs
@@ -5,7 +5,7 @@ use super::CpuConfigs;
 use eyre::eyre;
 use iris_mpc_common::{
     postgres::{AccessMode, PostgresClient},
-    IrisVectorId, MASK_CODE_LENGTH,
+    VectorId, MASK_CODE_LENGTH,
 };
 use iris_mpc_cpu::hawkers::plaintext_store::PlaintextStore;
 use iris_mpc_cpu::hnsw::graph::graph_store::{GraphCheckpointRow, GraphPg};
@@ -394,7 +394,7 @@ impl CpuNode {
                 // Convert GraphMem → GraphV3 by copying entry_points and layers,
                 // dropping the seq_no field that is absent in the V3 format.
                 let to_v3 = |g: GraphMem| -> graph_v3::GraphV3 {
-                    let vec_id = |v: &IrisVectorId| graph_v3::VectorId {
+                    let vec_id = |v: &VectorId| graph_v3::VectorId {
                         id: v.serial_id(),
                         version: v.version_id(),
                     };

--- a/iris-mpc/tests/utils/wal_builder.rs
+++ b/iris-mpc/tests/utils/wal_builder.rs
@@ -1,4 +1,4 @@
-use iris_mpc_common::IrisVectorId;
+use iris_mpc_common::VectorId;
 use iris_mpc_cpu::{
     execution::hawk_main::BothEyes,
     hawkers::plaintext_store::PlaintextStore,
@@ -73,10 +73,10 @@ impl WalMutationBuilder {
         for idx in starting_idx..new_len {
             let node_id = idx + 1;
             // All nodes added before this one become neighbors.
-            let neighbors: Vec<IrisVectorId> = (1..=node_id)
+            let neighbors: Vec<VectorId> = (1..=node_id)
                 .filter(|x| x != &node_id)
                 .map(|x| x as u32)
-                .map(IrisVectorId::from_serial_id)
+                .map(VectorId::from_serial_id)
                 .collect();
 
             let mut mutation = GraphMutation {
@@ -84,14 +84,14 @@ impl WalMutationBuilder {
                 ops: vec![],
             };
             mutation.ops.push(MutationOp::AddNode {
-                id: IrisVectorId::from_serial_id(node_id as _),
+                id: VectorId::from_serial_id(node_id as _),
                 height: 1,
                 update_ep: UpdateEntryPoint::False,
             });
 
             if !neighbors.is_empty() {
                 mutation.ops.push(MutationOp::AddEdges {
-                    base: IrisVectorId::from_serial_id(node_id as _),
+                    base: VectorId::from_serial_id(node_id as _),
                     neighbors,
                     layer: 0,
                     edge_type: EdgeType::All,
@@ -128,18 +128,18 @@ impl WalMutationBuilder {
     pub fn add_node_with_neighbors(&mut self, neighbor_ids: &[u32]) -> &mut Self {
         let node_id = (self.entries.len() + 1) as u32;
         let modification_id = node_id as i64;
-        let neighbors: Vec<IrisVectorId> = neighbor_ids
+        let neighbors: Vec<VectorId> = neighbor_ids
             .iter()
-            .map(|&id| IrisVectorId::from_serial_id(id))
+            .map(|&id| VectorId::from_serial_id(id))
             .collect();
         let mut ops = vec![MutationOp::AddNode {
-            id: IrisVectorId::from_serial_id(node_id),
+            id: VectorId::from_serial_id(node_id),
             height: 1,
             update_ep: UpdateEntryPoint::False,
         }];
         if !neighbors.is_empty() {
             ops.push(MutationOp::AddEdges {
-                base: IrisVectorId::from_serial_id(node_id),
+                base: VectorId::from_serial_id(node_id),
                 neighbors,
                 layer: 0,
                 edge_type: EdgeType::All,


### PR DESCRIPTION
Two type aliases to the vector id, serial id, and version id types are used throughout the codebase: the declared struct types `VectorId`, `SerialId`, and `VersionId` in `iris_mpc_common::vector_id`, and `IrisVectorId`, `IrisSerialId`, and `IrisVersionId` aliases declared at the iris-mpc-common module base.  This PR unifies the usage by changing the `Iris*` names to the shorter original type names, keeping the module base alias declarations, and redirecting all imports to the module base declarations.