### PR TITLE
Make checkpoint ring consensus tolerate cross-party startup skew

### DIFF
--- a/iris-mpc-cpu/src/checkpoint_protocol/mod.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/mod.rs
@@ -211,6 +211,10 @@ pub trait ConsensusTransport {
         cycle_nonce: u128,
         timeout: Duration,
     ) -> Result<Vec<T>, CycleError>;
+
+    /// Ring rendezvous: blocks (no per-round timeout) until all three parties
+    /// arrive. Absorbs cross-party arrival skew that a timed `exchange` can't.
+    async fn barrier(&self) -> Result<(), CycleError>;
 }
 
 #[async_trait]
@@ -363,6 +367,11 @@ where
 
     // Phase 4 — hash the materialized graph.
     let local_hash = hasher.hash_canonical(&graph);
+
+    // Align after the variable-time materialize so the timed hash exchange below
+    // isn't tripped by a party still materializing.
+    transport.barrier().await?;
+
     tracing::info!(
         local_hash = %hex::encode(local_hash),
         "checkpoint cycle: phase 5 — exchanging graph hashes"
@@ -390,6 +399,10 @@ where
             )));
         }
     }
+
+    // Commit barrier: don't run the terminal action until all parties agree, so
+    // none finalizes while a peer is still in the exchange.
+    transport.barrier().await?;
 
     tracing::info!(
         height = freeze.0,

--- a/iris-mpc-cpu/src/checkpoint_protocol/runner.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/runner.rs
@@ -255,6 +255,11 @@ pub enum RestartOutcome {
     NoCommonBase,
 }
 
+/// Max attempts for the restart consensus before giving up (and exiting).
+const RESTART_MAX_ATTEMPTS: usize = 30;
+/// Delay between restart consensus attempts.
+const RESTART_RETRY_DELAY: Duration = Duration::from_secs(5);
+
 /// Rebuild the live graph from the latest checkpoint + WAL replay, then
 /// install it into `target`. `min_mutations_to_apply=0` so the cycle
 /// proceeds even when there are no new mutations beyond the base.
@@ -277,33 +282,60 @@ pub async fn restart_from_checkpoint<V: VectorStore + Send + Sync>(
     // join the ring, or its peers block in the Phase 1 exchange until
     // timeout and crash-loop while this party silently boots empty.
     // "Nobody has a checkpoint" is a consensus outcome, not a local one.
-    let channel = networking
-        .control_channel()
-        .await
-        .map_err(|e| eyre!("open control_channel: {e}"))?;
-    let transport = RingConsensusTransport::new(channel);
-
-    let mut materializer = RebuildFromCheckpoint::new(graph_store, s3_client, bucket);
-    let mut finalizer = InstallAsServing::new(target);
     let hasher = Blake3GraphHasher::new();
-
     let cfg = CycleConfig {
         min_mutations_to_apply: 0,
         peer_round_timeout,
         checkpoint_window,
     };
 
-    let outcome = run_cycle(
-        &mut materializer,
-        &mut finalizer,
-        &transport,
-        graph_store,
-        &hasher,
-        &MostRecentCommon,
-        &cfg,
-    )
-    .await
-    .map_err(|e| eyre!("restart run_cycle: {e}"))?;
+    // Retry transient failures instead of exiting. Re-open the channel each
+    // attempt: a timed-out round can leave buffered frames that desync a reuse.
+    let outcome = {
+        let mut attempt = 0usize;
+        loop {
+            attempt += 1;
+            let channel = networking
+                .control_channel()
+                .await
+                .map_err(|e| eyre!("open control_channel: {e}"))?;
+            let transport = RingConsensusTransport::new(channel);
+            let mut materializer =
+                RebuildFromCheckpoint::new(graph_store, s3_client, bucket.clone());
+            let mut finalizer = InstallAsServing::new(target.clone());
+
+            match run_cycle(
+                &mut materializer,
+                &mut finalizer,
+                &transport,
+                graph_store,
+                &hasher,
+                &MostRecentCommon,
+                &cfg,
+            )
+            .await
+            {
+                Ok(outcome) => break outcome,
+                Err(CycleError::Transient(msg)) if attempt < RESTART_MAX_ATTEMPTS => {
+                    tracing::warn!(
+                        attempt,
+                        max = RESTART_MAX_ATTEMPTS,
+                        error = %msg,
+                        "restart run_cycle transient; retrying"
+                    );
+                    tokio::time::sleep(RESTART_RETRY_DELAY).await;
+                }
+                Err(CycleError::Transient(msg)) => {
+                    return Err(eyre!(
+                        "restart run_cycle: transient after {attempt} attempts: {msg}"
+                    ));
+                }
+                Err(CycleError::Fatal(msg)) => {
+                    return Err(eyre!("restart run_cycle: {msg}"));
+                }
+            }
+        }
+    };
 
     match outcome {
         Outcome::Finalized { height, .. } => {

--- a/iris-mpc-cpu/src/checkpoint_protocol/tests.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/tests.rs
@@ -178,6 +178,11 @@ impl ConsensusTransport for MockTransport {
         }
         Ok(projected)
     }
+
+    // No-op: peer replies come from the canned queue, which barrier doesn't touch.
+    async fn barrier(&self) -> Result<(), CycleError> {
+        Ok(())
+    }
 }
 
 // ── mock Materializer ────────────────────────────────────────────────────

--- a/iris-mpc-cpu/src/checkpoint_protocol/transport.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/transport.rs
@@ -98,6 +98,16 @@ impl ConsensusTransport for RingConsensusTransport {
 
         Ok(vec![parse(next_bytes)?, parse(prev_bytes)?])
     }
+
+    async fn barrier(&self) -> Result<(), CycleError> {
+        // `sync` is a no-timeout ring rendezvous; map its failures to transient.
+        self.channel
+            .lock()
+            .await
+            .sync()
+            .await
+            .map_err(|e| CycleError::Transient(format!("ring barrier (sync): {e}")))
+    }
 }
 
 /// Map a `ControlChannel` recv result to a payload byte vector. A non-Bytes
@@ -167,6 +177,12 @@ pub(crate) mod test_ring {
                 .ok_or_else(|| eyre::eyre!("recv_prev: channel closed"))
         }
         async fn sync(&mut self) -> Result<()> {
+            // Mirror the real ring barrier: send a token both ways, recv from each.
+            let token = NetworkValue::Bytes(vec![0x5e]);
+            self.send_next(token.clone()).await?;
+            self.send_prev(token).await?;
+            self.recv_next().await?;
+            self.recv_prev().await?;
             Ok(())
         }
     }
@@ -454,5 +470,30 @@ mod tests {
             any_transient,
             "expected at least one transient; got r0={r0:?}, r1={r1:?}"
         );
+    }
+
+    /// `barrier` blocks (no per-round timeout) until all three parties arrive,
+    /// then all complete — this is what absorbs cross-party arrival skew.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn ring_barrier_blocks_until_all_arrive() {
+        let [p0, p1, p2] = triangle(8);
+        let t0 = xport(p0);
+        let t1 = xport(p1);
+        let t2 = xport(p2);
+
+        // Two parties present: the barrier must not complete.
+        let h0 = tokio::spawn(async move { t0.barrier().await });
+        let h1 = tokio::spawn(async move { t1.barrier().await });
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        assert!(
+            !h0.is_finished() && !h1.is_finished(),
+            "barrier completed without the third party"
+        );
+
+        // Third party arrives → all three rendezvous and return Ok.
+        let h2 = tokio::spawn(async move { t2.barrier().await });
+        h0.await.expect("p0 join").expect("p0 barrier");
+        h1.await.expect("p1 join").expect("p1 barrier");
+        h2.await.expect("p2 join").expect("p2 barrier");
     }
 }


### PR DESCRIPTION
## Problem

On a 3-party restart, the graph-checkpoint consensus (`checkpoint_protocol/run_cycle`) runs its timed ring rounds **concurrently with the ~16-min iris load**, so parties reach phase 5 at very different times. Two failures result:

1. The phase-5 hash exchange is **not a barrier** — the first party to collect its two peer hashes finalizes and leaves; a peer a beat behind hits the 10s round timeout (`PEER_ROUND_TIMEOUT`). Because sends are buffered, the *late* party harvests the early parties' hashes and finalizes, while the *on-time* parties waiting on it time out.
2. The restart path treated that **transient** timeout as **fatal and exited**; the partial crash then stranded the survivor at the startup-sync barrier (ready, waiting for peers that restarted into "wait for all un-ready") → wedged until the 3600s timeout.

(This surfaced once the buffered-restore fix let the graph consensus actually complete-attempt during the iris load.)

## Fix

- `ConsensusTransport::barrier()` — a **no-timeout ring rendezvous** (`ControlChannel::sync`), called in `run_cycle`:
  - after materialize, before the timed hash exchange — so all parties enter phase 5 aligned and the 10s round can't be tripped by materialize skew;
  - after the hash compare, before the terminal action — a **commit barrier** so no party installs/uploads while a peer is still in the exchange.
- `restart_from_checkpoint` **retries transient** ring failures (re-opening the control channel each attempt to avoid buffered-frame desync) instead of exiting.
- Made the in-memory test ring's `sync()` a real rendezvous (it was a no-op stub, so the 3-party tests weren't actually exercising the barrier); added a `barrier` blocks-until-all-arrive test.

## Testing

48 `checkpoint_protocol` tests pass, incl. the three concurrent-ring tests now genuinely exercising both barriers; fmt/clippy/doc clean.

## Follow-up (out of scope)

A separate investigation found the same desync class in `ampc-common` `server_coordination` (the `set_node_ready` → `wait_for_others_ready` / `wait_for_others_unready` ready-vs-unready asymmetry can deadlock for up to 3600s on a partial crash; `init_heartbeat_task` `panic!`s on a peer UUID change). Tracking separately — not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)