### PR TITLE
Buffered restore for hawk-main checkpoint materialize

### DIFF
--- a/iris-mpc-cpu/src/checkpoint_protocol/materializer.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/materializer.rs
@@ -5,9 +5,9 @@ use crate::checkpoint_protocol::{
     CheckpointMeta, CycleError, FreezeHeight, Graph, Materializer, MutationStore,
 };
 use crate::execution::hawk_main::BothEyes;
-use crate::graph_checkpoint::stream_download_and_deserialize_graph_pair;
+use crate::graph_checkpoint::download_graph;
 use crate::hnsw::{graph::graph_store::GraphPg, VectorStore};
-use crate::utils::serialization::graph::GraphFormat;
+use crate::utils::serialization::graph::{read_graph_pair, GraphFormat};
 use futures::TryStreamExt;
 
 /// Rebuilds the graph from an S3 checkpoint plus WAL replay.
@@ -44,19 +44,27 @@ impl<V: VectorStore + Send + Sync> Materializer for RebuildFromCheckpoint<'_, V>
                 ))
             })?;
 
-        let (mut graph, downloaded_hash) = stream_download_and_deserialize_graph_pair(
-            self.s3_client,
-            &self.bucket,
-            &base.s3_key,
-            format,
-        )
+        // Download the whole checkpoint (parallel ranged GETs), then deserialize
+        // from memory. Trades peak memory, not a constraint here, for throughput.
+        let bytes = download_graph(self.s3_client, &self.bucket, &base.s3_key)
+            .await
+            .map_err(|e| {
+                CycleError::Fatal(format!(
+                    "download_graph({}/{}): {e}",
+                    self.bucket, base.s3_key
+                ))
+            })?;
+        // hash + deserialize are CPU-bound (seconds to minutes at prod scale);
+        // run off the async runtime so they don't block a reactor thread.
+        let label = format!("{}/{}", self.bucket, base.s3_key);
+        let (downloaded_hash, mut graph) = tokio::task::spawn_blocking(move || {
+            let hash = *blake3::hash(&bytes).as_bytes();
+            let graph = read_graph_pair(&mut std::io::Cursor::new(&bytes), format)
+                .map_err(|e| CycleError::Fatal(format!("read_graph_pair({label}): {e}")))?;
+            Ok::<_, CycleError>((hash, graph))
+        })
         .await
-        .map_err(|e| {
-            CycleError::Fatal(format!(
-                "stream_download_and_deserialize_graph_pair({}/{}): {e}",
-                self.bucket, base.s3_key,
-            ))
-        })?;
+        .map_err(|e| CycleError::Fatal(format!("materialize deserialize task: {e}")))??;
 
         let downloaded_hex = hex::encode(downloaded_hash);
         if downloaded_hex != base.blake3_hash {

--- a/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
@@ -635,6 +635,15 @@ impl Layer {
         }
     }
 
+    /// Empty layer with the link map pre-sized for `n` nodes, avoiding repeated
+    /// rehashing when bulk-loading a known-size layer.
+    pub fn with_capacity(n: usize) -> Self {
+        Layer {
+            links: HashMap::with_capacity(n),
+            set_hash: SetHash::default(),
+        }
+    }
+
     pub fn get_links(&self, from: &VectorId) -> Option<&[VectorId]> {
         self.links.get(from).map(|v| v.as_slice())
     }

--- a/iris-mpc-cpu/src/utils/serialization/graph.rs
+++ b/iris-mpc-cpu/src/utils/serialization/graph.rs
@@ -260,11 +260,21 @@ fn read_pair<R: std::io::Read + ?Sized, G: for<'a> Deserialize<'a>>(
     Ok(data)
 }
 
+/// Convert a decoded wire-format pair into `GraphMem`s, running the two eyes'
+/// (independent) conversions concurrently. The preceding bincode decode is serial.
+fn convert_pair_parallel<G>(pair: [G; 2]) -> [GraphMem; 2]
+where
+    G: Into<GraphMem> + Send,
+{
+    let [left, right] = pair;
+    let (left, right) = rayon::join(|| left.into(), || right.into());
+    [left, right]
+}
+
 /// Designated method for reading a pair of `GraphMem` structs. Currently goes
 /// through the `GraphV4` serialization type.
 pub fn read_graph_pair_current<R: std::io::Read + ?Sized>(reader: &mut R) -> Result<[GraphMem; 2]> {
-    let data = read_pair::<_, GraphV4>(reader)?.map(|graph| graph.into());
-    Ok(data)
+    Ok(convert_pair_parallel(read_pair::<_, GraphV4>(reader)?))
 }
 
 /// Designated method for writing a pair of `GraphMem` structs. Currently goes
@@ -305,14 +315,8 @@ pub fn read_graph_pair<R: std::io::Read + ?Sized>(
 ) -> Result<[GraphMem; 2]> {
     match format {
         GraphFormat::Current => read_graph_pair_current(reader),
-        GraphFormat::V4 => {
-            let graphs = read_pair::<_, GraphV4>(reader)?;
-            Ok(graphs.map(|graph| graph.into()))
-        }
-        GraphFormat::V3 => {
-            let graphs = read_pair::<_, GraphV3>(reader)?;
-            Ok(graphs.map(|graph| graph.into()))
-        }
+        GraphFormat::V4 => Ok(convert_pair_parallel(read_pair::<_, GraphV4>(reader)?)),
+        GraphFormat::V3 => Ok(convert_pair_parallel(read_pair::<_, GraphV3>(reader)?)),
         GraphFormat::V2 => {
             let graphs = read_pair::<_, GraphV2>(reader)?;
             Ok(graphs.map(|graph| graph.into()))
@@ -536,7 +540,10 @@ impl From<graph_v3::EntryPoint> for layered_graph::EntryPoint {
 
 impl From<graph_v3::Layer> for Layer {
     fn from(value: graph_v3::Layer) -> Self {
-        let mut layer = Layer::new();
+        // Recompute set_hash via set_links rather than trusting the stored
+        // value: older checkpoints carry a set_hash from a prior fold algorithm.
+        // Pre-size the map so the bulk insert doesn't rehash.
+        let mut layer = Layer::with_capacity(value.links.len());
         for (v, nb) in value.links.into_iter() {
             layer.set_links(v.into(), nb.0.into_iter().map(|x| x.into()).collect());
         }
@@ -574,7 +581,8 @@ impl From<graph_v4::EntryPoint> for layered_graph::EntryPoint {
 
 impl From<graph_v4::Layer> for Layer {
     fn from(value: graph_v4::Layer) -> Self {
-        let mut layer = Layer::new();
+        // See `From<graph_v3::Layer>`: recompute set_hash, pre-sized map.
+        let mut layer = Layer::with_capacity(value.links.len());
         for (v, nb) in value.links.into_iter() {
             layer.set_links(v.into(), nb.0.into_iter().map(|x| x.into()).collect());
         }
@@ -809,6 +817,72 @@ mod tests {
         assert_eq!(
             cur, raw,
             "GraphV4/Current serialization diverged from raw GraphMem bytes"
+        );
+    }
+
+    /// Per-layer checksum and links survive a write→read round trip: the
+    /// recomputed `set_hash` matches the source graph's.
+    #[test]
+    fn read_graph_pair_preserves_set_hash() {
+        let g = sample_graph();
+        let mut buf = Vec::new();
+        write_graph_pair_current(&mut buf, [g.clone(), g.clone()]).unwrap();
+
+        for fmt in [GraphFormat::Current, GraphFormat::V4] {
+            let pair = read_graph_pair(&mut Cursor::new(&buf), fmt).unwrap();
+            for restored in pair {
+                assert_eq!(restored.layers.len(), g.layers.len());
+                for (orig, got) in g.layers.iter().zip(restored.layers.iter()) {
+                    assert_eq!(
+                        orig.checksum(),
+                        got.checksum(),
+                        "set_hash drifted on read ({fmt:?})"
+                    );
+                    assert_eq!(
+                        orig.get_links_map(),
+                        got.get_links_map(),
+                        "links drifted on read ({fmt:?})"
+                    );
+                }
+            }
+        }
+    }
+
+    /// `From<graph_v3::Layer>` recomputes `set_hash` from links and ignores the
+    /// stored value (prod checkpoints carry an older-algorithm `set_hash`). Feed
+    /// a deliberately wrong stored value and assert it's ignored.
+    #[test]
+    fn from_graph_v3_layer_recomputes_ignoring_stored_set_hash() {
+        use crate::utils::serialization::types::graph_v3;
+        let wire = |id: u32| graph_v3::VectorId { id, version: 0 };
+        // Ordered slice (not HashMap iteration) per the iter_over_hash_type lint.
+        let entries: [(u32, Vec<u32>); 3] = [(7, vec![8, 9]), (3, vec![4]), (5, vec![])];
+        let mut links: std::collections::HashMap<graph_v3::VectorId, graph_v3::EdgeIds> =
+            std::collections::HashMap::new();
+        let mut reference = Layer::new();
+        for (n, nbs) in &entries {
+            let wnbs: Vec<graph_v3::VectorId> = nbs.iter().map(|&x| wire(x)).collect();
+            reference.set_links(wire(*n).into(), wnbs.iter().map(|x| (*x).into()).collect());
+            links.insert(wire(*n), graph_v3::EdgeIds(wnbs));
+        }
+        let recomputed = reference.checksum();
+
+        let got: Layer = graph_v3::Layer {
+            links,
+            // Deliberately wrong stored value; the conversion must ignore it.
+            set_hash: recomputed.wrapping_add(0xDEAD_BEEF),
+        }
+        .into();
+
+        assert_eq!(
+            got.checksum(),
+            recomputed,
+            "V3 conversion must recompute set_hash, not trust the stored value"
+        );
+        assert_eq!(
+            got.get_links_map(),
+            reference.get_links_map(),
+            "V3 conversion must preserve links"
         );
     }
 }


### PR DESCRIPTION
## Problem

The hawk-main WAL restart path deserializes the graph checkpoint via a single-threaded streaming reader. On a prod-scale checkpoint it's much slower than the pre-WAL parallel download and wedged startup for over an hour.

## Fix

Restore the buffered restore path for the restart materialize:
- `materializer.rs` — parallel `download_graph` → blake3 verify → `read_graph_pair` from memory, run on a blocking thread (off the async runtime).
- `From<graph_v{3,4}::Layer>` — pre-size the link map (`Layer::with_capacity`) to avoid rehashing.
- `read_graph_pair` — convert the two eyes concurrently (`rayon::join`); the bincode decode stays serial, the per-eye conversion is the dominant independent cost.

`set_hash` is recomputed from the links on load (not trusted from the checkpoint): older genesis checkpoints (e.g. the current prod base, written by genesis v0.31.11) carry a `set_hash` from a prior fold algorithm, so the stored value would diverge from what the running node computes and feeds into the cross-party `StateChecksum`.

Compatible with V3 (prod) and V4 (dev). Peak memory (the streaming path's only benefit) is irrelevant on the restart hosts.

## Testing

Unit tests: write→read round trip preserves the recomputed checksum; the V3 conversion ignores a deliberately-wrong stored `set_hash`. fmt/clippy/doc clean. Independent review: SHIP. Verified on the dev cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)