### PR TITLE
Retry transient AWS errors on the batch hot path

### DIFF
--- a/iris-mpc/src/services/aws/mod.rs
+++ b/iris-mpc/src/services/aws/mod.rs
@@ -1,4 +1,5 @@
 pub mod clients;
+pub mod retry;
 pub mod s3;
 pub mod sns;
 pub mod sqs;

--- a/iris-mpc/src/services/aws/retry.rs
+++ b/iris-mpc/src/services/aws/retry.rs
@@ -1,0 +1,46 @@
+use std::future::Future;
+use std::time::Duration;
+
+const MAX_BACKOFF: Duration = Duration::from_secs(5);
+
+/// Retry a fallible async AWS operation with exponential backoff to absorb
+/// transient failures (DNS/connection blips, throttling, brief 5xx) that the
+/// SDK's own bounded retry window did not outlast. After `max_attempts` the
+/// last error is returned, so a persistent failure still surfaces with the
+/// original semantics rather than looping forever.
+///
+/// Callers must only pass operations that are safe to repeat (reads, or writes
+/// the downstream deduplicates).
+pub async fn retry_transient<T, E, F, Fut>(
+    op_name: &str,
+    max_attempts: u32,
+    initial_backoff: Duration,
+    mut op: F,
+) -> Result<T, E>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, E>>,
+    E: std::fmt::Debug,
+{
+    let mut attempt = 0u32;
+    let mut backoff = initial_backoff;
+    loop {
+        attempt += 1;
+        match op().await {
+            Ok(value) => return Ok(value),
+            Err(err) if attempt >= max_attempts => return Err(err),
+            Err(err) => {
+                tracing::warn!(
+                    "{} failed (attempt {}/{}): {:?}. Retrying in {:?}...",
+                    op_name,
+                    attempt,
+                    max_attempts,
+                    err,
+                    backoff
+                );
+                tokio::time::sleep(backoff).await;
+                backoff = (backoff * 2).min(MAX_BACKOFF);
+            }
+        }
+    }
+}

--- a/iris-mpc/src/services/processors/batch.rs
+++ b/iris-mpc/src/services/processors/batch.rs
@@ -1,4 +1,5 @@
 use crate::server::MAX_CONCURRENT_REQUESTS;
+use crate::services::aws::retry::retry_transient;
 use crate::services::processors::get_iris_shares_parse_task;
 use crate::services::processors::result_message::send_error_results_to_sns;
 use ampc_server_utils::shutdown_handler::ShutdownHandler;
@@ -45,6 +46,13 @@ use std::sync::Arc;
 use tokio::sync::mpsc::Receiver;
 use tokio::sync::{mpsc, Semaphore};
 use tokio::task::JoinHandle;
+
+// Bounded app-level retry for the SQS calls on the batch-receive hot path, so a
+// transient blip (DNS/connection) that outlasts the SDK's own retry window is
+// absorbed instead of crashing the process. A persistent failure still surfaces
+// after the attempts are exhausted.
+const SQS_RETRY_MAX_ATTEMPTS: u32 = 5;
+const SQS_RETRY_INITIAL_BACKOFF: std::time::Duration = std::time::Duration::from_millis(200);
 
 #[allow(clippy::too_many_arguments)]
 pub fn receive_batch_stream(
@@ -358,17 +366,28 @@ impl<'a> BatchProcessor<'a> {
                 return Ok(()); // Exit if shutdown is signaled
             }
 
-            let rcv_message_output = self
-                .client
-                .receive_message()
-                // Set a short wait time to avoid busy-looping when the queue is temporarily empty
-                // but we still expect more messages for the current batch.
-                .wait_time_seconds(1) // Short poll to quickly check for messages
-                .max_number_of_messages(1) // Process one message at a time to respect num_to_poll accurately
-                .queue_url(queue_url)
-                .send()
-                .await
-                .map_err(ReceiveRequestError::from)?;
+            let rcv_message_output = retry_transient(
+                "SQS receive_message",
+                SQS_RETRY_MAX_ATTEMPTS,
+                SQS_RETRY_INITIAL_BACKOFF,
+                || {
+                    let client = self.client.clone();
+                    let queue_url = queue_url.clone();
+                    async move {
+                        client
+                            .receive_message()
+                            // Set a short wait time to avoid busy-looping when the queue is temporarily empty
+                            // but we still expect more messages for the current batch.
+                            .wait_time_seconds(1) // Short poll to quickly check for messages
+                            .max_number_of_messages(1) // Process one message at a time to respect num_to_poll accurately
+                            .queue_url(queue_url)
+                            .send()
+                            .await
+                    }
+                },
+            )
+            .await
+            .map_err(ReceiveRequestError::from)?;
 
             if let Some(messages) = rcv_message_output.messages {
                 if messages.is_empty() {
@@ -1304,8 +1323,15 @@ pub async fn get_own_batch_sync_state(
     sqs_client: &Client,
     current_batch_id: u64,
 ) -> Result<BatchSyncState> {
-    let approximate_visible_messages =
-        get_approximate_number_of_messages(&sqs_client.clone(), &config.requests_queue_url).await?;
+    let approximate_visible_messages = retry_transient(
+        "SQS get_approximate_number_of_messages",
+        SQS_RETRY_MAX_ATTEMPTS,
+        SQS_RETRY_INITIAL_BACKOFF,
+        move || async move {
+            get_approximate_number_of_messages(sqs_client, &config.requests_queue_url).await
+        },
+    )
+    .await?;
     tracing::info!(
         "fetching approximate_visible_messages: {}",
         approximate_visible_messages

--- a/iris-mpc/src/services/processors/result_message.rs
+++ b/iris-mpc/src/services/processors/result_message.rs
@@ -1,3 +1,4 @@
+use crate::services::aws::retry::retry_transient;
 use aws_sdk_sns::{types::MessageAttributeValue, Client as SNSClient};
 use eyre::Result;
 use iris_mpc_common::{
@@ -5,6 +6,10 @@ use iris_mpc_common::{
 };
 
 use std::collections::HashMap;
+use std::time::Duration;
+
+const SNS_RETRY_MAX_ATTEMPTS: u32 = 8;
+const SNS_RETRY_INITIAL_BACKOFF: Duration = Duration::from_millis(200);
 
 async fn send_message(
     results_topic_arn: String,
@@ -14,14 +19,33 @@ async fn send_message(
     message_attributes: HashMap<String, MessageAttributeValue>,
     metrics_message_type: String,
 ) -> Result<()> {
-    sns_client
-        .publish()
-        .topic_arn(results_topic_arn)
-        .message(message)
-        .message_group_id(message_group_id)
-        .set_message_attributes(Some(message_attributes))
-        .send()
-        .await?;
+    // Retry transient SNS failures rather than letting them bubble to the
+    // result-sender's `exit(1)`. The results topic is FIFO with content-based
+    // deduplication (no MessageDeduplicationId is set), so re-publishing an
+    // identical message is dedup-safe within the SNS dedup window.
+    retry_transient(
+        "SNS publish",
+        SNS_RETRY_MAX_ATTEMPTS,
+        SNS_RETRY_INITIAL_BACKOFF,
+        || {
+            let sns_client = sns_client.clone();
+            let results_topic_arn = results_topic_arn.clone();
+            let message = message.clone();
+            let message_group_id = message_group_id.clone();
+            let message_attributes = message_attributes.clone();
+            async move {
+                sns_client
+                    .publish()
+                    .topic_arn(results_topic_arn)
+                    .message(message)
+                    .message_group_id(message_group_id)
+                    .set_message_attributes(Some(message_attributes))
+                    .send()
+                    .await
+            }
+        },
+    )
+    .await?;
     metrics::counter!("result.sent", "type" => metrics_message_type).increment(1);
     Ok(())
 }


### PR DESCRIPTION
## What

Three AWS calls on Hawk Main's live request path crash the node on a **transient** failure (DNS blip, connection reset, brief throttle) instead of retrying:

- **SNS result publish** (`result_message.rs::send_message`) → bubbles to `process_job_result` → result-sender does `exit(1)` (`server/mod.rs:741`). Highest-impact: hardest crash, bypasses graceful shutdown, fires *after* the batch already computed.
- **SQS `get_approximate_number_of_messages`** (`batch.rs::get_own_batch_sync_state`) → `BatchSyncError` → main loop `return Err` → process exit. Same DNS-blip class as the batch-sync crash that was just fixed in ampc-common — but this call sits one step earlier in the same path and was uncovered.
- **SQS `receive_message`** (`batch.rs::poll_exact_messages`) → same main-loop exit. Runs per message.

These were the most-probable-in-practice crashers identified in a wider transient-blip audit; the worst offender (the cross-party `get_batch_sync_states` DNS crash) was already fixed upstream in ampc-common.

## How

New `services/aws/retry.rs::retry_transient` — a bounded exponential-backoff retry over an async closure (matches the codebase's existing app-level retry style, e.g. `server/mod.rs` sync loop and ampc-common's batch_sync). Backoff doubles from 200ms, caps at 5s. After the attempt budget is exhausted the **last error is returned**, so a persistent outage still surfaces with the original semantics (e.g. SNS still reaches `exit(1)` as a backstop — results are never silently dropped).

- SQS: 5 attempts (~3s worst-case added latency)
- SNS: 8 attempts (~16s worst-case before the `exit(1)` backstop)

### Retry safety
The results topic is FIFO and the code never sets a `MessageDeduplicationId`, so the topic runs with **content-based deduplication** — re-publishing an identical message is dedup-safe within SNS's 5-min window (well outside the ~16s retry budget). The two SQS calls are reads (idempotent).

## Verification
- `cargo fmt --check`, `cargo clippy --all-targets` clean.
- Reviewed by two independent passes: correctness (crash paths confirmed closed, dedup claim verified) and hazard analysis (retry is bounded/terminating; no locks/permits/txns held across backoff; no double-retry with the cross-party sync loop; `exit(1)` backstop preserved).

### Known trade-offs (bounded, called out for review)
- `retry_transient` is not shutdown-aware: an in-flight retry can delay graceful shutdown by up to ~3s (SQS) / ~16s per message (SNS). For SNS this is arguably desirable — it lets pending results drain rather than drop on shutdown. Can plumb the `ShutdownHandler` in if you'd prefer fail-fast.
- Attempt counts are constants, not config. Easy to make config-driven if wanted.

## Out of scope (follow-up)
Deliberately deferred from the same audit, different subsystems: DB `persist_modification` (needs a sqlx transient classifier + respects the intentional crash-to-recover contract), MPC session-rebuild wedge in `hawk_main.rs` health-check, sqlx pool config (`acquire_timeout`/`max_lifetime`/`test_before_acquire`), `delete_message`, and the MPC `processing_timeout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)