### PR TITLE
Quiet & clarify ampc-hnsw startup and batch-processing logs

### DIFF
--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -1525,7 +1525,7 @@ impl HawkResult {
             .map(|&d| matches!(d, ReauthUpdate(_)))
             .collect_vec();
 
-        tracing::info!(
+        tracing::debug!(
             "Reauths: {:?}, Unique insert: {:?}, Unique no-match (incl. skip): {:?}",
             successful_reauths,
             unique_insert,
@@ -1954,7 +1954,7 @@ impl HawkHandle {
             })
             .collect_vec();
 
-        tracing::info!("Updated decisions (reset + reauth): {:?}", update_ids);
+        tracing::debug!("Updated decisions (reset + reauth): {:?}", update_ids);
 
         // Get deleted vector IDs for RemoveNode mutations.
         let deleted_ids = request.deletion_ids(&*hawk_actor.registry[LEFT].read().await);
@@ -2008,7 +2008,7 @@ impl HawkHandle {
                 .filter(|decision| matches!(decision, UniqueInsertSkipped))
                 .count();
 
-            tracing::info!(
+            tracing::debug!(
                 "Unique insertions: {n_unique}, persistence skipped: {n_unique_skipped}"
             );
 

--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -515,7 +515,7 @@ WHERE id = $1;
         .fetch_one(&self.pool)
         .await?;
 
-        tracing::info!(
+        tracing::debug!(
             "Inserted {} modification: id={:?}, serial_id={:?}, request_type={}",
             MOD_STATUS_IN_PROGRESS,
             inserted.id,

--- a/iris-mpc-store/src/loader.rs
+++ b/iris-mpc-store/src/loader.rs
@@ -215,7 +215,7 @@ async fn load_iris_db_internal(
                 );
                 continue;
             } else if !all_serial_ids.contains(&(serial_id as i64)) {
-                tracing::warn!("Skip loading s3 retried item: serial_id {}", serial_id);
+                tracing::debug!("Skip loading s3 retried item: serial_id {}", serial_id);
                 continue;
             }
 
@@ -233,7 +233,7 @@ async fn load_iris_db_internal(
             );
             actor.increment_db_size(serial_id - 1);
 
-            if record_counter % 100_000 == 0 {
+            if record_counter % 500_000 == 0 {
                 let elapsed = now.elapsed();
                 tracing::info!(
                     "Loaded {} records into memory in {:?} ({:.2} entries/s)",

--- a/iris-mpc-store/src/loader.rs
+++ b/iris-mpc-store/src/loader.rs
@@ -200,10 +200,11 @@ async fn load_iris_db_internal(
                     None => break,
                 },
             };
+
             time_waiting_for_stream += load_summary_ts.elapsed();
             load_summary_ts = Instant::now();
-            let serial_id = iris.serial_id();
 
+            let serial_id = iris.serial_id();
             if serial_id == 0 {
                 tracing::error!("Invalid iris serial_id {}", serial_id);
                 bail!("Invalid iris serial_id {}", serial_id);
@@ -233,6 +234,12 @@ async fn load_iris_db_internal(
             );
             actor.increment_db_size(serial_id - 1);
 
+            time_loading_into_memory += load_summary_ts.elapsed();
+            load_summary_ts = Instant::now();
+
+            all_serial_ids.remove(&(serial_id as i64));
+            record_counter += 1;
+
             if record_counter % 500_000 == 0 {
                 let elapsed = now.elapsed();
                 tracing::info!(
@@ -242,12 +249,6 @@ async fn load_iris_db_internal(
                     record_counter as f64 / elapsed.as_secs_f64()
                 );
             }
-
-            time_loading_into_memory += load_summary_ts.elapsed();
-            load_summary_ts = Instant::now();
-
-            all_serial_ids.remove(&(serial_id as i64));
-            record_counter += 1;
         }
 
         // Reached only by breaking on a closed channel. If the task's result wasn't

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -661,7 +661,6 @@ async fn init_hawk_actor(
                         height, db_count
                     );
                 }
-                tracing::info!(height, "restart: installed graph from checkpoint");
                 graph_target.map(|arc| {
                     Arc::try_unwrap(arc)
                         .expect("graph Arc has exactly one owner after restart")

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -1,6 +1,6 @@
 use crate::services::aws::clients::AwsClients;
 use crate::services::processors::batch::receive_batch_stream;
-use crate::services::processors::job::process_job_result;
+use crate::services::processors::job::{process_job_result, BatchTimings};
 use aws_sdk_s3::Client;
 use aws_sdk_sns::types::MessageAttributeValue;
 use iris_mpc_cpu::checkpoint_protocol::{restart_from_checkpoint, sidecar_main, RestartOutcome};
@@ -710,17 +710,18 @@ async fn start_results_thread(
     task_monitor: &mut TaskMonitor,
     shutdown_handler: &Arc<ShutdownHandler>,
     sns_attributes_maps: SnsAttributesMaps,
-) -> Result<Sender<ServerJobResult>> {
-    let (tx, mut rx) = mpsc::channel::<ServerJobResult>(32); // TODO: pick some buffer value
+) -> Result<Sender<(BatchTimings, ServerJobResult)>> {
+    let (tx, mut rx) = mpsc::channel::<(BatchTimings, ServerJobResult)>(32); // TODO: pick some buffer value
     let sns_client_bg = aws_clients.sns_client.clone();
     let config_bg = config.clone();
     let store_bg = iris_store.clone();
     let shutdown_handler_bg = Arc::clone(shutdown_handler);
     let party_id = config.party_id;
     let _result_sender_abort = task_monitor.spawn(async move {
-        while let Some(job_result) = rx.recv().await {
+        while let Some((batch_timings, job_result)) = rx.recv().await {
             if let Err(e) = process_job_result(
                 job_result,
+                batch_timings,
                 party_id,
                 &store_bg,
                 &graph_store,
@@ -763,7 +764,7 @@ async fn run_main_server_loop(
     mut task_monitor: TaskMonitor,
     shutdown_handler: &Arc<ShutdownHandler>,
     hawk_actor: HawkActor,
-    tx_results: Sender<ServerJobResult>,
+    tx_results: Sender<(BatchTimings, ServerJobResult)>,
     current_batch_id_atomic: Arc<AtomicU64>,
     batch_sync_shared_state: Arc<tokio::sync::Mutex<BatchSyncSharedState>>,
 ) -> Result<()> {
@@ -881,24 +882,26 @@ async fn run_main_server_loop(
             metrics::histogram!("batch_sync_entries_retries").record((sync_attempts - 1) as f64);
             batch.retain_valid_entries();
 
+            // Batch receive wait (poll + sync), tracked separately from compute.
+            let batch_wait = now.elapsed();
+
             // start trace span - with single TraceId and single ParentTraceID
             tracing::info!(
                 "Received batch in {:.1}s ({} queries, sync {:.1}s/{} attempt{})",
-                now.elapsed().as_secs_f64(),
+                batch_wait.as_secs_f64(),
                 batch.request_types.len(),
                 sync_elapsed,
                 sync_attempts,
                 if sync_attempts != 1 { "s" } else { "" },
             );
 
-            metrics::histogram!("receive_batch_duration").record(now.elapsed().as_secs_f64());
+            metrics::histogram!("receive_batch_duration").record(batch_wait.as_secs_f64());
             metrics::gauge!("batch_size").set(batch.request_types.len() as f64);
 
-            // Iterate over a list of tracing payloads, and create logs with mappings to
-            // payloads Log at least a "start" event using a log with trace.id and
-            // parent.trace.id
+            tracing::info!("Started processing {} shares", batch.metadata.len());
+            // Per-share trace-id mappings kept at debug for DD trace correlation.
             for tracing_payload in batch.metadata.iter() {
-                tracing::info!(
+                tracing::debug!(
                     node_id = tracing_payload.node_id,
                     dd.trace_id = tracing_payload.trace_id,
                     dd.span_id = tracing_payload.span_id,
@@ -930,17 +933,13 @@ async fn run_main_server_loop(
             let result = timeout(processing_timeout, result_future.await)
                 .await
                 .map_err(|e| eyre!("HawkActor processing timeout: {:?}", e))??;
-            tx_results.send(result).await?;
-
-            tracing::info!(
-                "BATCH_SUMMARY batch_id={} party={} queries={} hash={} compute_ms={} total_ms={}",
-                current_batch_id_atomic.load(Ordering::SeqCst),
-                party_id,
-                batch.request_types.len(),
-                hex::encode(&batch_hash[0..4]),
-                pprof_start.elapsed().as_millis(),
-                now.elapsed().as_millis(),
-            );
+            let batch_timings = BatchTimings {
+                batch_id: current_batch_id_atomic.load(Ordering::SeqCst),
+                batch_hash: hex::encode(&batch_hash[0..4]),
+                receive_ms: batch_wait.as_millis(),
+                compute_ms: pprof_start.elapsed().as_millis(),
+            };
+            tx_results.send((batch_timings, result)).await?;
 
             // If enabled, stop pprof and upload artifacts tagged with batch info
             if let Some(guard) = pprof_guard.take() {

--- a/iris-mpc/src/services/processors/batch.rs
+++ b/iris-mpc/src/services/processors/batch.rs
@@ -1353,17 +1353,14 @@ pub async fn get_own_batch_sync_state(
         std::cmp::min(approximate_visible_messages, config.max_batch_size as u32)
     };
 
-    if messages_to_poll == 0 {
-        tracing::debug!(
-            "fetching approximate_visible_messages: {}",
-            approximate_visible_messages
-        );
-    } else {
-        tracing::info!(
-            "fetching approximate_visible_messages: {}",
-            approximate_visible_messages
-        );
-    }
+    let log_msg = format!(
+        "fetching approximate_visible_messages: {}",
+        approximate_visible_messages,
+    );
+    match messages_to_poll {
+        0 => tracing::debug!(log_msg),
+        _ => tracing::info!(log_msg),
+    };
 
     let batch_sync_state = BatchSyncState {
         messages_to_poll,

--- a/iris-mpc/src/services/processors/batch.rs
+++ b/iris-mpc/src/services/processors/batch.rs
@@ -269,11 +269,19 @@ impl<'a> BatchProcessor<'a> {
                     // we have already set this for this batch, so it might have gone out to other parties, so we need to update our own state to match what we already sent out
                     own_state.messages_to_poll = shared_state.messages_to_poll;
                 }
-                tracing::info!(
-                    "Updated shared batch sync state: batch_id={}, messages_to_poll={}",
-                    shared_state.batch_id,
-                    shared_state.messages_to_poll,
-                );
+                if shared_state.messages_to_poll == 0 {
+                    tracing::debug!(
+                        "Updated shared batch sync state: batch_id={}, messages_to_poll={}",
+                        shared_state.batch_id,
+                        shared_state.messages_to_poll,
+                    );
+                } else {
+                    tracing::info!(
+                        "Updated shared batch sync state: batch_id={}, messages_to_poll={}",
+                        shared_state.batch_id,
+                        shared_state.messages_to_poll,
+                    );
+                }
             }
 
             let server_coord_config = self.config.server_coordination.as_ref().ok_or(
@@ -293,19 +301,28 @@ impl<'a> BatchProcessor<'a> {
             let batch_sync_result = BatchSyncResult::new(own_state, all_states);
             let messages_to_poll = batch_sync_result.messages_to_poll();
 
-            tracing::info!(
-                "Batch ID: {}. Agreed to poll {} messages (max_batch_size: {}).",
-                current_batch_id,
-                messages_to_poll,
-                self.config.max_batch_size
-            );
+            if messages_to_poll == 0 {
+                tracing::debug!(
+                    "Batch ID: {}. Agreed to poll {} messages (max_batch_size: {}).",
+                    current_batch_id,
+                    messages_to_poll,
+                    self.config.max_batch_size
+                );
+            } else {
+                tracing::info!(
+                    "Batch ID: {}. Agreed to poll {} messages (max_batch_size: {}).",
+                    current_batch_id,
+                    messages_to_poll,
+                    self.config.max_batch_size
+                );
+            }
 
             // Poll the determined number of messages
             if messages_to_poll > 0 {
                 self.poll_exact_messages(messages_to_poll).await?;
                 break;
             } else {
-                tracing::info!(
+                tracing::debug!(
                     "Batch ID: {}. No messages to poll based on sync state. Will re-check after a short delay.",
                     current_batch_id
                 );
@@ -337,6 +354,39 @@ impl<'a> BatchProcessor<'a> {
                 .zip(self.batch_query.request_types.iter())
                 .collect::<Vec<_>>()
         );
+
+        if !self.batch_query.skip_persistence.is_empty() {
+            let skip_ids: Vec<&String> = self
+                .batch_query
+                .request_ids
+                .iter()
+                .zip(self.batch_query.skip_persistence.iter())
+                .filter_map(|(id, skip)| skip.then_some(id))
+                .collect();
+            tracing::info!(
+                "Batch ID: {}. skip_persistence enabled for {}/{} requests: {:?}",
+                batch_id,
+                skip_ids.len(),
+                self.batch_query.skip_persistence.len(),
+                skip_ids,
+            );
+        }
+
+        if !self.config.disable_persistence && !self.batch_query.modifications.is_empty() {
+            let mut mods: Vec<String> = self
+                .batch_query
+                .modifications
+                .values()
+                .map(|m| format!("{}#{} serial={:?}", m.request_type, m.id, m.serial_id))
+                .collect();
+            mods.sort();
+            tracing::info!(
+                "Batch ID: {}. Inserted {} IN_PROGRESS modifications: {:?}",
+                batch_id,
+                mods.len(),
+                mods,
+            );
+        }
 
         Ok(Some(self.batch_query.clone()))
     }
@@ -690,7 +740,7 @@ impl<'a> BatchProcessor<'a> {
             {
                 self.batch_query.full_face_mirror_attacks_detection_enabled = enable_mirror_attacks;
                 tracing::info!(
-                    "Setting mirror attack to {} for batch due to request from {}",
+                    "Setting full-face mirror-attack detection to {} for batch due to request from {}",
                     enable_mirror_attacks,
                     uniqueness_request.signup_id
                 );
@@ -709,14 +759,6 @@ impl<'a> BatchProcessor<'a> {
         );
 
         self.add_iris_shares_task(uniqueness_request.s3_key)?;
-
-        if let Some(skip_persistence) = uniqueness_request.skip_persistence {
-            tracing::info!(
-                "Setting skip_persistence to {} for request id {}",
-                skip_persistence,
-                uniqueness_request.signup_id
-            );
-        }
 
         Ok(())
     }
@@ -1306,10 +1348,6 @@ pub async fn get_own_batch_sync_state(
 ) -> Result<BatchSyncState> {
     let approximate_visible_messages =
         get_approximate_number_of_messages(&sqs_client.clone(), &config.requests_queue_url).await?;
-    tracing::info!(
-        "fetching approximate_visible_messages: {}",
-        approximate_visible_messages
-    );
 
     let index = (current_batch_id - 1) as usize;
 
@@ -1325,6 +1363,18 @@ pub async fn get_own_batch_sync_state(
         // Use the dynamic batch size calculation based on SQS approximate visible messages
         std::cmp::min(approximate_visible_messages, config.max_batch_size as u32)
     };
+
+    if messages_to_poll == 0 {
+        tracing::debug!(
+            "fetching approximate_visible_messages: {}",
+            approximate_visible_messages
+        );
+    } else {
+        tracing::info!(
+            "fetching approximate_visible_messages: {}",
+            approximate_visible_messages
+        );
+    }
 
     let batch_sync_state = BatchSyncState {
         messages_to_poll,

--- a/iris-mpc/src/services/processors/batch.rs
+++ b/iris-mpc/src/services/processors/batch.rs
@@ -269,19 +269,15 @@ impl<'a> BatchProcessor<'a> {
                     // we have already set this for this batch, so it might have gone out to other parties, so we need to update our own state to match what we already sent out
                     own_state.messages_to_poll = shared_state.messages_to_poll;
                 }
-                if shared_state.messages_to_poll == 0 {
-                    tracing::debug!(
-                        "Updated shared batch sync state: batch_id={}, messages_to_poll={}",
-                        shared_state.batch_id,
-                        shared_state.messages_to_poll,
-                    );
-                } else {
-                    tracing::info!(
-                        "Updated shared batch sync state: batch_id={}, messages_to_poll={}",
-                        shared_state.batch_id,
-                        shared_state.messages_to_poll,
-                    );
-                }
+
+                let log_msg = format!(
+                    "Updated shared batch sync state: batch_id={}, messages_to_poll={}",
+                    shared_state.batch_id, shared_state.messages_to_poll,
+                );
+                match shared_state.messages_to_poll {
+                    0 => tracing::debug!(log_msg),
+                    _ => tracing::info!(log_msg),
+                };
             }
 
             let server_coord_config = self.config.server_coordination.as_ref().ok_or(
@@ -301,21 +297,14 @@ impl<'a> BatchProcessor<'a> {
             let batch_sync_result = BatchSyncResult::new(own_state, all_states);
             let messages_to_poll = batch_sync_result.messages_to_poll();
 
-            if messages_to_poll == 0 {
-                tracing::debug!(
-                    "Batch ID: {}. Agreed to poll {} messages (max_batch_size: {}).",
-                    current_batch_id,
-                    messages_to_poll,
-                    self.config.max_batch_size
-                );
-            } else {
-                tracing::info!(
-                    "Batch ID: {}. Agreed to poll {} messages (max_batch_size: {}).",
-                    current_batch_id,
-                    messages_to_poll,
-                    self.config.max_batch_size
-                );
-            }
+            let log_msg = format!(
+                "Batch ID: {}. Agreed to poll {} messages (max_batch_size: {}).",
+                current_batch_id, messages_to_poll, self.config.max_batch_size
+            );
+            match messages_to_poll {
+                0 => tracing::debug!(log_msg),
+                _ => tracing::info!(log_msg),
+            };
 
             // Poll the determined number of messages
             if messages_to_poll > 0 {

--- a/iris-mpc/src/services/processors/job.rs
+++ b/iris-mpc/src/services/processors/job.rs
@@ -21,11 +21,21 @@ use iris_mpc_store::{Store, StoredIrisRef};
 use itertools::{izip, Itertools};
 use std::{collections::HashMap, time::Instant};
 
+/// Batch identity and stage timings carried to the result summaries.
+pub struct BatchTimings {
+    pub batch_id: u64,
+    /// Hex-encoded short prefix of the batch hash.
+    pub batch_hash: String,
+    pub receive_ms: u128,
+    pub compute_ms: u128,
+}
+
 /// Processes a ServerJobResult, storing data in the database and sending result messages
 /// through SNS.
 #[allow(clippy::too_many_arguments)]
 pub async fn process_job_result(
     job_result: ServerJobResult<HawkMutation>,
+    batch_timings: BatchTimings,
     party_id: usize,
     store: &Store,
     graph_store: &GraphStore,
@@ -419,6 +429,7 @@ pub async fn process_job_result(
         metrics::histogram!("persist_total_duration")
             .record(persist_total_start.elapsed().as_secs_f64());
     }
+    let persist_ms = persist_total_start.elapsed().as_millis();
 
     for memory_serial_id in memory_serial_ids {
         tracing::info!("Inserted serial_id: {}", memory_serial_id + 1);
@@ -529,8 +540,22 @@ pub async fn process_job_result(
 
     metrics::histogram!("process_job_duration").record(now.elapsed().as_secs_f64());
 
+    // batch_id/hash are shared with RESULT_SUMMARY to correlate the two lines.
     tracing::info!(
-        "RESULT_SUMMARY party={} uniqueness={} reauth={} reset_check={} reset_update={} recovery_update={} deletion={} recovery_check={} persist_ms={} total_ms={}",
+        "BATCH_SUMMARY batch_id={} hash={} party={} queries={} receive_ms={} compute_ms={} persist_ms={}",
+        batch_timings.batch_id,
+        batch_timings.batch_hash,
+        party_id,
+        request_ids.len(),
+        batch_timings.receive_ms,
+        batch_timings.compute_ms,
+        persist_ms,
+    );
+
+    tracing::info!(
+        "RESULT_SUMMARY batch_id={} hash={} party={} uniqueness={} reauth={} reset_check={} reset_update={} recovery_update={} deletion={} recovery_check={}",
+        batch_timings.batch_id,
+        batch_timings.batch_hash,
         party_id,
         n_uniqueness,
         n_reauth,
@@ -539,8 +564,6 @@ pub async fn process_job_result(
         n_recovery_update,
         n_deletion,
         n_recovery_check,
-        persist_total_start.elapsed().as_millis(),
-        now.elapsed().as_millis(),
     );
 
     shutdown_handler.decrement_batches_pending_completion();


### PR DESCRIPTION
Cuts prod log noise during startup and steady-state batch processing; clarifies a few confusing lines.

**Startup**
- `Skip loading s3 retried item` → debug (one WARN/record for a normal chunked-load skip; ~5k/party).
- Load progress logged every 500k records, not 100k.
- Drop duplicate `installed graph from checkpoint` (protocol layer already logs it).

**Batch processing**
- Idle poll chatter → debug (`No messages to poll`; poll-cycle lines when `messages_to_poll==0`; info kept for real batches).
- `Started processing share` (per share) → one `Started processing N shares`; per-share trace-ids at debug.
- `Inserted IN_PROGRESS modification` / `Setting skip_persistence` (per request) → debug, replaced by per-batch summaries in `receive_batch`.
- `Setting mirror attack to true` → `…mirror-attack detection to <bool>`.
- `BATCH_SUMMARY` now carries stage timings (`receive_ms`/`compute_ms`/`persist_ms`); `RESULT_SUMMARY` carries only counts; both tagged with `batch_id`+`hash`. Conflated `total_ms` removed.
- Redundant per-batch detail lines → debug.

Companion: worldcoin/ampc-common#118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)