### PR TITLE
[POP-4020] Add versioning to the WAL

### DIFF
--- a/iris-mpc-cpu/src/checkpoint_protocol/store.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/store.rs
@@ -75,6 +75,7 @@ mod tests {
         graph_store::test_utils::TestGraphPg,
         mutation::{GraphMutation, MutationOp},
     };
+    use crate::utils::serialization::graph_mutation::serialize_mutations_current;
     use futures::TryStreamExt;
     use iris_mpc_common::VectorId;
 
@@ -97,7 +98,7 @@ mod tests {
         modification_id: i64,
         payload: &BothEyes<Vec<GraphMutation>>,
     ) -> eyre::Result<()> {
-        let bytes = bincode::serialize(payload)?;
+        let bytes = serialize_mutations_current(payload)?;
         let mut graph_tx = store.tx().await?;
         store
             .upsert_hawk_graph_mutations(&mut graph_tx.tx, modification_id, &bytes)

--- a/iris-mpc-cpu/src/checkpoint_protocol/terminal.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/terminal.rs
@@ -223,7 +223,7 @@ mod tests {
                 ops: vec![MutationOp::AddNode {
                     id: vid(99),
                     height: 1,
-                    update_ep: UpdateEntryPoint::SetUnique { layer: 0 },
+                    update_ep: UpdateEntryPoint::Append { layer: 0 },
                 }],
             })
             .unwrap();
@@ -239,7 +239,7 @@ mod tests {
                     ops: vec![MutationOp::AddNode {
                         id: vid(1),
                         height: 1,
-                        update_ep: UpdateEntryPoint::SetUnique { layer: 0 },
+                        update_ep: UpdateEntryPoint::Append { layer: 0 },
                     }],
                 })
                 .unwrap();
@@ -286,7 +286,7 @@ mod tests {
             ops: vec![MutationOp::AddNode {
                 id: vid(7),
                 height: 2,
-                update_ep: UpdateEntryPoint::SetUnique { layer: 0 },
+                update_ep: UpdateEntryPoint::Append { layer: 0 },
             }],
         })
         .unwrap();
@@ -296,7 +296,7 @@ mod tests {
                 ops: vec![MutationOp::AddNode {
                     id: vid(11),
                     height: 1,
-                    update_ep: UpdateEntryPoint::SetUnique { layer: 0 },
+                    update_ep: UpdateEntryPoint::Append { layer: 0 },
                 }],
             })
             .unwrap();

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -1639,7 +1639,8 @@ impl HawkMutation {
             // for reference, see the end of handle_mutations()
             if let Some(ref modification_key) = mutation.modification_key {
                 if let Some(modification) = modifications.get_mut(modification_key) {
-                    let serialized = serialize_mutations_current(&mutation.plans)?;
+                    let serialized = serialize_mutations_current(&mutation.plans)
+                        .map_err(|e| eyre::eyre!("Failed to serialize graph mutation: {e}"))?;
 
                     graph_tx
                         .upsert_hawk_graph_mutations(modification.id, &serialized)

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -84,6 +84,7 @@ use crate::{
         ops::{setup_replicated_prf, setup_shared_seed},
         shared_iris::{ArcIris, GaloisRingSharedIris},
     },
+    utils::serialization::graph_mutation::serialize_mutations_current,
 };
 use ampc_actor_utils::network::tcp::TlsConfig;
 use ampc_anon_stats::types::Eye;
@@ -1638,8 +1639,7 @@ impl HawkMutation {
             // for reference, see the end of handle_mutations()
             if let Some(ref modification_key) = mutation.modification_key {
                 if let Some(modification) = modifications.get_mut(modification_key) {
-                    let serialized = bincode::serialize(&mutation.plans)
-                        .map_err(|e| eyre::eyre!("Failed to serialize graph mutation: {}", e))?;
+                    let serialized = serialize_mutations_current(&mutation.plans)?;
 
                     graph_tx
                         .upsert_hawk_graph_mutations(modification.id, &serialized)

--- a/iris-mpc-cpu/src/execution/hawk_main/insert.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/insert.rs
@@ -217,9 +217,6 @@ fn validate_ep_updates<V: VectorStore>(
         let Some(plan) = plan else { continue };
 
         match plan.update_ep {
-            UpdateEntryPoint::SetUnique { .. } => {
-                bail!("SetUnique entry point update encountered during LinearScan layer mode");
-            }
             UpdateEntryPoint::Append { layer } => {
                 if layer != max_graph_layer {
                     bail!("InsertPlan adds entry point at different layer than max graph layer during LinearScan layer mode")
@@ -243,9 +240,7 @@ mod tests {
     use super::*;
 
     fn dummy_insert_plan(ep_update: UpdateEntryPoint) -> InsertPlanV<PlaintextStore> {
-        let ins_layer = if let UpdateEntryPoint::SetUnique { layer }
-        | UpdateEntryPoint::Append { layer } = ep_update
-        {
+        let ins_layer = if let UpdateEntryPoint::Append { layer } = ep_update {
             layer
         } else {
             0
@@ -367,17 +362,6 @@ mod tests {
     #[test]
     fn test_ep_updates_validator_linear_scan() {
         let max_graph_layer = 3;
-
-        // LinearScan mode cannot have SetUnique updates
-        test_validate_ep_updates_helper(
-            &[
-                UpdateEntryPoint::Append { layer: 3 },
-                UpdateEntryPoint::Append { layer: 3 },
-                UpdateEntryPoint::SetUnique { layer: 3 },
-            ],
-            false,
-            max_graph_layer,
-        );
 
         // LinearScan mode cannot append entry points at layers besides the max graph layer
         test_validate_ep_updates_helper(
@@ -699,7 +683,7 @@ mod tests {
                 id,
                 height: 1,
                 update_ep: if i == 0 {
-                    UpdateEntryPoint::SetUnique { layer: 0 }
+                    UpdateEntryPoint::Append { layer: 0 }
                 } else {
                     UpdateEntryPoint::False
                 },

--- a/iris-mpc-cpu/src/execution/hawk_main/phase_tracer.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/phase_tracer.rs
@@ -2,7 +2,7 @@
 //!
 //! Records enter/exit timestamps for each phase per session, outputting
 //! Chrome Trace Event Format JSON that can be loaded into Perfetto UI
-//! (https://ui.perfetto.dev/) or `chrome://tracing`.
+//! (<https://ui.perfetto.dev/>) or `chrome://tracing`.
 //!
 //! Enabled at compile time via the `phase_trace` Cargo feature.
 //! Traces are flushed to `/tmp/hawk_phase_trace_party{N}_batch{B}.json`

--- a/iris-mpc-cpu/src/execution/hawk_main/state_check.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/state_check.rs
@@ -148,7 +148,7 @@ impl IrisDiffSearch {
     /// Returns `None` when the search is complete (worklist empty, sample
     /// cap reached, or round limit hit).  On `Some`, returns the ranges
     /// to split and this party's left-half hashes — pass both to
-    /// [`complete_round`] after exchanging hashes with neighbours.
+    /// `complete_round` after exchanging hashes with neighbours.
     pub fn prepare_round(
         &mut self,
         range_hash: impl Fn(u32, u32) -> u64,

--- a/iris-mpc-cpu/src/graph_checkpoint/s3_client/streaming_download.rs
+++ b/iris-mpc-cpu/src/graph_checkpoint/s3_client/streaming_download.rs
@@ -38,7 +38,7 @@
 //! cause the tee task to fail with `BrokenPipe` (the deserializer drops
 //! its end of the duplex once bincode is done), which surfaces as an
 //! error from the function. For S3 objects produced by
-//! [`super::stream_serialize_and_upload`] this is automatic; callers
+//! `stream_serialize_and_upload` this is automatic; callers
 //! wiring up other sources must respect the contract.
 
 use std::time::Duration;
@@ -137,7 +137,7 @@ where
 /// Unlike `stream_download_and_deserialize::<[GraphVN; 2]>` followed by
 /// `.into()`, this never holds a full intermediate `GraphVN` alongside the
 /// destination `GraphMem` — it reads one set of links at a time and calls
-/// [`Layer::set_links`] immediately.  For `Current`/V4 and V3 the peak
+/// `Layer::set_links` immediately.  For `Current`/V4 and V3 the peak
 /// transient allocation above the final `GraphMem` is roughly one layer's
 /// link data; older formats fall back to the standard path.
 pub async fn stream_download_and_deserialize_graph_pair(

--- a/iris-mpc-cpu/src/graph_checkpoint/synchronize.rs
+++ b/iris-mpc-cpu/src/graph_checkpoint/synchronize.rs
@@ -180,28 +180,34 @@ pub fn apply_graph_mutations(
 
 #[cfg(test)]
 mod tests {
+    use iris_mpc_common::VectorId;
+
     use super::*;
     use crate::hnsw::graph::mutation::{MutationOp, UpdateEntryPoint};
-    use iris_mpc_common::VectorId;
+    use crate::utils::serialization::graph_mutation::{
+        serialize_mutations_current, GraphMutationFormat,
+    };
 
     // ── helpers ───────────────────────────────────────────────────────────────
 
     /// Serialize a pair of mutation lists into the bincode format expected by
     /// `GraphMutationRow`.
-    fn serialize_mutations(left: Vec<GraphMutation>, right: Vec<GraphMutation>) -> Vec<u8> {
+    fn serialize_mutations(left: Vec<GraphMutation>, right: Vec<GraphMutation>) -> Result<Vec<u8>> {
         let both_eyes: [Vec<GraphMutation>; 2] = [left, right];
-        bincode::serialize(&both_eyes).expect("bincode serialization failed")
+        serialize_mutations_current(&both_eyes)
     }
 
     fn make_row(
         modification_id: i64,
         left: Vec<GraphMutation>,
         right: Vec<GraphMutation>,
-    ) -> GraphMutationRow {
-        GraphMutationRow {
+    ) -> Result<GraphMutationRow> {
+        let serialized_mutations = serialize_mutations(left, right)?;
+        Ok(GraphMutationRow {
             modification_id,
-            serialized_mutations: serialize_mutations(left, right),
-        }
+            mutation_format_version: GraphMutationFormat::Current.version(),
+            serialized_mutations,
+        })
     }
 
     /// Construct a `VectorId` from a plain serial id for use in tests.
@@ -242,7 +248,7 @@ mod tests {
     fn add_node_appears_in_correct_eye() {
         let mut both_eyes = [GraphMem::new(), GraphMem::new()];
         // Left eye gets node 1; right eye gets nothing.
-        let row = make_row(1, vec![add_node(vid(1))], vec![]);
+        let row = make_row(1, vec![add_node(vid(1))], vec![]).unwrap();
         apply_graph_mutations(&mut both_eyes, vec![row]).unwrap();
 
         assert_eq!(
@@ -264,7 +270,7 @@ mod tests {
     #[test]
     fn mutations_applied_to_both_eyes_independently() {
         let mut both_eyes = [GraphMem::new(), GraphMem::new()];
-        let row = make_row(1, vec![add_node(vid(1))], vec![add_node(vid(10))]);
+        let row = make_row(1, vec![add_node(vid(1))], vec![add_node(vid(10))]).unwrap();
         apply_graph_mutations(&mut both_eyes, vec![row]).unwrap();
 
         assert_eq!(
@@ -284,9 +290,9 @@ mod tests {
     fn multiple_rows_applied_in_order() {
         let mut both_eyes = [GraphMem::new(), GraphMem::new()];
         let rows = vec![
-            make_row(1, vec![add_node(vid(1))], vec![add_node(vid(10))]),
-            make_row(2, vec![add_node(vid(2))], vec![add_node(vid(20))]),
-            make_row(3, vec![add_node(vid(3))], vec![add_node(vid(30))]),
+            make_row(1, vec![add_node(vid(1))], vec![add_node(vid(10))]).unwrap(),
+            make_row(2, vec![add_node(vid(2))], vec![add_node(vid(20))]).unwrap(),
+            make_row(3, vec![add_node(vid(3))], vec![add_node(vid(30))]).unwrap(),
         ];
         apply_graph_mutations(&mut both_eyes, rows).unwrap();
 
@@ -311,6 +317,7 @@ mod tests {
         let mut both_eyes = [GraphMem::new(), GraphMem::new()];
         let bad_row = GraphMutationRow {
             modification_id: 99,
+            mutation_format_version: 1,
             serialized_mutations: vec![0xFF, 0xFE, 0xFD], // not valid bincode
         };
         assert!(

--- a/iris-mpc-cpu/src/graph_checkpoint/synchronize.rs
+++ b/iris-mpc-cpu/src/graph_checkpoint/synchronize.rs
@@ -205,7 +205,7 @@ mod tests {
         let serialized_mutations = serialize_mutations(left, right);
         GraphMutationRow {
             modification_id,
-            mutation_format_version: GraphMutationFormat::Current.version(),
+            mutation_format_version: GraphMutationFormat::CURRENT.version(),
             serialized_mutations,
         }
     }
@@ -317,7 +317,7 @@ mod tests {
         let mut both_eyes = [GraphMem::new(), GraphMem::new()];
         let bad_row = GraphMutationRow {
             modification_id: 99,
-            mutation_format_version: GraphMutationFormat::Current.version(),
+            mutation_format_version: GraphMutationFormat::CURRENT.version(),
             serialized_mutations: vec![0xFF, 0xFE, 0xFD], // not valid bincode
         };
         assert!(

--- a/iris-mpc-cpu/src/graph_checkpoint/synchronize.rs
+++ b/iris-mpc-cpu/src/graph_checkpoint/synchronize.rs
@@ -317,7 +317,7 @@ mod tests {
         let mut both_eyes = [GraphMem::new(), GraphMem::new()];
         let bad_row = GraphMutationRow {
             modification_id: 99,
-            mutation_format_version: GraphMutationFormat::Current,
+            mutation_format_version: GraphMutationFormat::Current.version(),
             serialized_mutations: vec![0xFF, 0xFE, 0xFD], // not valid bincode
         };
         assert!(

--- a/iris-mpc-cpu/src/graph_checkpoint/synchronize.rs
+++ b/iris-mpc-cpu/src/graph_checkpoint/synchronize.rs
@@ -192,22 +192,22 @@ mod tests {
 
     /// Serialize a pair of mutation lists into the bincode format expected by
     /// `GraphMutationRow`.
-    fn serialize_mutations(left: Vec<GraphMutation>, right: Vec<GraphMutation>) -> Result<Vec<u8>> {
+    fn serialize_mutations(left: Vec<GraphMutation>, right: Vec<GraphMutation>) -> Vec<u8> {
         let both_eyes: [Vec<GraphMutation>; 2] = [left, right];
-        serialize_mutations_current(&both_eyes)
+        serialize_mutations_current(&both_eyes).expect("bincode serialization failed")
     }
 
     fn make_row(
         modification_id: i64,
         left: Vec<GraphMutation>,
         right: Vec<GraphMutation>,
-    ) -> Result<GraphMutationRow> {
-        let serialized_mutations = serialize_mutations(left, right)?;
-        Ok(GraphMutationRow {
+    ) -> GraphMutationRow {
+        let serialized_mutations = serialize_mutations(left, right);
+        GraphMutationRow {
             modification_id,
             mutation_format_version: GraphMutationFormat::Current.version(),
             serialized_mutations,
-        })
+        }
     }
 
     /// Construct a `VectorId` from a plain serial id for use in tests.
@@ -248,7 +248,7 @@ mod tests {
     fn add_node_appears_in_correct_eye() {
         let mut both_eyes = [GraphMem::new(), GraphMem::new()];
         // Left eye gets node 1; right eye gets nothing.
-        let row = make_row(1, vec![add_node(vid(1))], vec![]).unwrap();
+        let row = make_row(1, vec![add_node(vid(1))], vec![]);
         apply_graph_mutations(&mut both_eyes, vec![row]).unwrap();
 
         assert_eq!(
@@ -270,7 +270,7 @@ mod tests {
     #[test]
     fn mutations_applied_to_both_eyes_independently() {
         let mut both_eyes = [GraphMem::new(), GraphMem::new()];
-        let row = make_row(1, vec![add_node(vid(1))], vec![add_node(vid(10))]).unwrap();
+        let row = make_row(1, vec![add_node(vid(1))], vec![add_node(vid(10))]);
         apply_graph_mutations(&mut both_eyes, vec![row]).unwrap();
 
         assert_eq!(
@@ -290,9 +290,9 @@ mod tests {
     fn multiple_rows_applied_in_order() {
         let mut both_eyes = [GraphMem::new(), GraphMem::new()];
         let rows = vec![
-            make_row(1, vec![add_node(vid(1))], vec![add_node(vid(10))]).unwrap(),
-            make_row(2, vec![add_node(vid(2))], vec![add_node(vid(20))]).unwrap(),
-            make_row(3, vec![add_node(vid(3))], vec![add_node(vid(30))]).unwrap(),
+            make_row(1, vec![add_node(vid(1))], vec![add_node(vid(10))]),
+            make_row(2, vec![add_node(vid(2))], vec![add_node(vid(20))]),
+            make_row(3, vec![add_node(vid(3))], vec![add_node(vid(30))]),
         ];
         apply_graph_mutations(&mut both_eyes, rows).unwrap();
 
@@ -317,7 +317,7 @@ mod tests {
         let mut both_eyes = [GraphMem::new(), GraphMem::new()];
         let bad_row = GraphMutationRow {
             modification_id: 99,
-            mutation_format_version: 1,
+            mutation_format_version: GraphMutationFormat::Current,
             serialized_mutations: vec![0xFF, 0xFE, 0xFD], // not valid bincode
         };
         assert!(

--- a/iris-mpc-cpu/src/hawkers/plaintext_deep_id_store.rs
+++ b/iris-mpc-cpu/src/hawkers/plaintext_deep_id_store.rs
@@ -81,7 +81,7 @@ impl Int4Vector {
     /// `{-8..=7}`.
     ///
     /// Out-of-range values follow the same masking behavior as
-    /// [`Self::encode_nibble`]: silently masked in release, debug-asserted.
+    /// `encode_nibble`: silently masked in release, debug-asserted.
     pub fn set(&mut self, i: usize, value: i8) {
         let byte = &mut self.packed[i / 2];
         let nibble = Self::encode_nibble(value);

--- a/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/encoded_neighborhood.rs
@@ -336,7 +336,7 @@ impl<'a> BitReader<'a> {
 /// `b ≈ floor(log2(μ · ln 2))`, which we approximate here as `floor(log2(μ))`
 /// (about half a bit too high on average — at most one extra bit per symbol).
 ///
-/// `μ` is the mean of the `k` values actually Rice-coded by [`encode`]: the
+/// `μ` is the mean of the `k` values actually Rice-coded by the encode operation: the
 /// absolute first id plus the `(k-1)` inter-element gaps `ids[i] - ids[i-1] - 1`,
 /// which sum to `ids[k-1] - (k-1)`.
 fn compute_b(ids: &[u32]) -> u8 {

--- a/iris-mpc-cpu/src/hnsw/graph/graph_store.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/graph_store.rs
@@ -1,6 +1,7 @@
 use crate::{
     execution::hawk_main::BothEyes,
     hnsw::{graph::GraphMutation, VectorStore},
+    utils::serialization::graph_mutation::{deserialize_mutations, GraphMutationFormat},
 };
 use eyre::{eyre, Result};
 use iris_mpc_common::postgres::PostgresClient;
@@ -24,8 +25,9 @@ pub struct GraphCheckpointRow {
 #[derive(sqlx::FromRow, Debug, Clone, PartialEq, Eq)]
 pub struct GraphMutationRow {
     pub modification_id: i64,
-    /// Bincode-serialized `BothEyes<Vec<GraphMutation>>` (mutations for both eyes)
+    /// Bincode-serialized `BothEyes<Vec<GraphMutation<VectorId>>>` (mutations for both eyes)
     pub serialized_mutations: Vec<u8>,
+    pub mutation_format_version: i16,
 }
 
 pub struct GraphPg<V: VectorStore> {
@@ -36,9 +38,8 @@ pub struct GraphPg<V: VectorStore> {
 
 impl GraphMutationRow {
     pub fn deserialize_mutations(&self) -> Result<BothEyes<Vec<GraphMutation>>> {
-        let both_eyes: BothEyes<Vec<GraphMutation>> =
-            bincode::deserialize(&self.serialized_mutations)?;
-        Ok(both_eyes)
+        let format = GraphMutationFormat::try_from(self.mutation_format_version)?;
+        deserialize_mutations(format, &self.serialized_mutations)
     }
 }
 
@@ -288,15 +289,17 @@ impl<V: VectorStore> GraphPg<V> {
     ) -> Result<Vec<GraphMutationRow>> {
         let rows = sqlx::query_as::<_, GraphMutationRow>(
             r#"
-            INSERT INTO hawk_graph_mutations (modification_id, serialized_mutations)
-            VALUES ($1, $2)
+            INSERT INTO hawk_graph_mutations (modification_id, serialized_mutations, mutation_format_version)
+            VALUES ($1, $2, $3)
             ON CONFLICT (modification_id) DO UPDATE
-            SET serialized_mutations = EXCLUDED.serialized_mutations
-            RETURNING modification_id, serialized_mutations
+            SET serialized_mutations = EXCLUDED.serialized_mutations,
+                mutation_format_version = EXCLUDED.mutation_format_version
+            RETURNING modification_id, mutation_format_version, serialized_mutations
             "#,
         )
         .bind(modification_id)
         .bind(serialized_mutations)
+        .bind(GraphMutationFormat::Current.version())
         .fetch_all(tx.deref_mut())
         .await?;
 
@@ -309,7 +312,7 @@ impl<V: VectorStore> GraphPg<V> {
     ) -> Result<Vec<GraphMutationRow>> {
         let rows = sqlx::query_as::<_, GraphMutationRow>(
             r#"
-            SELECT modification_id, serialized_mutations
+            SELECT modification_id, mutation_format_version, serialized_mutations
             FROM hawk_graph_mutations
             WHERE $1::bigint IS NULL OR modification_id <= $1
             ORDER BY modification_id ASC
@@ -328,7 +331,7 @@ impl<V: VectorStore> GraphPg<V> {
     ) -> Result<Vec<GraphMutationRow>> {
         let rows = sqlx::query_as::<_, GraphMutationRow>(
             r#"
-            SELECT modification_id, serialized_mutations
+            SELECT modification_id, mutation_format_version, serialized_mutations
             FROM hawk_graph_mutations
             WHERE $1::bigint IS NULL OR modification_id > $1
             ORDER BY modification_id ASC
@@ -361,7 +364,7 @@ impl<V: VectorStore> GraphPg<V> {
         use futures::StreamExt;
         sqlx::query_as::<_, GraphMutationRow>(
             r#"
-            SELECT modification_id, serialized_mutations
+            SELECT modification_id, mutation_format_version, serialized_mutations
             FROM hawk_graph_mutations
             WHERE modification_id > $1 AND modification_id <= $2
             ORDER BY modification_id ASC
@@ -382,7 +385,7 @@ impl<V: VectorStore> GraphPg<V> {
     ) -> Result<Vec<GraphMutationRow>> {
         let rows = sqlx::query_as::<_, GraphMutationRow>(
             r#"
-            SELECT modification_id, serialized_mutations
+            SELECT modification_id, mutation_format_version, serialized_mutations
             FROM hawk_graph_mutations
             WHERE modification_id >= $1
             ORDER BY modification_id ASC
@@ -462,14 +465,16 @@ impl<'b, V: VectorStore> GraphTx<'b, V> {
     ) -> Result<()> {
         sqlx::query(
             r#"
-            INSERT INTO hawk_graph_mutations (modification_id, serialized_mutations)
-            VALUES ($1, $2)
+            INSERT INTO hawk_graph_mutations (modification_id, serialized_mutations, mutation_format_version)
+            VALUES ($1, $2, $3)
             ON CONFLICT (modification_id) DO UPDATE
-            SET serialized_mutations = EXCLUDED.serialized_mutations
+            SET serialized_mutations = EXCLUDED.serialized_mutations,
+                mutation_format_version = EXCLUDED.mutation_format_version
             "#,
         )
         .bind(modification_id)
         .bind(serialized_mutations)
+        .bind(GraphMutationFormat::Current.version())
         .execute(self.tx.deref_mut())
         .await?;
 

--- a/iris-mpc-cpu/src/hnsw/graph/graph_store.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/graph_store.rs
@@ -281,6 +281,8 @@ impl<V: VectorStore> GraphPg<V> {
         Ok(())
     }
 
+    /// INVARIANT: this function is only given GraphMutaionFormat::Current mutations.
+    /// Do not serialize into an old mutation format.
     pub async fn upsert_hawk_graph_mutations(
         &self,
         tx: &mut Transaction<'_, Postgres>,

--- a/iris-mpc-cpu/src/hnsw/graph/graph_store.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/graph_store.rs
@@ -834,7 +834,7 @@ mod tests {
             ops: vec![MutationOp::AddNode {
                 id: VectorId::from_serial_id(1),
                 height: 1,
-                update_ep: UpdateEntryPoint::SetUnique { layer: 0 },
+                update_ep: UpdateEntryPoint::Append { layer: 0 },
             }],
         };
         let plan_right = GraphMutation {
@@ -842,7 +842,7 @@ mod tests {
             ops: vec![MutationOp::AddNode {
                 id: VectorId::from_serial_id(2),
                 height: 1,
-                update_ep: UpdateEntryPoint::SetUnique { layer: 0 },
+                update_ep: UpdateEntryPoint::Append { layer: 0 },
             }],
         };
         let both: BothEyes<Vec<GraphMutation>> =

--- a/iris-mpc-cpu/src/hnsw/graph/graph_store.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/graph_store.rs
@@ -25,7 +25,7 @@ pub struct GraphCheckpointRow {
 #[derive(sqlx::FromRow, Debug, Clone, PartialEq, Eq)]
 pub struct GraphMutationRow {
     pub modification_id: i64,
-    /// Bincode-serialized `BothEyes<Vec<GraphMutation<VectorId>>>` (mutations for both eyes)
+    /// Bincode-serialized `BothEyes<Vec<GraphMutation>>` (mutations for both eyes)
     pub serialized_mutations: Vec<u8>,
     pub mutation_format_version: i16,
 }

--- a/iris-mpc-cpu/src/hnsw/graph/graph_store.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/graph_store.rs
@@ -301,7 +301,7 @@ impl<V: VectorStore> GraphPg<V> {
         )
         .bind(modification_id)
         .bind(serialized_mutations)
-        .bind(GraphMutationFormat::Current.version())
+        .bind(GraphMutationFormat::CURRENT.version())
         .fetch_all(tx.deref_mut())
         .await?;
 
@@ -476,7 +476,7 @@ impl<'b, V: VectorStore> GraphTx<'b, V> {
         )
         .bind(modification_id)
         .bind(serialized_mutations)
-        .bind(GraphMutationFormat::Current.version())
+        .bind(GraphMutationFormat::CURRENT.version())
         .execute(self.tx.deref_mut())
         .await?;
 

--- a/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
@@ -211,15 +211,6 @@ impl GraphMem {
                     update_ep,
                 } => {
                     match update_ep {
-                        UpdateEntryPoint::SetUnique { layer } => {
-                            if self.layers.len() < *layer + 1 {
-                                self.layers.resize(*layer + 1, Layer::new());
-                            }
-                            self.entry_points = vec![EntryPoint {
-                                point: *id,
-                                layer: *layer,
-                            }];
-                        }
                         UpdateEntryPoint::Append { layer } => {
                             self.entry_points.push(EntryPoint {
                                 point: *id,
@@ -1117,7 +1108,7 @@ mod tests {
                     MutationOp::AddNode {
                         id: a,
                         height: 1,
-                        update_ep: UpdateEntryPoint::SetUnique { layer: 1 },
+                        update_ep: UpdateEntryPoint::Append { layer: 1 },
                     },
                     MutationOp::AddNode {
                         id: b,
@@ -1161,7 +1152,7 @@ mod tests {
                     MutationOp::AddNode {
                         id: a,
                         height: 1,
-                        update_ep: UpdateEntryPoint::SetUnique { layer: 1 },
+                        update_ep: UpdateEntryPoint::Append { layer: 1 },
                     },
                     MutationOp::AddNode {
                         id: b,
@@ -1205,7 +1196,7 @@ mod tests {
                     MutationOp::AddNode {
                         id: a,
                         height: 1,
-                        update_ep: UpdateEntryPoint::SetUnique { layer: 1 },
+                        update_ep: UpdateEntryPoint::Append { layer: 1 },
                     },
                     MutationOp::AddNode {
                         id: b,
@@ -1249,7 +1240,7 @@ mod tests {
                     MutationOp::AddNode {
                         id: a,
                         height: 1,
-                        update_ep: UpdateEntryPoint::SetUnique { layer: 1 },
+                        update_ep: UpdateEntryPoint::Append { layer: 1 },
                     },
                     MutationOp::AddEdges {
                         base: a,
@@ -1320,7 +1311,7 @@ mod tests {
                     MutationOp::AddNode {
                         id: a,
                         height: 1,
-                        update_ep: UpdateEntryPoint::SetUnique { layer: 0 },
+                        update_ep: UpdateEntryPoint::Append { layer: 0 },
                     },
                     MutationOp::AddNode {
                         id: b,
@@ -1356,7 +1347,7 @@ mod tests {
             ops: vec![MutationOp::AddNode {
                 id: a,
                 height: 1,
-                update_ep: UpdateEntryPoint::SetUnique { layer: 0 },
+                update_ep: UpdateEntryPoint::Append { layer: 0 },
             }],
         };
         graph
@@ -1374,7 +1365,7 @@ mod tests {
             ops: vec![MutationOp::AddNode {
                 id: VectorId::from_serial_id(1),
                 height: 1,
-                update_ep: UpdateEntryPoint::SetUnique { layer: 0 },
+                update_ep: UpdateEntryPoint::Append { layer: 0 },
             }],
         };
         let res = graph.insert_apply(&mutation);
@@ -1395,7 +1386,7 @@ mod tests {
             ops: vec![MutationOp::AddNode {
                 id: VectorId::from_serial_id(1),
                 height: 1,
-                update_ep: UpdateEntryPoint::SetUnique { layer: 0 },
+                update_ep: UpdateEntryPoint::Append { layer: 0 },
             }],
         };
         let res = graph.insert_apply(&mutation);
@@ -1414,7 +1405,7 @@ mod tests {
                 ops: vec![MutationOp::AddNode {
                     id: a,
                     height: 1,
-                    update_ep: UpdateEntryPoint::SetUnique { layer: 0 },
+                    update_ep: UpdateEntryPoint::Append { layer: 0 },
                 }],
             },
             // Equal seq_no — should fail.

--- a/iris-mpc-cpu/src/hnsw/graph/mutation.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/mutation.rs
@@ -186,9 +186,6 @@ pub enum UpdateEntryPoint {
     /// Do not update entry points based on inserted vector.
     False,
 
-    /// Set a new unique entry point.
-    SetUnique { layer: usize },
-
     /// Append a new entry point to the current list.
     Append { layer: usize },
 }

--- a/iris-mpc-cpu/src/hnsw/graph/test_utils.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/test_utils.rs
@@ -371,11 +371,11 @@ impl DbContext {
         // Build the graph topology as mutations, then apply to an in-memory graph
         let mut left_graph = GraphMem::new();
 
-        // Set entry point via InsertNode with SetUnique
+        // Set entry point via InsertNode with Append
         let ep_mutation = MutationOp::AddNode {
             id: vectors[0],
             height: 1,
-            update_ep: UpdateEntryPoint::SetUnique { layer: 0 },
+            update_ep: UpdateEntryPoint::Append { layer: 0 },
         };
         left_graph
             .insert_apply(&GraphMutation {

--- a/iris-mpc-cpu/src/hnsw/sorting/min_k_batcher.rs
+++ b/iris-mpc-cpu/src/hnsw/sorting/min_k_batcher.rs
@@ -83,7 +83,7 @@ fn chunk_size(d: usize, k: usize) -> usize {
     }
 }
 
-/// - See Algorithm 2 in [1]
+/// - See Algorithm 2 in \[1\]
 /// - Append layers which merge sequences `x` and `y`, assuming that these correspond to sorted values. Note that `x` and `y` are sequences of indices.
 /// - `start_layer` points to the layer in the global network on top of which this method should build.
 /// - Returns (indices which form the result, total depth of the built network)
@@ -195,7 +195,7 @@ fn alekseev_merge(
     (res_perm, 1)
 }
 
-/// - Algorithm 3 in [1]
+/// - Algorithm 3 in \[1\]
 /// - Builds a network that selects the `k` smallest values corresponding to `x_indices`.
 /// - `start_layer` points to the layer in the global network on top of which this method should build.
 /// - `is_top_level` is tracked so that we can apply Alekseev's merge as an optimization.

--- a/iris-mpc-cpu/src/utils/serialization/graph_mutation.rs
+++ b/iris-mpc-cpu/src/utils/serialization/graph_mutation.rs
@@ -163,3 +163,125 @@ impl From<GraphMutationV0> for GraphMutation {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_v0_deserialize() {
+        // Create test vector IDs
+        let vid1 = graph_mutation_v0::VectorId { id: 42, version: 1 };
+        let vid2 = graph_mutation_v0::VectorId { id: 99, version: 2 };
+        let vid3 = graph_mutation_v0::VectorId {
+            id: 100,
+            version: 3,
+        };
+
+        // Create test mutation operations
+        let ops = vec![
+            graph_mutation_v0::MutationOp::AddNode {
+                id: vid1.clone(),
+                height: 3,
+                update_ep: graph_mutation_v0::UpdateEntryPoint::Append { layer: 2 },
+            },
+            graph_mutation_v0::MutationOp::AddEdges {
+                base: vid2.clone(),
+                neighbors: vec![vid1.clone(), vid3.clone()],
+                layer: 1,
+                edge_type: graph_mutation_v0::EdgeType::All,
+            },
+            graph_mutation_v0::MutationOp::RemoveNode { id: vid3.clone() },
+        ];
+
+        // Create GraphMutationV0
+        let v0_mutation = graph_mutation_v0::GraphMutationV0 { seq_no: 12345, ops };
+
+        // Create BothEyes structure (array of 2)
+        let both_eyes: BothEyes<Vec<graph_mutation_v0::GraphMutationV0>> =
+            [vec![v0_mutation.clone()], vec![]];
+
+        // Serialize using bincode
+        let serialized = bincode::serialize(&both_eyes).expect("serialization failed");
+
+        // Deserialize using the public deserialize_mutations function
+        let deserialized = deserialize_mutations(GraphMutationFormat::V0, &serialized)
+            .expect("deserialization failed");
+
+        // Validate the deserialized data
+        assert_eq!(deserialized.len(), 2, "should have 2 eyes");
+        assert_eq!(deserialized[0].len(), 1, "first eye should have 1 mutation");
+        assert_eq!(
+            deserialized[1].len(),
+            0,
+            "second eye should have 0 mutations"
+        );
+
+        let converted_mutation = &deserialized[0][0];
+        assert_eq!(
+            converted_mutation.seq_no, 12345,
+            "seq_no should be preserved"
+        );
+        assert_eq!(converted_mutation.ops.len(), 3, "should have 3 ops");
+
+        // Validate first op (AddNode)
+        match &converted_mutation.ops[0] {
+            MutationOp::AddNode {
+                id,
+                height,
+                update_ep,
+            } => {
+                assert_eq!(id.serial_id(), 42, "first op: node id should be 42");
+                assert_eq!(id.version_id(), 1, "first op: node version should be 1");
+                assert_eq!(*height, 3, "first op: height should be 3");
+                match update_ep {
+                    UpdateEntryPoint::Append { layer } => {
+                        assert_eq!(*layer, 2, "first op: layer should be 2");
+                    }
+                    _ => panic!("expected Append update entry point"),
+                }
+            }
+            _ => panic!("expected AddNode op"),
+        }
+
+        // Validate second op (AddEdges)
+        match &converted_mutation.ops[1] {
+            MutationOp::AddEdges {
+                base,
+                neighbors,
+                layer,
+                edge_type,
+            } => {
+                assert_eq!(base.serial_id(), 99, "second op: base id should be 99");
+                assert_eq!(base.version_id(), 2, "second op: base version should be 2");
+                assert_eq!(*layer, 1, "second op: layer should be 1");
+                assert_eq!(neighbors.len(), 2, "second op: should have 2 neighbors");
+                assert_eq!(
+                    neighbors[0].serial_id(),
+                    42,
+                    "second op: first neighbor id should be 42"
+                );
+                assert_eq!(
+                    neighbors[1].serial_id(),
+                    100,
+                    "second op: second neighbor id should be 100"
+                );
+                assert_eq!(
+                    *edge_type,
+                    EdgeType::All,
+                    "second op: edge type should be All"
+                );
+            }
+            _ => panic!("expected AddEdges op"),
+        }
+
+        // Validate third op (RemoveNode)
+        match &converted_mutation.ops[2] {
+            MutationOp::RemoveNode { id } => {
+                assert_eq!(id.serial_id(), 100, "third op: node id should be 100");
+                assert_eq!(id.version_id(), 3, "third op: node version should be 3");
+            }
+            _ => panic!("expected RemoveNode op"),
+        }
+    }
+}

--- a/iris-mpc-cpu/src/utils/serialization/graph_mutation.rs
+++ b/iris-mpc-cpu/src/utils/serialization/graph_mutation.rs
@@ -6,7 +6,7 @@ use crate::{
     },
     utils::serialization::types::graph_mutation_v0::{self, GraphMutationV0},
 };
-use eyre::Result;
+use eyre::{Result, WrapErr};
 use iris_mpc_common::VectorId;
 use serde::{Deserialize, Serialize};
 
@@ -19,9 +19,6 @@ use serde::{Deserialize, Serialize};
 /// so that the deserializer can dispatch without inspecting the blob bytes.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum GraphMutationFormat {
-    /// Designated current stable format — resolves to `V0`.
-    Current,
-
     /// V0: plain `bincode::serialize(BothEyes<Vec<GraphMutation>>)`.
     ///
     /// This is the format that existed before versioning was introduced.
@@ -30,10 +27,13 @@ pub enum GraphMutationFormat {
 }
 
 impl GraphMutationFormat {
+    /// The format new writes are emitted in.
+    pub const CURRENT: Self = Self::V0;
+
     /// Integer stored in `mutation_format_version` DB column.
     pub fn version(&self) -> i16 {
         match self {
-            GraphMutationFormat::Current | GraphMutationFormat::V0 => 0,
+            GraphMutationFormat::V0 => 0,
         }
     }
 }
@@ -71,7 +71,7 @@ pub fn deserialize_mutations(
     bytes: &[u8],
 ) -> Result<BothEyes<Vec<GraphMutation>>> {
     match format {
-        GraphMutationFormat::Current | GraphMutationFormat::V0 => deserialize_v0_to_current(bytes),
+        GraphMutationFormat::V0 => deserialize_v0_to_current(bytes),
         // When a V1 is added: add arm here, define a types/graph_mutation_v1.rs
         // intermediate struct with From<GraphMutationV1> → BothEyes<Vec<GraphMutation>>,
         // and call bincode::deserialize::<GraphMutationV1>(bytes)?.into()
@@ -81,7 +81,12 @@ pub fn deserialize_mutations(
 /* ------------- Deserialize Helpers ------------- */
 
 fn deserialize_v0_to_current(bytes: &[u8]) -> Result<BothEyes<Vec<GraphMutation>>> {
-    let v0: BothEyes<Vec<GraphMutationV0>> = bincode::deserialize(bytes)?;
+    let v0: BothEyes<Vec<GraphMutationV0>> = bincode::deserialize(bytes).wrap_err_with(|| {
+        format!(
+            "deserializing GraphMutation V0 blob ({} bytes)",
+            bytes.len()
+        )
+    })?;
     Ok(v0.map(|eye| eye.into_iter().map(|m| m.into()).collect()))
 }
 

--- a/iris-mpc-cpu/src/utils/serialization/graph_mutation.rs
+++ b/iris-mpc-cpu/src/utils/serialization/graph_mutation.rs
@@ -1,4 +1,7 @@
-use crate::{execution::hawk_main::BothEyes, hnsw::graph::GraphMutation};
+use crate::{
+    execution::hawk_main::BothEyes, hnsw::graph::GraphMutation,
+    utils::serialization::types::graph_mutation_v0::GraphMutationV0,
+};
 use eyre::Result;
 use serde::{Deserialize, Serialize};
 
@@ -63,9 +66,15 @@ pub fn deserialize_mutations(
     bytes: &[u8],
 ) -> Result<BothEyes<Vec<GraphMutation>>> {
     match format {
-        GraphMutationFormat::Current | GraphMutationFormat::V0 => Ok(bincode::deserialize(bytes)?),
+        GraphMutationFormat::Current | GraphMutationFormat::V0 => deserialize_v0_to_current(bytes),
         // When a V2 is added: add arm here, define a types/graph_mutation_v2.rs
         // intermediate struct with From<GraphMutationV2> → BothEyes<Vec<GraphMutation>>,
         // and call bincode::deserialize::<GraphMutationV2>(bytes)?.into()
     }
+}
+
+/* ------------- Private Helpers ------------- */
+
+fn deserialize_v0_to_current(bytes: &[u8]) -> Result<BothEyes<Vec<GraphMutation>>> {
+    let v0: BothEyes<Vec<GraphMutationV0>> = bincode::deserialize(bytes)?;
 }

--- a/iris-mpc-cpu/src/utils/serialization/graph_mutation.rs
+++ b/iris-mpc-cpu/src/utils/serialization/graph_mutation.rs
@@ -14,18 +14,18 @@ pub enum GraphMutationFormat {
     /// Designated current stable format — resolves to `V1`.
     Current,
 
-    /// V1: plain `bincode::serialize(BothEyes<Vec<GraphMutation>>)`.
+    /// V0: plain `bincode::serialize(BothEyes<Vec<GraphMutation>>)`.
     ///
     /// This is the format that existed before versioning was introduced.
-    /// All previously-written rows are implicitly V1.
-    V1,
+    /// All previously-written rows are implicitly V0.
+    V0,
 }
 
 impl GraphMutationFormat {
     /// Integer stored in `mutation_format_version` DB column.
     pub fn version(&self) -> i16 {
         match self {
-            GraphMutationFormat::Current | GraphMutationFormat::V1 => 1,
+            GraphMutationFormat::Current | GraphMutationFormat::V0 => 1,
         }
     }
 }
@@ -35,7 +35,7 @@ impl TryFrom<i16> for GraphMutationFormat {
 
     fn try_from(v: i16) -> Result<Self> {
         match v {
-            1 => Ok(GraphMutationFormat::V1),
+            1 => Ok(GraphMutationFormat::V0),
             _ => Err(eyre::eyre!(
                 "unsupported GraphMutation format version: {}",
                 v
@@ -63,8 +63,9 @@ pub fn deserialize_mutations(
     bytes: &[u8],
 ) -> Result<BothEyes<Vec<GraphMutation>>> {
     match format {
-        GraphMutationFormat::Current | GraphMutationFormat::V1 => Ok(bincode::deserialize(bytes)?), // When a V2 is added: add arm here, define a types/graph_mutation_v2.rs
-                                                                                                    // intermediate struct with From<GraphMutationV2> → BothEyes<Vec<GraphMutation>>,
-                                                                                                    // and call bincode::deserialize::<GraphMutationV2>(bytes)?.into()
+        GraphMutationFormat::Current | GraphMutationFormat::V0 => Ok(bincode::deserialize(bytes)?),
+        // When a V2 is added: add arm here, define a types/graph_mutation_v2.rs
+        // intermediate struct with From<GraphMutationV2> → BothEyes<Vec<GraphMutation>>,
+        // and call bincode::deserialize::<GraphMutationV2>(bytes)?.into()
     }
 }

--- a/iris-mpc-cpu/src/utils/serialization/graph_mutation.rs
+++ b/iris-mpc-cpu/src/utils/serialization/graph_mutation.rs
@@ -1,0 +1,70 @@
+use crate::{execution::hawk_main::BothEyes, hnsw::graph::GraphMutation};
+use eyre::Result;
+use serde::{Deserialize, Serialize};
+
+/* ----------- GraphMutationFormat enum (mirrors GraphFormat) ----------- */
+
+/// Serialization format version for `BothEyes<Vec<GraphMutation>>` blobs
+/// stored in the `hawk_graph_mutations.serialized_mutations` column.
+///
+/// The active version is persisted in `hawk_graph_mutations.mutation_format_version`
+/// so that the deserializer can dispatch without inspecting the blob bytes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum GraphMutationFormat {
+    /// Designated current stable format — resolves to `V1`.
+    Current,
+
+    /// V1: plain `bincode::serialize(BothEyes<Vec<GraphMutation<IrisVectorId>>>)`.
+    ///
+    /// This is the format that existed before versioning was introduced.
+    /// All previously-written rows are implicitly V1.
+    V1,
+}
+
+impl GraphMutationFormat {
+    /// Integer stored in `mutation_format_version` DB column.
+    pub fn version(&self) -> i16 {
+        match self {
+            GraphMutationFormat::Current | GraphMutationFormat::V1 => 1,
+        }
+    }
+}
+
+impl TryFrom<i16> for GraphMutationFormat {
+    type Error = eyre::Error;
+
+    fn try_from(v: i16) -> Result<Self> {
+        match v {
+            1 => Ok(GraphMutationFormat::V1),
+            _ => Err(eyre::eyre!(
+                "unsupported GraphMutation format version: {}",
+                v
+            )),
+        }
+    }
+}
+
+/* ------------- Public serialization API ------------- */
+
+/// Serialize using the current stable format.
+pub fn serialize_mutations_current(data: &BothEyes<Vec<GraphMutation>>) -> Result<Vec<u8>> {
+    // V1: plain bincode — no prefix bytes in the blob itself; version is tracked
+    // in the DB column `mutation_format_version`.
+    Ok(bincode::serialize(data)?)
+}
+
+/// Deserialize from `bytes` using the specified `format`.
+///
+/// `bytes` is the raw `serialized_mutations` blob from Postgres.
+/// The caller is responsible for reading `mutation_format_version` from the
+/// same row and converting it via `GraphMutationFormat::try_from`.
+pub fn deserialize_mutations(
+    format: GraphMutationFormat,
+    bytes: &[u8],
+) -> Result<BothEyes<Vec<GraphMutation>>> {
+    match format {
+        GraphMutationFormat::Current | GraphMutationFormat::V1 => Ok(bincode::deserialize(bytes)?), // When a V2 is added: add arm here, define a types/graph_mutation_v2.rs
+                                                                                                    // intermediate struct with From<GraphMutationV2> → BothEyes<Vec<GraphMutation>>,
+                                                                                                    // and call bincode::deserialize::<GraphMutationV2>(bytes)?.into()
+    }
+}

--- a/iris-mpc-cpu/src/utils/serialization/graph_mutation.rs
+++ b/iris-mpc-cpu/src/utils/serialization/graph_mutation.rs
@@ -33,7 +33,7 @@ impl GraphMutationFormat {
     /// Integer stored in `mutation_format_version` DB column.
     pub fn version(&self) -> i16 {
         match self {
-            GraphMutationFormat::Current | GraphMutationFormat::V0 => 1,
+            GraphMutationFormat::Current | GraphMutationFormat::V0 => 0,
         }
     }
 }
@@ -43,7 +43,7 @@ impl TryFrom<i16> for GraphMutationFormat {
 
     fn try_from(v: i16) -> Result<Self> {
         match v {
-            1 => Ok(GraphMutationFormat::V0),
+            0 => Ok(GraphMutationFormat::V0),
             _ => Err(eyre::eyre!(
                 "unsupported GraphMutation format version: {}",
                 v

--- a/iris-mpc-cpu/src/utils/serialization/graph_mutation.rs
+++ b/iris-mpc-cpu/src/utils/serialization/graph_mutation.rs
@@ -1,8 +1,13 @@
 use crate::{
-    execution::hawk_main::BothEyes, hnsw::graph::GraphMutation,
-    utils::serialization::types::graph_mutation_v0::GraphMutationV0,
+    execution::hawk_main::BothEyes,
+    hnsw::graph::{
+        mutation::{EdgeType, MutationOp, UpdateEntryPoint},
+        GraphMutation,
+    },
+    utils::serialization::types::graph_mutation_v0::{self, GraphMutationV0},
 };
 use eyre::Result;
+use iris_mpc_common::VectorId;
 use serde::{Deserialize, Serialize};
 
 /* ----------- GraphMutationFormat enum (mirrors GraphFormat) ----------- */
@@ -73,8 +78,88 @@ pub fn deserialize_mutations(
     }
 }
 
-/* ------------- Private Helpers ------------- */
+/* ------------- Deserialize Helpers ------------- */
 
 fn deserialize_v0_to_current(bytes: &[u8]) -> Result<BothEyes<Vec<GraphMutation>>> {
     let v0: BothEyes<Vec<GraphMutationV0>> = bincode::deserialize(bytes)?;
+    Ok(v0.map(|eye| eye.into_iter().map(|m| m.into()).collect()))
+}
+
+/* ----------- Conversion GraphMutationV0 -> GraphMutation ----------- */
+
+impl From<graph_mutation_v0::VectorId> for VectorId {
+    fn from(value: graph_mutation_v0::VectorId) -> Self {
+        VectorId::new(value.id, value.version)
+    }
+}
+
+impl From<graph_mutation_v0::EdgeType> for EdgeType {
+    fn from(value: graph_mutation_v0::EdgeType) -> Self {
+        match value {
+            graph_mutation_v0::EdgeType::Base => EdgeType::Base,
+            graph_mutation_v0::EdgeType::Neighbors => EdgeType::Neighbors,
+            graph_mutation_v0::EdgeType::All => EdgeType::All,
+        }
+    }
+}
+
+impl From<graph_mutation_v0::UpdateEntryPoint> for UpdateEntryPoint {
+    fn from(value: graph_mutation_v0::UpdateEntryPoint) -> Self {
+        match value {
+            graph_mutation_v0::UpdateEntryPoint::False => UpdateEntryPoint::False,
+            graph_mutation_v0::UpdateEntryPoint::Append { layer } => {
+                UpdateEntryPoint::Append { layer }
+            }
+        }
+    }
+}
+
+impl From<graph_mutation_v0::MutationOp> for MutationOp {
+    fn from(value: graph_mutation_v0::MutationOp) -> Self {
+        match value {
+            graph_mutation_v0::MutationOp::AddNode {
+                id,
+                height,
+                update_ep,
+            } => MutationOp::AddNode {
+                id: id.into(),
+                height,
+                update_ep: update_ep.into(),
+            },
+            graph_mutation_v0::MutationOp::RemoveNode { id } => {
+                MutationOp::RemoveNode { id: id.into() }
+            }
+            graph_mutation_v0::MutationOp::AddEdges {
+                base,
+                neighbors,
+                layer,
+                edge_type,
+            } => MutationOp::AddEdges {
+                base: base.into(),
+                neighbors: neighbors.into_iter().map(|n| n.into()).collect(),
+                layer,
+                edge_type: edge_type.into(),
+            },
+            graph_mutation_v0::MutationOp::RemoveEdges {
+                base,
+                neighbors,
+                layer,
+                edge_type,
+            } => MutationOp::RemoveEdges {
+                base: base.into(),
+                neighbors: neighbors.into_iter().map(|n| n.into()).collect(),
+                layer,
+                edge_type: edge_type.into(),
+            },
+        }
+    }
+}
+
+impl From<GraphMutationV0> for GraphMutation {
+    fn from(value: GraphMutationV0) -> Self {
+        GraphMutation {
+            seq_no: value.seq_no,
+            ops: value.ops.into_iter().map(|op| op.into()).collect(),
+        }
+    }
 }

--- a/iris-mpc-cpu/src/utils/serialization/graph_mutation.rs
+++ b/iris-mpc-cpu/src/utils/serialization/graph_mutation.rs
@@ -14,7 +14,7 @@ pub enum GraphMutationFormat {
     /// Designated current stable format — resolves to `V1`.
     Current,
 
-    /// V1: plain `bincode::serialize(BothEyes<Vec<GraphMutation<IrisVectorId>>>)`.
+    /// V1: plain `bincode::serialize(BothEyes<Vec<GraphMutation>>)`.
     ///
     /// This is the format that existed before versioning was introduced.
     /// All previously-written rows are implicitly V1.

--- a/iris-mpc-cpu/src/utils/serialization/graph_mutation.rs
+++ b/iris-mpc-cpu/src/utils/serialization/graph_mutation.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 /// so that the deserializer can dispatch without inspecting the blob bytes.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum GraphMutationFormat {
-    /// Designated current stable format — resolves to `V1`.
+    /// Designated current stable format — resolves to `V0`.
     Current,
 
     /// V0: plain `bincode::serialize(BothEyes<Vec<GraphMutation>>)`.
@@ -56,7 +56,7 @@ impl TryFrom<i16> for GraphMutationFormat {
 
 /// Serialize using the current stable format.
 pub fn serialize_mutations_current(data: &BothEyes<Vec<GraphMutation>>) -> Result<Vec<u8>> {
-    // V1: plain bincode — no prefix bytes in the blob itself; version is tracked
+    // V0: plain bincode — no prefix bytes in the blob itself; version is tracked
     // in the DB column `mutation_format_version`.
     Ok(bincode::serialize(data)?)
 }
@@ -72,9 +72,9 @@ pub fn deserialize_mutations(
 ) -> Result<BothEyes<Vec<GraphMutation>>> {
     match format {
         GraphMutationFormat::Current | GraphMutationFormat::V0 => deserialize_v0_to_current(bytes),
-        // When a V2 is added: add arm here, define a types/graph_mutation_v2.rs
-        // intermediate struct with From<GraphMutationV2> → BothEyes<Vec<GraphMutation>>,
-        // and call bincode::deserialize::<GraphMutationV2>(bytes)?.into()
+        // When a V1 is added: add arm here, define a types/graph_mutation_v1.rs
+        // intermediate struct with From<GraphMutationV1> → BothEyes<Vec<GraphMutation>>,
+        // and call bincode::deserialize::<GraphMutationV1>(bytes)?.into()
     }
 }
 
@@ -170,7 +170,8 @@ mod tests {
 
     #[test]
     fn validate_v0_deserialize() {
-        // Create test vector IDs
+        // Input in the V0 wire types: one mutation on the first eye, none on the
+        // second.
         let vid1 = graph_mutation_v0::VectorId { id: 42, version: 1 };
         let vid2 = graph_mutation_v0::VectorId { id: 99, version: 2 };
         let vid3 = graph_mutation_v0::VectorId {
@@ -178,110 +179,57 @@ mod tests {
             version: 3,
         };
 
-        // Create test mutation operations
-        let ops = vec![
-            graph_mutation_v0::MutationOp::AddNode {
-                id: vid1.clone(),
-                height: 3,
-                update_ep: graph_mutation_v0::UpdateEntryPoint::Append { layer: 2 },
-            },
-            graph_mutation_v0::MutationOp::AddEdges {
-                base: vid2.clone(),
-                neighbors: vec![vid1.clone(), vid3.clone()],
-                layer: 1,
-                edge_type: graph_mutation_v0::EdgeType::All,
-            },
-            graph_mutation_v0::MutationOp::RemoveNode { id: vid3.clone() },
+        let both_eyes: BothEyes<Vec<graph_mutation_v0::GraphMutationV0>> = [
+            vec![graph_mutation_v0::GraphMutationV0 {
+                seq_no: 12345,
+                ops: vec![
+                    graph_mutation_v0::MutationOp::AddNode {
+                        id: vid1.clone(),
+                        height: 3,
+                        update_ep: graph_mutation_v0::UpdateEntryPoint::Append { layer: 2 },
+                    },
+                    graph_mutation_v0::MutationOp::AddEdges {
+                        base: vid2.clone(),
+                        neighbors: vec![vid1.clone(), vid3.clone()],
+                        layer: 1,
+                        edge_type: graph_mutation_v0::EdgeType::All,
+                    },
+                    graph_mutation_v0::MutationOp::RemoveNode { id: vid3.clone() },
+                ],
+            }],
+            vec![],
         ];
 
-        // Create GraphMutationV0
-        let v0_mutation = graph_mutation_v0::GraphMutationV0 { seq_no: 12345, ops };
+        // Hand-built target in the *current* types. Deliberately constructed
+        // literally rather than via `.into()`, so the V0 -> current conversion is
+        // actually under test instead of being asserted against itself.
+        let expected: BothEyes<Vec<GraphMutation>> = [
+            vec![GraphMutation {
+                seq_no: 12345,
+                ops: vec![
+                    MutationOp::AddNode {
+                        id: VectorId::new(42, 1),
+                        height: 3,
+                        update_ep: UpdateEntryPoint::Append { layer: 2 },
+                    },
+                    MutationOp::AddEdges {
+                        base: VectorId::new(99, 2),
+                        neighbors: vec![VectorId::new(42, 1), VectorId::new(100, 3)],
+                        layer: 1,
+                        edge_type: EdgeType::All,
+                    },
+                    MutationOp::RemoveNode {
+                        id: VectorId::new(100, 3),
+                    },
+                ],
+            }],
+            vec![],
+        ];
 
-        // Create BothEyes structure (array of 2)
-        let both_eyes: BothEyes<Vec<graph_mutation_v0::GraphMutationV0>> =
-            [vec![v0_mutation.clone()], vec![]];
-
-        // Serialize using bincode
         let serialized = bincode::serialize(&both_eyes).expect("serialization failed");
-
-        // Deserialize using the public deserialize_mutations function
         let deserialized = deserialize_mutations(GraphMutationFormat::V0, &serialized)
             .expect("deserialization failed");
 
-        // Validate the deserialized data
-        assert_eq!(deserialized.len(), 2, "should have 2 eyes");
-        assert_eq!(deserialized[0].len(), 1, "first eye should have 1 mutation");
-        assert_eq!(
-            deserialized[1].len(),
-            0,
-            "second eye should have 0 mutations"
-        );
-
-        let converted_mutation = &deserialized[0][0];
-        assert_eq!(
-            converted_mutation.seq_no, 12345,
-            "seq_no should be preserved"
-        );
-        assert_eq!(converted_mutation.ops.len(), 3, "should have 3 ops");
-
-        // Validate first op (AddNode)
-        match &converted_mutation.ops[0] {
-            MutationOp::AddNode {
-                id,
-                height,
-                update_ep,
-            } => {
-                assert_eq!(id.serial_id(), 42, "first op: node id should be 42");
-                assert_eq!(id.version_id(), 1, "first op: node version should be 1");
-                assert_eq!(*height, 3, "first op: height should be 3");
-                match update_ep {
-                    UpdateEntryPoint::Append { layer } => {
-                        assert_eq!(*layer, 2, "first op: layer should be 2");
-                    }
-                    _ => panic!("expected Append update entry point"),
-                }
-            }
-            _ => panic!("expected AddNode op"),
-        }
-
-        // Validate second op (AddEdges)
-        match &converted_mutation.ops[1] {
-            MutationOp::AddEdges {
-                base,
-                neighbors,
-                layer,
-                edge_type,
-            } => {
-                assert_eq!(base.serial_id(), 99, "second op: base id should be 99");
-                assert_eq!(base.version_id(), 2, "second op: base version should be 2");
-                assert_eq!(*layer, 1, "second op: layer should be 1");
-                assert_eq!(neighbors.len(), 2, "second op: should have 2 neighbors");
-                assert_eq!(
-                    neighbors[0].serial_id(),
-                    42,
-                    "second op: first neighbor id should be 42"
-                );
-                assert_eq!(
-                    neighbors[1].serial_id(),
-                    100,
-                    "second op: second neighbor id should be 100"
-                );
-                assert_eq!(
-                    *edge_type,
-                    EdgeType::All,
-                    "second op: edge type should be All"
-                );
-            }
-            _ => panic!("expected AddEdges op"),
-        }
-
-        // Validate third op (RemoveNode)
-        match &converted_mutation.ops[2] {
-            MutationOp::RemoveNode { id } => {
-                assert_eq!(id.serial_id(), 100, "third op: node id should be 100");
-                assert_eq!(id.version_id(), 3, "third op: node version should be 3");
-            }
-            _ => panic!("expected RemoveNode op"),
-        }
+        assert_eq!(deserialized, expected);
     }
 }

--- a/iris-mpc-cpu/src/utils/serialization/mod.rs
+++ b/iris-mpc-cpu/src/utils/serialization/mod.rs
@@ -6,6 +6,7 @@ use std::io::{BufReader, BufWriter};
 use std::path::Path;
 
 pub mod graph;
+pub mod graph_mutation;
 pub mod int4_ndjson;
 pub mod iris_ndjson;
 pub mod types;

--- a/iris-mpc-cpu/src/utils/serialization/types/graph_mutation_v0.rs
+++ b/iris-mpc-cpu/src/utils/serialization/types/graph_mutation_v0.rs
@@ -1,0 +1,63 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct GraphMutationV0 {
+    pub seq_no: u64,
+    pub ops: Vec<MutationOp>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct VectorId {
+    id: u32,
+    version: i16,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+enum EdgeType {
+    /// Affects forward edges from the base node
+    Base,
+
+    /// Affects back edges into the base node
+    Neighbors,
+
+    /// Affects both forward edges from and back edges into the base node
+    All,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+enum UpdateEntryPoint {
+    /// Do not update entry points based on inserted vector.
+    False,
+
+    /// Set a new unique entry point.
+    SetUnique { layer: usize },
+
+    /// Append a new entry point to the current list.
+    Append { layer: usize },
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+enum MutationOp {
+    AddNode {
+        id: VectorId,
+        /// Number of real graph layers this node is included in. The node will
+        /// be present in layers `0..height`.
+        height: usize,
+        update_ep: UpdateEntryPoint,
+    },
+    RemoveNode {
+        id: VectorId,
+    },
+    AddEdges {
+        base: VectorId,
+        neighbors: Vec<VectorId>,
+        layer: usize,
+        edge_type: EdgeType,
+    },
+    RemoveEdges {
+        base: VectorId,
+        neighbors: Vec<VectorId>,
+        layer: usize,
+        edge_type: EdgeType,
+    },
+}

--- a/iris-mpc-cpu/src/utils/serialization/types/graph_mutation_v0.rs
+++ b/iris-mpc-cpu/src/utils/serialization/types/graph_mutation_v0.rs
@@ -7,13 +7,13 @@ pub struct GraphMutationV0 {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-struct VectorId {
-    id: u32,
-    version: i16,
+pub struct VectorId {
+    pub id: u32,
+    pub version: i16,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-enum EdgeType {
+pub enum EdgeType {
     /// Affects forward edges from the base node
     Base,
 
@@ -25,19 +25,16 @@ enum EdgeType {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-enum UpdateEntryPoint {
+pub enum UpdateEntryPoint {
     /// Do not update entry points based on inserted vector.
     False,
-
-    /// Set a new unique entry point.
-    SetUnique { layer: usize },
 
     /// Append a new entry point to the current list.
     Append { layer: usize },
 }
 
 #[derive(Clone, Serialize, Deserialize)]
-enum MutationOp {
+pub enum MutationOp {
     AddNode {
         id: VectorId,
         /// Number of real graph layers this node is included in. The node will

--- a/iris-mpc-cpu/src/utils/serialization/types/mod.rs
+++ b/iris-mpc-cpu/src/utils/serialization/types/mod.rs
@@ -5,6 +5,7 @@
 //! possible exceptions for lower-level data types related to serialization
 //! formats of external libraries.
 
+pub mod graph_mutation_v0;
 pub mod graph_v0;
 pub mod graph_v1;
 pub mod graph_v2;

--- a/iris-mpc/tests/utils/wal_builder.rs
+++ b/iris-mpc/tests/utils/wal_builder.rs
@@ -6,6 +6,7 @@ use iris_mpc_cpu::{
         graph_store::GraphPg,
         mutation::{EdgeType, GraphMutation, MutationOp, UpdateEntryPoint},
     },
+    utils::serialization::graph_mutation::serialize_mutations_current,
 };
 use std::collections::HashMap;
 
@@ -169,7 +170,7 @@ impl WalMutationBuilder {
             let modification_id = m.seq_no as _;
             let m = vec![m];
             let both_eyes: BothEyes<Vec<GraphMutation>> = [m.clone(), m];
-            let bytes = bincode::serialize(&both_eyes)?;
+            let bytes = serialize_mutations_current(&both_eyes)?;
             graph
                 .upsert_hawk_graph_mutations(&mut tx, modification_id, &bytes)
                 .await?;

--- a/migrations/20260616000001_add_mutation_format_version.down.sql
+++ b/migrations/20260616000001_add_mutation_format_version.down.sql
@@ -1,0 +1,3 @@
+-- Rollback: remove mutation_format_version column
+ALTER TABLE hawk_graph_mutations
+  DROP COLUMN IF EXISTS mutation_format_version;

--- a/migrations/20260616000001_add_mutation_format_version.up.sql
+++ b/migrations/20260616000001_add_mutation_format_version.up.sql
@@ -5,4 +5,4 @@
 -- New writes set this column explicitly via serialize_mutations_current().
 
 ALTER TABLE hawk_graph_mutations
-  ADD COLUMN mutation_format_version SMALLINT NOT NULL DEFAULT 1;
+  ADD COLUMN mutation_format_version SMALLINT NOT NULL DEFAULT 1 CHECK (mutation_format_version >= 1);

--- a/migrations/20260616000001_add_mutation_format_version.up.sql
+++ b/migrations/20260616000001_add_mutation_format_version.up.sql
@@ -1,0 +1,8 @@
+-- Add mutation_format_version column to track serialization format of serialized_mutations blob.
+-- This enables backward compatibility when GraphMutation struct changes incompatibly.
+--
+-- Default of 1 back-fills all existing rows as V1 (the format that existed before versioning).
+-- New writes set this column explicitly via serialize_mutations_current().
+
+ALTER TABLE hawk_graph_mutations
+  ADD COLUMN mutation_format_version SMALLINT NOT NULL DEFAULT 1;

--- a/migrations/20260616000001_add_mutation_format_version.up.sql
+++ b/migrations/20260616000001_add_mutation_format_version.up.sql
@@ -1,8 +1,8 @@
 -- Add mutation_format_version column to track serialization format of serialized_mutations blob.
 -- This enables backward compatibility when GraphMutation struct changes incompatibly.
 --
--- Default of 1 back-fills all existing rows as V1 (the format that existed before versioning).
+-- Default of 0 back-fills all existing rows as V0 (the format that existed before versioning).
 -- New writes set this column explicitly via serialize_mutations_current().
 
 ALTER TABLE hawk_graph_mutations
-  ADD COLUMN mutation_format_version SMALLINT NOT NULL DEFAULT 1 CHECK (mutation_format_version >= 1);
+  ADD COLUMN mutation_format_version SMALLINT NOT NULL DEFAULT 0 CHECK (mutation_format_version >= 0);


### PR DESCRIPTION
This is needed in case the WAL format ever changes, which is expected to happen at least once. 

Also remove `SetEntryPoint::Unique` variant (was left out of a previous PR) but is relevant here because the MutationV0 struct needs its own mirror of `SetEntryPoint`. 