### PR TITLE
Retry transient SQS delete_message on the batch hot path

### DIFF
--- a/iris-mpc/src/services/processors/batch.rs
+++ b/iris-mpc/src/services/processors/batch.rs
@@ -1228,13 +1228,30 @@ impl<'a> BatchProcessor<'a> {
                 sqs_message.message_id
             ))
         })?;
-        self.client
-            .delete_message()
-            .queue_url(&self.config.requests_queue_url)
-            .receipt_handle(receipt_handle)
-            .send()
-            .await
-            .map_err(ReceiveRequestError::from)?;
+        // DeleteMessage is idempotent, so a transient blip here is safe to
+        // retry. The crash-to-recover contract above is preserved: if the ack
+        // still fails after the attempts are exhausted, the error propagates
+        // and the restart path (orphan-row GC + SQS redelivery) runs.
+        retry_transient(
+            "SQS delete_message",
+            SQS_RETRY_MAX_ATTEMPTS,
+            SQS_RETRY_INITIAL_BACKOFF,
+            || {
+                let client = self.client.clone();
+                let queue_url = self.config.requests_queue_url.clone();
+                let receipt_handle = receipt_handle.to_owned();
+                async move {
+                    client
+                        .delete_message()
+                        .queue_url(queue_url)
+                        .receipt_handle(receipt_handle)
+                        .send()
+                        .await
+                }
+            },
+        )
+        .await
+        .map_err(ReceiveRequestError::from)?;
         tracing::debug!("Deleted message: {:?}", sqs_message.message_id);
         Ok(())
     }


### PR DESCRIPTION
**Stacked on #2217** (reuses `retry_transient`). Review/merge #2217 first; GitHub will retarget this to `main` automatically once it lands.

## What
The post-persist `DeleteMessage` ack (`batch.rs::delete_message`) propagated a transient SQS failure out of `receive_batch`, restarting the node on a momentary blip. This was deferred from #2217 because of its deliberate crash-to-recover semantics — addressed here explicitly.

## How
Wrap the `delete_message` send in the same bounded `retry_transient` (5 attempts, 200ms→5s backoff) as the other hot-path SQS calls. `DeleteMessage` is idempotent (deleting an already-deleted/expired receipt is harmless), so retrying is safe.

The **crash-to-recover contract is preserved** (see the comment block at batch.rs:448-466): the `?` is still the trigger for orphan-row GC. A *persistent* failure still propagates after the attempts are exhausted → node restarts → `modifications_sync` GCs the orphan IN_PROGRESS row → the redelivered SQS message re-ingests cleanly. The only behavior change is that a *transient* blip no longer forces that (correct but expensive) restart cycle.

## Verification
`cargo fmt --check` + `cargo clippy --all-targets` clean.

## Note on the other deferred "small remainder"
`processing_timeout` (server/mod.rs:929-933) was also in scope but is **deliberately excluded**: it wraps `hawk_handle.submit_batch_query`, a full lockstep MPC search+insert across all 3 parties. Naively retrying the batch risks double-applied graph/DB mutations and cross-party desync (one party re-running alone has no peers). The correct fix for a transient cross-party stall is MPC session-rebuild resilience in `hawk_main.rs` health-check, which will be handled in that PR instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)