### PR TITLE
Add liveness barrier to checkpoint protocol run_cycle

### DIFF
--- a/iris-mpc-cpu/src/checkpoint_protocol/mod.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/mod.rs
@@ -211,6 +211,14 @@ pub trait ConsensusTransport {
         cycle_nonce: u128,
         timeout: Duration,
     ) -> Result<Vec<T>, CycleError>;
+
+    /// Confirm both ring neighbours are live *right now* before any agreement
+    /// round runs. A fresh random nonce is challenged to each neighbour and
+    /// must be echoed back this call; a peer that has since died — or whose
+    /// earlier traffic merely sat buffered in the socket — cannot produce the
+    /// echo, so a party never proceeds on a partial ring. Run once at the top
+    /// of [`run_cycle`].
+    async fn liveness_barrier(&self, timeout: Duration) -> Result<(), CycleError>;
 }
 
 #[async_trait]
@@ -265,6 +273,11 @@ where
     H: GraphHasher,
     Sel: BaseSelector,
 {
+    // Liveness barrier — fail fast unless both neighbours are live this cycle,
+    // so no party agrees a base, materializes, or hashes against a partial ring
+    // or a since-dead peer's buffered traffic.
+    transport.liveness_barrier(cfg.peer_round_timeout).await?;
+
     // Phase 1 — base agreement.
     let my_recent = store.recent_checkpoints(cfg.checkpoint_window).await?;
     tracing::info!(

--- a/iris-mpc-cpu/src/checkpoint_protocol/tests.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/tests.rs
@@ -123,6 +123,8 @@ struct MockTransport {
     calls: Arc<Mutex<Vec<ExchangeCall>>>,
     // FIFO queue of canned peer responses; each phase pops one entry.
     canned: Arc<Mutex<Vec<Vec<ConsensusMessage>>>>,
+    // When set, `liveness_barrier` fails transiently with this message.
+    barrier_err: Option<String>,
 }
 
 impl MockTransport {
@@ -130,6 +132,14 @@ impl MockTransport {
         Self {
             calls: Arc::new(Mutex::new(vec![])),
             canned: Arc::new(Mutex::new(canned)),
+            barrier_err: None,
+        }
+    }
+
+    fn with_barrier_err(canned: Vec<Vec<ConsensusMessage>>, msg: &str) -> Self {
+        Self {
+            barrier_err: Some(msg.to_string()),
+            ..Self::new(canned)
         }
     }
 }
@@ -180,7 +190,10 @@ impl ConsensusTransport for MockTransport {
     }
 
     async fn liveness_barrier(&self, _timeout: Duration) -> Result<(), CycleError> {
-        Ok(())
+        match &self.barrier_err {
+            Some(msg) => Err(CycleError::Transient(msg.clone())),
+            None => Ok(()),
+        }
     }
 }
 
@@ -261,6 +274,45 @@ fn hash_b() -> Blake3Hash {
 }
 
 // ── happy path ───────────────────────────────────────────────────────────
+
+/// A failing liveness barrier aborts the cycle before any agreement round or
+/// graph work — no exchange, no materialize, no finalize.
+#[tokio::test]
+async fn barrier_failure_short_circuits_before_side_effects() {
+    let mut mat = MockMaterializer::new();
+    let mut fin = MockFinalizer::new();
+    let store = MockStore::with_latest(meta(1, Some(0)), 100);
+    // Empty canned: reaching any exchange would itself error, so a clean
+    // Transient from the barrier proves it short-circuited first.
+    let transport = MockTransport::with_barrier_err(vec![], "peer down");
+    let hasher = ConstHasher(hash_a());
+
+    let err = run_cycle(
+        &mut mat,
+        &mut fin,
+        &transport,
+        &store,
+        &hasher,
+        &StrictLatest,
+        &cfg(10),
+    )
+    .await
+    .expect_err("barrier failure must abort the cycle");
+
+    assert!(matches!(err, CycleError::Transient(_)), "got {err:?}");
+    assert!(
+        transport.calls.lock().unwrap().is_empty(),
+        "no agreement round should run"
+    );
+    assert!(
+        mat.freezes.lock().unwrap().is_empty(),
+        "materializer must not run"
+    );
+    assert!(
+        fin.calls.lock().unwrap().is_empty(),
+        "finalizer must not run"
+    );
+}
 
 #[tokio::test]
 async fn happy_path_finalizes() {

--- a/iris-mpc-cpu/src/checkpoint_protocol/tests.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/tests.rs
@@ -178,6 +178,10 @@ impl ConsensusTransport for MockTransport {
         }
         Ok(projected)
     }
+
+    async fn liveness_barrier(&self, _timeout: Duration) -> Result<(), CycleError> {
+        Ok(())
+    }
 }
 
 // ── mock Materializer ────────────────────────────────────────────────────

--- a/iris-mpc-cpu/src/checkpoint_protocol/transport.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/transport.rs
@@ -5,7 +5,10 @@
 //! `exchange` issues both sends before either receive — matches
 //! `ControlChannel::sync`'s deadlock-avoidance pattern. With enough channel
 //! buffering for one proposal, all parties' sends finish before any blocks
-//! on a recv.
+//! on a recv. `liveness_barrier` follows the same sends-before-recvs shape
+//! across two rounds, so it needs buffering for two small messages per leg —
+//! trivially satisfied by TCP socket buffers (production `ControlChannel`
+//! sends block only until flushed, not until the peer consumes).
 
 use std::time::Duration;
 

--- a/iris-mpc-cpu/src/checkpoint_protocol/transport.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/transport.rs
@@ -98,6 +98,62 @@ impl ConsensusTransport for RingConsensusTransport {
 
         Ok(vec![parse(next_bytes)?, parse(prev_bytes)?])
     }
+
+    async fn liveness_barrier(&self, timeout: Duration) -> Result<(), CycleError> {
+        let my_nonce: u128 = rand::random();
+        let mut ch = self.channel.lock().await;
+        let result = tokio::time::timeout(timeout, async {
+            // Round 1 (challenge): send our fresh nonce to both neighbours.
+            // Sends precede receives — same deadlock-avoidance as `exchange`.
+            let challenge = NetworkValue::Bytes(my_nonce.to_le_bytes().to_vec());
+            ch.send_next(challenge.clone())
+                .await
+                .map_err(|e| CycleError::Transient(format!("liveness send_next: {e}")))?;
+            ch.send_prev(challenge)
+                .await
+                .map_err(|e| CycleError::Transient(format!("liveness send_prev: {e}")))?;
+            let next_nonce = recv_nonce("liveness recv_next", ch.recv_next().await)?;
+            let prev_nonce = recv_nonce("liveness recv_prev", ch.recv_prev().await)?;
+
+            // Round 2 (response): echo each neighbour's nonce back to it, and
+            // expect our own nonce echoed in return. A peer that is dead — or
+            // whose round-1 nonce merely sat buffered — cannot complete this
+            // round, because it never received this call's challenge.
+            ch.send_next(NetworkValue::Bytes(next_nonce.to_le_bytes().to_vec()))
+                .await
+                .map_err(|e| CycleError::Transient(format!("liveness echo_next: {e}")))?;
+            ch.send_prev(NetworkValue::Bytes(prev_nonce.to_le_bytes().to_vec()))
+                .await
+                .map_err(|e| CycleError::Transient(format!("liveness echo_prev: {e}")))?;
+            let echo_next = recv_nonce("liveness echo recv_next", ch.recv_next().await)?;
+            let echo_prev = recv_nonce("liveness echo recv_prev", ch.recv_prev().await)?;
+            Ok::<(u128, u128), CycleError>((echo_next, echo_prev))
+        })
+        .await;
+
+        let (echo_next, echo_prev) = match result {
+            Ok(Ok(pair)) => pair,
+            Ok(Err(e)) => return Err(e),
+            Err(_elapsed) => {
+                return Err(CycleError::Transient(format!(
+                    "liveness barrier timed out after {timeout:?}"
+                )))
+            }
+        };
+        // A wrong echo means a neighbour never saw this call's nonce — crossed
+        // wires or a buggy peer, not mere lateness; treat as fatal.
+        if echo_next != my_nonce {
+            return Err(CycleError::Fatal(
+                "liveness barrier: next neighbour echoed wrong nonce".into(),
+            ));
+        }
+        if echo_prev != my_nonce {
+            return Err(CycleError::Fatal(
+                "liveness barrier: prev neighbour echoed wrong nonce".into(),
+            ));
+        }
+        Ok(())
+    }
 }
 
 /// Map a `ControlChannel` recv result to a payload byte vector. A non-Bytes
@@ -114,6 +170,25 @@ async fn recv_bytes(
         Err(e) => Err(CycleError::Transient(format!(
             "control_channel.{label}: {e}"
         ))),
+    }
+}
+
+/// Parse a 16-byte little-endian `u128` nonce from a control-channel receive.
+fn recv_nonce(label: &str, result: eyre::Result<NetworkValue>) -> Result<u128, CycleError> {
+    match result {
+        Ok(NetworkValue::Bytes(b)) => {
+            let arr: [u8; 16] = b.as_slice().try_into().map_err(|_| {
+                CycleError::Fatal(format!(
+                    "{label}: expected 16-byte nonce, got {} bytes",
+                    b.len()
+                ))
+            })?;
+            Ok(u128::from_le_bytes(arr))
+        }
+        Ok(other) => Err(CycleError::Fatal(format!(
+            "{label}: expected NetworkValue::Bytes, got {other:?}"
+        ))),
+        Err(e) => Err(CycleError::Transient(format!("{label}: {e}"))),
     }
 }
 
@@ -454,5 +529,53 @@ mod tests {
             any_transient,
             "expected at least one transient; got r0={r0:?}, r1={r1:?}"
         );
+    }
+
+    /// All three parties live → every barrier completes.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn liveness_barrier_passes_when_all_live() {
+        let [p0, p1, p2] = triangle(8);
+        let t0 = xport(p0);
+        let t1 = xport(p1);
+        let t2 = xport(p2);
+        let timeout = Duration::from_secs(2);
+
+        let h0 = tokio::spawn(async move { t0.liveness_barrier(timeout).await });
+        let h1 = tokio::spawn(async move { t1.liveness_barrier(timeout).await });
+        let h2 = tokio::spawn(async move { t2.liveness_barrier(timeout).await });
+
+        assert!(h0.await.unwrap().is_ok());
+        assert!(h1.await.unwrap().is_ok());
+        assert!(h2.await.unwrap().is_ok());
+    }
+
+    /// A peer whose round-1 challenge is buffered for its neighbours but which
+    /// never performs the round-2 echo must NOT let either neighbour pass — the
+    /// whole point of the challenge/response. `p2` is kept alive (so the peers'
+    /// sends still succeed and buffer) but stays silent after round 1.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn liveness_barrier_rejects_buffered_but_dead_peer() {
+        let [p0, p1, mut p2] = triangle(8);
+        let t0 = xport(p0);
+        let t1 = xport(p1);
+        let timeout = Duration::from_millis(300);
+
+        // p2's round-1 traffic only: lands buffered in each neighbour's channel.
+        let nonce = NetworkValue::Bytes(0u128.to_le_bytes().to_vec());
+        p2.send_next(nonce.clone()).await.unwrap();
+        p2.send_prev(nonce).await.unwrap();
+
+        let h0 = tokio::spawn(async move { t0.liveness_barrier(timeout).await });
+        let h1 = tokio::spawn(async move { t1.liveness_barrier(timeout).await });
+        let r0 = h0.await.unwrap();
+        let r1 = h1.await.unwrap();
+
+        // Neither neighbour may report success: p2 never echoed their nonces.
+        assert!(r0.is_err(), "p0 should not pass against a dead p2: {r0:?}");
+        assert!(r1.is_err(), "p1 should not pass against a dead p2: {r1:?}");
+
+        // Keep p2's receivers open until the peers have finished, so the failure
+        // is the round-2 echo timeout — not a closed-channel send error.
+        drop(p2);
     }
 }


### PR DESCRIPTION
## Problem

`run_cycle` (shared by the WAL sidecar cycle and the Hawk restart path) could agree a base, materialize a graph, and compute a hash **against a partial ring**:

- A peer that crashed *after* sending its phase-1 proposal still satisfied a neighbour's round, because the proposal sat **buffered in the socket** and was consumed later — so a since-dead peer's stale data could carry the agreement phases.
- A peer reached via **stale DNS** (a since-terminated/wrong pod) could complete connection setup without ever participating in this cycle.

In both cases a party does work — and wastes it — on a ring that was never fully live, only to fail in a later round. Observed in a dev sidecar fire where one party timed out at the ring exchange while the other two reached "base agreed" and even hashed before failing.

## Fix

Add a **challenge/response liveness barrier** at the top of `run_cycle`, before any agreement round. Each party challenges *both* ring neighbours with a fresh per-call random nonce and requires that exact nonce echoed back **this round**. A dead peer — or one whose only traffic is buffered round-1 data — cannot produce the echo, so the cycle fails fast (`Transient`) instead of proceeding on a partial ring. A single-token barrier would *not* suffice: a buffered token from a since-dead peer would satisfy it; the echo round is what makes it buffer-proof.

This is a new required method on `ConsensusTransport` (`liveness_barrier`), implemented over the ring `ControlChannel` in `RingConsensusTransport` and a no-op in the test `MockTransport`. It covers both the sidecar cycle and the Hawk restart path, which share `run_cycle`.

## Tests

- `liveness_barrier_passes_when_all_live` — 3 live parties all complete.
- `liveness_barrier_rejects_buffered_but_dead_peer` — a peer whose round-1 nonce is buffered but which never echoes does **not** let either neighbour pass (the buffer-proof case).
- Existing 47 `checkpoint_protocol` tests unchanged; full suite green. `cargo fmt` + `clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)