### PR TITLE
deploy(retention): migrate to common-cronjob 1.11.0 env map format

### DIFF
--- a/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw-anon-stats-retention.yaml
+++ b/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw-anon-stats-retention.yaml
@@ -1,34 +1,26 @@
 # POP-3905 — anon-stats retention (retention-reaper), ampc-hnsw party 0 (stage). Per-node.
 # Generic RETENTION__* config (config crate, __ separator) — same mechanics as SMPC__.
 # Schema anon_stats_mpc matches anon-stats-server; guard=processed=TRUE reaps only collected rows.
+# env uses the common-cronjob 1.11.0 map format (renderEnv): scalars → value, valueFrom → valueFrom.
 env:
-  - name: RUST_LOG
-    value: "info"
-  - name: RETENTION__DB_URL
+  RUST_LOG: "info"
+  RETENTION__DB_SCHEMA: "anon_stats_mpc"
+  RETENTION__PARTY: "0"
+  RETENTION__SERVICE__SERVICE_NAME: "retention-reaper-anon-stats-hnsw-0"
+  RETENTION__SERVICE__METRICS__PORT: "8125"
+  RETENTION__SERVICE__METRICS__QUEUE_SIZE: "5000"
+  RETENTION__SERVICE__METRICS__BUFFER_SIZE: "256"
+  RETENTION__SERVICE__METRICS__PREFIX: "retention-reaper-anon-stats-hnsw-0"
+  RETENTION__DB_URL:
     valueFrom:
       secretKeyRef:
-        key: DATABASE_AURORA_URL
         name: application
-  - name: RETENTION__DB_SCHEMA
-    value: "anon_stats_mpc"
-  - name: RETENTION__PARTY
-    value: "0"
-  - name: RETENTION__SERVICE__SERVICE_NAME
-    value: "retention-reaper-anon-stats-hnsw-0"
-  - name: RETENTION__SERVICE__METRICS__HOST
+        key: DATABASE_AURORA_URL
+  RETENTION__SERVICE__METRICS__HOST:
     valueFrom:
       fieldRef:
         fieldPath: status.hostIP
-  - name: RETENTION__SERVICE__METRICS__PORT
-    value: "8125"
-  - name: RETENTION__SERVICE__METRICS__QUEUE_SIZE
-    value: "5000"
-  - name: RETENTION__SERVICE__METRICS__BUFFER_SIZE
-    value: "256"
-  - name: RETENTION__SERVICE__METRICS__PREFIX
-    value: "retention-reaper-anon-stats-hnsw-0"
-  - name: RETENTION_JOBS
-    value: '[{"table":"anon_stats_1d","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_1d_lifted","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_2d","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_2d_lifted","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_face","retention":"14 days","guard":"processed = TRUE"}]'
+  RETENTION_JOBS: '[{"table":"anon_stats_1d","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_1d_lifted","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_2d","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_2d_lifted","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_face","retention":"14 days","guard":"processed = TRUE"}]'
 
 # Lets the pod reach the anon-stats Aurora — mirrors ampc-hnsw-anon-stats-server (same DB, same SG).
 attachSecurityGroupPolicy:

--- a/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw-anon-stats-retention.yaml
+++ b/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw-anon-stats-retention.yaml
@@ -1,34 +1,26 @@
 # POP-3905 — anon-stats retention (retention-reaper), ampc-hnsw party 1 (stage). Per-node.
 # Generic RETENTION__* config (config crate, __ separator) — same mechanics as SMPC__.
 # Schema anon_stats_mpc matches anon-stats-server; guard=processed=TRUE reaps only collected rows.
+# env uses the common-cronjob 1.11.0 map format (renderEnv): scalars → value, valueFrom → valueFrom.
 env:
-  - name: RUST_LOG
-    value: "info"
-  - name: RETENTION__DB_URL
+  RUST_LOG: "info"
+  RETENTION__DB_SCHEMA: "anon_stats_mpc"
+  RETENTION__PARTY: "1"
+  RETENTION__SERVICE__SERVICE_NAME: "retention-reaper-anon-stats-hnsw-1"
+  RETENTION__SERVICE__METRICS__PORT: "8125"
+  RETENTION__SERVICE__METRICS__QUEUE_SIZE: "5000"
+  RETENTION__SERVICE__METRICS__BUFFER_SIZE: "256"
+  RETENTION__SERVICE__METRICS__PREFIX: "retention-reaper-anon-stats-hnsw-1"
+  RETENTION__DB_URL:
     valueFrom:
       secretKeyRef:
-        key: DATABASE_AURORA_URL
         name: application
-  - name: RETENTION__DB_SCHEMA
-    value: "anon_stats_mpc"
-  - name: RETENTION__PARTY
-    value: "1"
-  - name: RETENTION__SERVICE__SERVICE_NAME
-    value: "retention-reaper-anon-stats-hnsw-1"
-  - name: RETENTION__SERVICE__METRICS__HOST
+        key: DATABASE_AURORA_URL
+  RETENTION__SERVICE__METRICS__HOST:
     valueFrom:
       fieldRef:
         fieldPath: status.hostIP
-  - name: RETENTION__SERVICE__METRICS__PORT
-    value: "8125"
-  - name: RETENTION__SERVICE__METRICS__QUEUE_SIZE
-    value: "5000"
-  - name: RETENTION__SERVICE__METRICS__BUFFER_SIZE
-    value: "256"
-  - name: RETENTION__SERVICE__METRICS__PREFIX
-    value: "retention-reaper-anon-stats-hnsw-1"
-  - name: RETENTION_JOBS
-    value: '[{"table":"anon_stats_1d","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_1d_lifted","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_2d","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_2d_lifted","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_face","retention":"14 days","guard":"processed = TRUE"}]'
+  RETENTION_JOBS: '[{"table":"anon_stats_1d","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_1d_lifted","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_2d","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_2d_lifted","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_face","retention":"14 days","guard":"processed = TRUE"}]'
 
 # Lets the pod reach the anon-stats Aurora — mirrors ampc-hnsw-anon-stats-server (same DB, same SG).
 attachSecurityGroupPolicy:

--- a/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw-anon-stats-retention.yaml
+++ b/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw-anon-stats-retention.yaml
@@ -1,34 +1,26 @@
 # POP-3905 — anon-stats retention (retention-reaper), ampc-hnsw party 2 (stage). Per-node.
 # Generic RETENTION__* config (config crate, __ separator) — same mechanics as SMPC__.
 # Schema anon_stats_mpc matches anon-stats-server; guard=processed=TRUE reaps only collected rows.
+# env uses the common-cronjob 1.11.0 map format (renderEnv): scalars → value, valueFrom → valueFrom.
 env:
-  - name: RUST_LOG
-    value: "info"
-  - name: RETENTION__DB_URL
+  RUST_LOG: "info"
+  RETENTION__DB_SCHEMA: "anon_stats_mpc"
+  RETENTION__PARTY: "2"
+  RETENTION__SERVICE__SERVICE_NAME: "retention-reaper-anon-stats-hnsw-2"
+  RETENTION__SERVICE__METRICS__PORT: "8125"
+  RETENTION__SERVICE__METRICS__QUEUE_SIZE: "5000"
+  RETENTION__SERVICE__METRICS__BUFFER_SIZE: "256"
+  RETENTION__SERVICE__METRICS__PREFIX: "retention-reaper-anon-stats-hnsw-2"
+  RETENTION__DB_URL:
     valueFrom:
       secretKeyRef:
-        key: DATABASE_AURORA_URL
         name: application
-  - name: RETENTION__DB_SCHEMA
-    value: "anon_stats_mpc"
-  - name: RETENTION__PARTY
-    value: "2"
-  - name: RETENTION__SERVICE__SERVICE_NAME
-    value: "retention-reaper-anon-stats-hnsw-2"
-  - name: RETENTION__SERVICE__METRICS__HOST
+        key: DATABASE_AURORA_URL
+  RETENTION__SERVICE__METRICS__HOST:
     valueFrom:
       fieldRef:
         fieldPath: status.hostIP
-  - name: RETENTION__SERVICE__METRICS__PORT
-    value: "8125"
-  - name: RETENTION__SERVICE__METRICS__QUEUE_SIZE
-    value: "5000"
-  - name: RETENTION__SERVICE__METRICS__BUFFER_SIZE
-    value: "256"
-  - name: RETENTION__SERVICE__METRICS__PREFIX
-    value: "retention-reaper-anon-stats-hnsw-2"
-  - name: RETENTION_JOBS
-    value: '[{"table":"anon_stats_1d","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_1d_lifted","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_2d","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_2d_lifted","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_face","retention":"14 days","guard":"processed = TRUE"}]'
+  RETENTION_JOBS: '[{"table":"anon_stats_1d","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_1d_lifted","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_2d","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_2d_lifted","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_face","retention":"14 days","guard":"processed = TRUE"}]'
 
 # Lets the pod reach the anon-stats Aurora — mirrors ampc-hnsw-anon-stats-server (same DB, same SG).
 attachSecurityGroupPolicy:

--- a/deploy/stage/common-values-ampc-hnsw-anon-stats-retention.yaml
+++ b/deploy/stage/common-values-ampc-hnsw-anon-stats-retention.yaml
@@ -1,6 +1,7 @@
-# POP-3905 — anon-stats retention CronJob (stage, ampc-hnsw). common-cronjob chart (1.8.5)
-# via wf-cluster-apps, mirroring ampc-hnsw-db-exporter. Per-cluster env + the
-# attachSecurityGroupPolicy that lets the pod reach the anon-stats Aurora live per-node.
+# POP-3905 — anon-stats retention CronJob (stage, ampc-hnsw). common-cronjob chart (1.11.0,
+# worldcoin-foundation/common-cronjob) via wf-cluster-apps, mirroring ampc-hnsw-db-exporter.
+# Per-cluster env (map format) + the attachSecurityGroupPolicy that lets the pod reach the
+# anon-stats Aurora live per-node.
 image: "ghcr.io/worldcoin/retention-reaper:latest"
 
 replicaCount: 1

--- a/deploy/stage/common-values-anon-stats-retention.yaml
+++ b/deploy/stage/common-values-anon-stats-retention.yaml
@@ -1,6 +1,6 @@
 # POP-3905 — anon-stats retention CronJob (stage, smpcv2). Uses the common-cronjob chart
-# (chartVersion 1.8.5) via wf-cluster-apps, mirroring iris-mpc-db-exporter. Per-cluster env
-# (RETENTION__*) lives in the per-node values files.
+# (chartVersion 1.11.0, worldcoin-foundation/common-cronjob) via wf-cluster-apps, mirroring
+# iris-mpc-db-exporter. Per-cluster env (RETENTION__*, map format) lives in the per-node values files.
 image: "ghcr.io/worldcoin/retention-reaper:latest"
 
 replicaCount: 1

--- a/deploy/stage/smpcv2-0-stage/values-anon-stats-retention.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-anon-stats-retention.yaml
@@ -2,31 +2,23 @@
 # Generic RETENTION__* config via the config crate (prefix + __ separator + try_deserialize),
 # same mechanics as the servers' SMPC__* config. Schema anon_stats_mpc matches
 # anon-stats-server; guard=processed=TRUE reaps only collected rows.
+# env uses the common-cronjob 1.11.0 map format (renderEnv): scalars → value, valueFrom → valueFrom.
 env:
-  - name: RUST_LOG
-    value: "info"
-  - name: RETENTION__DB_URL
+  RUST_LOG: "info"
+  RETENTION__DB_SCHEMA: "anon_stats_mpc"
+  RETENTION__PARTY: "0"
+  RETENTION__SERVICE__SERVICE_NAME: "retention-reaper-anon-stats-smpcv2-0"
+  RETENTION__SERVICE__METRICS__PORT: "8125"
+  RETENTION__SERVICE__METRICS__QUEUE_SIZE: "5000"
+  RETENTION__SERVICE__METRICS__BUFFER_SIZE: "256"
+  RETENTION__SERVICE__METRICS__PREFIX: "retention-reaper-anon-stats-smpcv2-0"
+  RETENTION__DB_URL:
     valueFrom:
       secretKeyRef:
-        key: DATABASE_AURORA_URL
         name: application
-  - name: RETENTION__DB_SCHEMA
-    value: "anon_stats_mpc"
-  - name: RETENTION__PARTY
-    value: "0"
-  - name: RETENTION__SERVICE__SERVICE_NAME
-    value: "retention-reaper-anon-stats-smpcv2-0"
-  - name: RETENTION__SERVICE__METRICS__HOST
+        key: DATABASE_AURORA_URL
+  RETENTION__SERVICE__METRICS__HOST:
     valueFrom:
       fieldRef:
         fieldPath: status.hostIP
-  - name: RETENTION__SERVICE__METRICS__PORT
-    value: "8125"
-  - name: RETENTION__SERVICE__METRICS__QUEUE_SIZE
-    value: "5000"
-  - name: RETENTION__SERVICE__METRICS__BUFFER_SIZE
-    value: "256"
-  - name: RETENTION__SERVICE__METRICS__PREFIX
-    value: "retention-reaper-anon-stats-smpcv2-0"
-  - name: RETENTION_JOBS
-    value: '[{"table":"anon_stats_1d","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_1d_lifted","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_2d","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_2d_lifted","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_face","retention":"14 days","guard":"processed = TRUE"}]'
+  RETENTION_JOBS: '[{"table":"anon_stats_1d","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_1d_lifted","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_2d","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_2d_lifted","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_face","retention":"14 days","guard":"processed = TRUE"}]'

--- a/deploy/stage/smpcv2-1-stage/values-anon-stats-retention.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-anon-stats-retention.yaml
@@ -2,31 +2,23 @@
 # Generic RETENTION__* config via the config crate (prefix + __ separator + try_deserialize),
 # same mechanics as the servers' SMPC__* config. Schema anon_stats_mpc matches
 # anon-stats-server; guard=processed=TRUE reaps only collected rows.
+# env uses the common-cronjob 1.11.0 map format (renderEnv): scalars → value, valueFrom → valueFrom.
 env:
-  - name: RUST_LOG
-    value: "info"
-  - name: RETENTION__DB_URL
+  RUST_LOG: "info"
+  RETENTION__DB_SCHEMA: "anon_stats_mpc"
+  RETENTION__PARTY: "1"
+  RETENTION__SERVICE__SERVICE_NAME: "retention-reaper-anon-stats-smpcv2-1"
+  RETENTION__SERVICE__METRICS__PORT: "8125"
+  RETENTION__SERVICE__METRICS__QUEUE_SIZE: "5000"
+  RETENTION__SERVICE__METRICS__BUFFER_SIZE: "256"
+  RETENTION__SERVICE__METRICS__PREFIX: "retention-reaper-anon-stats-smpcv2-1"
+  RETENTION__DB_URL:
     valueFrom:
       secretKeyRef:
-        key: DATABASE_AURORA_URL
         name: application
-  - name: RETENTION__DB_SCHEMA
-    value: "anon_stats_mpc"
-  - name: RETENTION__PARTY
-    value: "1"
-  - name: RETENTION__SERVICE__SERVICE_NAME
-    value: "retention-reaper-anon-stats-smpcv2-1"
-  - name: RETENTION__SERVICE__METRICS__HOST
+        key: DATABASE_AURORA_URL
+  RETENTION__SERVICE__METRICS__HOST:
     valueFrom:
       fieldRef:
         fieldPath: status.hostIP
-  - name: RETENTION__SERVICE__METRICS__PORT
-    value: "8125"
-  - name: RETENTION__SERVICE__METRICS__QUEUE_SIZE
-    value: "5000"
-  - name: RETENTION__SERVICE__METRICS__BUFFER_SIZE
-    value: "256"
-  - name: RETENTION__SERVICE__METRICS__PREFIX
-    value: "retention-reaper-anon-stats-smpcv2-1"
-  - name: RETENTION_JOBS
-    value: '[{"table":"anon_stats_1d","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_1d_lifted","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_2d","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_2d_lifted","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_face","retention":"14 days","guard":"processed = TRUE"}]'
+  RETENTION_JOBS: '[{"table":"anon_stats_1d","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_1d_lifted","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_2d","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_2d_lifted","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_face","retention":"14 days","guard":"processed = TRUE"}]'

--- a/deploy/stage/smpcv2-2-stage/values-anon-stats-retention.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-anon-stats-retention.yaml
@@ -2,31 +2,23 @@
 # Generic RETENTION__* config via the config crate (prefix + __ separator + try_deserialize),
 # same mechanics as the servers' SMPC__* config. Schema anon_stats_mpc matches
 # anon-stats-server; guard=processed=TRUE reaps only collected rows.
+# env uses the common-cronjob 1.11.0 map format (renderEnv): scalars → value, valueFrom → valueFrom.
 env:
-  - name: RUST_LOG
-    value: "info"
-  - name: RETENTION__DB_URL
+  RUST_LOG: "info"
+  RETENTION__DB_SCHEMA: "anon_stats_mpc"
+  RETENTION__PARTY: "2"
+  RETENTION__SERVICE__SERVICE_NAME: "retention-reaper-anon-stats-smpcv2-2"
+  RETENTION__SERVICE__METRICS__PORT: "8125"
+  RETENTION__SERVICE__METRICS__QUEUE_SIZE: "5000"
+  RETENTION__SERVICE__METRICS__BUFFER_SIZE: "256"
+  RETENTION__SERVICE__METRICS__PREFIX: "retention-reaper-anon-stats-smpcv2-2"
+  RETENTION__DB_URL:
     valueFrom:
       secretKeyRef:
-        key: DATABASE_AURORA_URL
         name: application
-  - name: RETENTION__DB_SCHEMA
-    value: "anon_stats_mpc"
-  - name: RETENTION__PARTY
-    value: "2"
-  - name: RETENTION__SERVICE__SERVICE_NAME
-    value: "retention-reaper-anon-stats-smpcv2-2"
-  - name: RETENTION__SERVICE__METRICS__HOST
+        key: DATABASE_AURORA_URL
+  RETENTION__SERVICE__METRICS__HOST:
     valueFrom:
       fieldRef:
         fieldPath: status.hostIP
-  - name: RETENTION__SERVICE__METRICS__PORT
-    value: "8125"
-  - name: RETENTION__SERVICE__METRICS__QUEUE_SIZE
-    value: "5000"
-  - name: RETENTION__SERVICE__METRICS__BUFFER_SIZE
-    value: "256"
-  - name: RETENTION__SERVICE__METRICS__PREFIX
-    value: "retention-reaper-anon-stats-smpcv2-2"
-  - name: RETENTION_JOBS
-    value: '[{"table":"anon_stats_1d","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_1d_lifted","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_2d","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_2d_lifted","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_face","retention":"14 days","guard":"processed = TRUE"}]'
+  RETENTION_JOBS: '[{"table":"anon_stats_1d","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_1d_lifted","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_2d","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_2d_lifted","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_face","retention":"14 days","guard":"processed = TRUE"}]'


### PR DESCRIPTION
Convert the 6 per-cluster anon-stats-retention values from the env list to the map format supported by worldcoin-foundation/common-cronjob 1.11.0 (renderEnv helper). valueFrom (secretKeyRef/fieldRef) preserved; RETENTION_JOBS stays a JSON string; hnsw attachSecurityGroupPolicy unchanged. Verified with helm template against the 1.11.0 chart (valid YAML, all RETENTION__* present, SecurityGroupPolicy renders, DD_* injected). Chart bump lives in wf-cluster-apps.