### PR TITLE
Bump ampc-common to 34170ed (coordination-server log demotions)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 [[package]]
 name = "ampc-actor-utils"
 version = "0.1.0"
-source = "git+https://github.com/worldcoin/ampc-common.git?rev=2dc1f945f609d718c5e35eace83d9a1f57e4ee11#2dc1f945f609d718c5e35eace83d9a1f57e4ee11"
+source = "git+https://github.com/worldcoin/ampc-common.git?rev=34170ed878ea13ab59170b2d1741407e5c8c53eb#34170ed878ea13ab59170b2d1741407e5c8c53eb"
 dependencies = [
  "aes-prng",
  "ampc-secret-sharing",
@@ -111,7 +111,7 @@ dependencies = [
 [[package]]
 name = "ampc-anon-stats"
 version = "0.1.0"
-source = "git+https://github.com/worldcoin/ampc-common.git?rev=2dc1f945f609d718c5e35eace83d9a1f57e4ee11#2dc1f945f609d718c5e35eace83d9a1f57e4ee11"
+source = "git+https://github.com/worldcoin/ampc-common.git?rev=34170ed878ea13ab59170b2d1741407e5c8c53eb#34170ed878ea13ab59170b2d1741407e5c8c53eb"
 dependencies = [
  "ampc-actor-utils",
  "ampc-secret-sharing",
@@ -137,7 +137,7 @@ dependencies = [
 [[package]]
 name = "ampc-secret-sharing"
 version = "0.1.0"
-source = "git+https://github.com/worldcoin/ampc-common.git?rev=2dc1f945f609d718c5e35eace83d9a1f57e4ee11#2dc1f945f609d718c5e35eace83d9a1f57e4ee11"
+source = "git+https://github.com/worldcoin/ampc-common.git?rev=34170ed878ea13ab59170b2d1741407e5c8c53eb#34170ed878ea13ab59170b2d1741407e5c8c53eb"
 dependencies = [
  "aes-prng",
  "base64",
@@ -153,7 +153,7 @@ dependencies = [
 [[package]]
 name = "ampc-server-utils"
 version = "0.1.0"
-source = "git+https://github.com/worldcoin/ampc-common.git?rev=2dc1f945f609d718c5e35eace83d9a1f57e4ee11#2dc1f945f609d718c5e35eace83d9a1f57e4ee11"
+source = "git+https://github.com/worldcoin/ampc-common.git?rev=34170ed878ea13ab59170b2d1741407e5c8c53eb#34170ed878ea13ab59170b2d1741407e5c8c53eb"
 dependencies = [
  "aws-sdk-secretsmanager",
  "aws-sdk-sqs",
@@ -4611,7 +4611,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -4644,7 +4644,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,10 +86,10 @@ tokio-util = "0.7.15"
 toml = { version = "0.8.23", features = ["preserve_order"] }
 uuid = { version = "1", features = ["v4"] }
 iris-mpc-cpu = { path = "./iris-mpc-cpu" }
-ampc-anon-stats = { git = "https://github.com/worldcoin/ampc-common.git", rev = "2dc1f945f609d718c5e35eace83d9a1f57e4ee11" }
-ampc-actor-utils = { git = "https://github.com/worldcoin/ampc-common.git", rev = "2dc1f945f609d718c5e35eace83d9a1f57e4ee11" }
-ampc-secret-sharing = { git = "https://github.com/worldcoin/ampc-common.git", rev = "2dc1f945f609d718c5e35eace83d9a1f57e4ee11" }
-ampc-server-utils = { git = "https://github.com/worldcoin/ampc-common.git", rev = "2dc1f945f609d718c5e35eace83d9a1f57e4ee11" }
+ampc-anon-stats = { git = "https://github.com/worldcoin/ampc-common.git", rev = "34170ed878ea13ab59170b2d1741407e5c8c53eb" }
+ampc-actor-utils = { git = "https://github.com/worldcoin/ampc-common.git", rev = "34170ed878ea13ab59170b2d1741407e5c8c53eb" }
+ampc-secret-sharing = { git = "https://github.com/worldcoin/ampc-common.git", rev = "34170ed878ea13ab59170b2d1741407e5c8c53eb" }
+ampc-server-utils = { git = "https://github.com/worldcoin/ampc-common.git", rev = "34170ed878ea13ab59170b2d1741407e5c8c53eb" }
 
 # Abort on panics rather than unwinding.
 # This improves performance and makes panic propagation more reliable.


### PR DESCRIPTION
Bumps the pinned `worldcoin/ampc-common` rev (all 4 deps) `2dc1f94` → `34170ed`, picking up worldcoin/ampc-common#118: `/health`, `/ready`, and batch-sync peer-convergence logs demoted to debug.

Cargo.toml + Cargo.lock only. Builds clean. Commit verified as the merge of PR #118 on ampc-common main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)