### PR TITLE
chore: bump memmap2 0.9.10 -> 0.9.11 (RUSTSEC-2026-0186)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3763,9 +3763,9 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]


### PR DESCRIPTION
## What

Bumps `memmap2` from `0.9.10` to `0.9.11` in `Cargo.lock` to clear the cargo-deny advisory failure on `main`.

## Why

`cargo-deny` fails CI with `RUSTSEC-2026-0186` (unsound):

> memmap2 0.9.10 did not perform enough validation on the `offset`/`len` parameters of `advise_range()` / `flush_range()`. An out-of-bounds range produces an invalid pointer passed to the `madvise`/`msync` syscalls (and Windows equivalents). Fixed in 0.9.11.

memmap2 reaches us transitively (`iris-mpc-gpu` directly; also via `pprof → symbolic-demangle → symbolic-common`). The workspace requirement is already `memmap2 = "0.9.5"`, so 0.9.11 is within range — this is a lockfile-only change, no manifest edit needed.

## Change

- `Cargo.lock`: `memmap2 0.9.10 -> 0.9.11` (single entry, patch-level bump)

## Verification

`cargo deny --all-features check advisories` locally now reports `advisories ok`. The advisory no longer appears.