### PR TITLE
Retry session rebuild in health_check to avoid permanent wedge

### DIFF
--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -130,7 +130,7 @@ use std::{
     future::Future,
     hash::{Hash, Hasher},
     sync::Arc,
-    time::Instant,
+    time::{Duration, Instant},
     vec,
 };
 use tokio::sync::{mpsc, oneshot, RwLock, RwLockWriteGuard};
@@ -2126,7 +2126,35 @@ impl HawkHandle {
         if job_failed {
             tracing::error!("job failed. recreating sessions");
             // There is some error so the sessions may be somehow invalid. Make new ones.
-            *sessions = hawk_actor.new_session_groups().await?;
+            //
+            // Retried because otherwise a single transient blip during the rebuild
+            // returns Err -> stop=true in the run loop -> the actor halts
+            // permanently. Safe to retry here: the PRF key is already initialized
+            // (get_or_init_prf_key is a no-op), so only the inter-party network is
+            // re-established, and all parties enter this path together. A
+            // persistent failure still surfaces once attempts are exhausted.
+            const MAX_ATTEMPTS: u32 = 5;
+            const MAX_BACKOFF: Duration = Duration::from_secs(5);
+            let mut attempt = 0u32;
+            let mut backoff = Duration::from_millis(200);
+            *sessions = loop {
+                attempt += 1;
+                match hawk_actor.new_session_groups().await {
+                    Ok(new_sessions) => break new_sessions,
+                    Err(e) if attempt >= MAX_ATTEMPTS => return Err(e),
+                    Err(e) => {
+                        tracing::warn!(
+                            "Failed to recreate sessions (attempt {}/{}): {:?}. Retrying in {:?}...",
+                            attempt,
+                            MAX_ATTEMPTS,
+                            e,
+                            backoff
+                        );
+                        tokio::time::sleep(backoff).await;
+                        backoff = (backoff * 2).min(MAX_BACKOFF);
+                    }
+                }
+            };
         }
 
         // Validate the common state after processing the requests.


### PR DESCRIPTION
> **Draft** — opening for review of the approach before merge.

## What
The worst-impact transient-blip failure mode from the audit: after a job error, `HawkHandle::health_check` recreates the inter-party sessions (`new_session_groups` → `make_network_sessions`, TCP re-establishment). A *transient* blip during that rebuild returned `Err` → `stop=true` in the run loop → **the actor halts permanently**. Unlike the other findings this one has no self-heal — the node is wedged until a process restart.

## How
Wrap `new_session_groups()` in `health_check` in a bounded retry-with-backoff (5 attempts, 200ms→5s). A persistent failure still returns `Err` after the attempts exhaust, preserving the existing stop behavior — this *narrows* the stop condition to genuine faults, it doesn't remove it.

### Why it's safe to retry here (the load-bearing reasoning)
- **PRF key is not re-derived.** `new_sessions` calls `get_or_init_prf_key`, which derives the shared key via MPC only when `prf_key.is_none()`. In the health_check path the key was already initialized at startup, so retry only re-establishes the network — no key re-derivation, no desync risk.
- **Startup call deliberately NOT wrapped.** At `HawkHandle::new` (~line 1704) `prf_key.is_none()`, so a retry there *could* re-enter the PRF MPC exchange with partial cross-party completion → divergence. Left as-is (and startup failure self-heals via k8s restart anyway).
- **`state_check` deliberately NOT wrapped.** It's the cross-party consistency check; a failure there can mean genuine state divergence, which *must* still wedge the node. Discriminating network-error from real divergence is separate, riskier work.
- **Converges cross-party.** All 3 parties enter health_check together after a shared error and retry concurrently; the inner `connect_loop` self-heals misaligned windows, so no party is stranded.

## Verification
- `cargo fmt --check` + `cargo clippy -p iris-mpc-cpu --all-targets` clean.
- Independent review pass: **SAFE** — bounded/terminating; no resource leak across retries (failed attempts cancel their `session_err_ct` and close sockets); `error_ct` is only reassigned from a successful rebuild and reclone happens per loop iteration; PRF idempotency confirmed.

### Note on the bound
"5 attempts × 5s" is not a tight wall-clock bound: the inner `connect_loop` (ampc-actor-utils) already retries transient connect errors on its own ~2s loop, so a single outer attempt can block longer on a sustained peer outage. This isn't a wedge — shutdown still cancels — but the outer retry's main marginal value is over `validate_sessions` races and transient `session_err_ct` cancellations rather than raw connect failures.

## Relation to processing_timeout
This also addresses the root cause behind the `processing_timeout` crash (dropped from #2218 as unsafe to retry at the batch level): making the MPC layer survive transient cross-party blips is the correct place to handle that failure mode, rather than re-submitting a partially-applied batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)