### PR TITLE
Speed up streaming checkpoint restore

### DIFF
--- a/iris-mpc-cpu/src/execution/hawk_main/state_check.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/state_check.rs
@@ -97,6 +97,13 @@ impl SetHash {
         self.accumulator
     }
 
+    /// Reconstruct from a precomputed accumulator, e.g. the wrapping-sum of
+    /// per-chunk checksums from a parallel fold. Sound because the fold is
+    /// associative and commutative.
+    pub(crate) fn from_accumulator(accumulator: u64) -> Self {
+        Self { accumulator }
+    }
+
     pub(crate) fn hash(value: impl Hash) -> u64 {
         let mut hasher = SipHasher13::default();
         value.hash(&mut hasher);

--- a/iris-mpc-cpu/src/graph_checkpoint/s3_client/streaming_download.rs
+++ b/iris-mpc-cpu/src/graph_checkpoint/s3_client/streaming_download.rs
@@ -14,20 +14,19 @@
 //!
 //! Compare to [`super::multipart::download_graph`], which uses parallel
 //! range GETs into a `BytesMut` and returns a fully buffered `Bytes`. The
-//! streaming path takes one range at a time — slower in aggregate, but the
-//! deserialized value never coexists in memory with a fully buffered copy
-//! of the bytes.
+//! streaming path fans out the same way (see [`DEFAULT_DOWNLOAD_PARALLELISM`])
+//! but emits ranges in order into a bounded pipe, so the deserialized value
+//! never coexists in memory with a fully buffered copy of the bytes.
 //!
 //! # Range cadence and retry
 //!
-//! The download is split into `⌈size / range_size⌉` sequential range GETs
-//! (`Range: bytes=START-END`). Each range is fetched independently and
-//! retried up to [`RANGE_MAX_RETRIES`] times with [`RANGE_RETRY_DELAY`]
-//! between attempts before it bubbles up as a fatal error. Transient
-//! network errors thus cost at most one range re-fetch, not a full
-//! restart of the download — which is the property the buffered
-//! parallel-range path also has, kept here without paying for an
-//! out-of-order reassembly buffer.
+//! The download is split into `⌈size / range_size⌉` range GETs
+//! (`Range: bytes=START-END`), up to [`DEFAULT_DOWNLOAD_PARALLELISM`] in
+//! flight at once and emitted in ascending offset order. Each range is
+//! fetched independently and retried up to [`RANGE_MAX_RETRIES`] times with
+//! [`RANGE_RETRY_DELAY`] between attempts before it bubbles up as a fatal
+//! error. Transient network errors thus cost at most one range re-fetch,
+//! not a full restart of the download.
 //!
 //! The `head_object` size probe is subject to the same per-attempt retry.
 //!
@@ -46,7 +45,7 @@ use std::time::Duration;
 use aws_sdk_s3::Client as S3Client;
 use bytes::Bytes;
 use eyre::{eyre, Result};
-use futures::stream::{self, Stream};
+use futures::stream::{self, Stream, StreamExt};
 use serde::de::DeserializeOwned;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
 use tokio::time::sleep;
@@ -68,8 +67,22 @@ pub const DEFAULT_DOWNLOAD_PIPE_CAPACITY: usize = 8 * 1024 * 1024;
 
 /// Default per-range fetch size. Each range becomes one `GetObject` with
 /// a `Range` header. Larger ⇒ fewer requests, more work to redo on a
-/// flaky range; smaller ⇒ more requests, finer-grained retry.
-pub const DEFAULT_DOWNLOAD_RANGE_SIZE: usize = 64 * 1024 * 1024;
+/// flaky range; smaller ⇒ more requests, finer-grained retry. With
+/// [`DEFAULT_DOWNLOAD_PARALLELISM`] in-flight, peak download buffering is
+/// roughly `parallelism * range_size`.
+pub const DEFAULT_DOWNLOAD_RANGE_SIZE: usize = 16 * 1024 * 1024;
+
+/// Default number of range GETs kept in flight concurrently. Results are
+/// emitted to the deserializer in offset order, so this bounds throughput
+/// without unbounding memory: peak buffered bytes ≈ `parallelism *
+/// range_size` (here ~512 MB). Mirrors the buffered path's 32-way fan-out,
+/// which sustains ~1.2 GB/s.
+pub const DEFAULT_DOWNLOAD_PARALLELISM: usize = 32;
+
+/// Buffer placed between the bincode graph decoder and the `SyncIoBridge`
+/// over the duplex pipe. bincode issues many small reads per node; without
+/// this each one would block across the async bridge individually.
+const GRAPH_DECODE_BUFFER: usize = 1024 * 1024;
 
 /// Stream the object at `s3://{bucket}/{key}` through BLAKE3 and bincode
 /// in one pass. Returns the deserialized value and the BLAKE3 digest of
@@ -92,6 +105,7 @@ where
         key,
         DEFAULT_DOWNLOAD_PIPE_CAPACITY,
         DEFAULT_DOWNLOAD_RANGE_SIZE,
+        DEFAULT_DOWNLOAD_PARALLELISM,
     )
     .await
 }
@@ -102,13 +116,14 @@ pub async fn stream_download_and_deserialize_with<T>(
     key: &str,
     pipe_capacity: usize,
     range_size: usize,
+    parallelism: usize,
 ) -> Result<(T, [u8; 32])>
 where
     T: DeserializeOwned + Send + 'static,
 {
     tracing::info!(
         "Streaming download + deserialize: bucket={bucket}, key={key}, \
-         pipe_capacity={pipe_capacity}, range_size={range_size}"
+         pipe_capacity={pipe_capacity}, range_size={range_size}, parallelism={parallelism}"
     );
 
     if range_size == 0 {
@@ -117,14 +132,13 @@ where
 
     let total_size = head_object_size_with_retry(s3_client, bucket, key).await?;
 
-    // `stream::unfold`'s state machine is `!Unpin`; `StreamReader` needs
-    // `Unpin`. Pin the boxed stream once and feed it through.
     let stream = Box::pin(range_stream(
         s3_client.clone(),
         bucket.to_string(),
         key.to_string(),
         total_size,
         range_size as u64,
+        parallelism,
     ));
     let reader = StreamReader::new(stream);
     deserialize_and_hash_from(reader, pipe_capacity).await
@@ -153,12 +167,13 @@ pub async fn stream_download_and_deserialize_graph_pair(
         format,
         DEFAULT_DOWNLOAD_PIPE_CAPACITY,
         DEFAULT_DOWNLOAD_RANGE_SIZE,
+        DEFAULT_DOWNLOAD_PARALLELISM,
     )
     .await
 }
 
 /// Like [`stream_download_and_deserialize_graph_pair`] but with explicit
-/// `pipe_capacity` and `range_size` knobs.
+/// `pipe_capacity`, `range_size`, and `parallelism` knobs.
 pub async fn stream_download_and_deserialize_graph_pair_with(
     s3_client: &S3Client,
     bucket: &str,
@@ -166,10 +181,12 @@ pub async fn stream_download_and_deserialize_graph_pair_with(
     format: GraphFormat,
     pipe_capacity: usize,
     range_size: usize,
+    parallelism: usize,
 ) -> Result<([GraphMem; 2], [u8; 32])> {
     tracing::info!(
         "Streaming download + deserialize graph pair: bucket={bucket}, key={key}, \
-         format={format}, pipe_capacity={pipe_capacity}, range_size={range_size}"
+         format={format}, pipe_capacity={pipe_capacity}, range_size={range_size}, \
+         parallelism={parallelism}"
     );
 
     if range_size == 0 {
@@ -187,10 +204,15 @@ pub async fn stream_download_and_deserialize_graph_pair_with(
         key.to_string(),
         total_size,
         range_size as u64,
+        parallelism,
     ));
     let reader = StreamReader::new(stream);
     deserialize_and_hash_from_fn(reader, pipe_capacity, move |r| {
-        read_graph_pair_streaming(r, format)
+        // bincode reads the graph field-by-field (count, then per-entry
+        // VectorId + edge Vec); without buffering each tiny read blocks
+        // across the duplex via SyncIoBridge — ~10x slower at prod scale.
+        let mut buf = std::io::BufReader::with_capacity(GRAPH_DECODE_BUFFER, r);
+        read_graph_pair_streaming(&mut buf, format)
     })
     .await
 }
@@ -223,49 +245,47 @@ async fn head_object_size_with_retry(s3_client: &S3Client, bucket: &str, key: &s
     }
 }
 
-/// Produce ranges of the object in ascending offset order, one at a time.
-/// Each yielded `Bytes` is the complete body of one `GetObject(Range)`;
-/// the next range is not requested until the consumer pulls again, so the
-/// duplex pipe's back-pressure naturally throttles fetch cadence.
+/// Produce the object's ranges in ascending offset order, keeping up to
+/// `parallelism` `GetObject(Range)` requests in flight at once. `buffered`
+/// preserves emission order regardless of completion order, so the
+/// downstream `StreamReader` sees a contiguous byte stream while up to
+/// `parallelism * range_size` bytes are buffered in flight.
 ///
-/// Per-range retry is internal to each `unfold` step. After
-/// [`RANGE_MAX_RETRIES`] failures on a single range, the stream emits an
-/// `Err` and ends — the downstream `StreamReader` will then surface the
-/// error to its reader.
+/// Per-range retry is internal to [`fetch_range`]. After [`RANGE_MAX_RETRIES`]
+/// failures on a single range, that range yields an `Err`; the downstream
+/// `StreamReader` fuses on the first `Err` and surfaces it to its reader,
+/// at which point the dropped stream cancels any still-in-flight fetches.
 fn range_stream(
     s3_client: S3Client,
     bucket: String,
     key: String,
     total_size: u64,
     range_size: u64,
+    parallelism: usize,
 ) -> impl Stream<Item = std::io::Result<Bytes>> {
-    stream::unfold(0u64, move |offset| {
-        let s3_client = s3_client.clone();
-        let bucket = bucket.clone();
-        let key = key.clone();
-        async move {
-            if offset >= total_size {
-                return None;
-            }
-            let end_inclusive = std::cmp::min(offset + range_size, total_size) - 1;
-            let range = format!("bytes={offset}-{end_inclusive}");
-            let next_offset = end_inclusive + 1;
+    let mut ranges = Vec::new();
+    let mut offset = 0u64;
+    while offset < total_size {
+        let end_inclusive = std::cmp::min(offset + range_size, total_size) - 1;
+        ranges.push((offset, end_inclusive));
+        offset = end_inclusive + 1;
+    }
 
-            match fetch_range(&s3_client, &bucket, &key, &range).await {
-                Ok(bytes) => Some((Ok(bytes), next_offset)),
-                Err(e) => Some((
-                    Err(std::io::Error::other(format!(
-                        "range {range} of s3://{bucket}/{key}: {e}"
-                    ))),
-                    // Offset value is irrelevant — stream terminates after
-                    // yielding the error since StreamReader fuses on first
-                    // Err. We pass `total_size` so a buggy continuation
-                    // would short-circuit immediately.
-                    total_size,
-                )),
+    stream::iter(ranges)
+        .map(move |(start, end_inclusive)| {
+            let s3_client = s3_client.clone();
+            let bucket = bucket.clone();
+            let key = key.clone();
+            async move {
+                let range = format!("bytes={start}-{end_inclusive}");
+                fetch_range(&s3_client, &bucket, &key, &range)
+                    .await
+                    .map_err(|e| {
+                        std::io::Error::other(format!("range {range} of s3://{bucket}/{key}: {e}"))
+                    })
             }
-        }
-    })
+        })
+        .buffered(parallelism.max(1))
 }
 
 /// Fetch one S3 range. Buffers the response body in memory so a mid-body

--- a/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
@@ -644,6 +644,26 @@ impl Layer {
         }
     }
 
+    /// Build a layer from a fully-populated link map, computing `set_hash` in
+    /// parallel over the entries. The fold is wrapping addition (associative +
+    /// commutative), so per-chunk partials combine into the exact checksum a
+    /// serial sequence of [`Self::set_links`] would produce — at prod scale
+    /// this is ~10x faster than rehashing every edge on insert.
+    pub fn from_links(links: HashMap<VectorId, Vec<VectorId>>) -> Self {
+        let accumulator = (&links)
+            .into_par_iter()
+            .fold(SetHash::default, |mut sh, (k, v)| {
+                sh.add_unordered_set(k, v.iter());
+                sh
+            })
+            .map(|sh| sh.checksum())
+            .reduce(|| 0u64, |a, b| a.wrapping_add(b));
+        Layer {
+            links,
+            set_hash: SetHash::from_accumulator(accumulator),
+        }
+    }
+
     pub fn get_links(&self, from: &VectorId) -> Option<&[VectorId]> {
         self.links.get(from).map(|v| v.as_slice())
     }

--- a/iris-mpc-cpu/src/utils/serialization/graph.rs
+++ b/iris-mpc-cpu/src/utils/serialization/graph.rs
@@ -540,14 +540,15 @@ impl From<graph_v3::EntryPoint> for layered_graph::EntryPoint {
 
 impl From<graph_v3::Layer> for Layer {
     fn from(value: graph_v3::Layer) -> Self {
-        // Recompute set_hash via set_links rather than trusting the stored
-        // value: older checkpoints carry a set_hash from a prior fold algorithm.
-        // Pre-size the map so the bulk insert doesn't rehash.
-        let mut layer = Layer::with_capacity(value.links.len());
-        for (v, nb) in value.links.into_iter() {
-            layer.set_links(v.into(), nb.0.into_iter().map(|x| x.into()).collect());
-        }
-        layer
+        // Recompute set_hash rather than trusting the stored value: older
+        // checkpoints carry a set_hash from a prior fold algorithm. Build the
+        // map, then fold the checksum in parallel (see `Layer::from_links`).
+        let links = value
+            .links
+            .into_iter()
+            .map(|(v, nb)| (v.into(), nb.0.into_iter().map(|x| x.into()).collect()))
+            .collect();
+        Layer::from_links(links)
     }
 }
 
@@ -581,12 +582,13 @@ impl From<graph_v4::EntryPoint> for layered_graph::EntryPoint {
 
 impl From<graph_v4::Layer> for Layer {
     fn from(value: graph_v4::Layer) -> Self {
-        // See `From<graph_v3::Layer>`: recompute set_hash, pre-sized map.
-        let mut layer = Layer::with_capacity(value.links.len());
-        for (v, nb) in value.links.into_iter() {
-            layer.set_links(v.into(), nb.0.into_iter().map(|x| x.into()).collect());
-        }
-        layer
+        // See `From<graph_v3::Layer>`: recompute set_hash via parallel fold.
+        let links = value
+            .links
+            .into_iter()
+            .map(|(v, nb)| (v.into(), nb.0.into_iter().map(|x| x.into()).collect()))
+            .collect();
+        Layer::from_links(links)
     }
 }
 

--- a/iris-mpc-cpu/tests/streaming_s3_integration.rs
+++ b/iris-mpc-cpu/tests/streaming_s3_integration.rs
@@ -210,6 +210,7 @@ async fn streaming_download_round_trip() -> Result<()> {
         key,
         4 * 1024 * 1024,
         3 * 1024 * 1024,
+        4,
     )
     .await;
     cleanup_bucket(&client, &bucket).await;


### PR DESCRIPTION
## What

Make the streaming graph-checkpoint restore path fast. It's used by **Genesis startup**, db-sanity-check, and the sidecar (hawk-main restart already uses the buffered path from #2229). At prod scale (17.4M nodes/eye, M=320, 93.6 GB pair) it took >20 min.

## Profile

Local harness, N=500K nodes/eye, degree 475 (35× → prod, all costs linear):

| stage | local | prod est |
|---|---|---|
| buffered `read_graph_pair` (decode+From) | 2.6s | ~91s |
| streaming via `SyncIoBridge`, **no BufReader** (today) | 34.8s | **~1211s (~20min)** |
| streaming via `SyncIoBridge`, **1 MB BufReader** | 3.0s | ~105s |
| `set_hash` recompute alone (inside From) | 0.55s | ~19s |
| `set_hash` parallelized (rayon) | 0.056s | ~1.9s |

The slowness was **not** the network: the old 19 MB/s was back-pressure from the unbuffered bridge. bincode issues millions of tiny reads, each blocking across the duplex individually.

## Changes

- **BufReader** between the bincode decoder and `SyncIoBridge` (~11×).
- **Bounded parallel-range download**: `range_stream` keeps `DEFAULT_DOWNLOAD_PARALLELISM=32` range GETs in flight via `buffered()` (emitted in offset order), 16 MB ranges → ~512 MB bounded window. Mirrors the buffered path's 32-way fan-out (~1.2 GB/s) but streams in order into the pipe, so the full object never coexists in RAM with the deserialized graph.
- **Parallel `set_hash`**: `Layer::from_links` builds the map then folds the checksum with rayon. Wrapping-add is associative + commutative, so per-chunk partials sum to the **bit-identical** checksum (the two pinned `set_hash` tests pass). `From<graph_v{3,4}::Layer>` use it; this also speeds the buffered hawk-main restart path.

## Expected

Prod restore: >20 min → **download (~78s) overlapped with decode (~80s) ≈ ~80–90s wall**, at bounded ~512 MB instead of holding all 93 GB in RAM. New floor is the serial bincode decode (~65s).

## Validation

- cpu lib builds; serialization + layered_graph + state_check tests green; fmt + clippy clean.
- ⚠️ **Download throughput (the parallel fan-out) is not validatable locally (no S3) — needs a dev/prod-scale run** to confirm it saturates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)