### PR TITLE
graph_v5: version-carrying content clock + WAL-explicit stale drops

### DIFF
--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -2513,9 +2513,9 @@ mod hawk_mutation_tests {
                     update_ep: UpdateEntryPoint::False,
                 },
                 MutationOp::AddEdges {
-                    base: vector_id,
+                    base: vector_id.serial_id(),
                     layer: 0,
-                    neighbors: vec![vector_id],
+                    neighbors: vec![vector_id.serial_id()],
                     edge_type: EdgeType::Base,
                 },
             ],

--- a/iris-mpc-cpu/src/execution/hawk_main/insert.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/insert.rs
@@ -11,7 +11,7 @@ use crate::hnsw::{
 use super::VecRequests;
 
 use eyre::{bail, Result};
-use iris_mpc_common::VectorId;
+use iris_mpc_common::{SerialId, VectorId};
 use itertools::izip;
 use std::collections::BTreeSet;
 
@@ -101,7 +101,7 @@ pub async fn insert<V: VectorStoreMut>(
 
     let mut slot_outputs: Vec<Vec<ConnectPlanV>> = vec![vec![]; insert_plans.len()];
     let mut slot_inserted_ids: Vec<Option<VectorId>> = vec![None; insert_plans.len()];
-    let mut batch_expanded: BTreeSet<(VectorId, usize)> = BTreeSet::new();
+    let mut batch_expanded: BTreeSet<(SerialId, usize)> = BTreeSet::new();
 
     for (idx, (plan, insert_id, replace_id)) in
         izip!(insert_plans, insert_ids, replace_ids).enumerate()
@@ -143,9 +143,9 @@ pub async fn insert<V: VectorStoreMut>(
             }];
             for (layer_idx, layer_links) in links.into_iter().enumerate() {
                 ops.push(MutationOp::AddEdges {
-                    base: inserted_id,
+                    base: inserted_id.serial_id(),
                     layer: layer_idx,
-                    neighbors: layer_links,
+                    neighbors: layer_links.iter().map(|v| v.serial_id()).collect(),
                     edge_type: EdgeType::All,
                 });
             }
@@ -671,11 +671,11 @@ mod tests {
                 .iter()
                 .enumerate()
                 .filter(|(j, _)| *j != i)
-                .map(|(_, v)| *v)
+                .map(|(_, v)| v.serial_id())
                 .collect();
             assert_eq!(neighbors.len(), m_limit);
             setup_ops.push(MutationOp::AddEdges {
-                base: id,
+                base: id.serial_id(),
                 layer: 0,
                 neighbors,
                 edge_type: EdgeType::Base,
@@ -748,5 +748,106 @@ mod tests {
             max_seq_overall, last_seq_slot0,
             "global compaction mutation should be the LAST entry in the last non-empty slot"
         );
+
+        // The minted stream — setup plus slot mutations, including the
+        // compaction-minted RemoveEdges — replays literally to the same graph.
+        let mut fresh: GraphMem = GraphMem::new();
+        fresh.insert_apply(&setup).expect("replay setup");
+        for m in grouped.iter().flatten() {
+            fresh.insert_apply(m).expect("replay slot mutation");
+        }
+        assert_eq!(
+            graph.checksum(),
+            fresh.checksum(),
+            "replay diverged from mint"
+        );
+    }
+
+    /// A replace (reauth-style) slot leaves the old node's back-edge dangling in
+    /// its neighbor's list; the new node's back-edge touch drops it at mint and
+    /// must record the drop explicitly, so the persisted mutations replay
+    /// literally to the identical graph.
+    #[tokio::test]
+    async fn test_insert_replace_mutations_replay_literally_to_same_graph() {
+        use crate::hnsw::graph::mutation::UnstampedMutation;
+
+        let mut store = PlaintextStore::default();
+        let mut graph: GraphMem = GraphMem::new();
+        let searcher = HnswSearcher::new_with_test_parameters();
+        let mut wal: Vec<GraphMutation> = Vec::new();
+
+        // Seed: A and B as symmetrically-linked graph nodes, minted so the
+        // seeding is itself part of the replayable stream.
+        let a = store.insert(&Arc::new(IrisCode::default())).await;
+        let b = store.insert(&Arc::new(IrisCode::default())).await;
+        wal.push(
+            graph
+                .apply_new(UnstampedMutation {
+                    ops: vec![
+                        MutationOp::AddNode {
+                            id: a,
+                            height: 1,
+                            update_ep: UpdateEntryPoint::Append { layer: 0 },
+                        },
+                        MutationOp::AddNode {
+                            id: b,
+                            height: 1,
+                            update_ep: UpdateEntryPoint::False,
+                        },
+                    ],
+                })
+                .unwrap(),
+        );
+        wal.push(
+            graph
+                .apply_new(UnstampedMutation {
+                    ops: vec![MutationOp::AddEdges {
+                        base: a.serial_id(),
+                        neighbors: vec![b.serial_id()],
+                        layer: 0,
+                        edge_type: EdgeType::All,
+                    }],
+                })
+                .unwrap(),
+        );
+
+        // Replace A with a new vector linked to B: B's list still holds the
+        // dangling edge to A when the new node's back-edge touches it.
+        let plans = vec![Some(dummy_insert_plan_with_links(
+            UpdateEntryPoint::False,
+            vec![vec![b]],
+        ))];
+        let insert_ids: VecRequests<Option<VectorId>> = vec![None];
+        let replace_ids: VecRequests<Option<VectorId>> = vec![Some(a)];
+        let (grouped, _) = insert(
+            &mut store,
+            &mut graph,
+            &searcher,
+            plans,
+            &insert_ids,
+            &replace_ids,
+        )
+        .await
+        .expect("insert should succeed");
+        wal.extend(grouped.into_iter().flatten());
+
+        // The dangling-A drop from B's list was recorded explicitly.
+        assert!(
+            wal.iter().any(|m| m.ops.iter().any(|op| matches!(
+                op,
+                MutationOp::RemoveEdges { base, neighbors, .. }
+                    if *base == b.serial_id() && *neighbors == vec![a.serial_id()]
+            ))),
+            "expected a synthesized RemoveEdges for B's dangling edge to A"
+        );
+
+        let mut fresh: GraphMem = GraphMem::new();
+        fresh.insert_apply_all(&wal).expect("literal replay");
+        assert_eq!(
+            graph.checksum(),
+            fresh.checksum(),
+            "replay diverged from mint"
+        );
+        assert_eq!(graph, fresh, "replay diverged from mint");
     }
 }

--- a/iris-mpc-cpu/src/execution/hawk_main/test_utils.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/test_utils.rs
@@ -91,7 +91,7 @@ pub async fn init_graph(actor: &mut HawkActor) -> Result<()> {
         // Phase 1: insert all nodes. The ring links each node to the *next* one,
         // so all endpoints must exist before edges are wired — otherwise an edge
         // would point at a node whose content clock postdates the edge's
-        // neighborhood and the stale-edge filter in `insert_apply` would drop it.
+        // neighborhood and the read-path staleness filter would skip it.
         for i in 0..db_size {
             seq += 1;
             graph
@@ -112,9 +112,9 @@ pub async fn init_graph(actor: &mut HawkActor) -> Result<()> {
                 .insert_apply(&GraphMutation {
                     seq_no: seq,
                     ops: vec![MutationOp::AddEdges {
-                        base: id(i),
+                        base: id(i).serial_id(),
                         layer: 0,
-                        neighbors: edges(i),
+                        neighbors: edges(i).iter().map(|v| v.serial_id()).collect(),
                         edge_type: EdgeType::All,
                     }],
                 })

--- a/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
+++ b/iris-mpc-cpu/src/hawkers/aby3/aby3_store.rs
@@ -590,15 +590,6 @@ where
             .collect()
     }
 
-    async fn only_valid_entry_points(
-        &mut self,
-        mut entry_points: Vec<(VectorId, usize)>,
-    ) -> Vec<(VectorId, usize)> {
-        let registry = self.registry.read().await;
-        entry_points.retain(|(v, _)| registry.contains(v));
-        entry_points
-    }
-
     #[instrument(level = "trace", target = "searcher::network", skip_all)]
     async fn eval_distance(
         &mut self,

--- a/iris-mpc-cpu/src/hawkers/plaintext_deep_id_store.rs
+++ b/iris-mpc-cpu/src/hawkers/plaintext_deep_id_store.rs
@@ -307,14 +307,6 @@ impl VectorStore for PlaintextDeepIDStore {
         Ok(results)
     }
 
-    async fn only_valid_entry_points(
-        &mut self,
-        mut entry_points: Vec<(VectorId, usize)>,
-    ) -> Vec<(VectorId, usize)> {
-        entry_points.retain(|(v, _)| self.storage.contains(v));
-        entry_points
-    }
-
     async fn serials_to_vector_ids(&self, serial_ids: &[SerialId]) -> Vec<Option<VectorId>> {
         serial_ids
             .iter()
@@ -442,15 +434,6 @@ impl VectorStore for SharedPlaintextDeepIDStore {
         }
         metrics::counter!("less_than").increment(distances.len() as u64);
         Ok(results)
-    }
-
-    async fn only_valid_entry_points(
-        &mut self,
-        mut entry_points: Vec<(VectorId, usize)>,
-    ) -> Vec<(VectorId, usize)> {
-        let store = self.storage.read().await;
-        entry_points.retain(|(v, _)| store.contains(v));
-        entry_points
     }
 
     async fn serials_to_vector_ids(&self, serial_ids: &[SerialId]) -> Vec<Option<VectorId>> {

--- a/iris-mpc-cpu/src/hawkers/plaintext_store.rs
+++ b/iris-mpc-cpu/src/hawkers/plaintext_store.rs
@@ -156,12 +156,27 @@ impl<D: DistanceOps> VectorStore for PlaintextStore<D> {
         vector: &VectorId,
     ) -> Result<Self::DistanceRef> {
         debug!(event_type = EvaluateDistance.id());
-        let vector_code = self.storage.get_vector(vector).ok_or_else(|| {
-            eyre::eyre!(
-                "Vector ID not found in store for serial {}",
-                vector.serial_id()
-            )
-        })?;
+        // A present serial at a newer version is the sanctioned lag window (the
+        // store runs ahead of the graph clock until the graph mutation lands):
+        // evaluate against the empty iris, which matches nothing — mirroring
+        // the shared-store `get_vector_or_empty` fetch. An absent serial is a
+        // genuine error.
+        let vector_code = match self.storage.get_vector(vector) {
+            Some(code) => code,
+            None if self
+                .storage
+                .get_current_version(vector.serial_id())
+                .is_some() =>
+            {
+                self.storage.get_vector_or_empty(vector)
+            }
+            None => {
+                return Err(eyre::eyre!(
+                    "Vector ID not found in store for serial {}",
+                    vector.serial_id()
+                ))
+            }
+        };
         let distance = D::plaintext_distance(vector_code, query, self.distance_mode);
         Ok(distance)
     }
@@ -201,14 +216,6 @@ impl<D: DistanceOps> VectorStore for PlaintextStore<D> {
                     .map(|version| VectorId::new(serial_id, version))
             })
             .collect()
-    }
-
-    async fn only_valid_entry_points(
-        &mut self,
-        mut entry_points: Vec<(VectorId, usize)>,
-    ) -> Vec<(VectorId, usize)> {
-        entry_points.retain(|(v, _)| self.storage.contains(v));
-        entry_points
     }
 }
 
@@ -307,13 +314,21 @@ impl<D: DistanceOps> VectorStore for SharedPlaintextStore<D> {
     ) -> Result<Vec<Self::DistanceRef>> {
         debug!(event_type = EvaluateDistance.id());
         let store = self.storage.read().await;
+        // See `PlaintextStore::eval_distance` for the lag-window fallback.
         let vector_codes = vectors
             .iter()
             .map(|v| {
                 let serial_id = v.serial_id();
-                store.get_vector(v).ok_or_else(|| {
-                    eyre::eyre!("Vector ID not found in store for serial {}", serial_id)
-                })
+                match store.get_vector(v) {
+                    Some(code) => Ok(code),
+                    None if store.get_current_version(serial_id).is_some() => {
+                        Ok(store.get_vector_or_empty(v))
+                    }
+                    None => Err(eyre::eyre!(
+                        "Vector ID not found in store for serial {}",
+                        serial_id
+                    )),
+                }
             })
             .collect::<Result<Vec<_>>>()?;
         Ok(vector_codes
@@ -358,15 +373,6 @@ impl<D: DistanceOps> VectorStore for SharedPlaintextStore<D> {
                     .map(|version| VectorId::new(serial_id, version))
             })
             .collect()
-    }
-
-    async fn only_valid_entry_points(
-        &mut self,
-        mut entry_points: Vec<(VectorId, usize)>,
-    ) -> Vec<(VectorId, usize)> {
-        let storage = self.storage.read().await;
-        entry_points.retain(|(v, _)| storage.contains(v));
-        entry_points
     }
 }
 

--- a/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 use eyre::Result;
-use iris_mpc_common::{iris_db::iris::IrisCode, SerialId};
+use iris_mpc_common::{iris_db::iris::IrisCode, SerialId, VectorId, VersionId};
 use itertools::{izip, Itertools};
 use serde::{
     ser::{SerializeMap, SerializeStruct, Serializer},
@@ -77,6 +77,28 @@ impl Neighborhood {
     }
 }
 
+/// Content-clock entry of one live node: the seq_no of its last (re-)insertion
+/// and the iris version it was inserted at. The version makes the graph the
+/// self-contained source of truth for the current `VectorId` of in-graph nodes
+/// (see [`GraphMem::vector_id_of`]); it can be cross-checked against the vector
+/// store's registry where one is in context.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NodeInit {
+    /// Seq_no of the node's last `AddNode`. Gates edge liveness via [`is_active`].
+    pub seq_no: u64,
+    /// Iris version carried by that `AddNode`'s `VectorId`.
+    pub version: VersionId,
+}
+
+impl NodeInit {
+    /// Whether this node's content is unchanged since a neighborhood was
+    /// certified at `old_seq` — the sole definition of the staleness
+    /// comparison; see [`is_active`].
+    fn active_at(self, old_seq: u64) -> bool {
+        self.seq_no <= old_seq
+    }
+}
+
 /// Whether edge `A -> z` is valid for a neighborhood last certified at `old_seq`:
 /// `z` must be a live node (present in the content clock) *and* its content must
 /// not have advanced past `old_seq`. An absent stamp means dead (removed or never
@@ -86,8 +108,8 @@ impl Neighborhood {
 /// Used both at write time (the filter-on-bump in `insert_apply`, which drops
 /// invalid edges before re-stamping a neighborhood) and at read time
 /// ([`GraphMem::get_active_links`], which skips them during traversal).
-fn is_active(content: &HashMap<SerialId, u64>, z: SerialId, old_seq: u64) -> bool {
-    content.get(&z).is_some_and(|&c| c <= old_seq)
+fn is_active(content: &HashMap<SerialId, NodeInit>, z: SerialId, old_seq: u64) -> bool {
+    content.get(&z).is_some_and(|ni| ni.active_at(old_seq))
 }
 
 /// Representation of the entry point of HNSW search in a layered graph.
@@ -121,17 +143,19 @@ pub struct GraphMem {
     /// success.
     pub last_update_seq_no: u64,
 
-    /// Content clock: the seq_no at which each node was last (re-)inserted
-    /// (`AddNode`). Bumped only by a node's own insertion, never by edge
-    /// changes; removed on deletion. Gates edge liveness via [`is_active`].
-    pub node_init_seq_no: HashMap<SerialId, u64>,
+    /// Content clock: for each live node, the seq_no at which it was last
+    /// (re-)inserted (`AddNode`) and the iris version that insertion carried.
+    /// Bumped only by a node's own insertion, never by edge changes; removed on
+    /// deletion. Gates edge liveness via [`is_active`] and resolves serials to
+    /// current `VectorId`s via [`GraphMem::vector_id_of`].
+    pub node_init: HashMap<SerialId, NodeInit>,
 
-    /// Incrementally-maintained order-agnostic hash of `node_init_seq_no`,
-    /// folded into [`GraphMem::checksum`] so the content clock is part of
-    /// cross-party consensus (it gates edge liveness via `is_active`). Derived
-    /// state: not serialized; recomputed from `node_init_seq_no` on construction
-    /// and deserialization, kept in sync by `insert_apply`. Private so all
-    /// construction routes through `from_parts`, which computes it.
+    /// Incrementally-maintained order-agnostic hash of `node_init`, folded
+    /// into [`GraphMem::checksum`] so the content clock (liveness + version)
+    /// is part of cross-party consensus. Derived state: not serialized;
+    /// recomputed from `node_init` on construction and deserialization, kept
+    /// in sync by `insert_apply`. Private so all construction routes through
+    /// `from_parts`, which computes it.
     node_init_hash: SetHash,
 }
 
@@ -174,7 +198,7 @@ impl Clone for GraphMem {
             entry_points: self.entry_points.clone(),
             layers: self.layers.clone(),
             last_update_seq_no: self.last_update_seq_no,
-            node_init_seq_no: self.node_init_seq_no.clone(),
+            node_init: self.node_init.clone(),
             node_init_hash: self.node_init_hash.clone(),
         }
     }
@@ -192,14 +216,14 @@ impl<'de> Deserialize<'de> for GraphMem {
             entry_points: Vec<EntryPoint>,
             layers: Vec<Layer>,
             last_update_seq_no: u64,
-            node_init_seq_no: HashMap<SerialId, u64>,
+            node_init: HashMap<SerialId, NodeInit>,
         }
         let d = GraphMemData::deserialize(deserializer)?;
         Ok(GraphMem::from_parts(
             d.entry_points,
             d.layers,
             d.last_update_seq_no,
-            d.node_init_seq_no,
+            d.node_init,
         ))
     }
 }
@@ -210,7 +234,7 @@ impl GraphMem {
             entry_points: vec![],
             layers: vec![],
             last_update_seq_no: 0,
-            node_init_seq_no: HashMap::new(),
+            node_init: HashMap::new(),
             node_init_hash: SetHash::default(),
         }
     }
@@ -222,30 +246,32 @@ impl GraphMem {
         entry_points: Vec<EntryPoint>,
         layers: Vec<Layer>,
         last_update_seq_no: u64,
-        node_init_seq_no: HashMap<SerialId, u64>,
+        node_init: HashMap<SerialId, NodeInit>,
     ) -> Self {
         let mut node_init_hash = SetHash::default();
         // SetHash folds via commutative wrapping addition, so iteration order is
         // irrelevant to the result.
         #[allow(clippy::iter_over_hash_type)]
-        for (&serial, &seq) in &node_init_seq_no {
-            node_init_hash.add_unordered(Self::node_init_contribution(serial, seq));
+        for (&serial, &init) in &node_init {
+            node_init_hash.add_unordered(Self::node_init_contribution(serial, init));
         }
         GraphMem {
             entry_points,
             layers,
             last_update_seq_no,
-            node_init_seq_no,
+            node_init,
             node_init_hash,
         }
     }
 
-    /// Single source of truth for how a `(serial, seq)` content-clock entry is
-    /// folded into `node_init_hash` — used by both the bulk build in
-    /// `from_parts` and the incremental updates in `insert_apply`, so the two
-    /// can never drift.
-    fn node_init_contribution(serial: SerialId, seq: u64) -> (&'static str, SerialId, u64) {
-        ("node_init", serial, seq)
+    /// Single source of truth for how a content-clock entry is folded into
+    /// `node_init_hash` — used by both the bulk build in `from_parts` and the
+    /// incremental updates in `insert_apply`, so the two can never drift.
+    fn node_init_contribution(
+        serial: SerialId,
+        init: NodeInit,
+    ) -> (&'static str, SerialId, u64, VersionId) {
+        ("node_init", serial, init.seq_no, init.version)
     }
 
     /// Returns the sequence number that the next applied `GraphMutation` must
@@ -259,13 +285,21 @@ impl GraphMem {
     }
 
     pub fn from_precomputed(entry_points: Vec<(SerialId, usize)>, layers: Vec<Layer>) -> Self {
-        // Seed the content clock at 0 for every node so the read-path liveness
-        // filter (`is_active`) treats these trusted nodes as live; without this
-        // `get_active_links` would drop every edge.
-        let node_init_seq_no = layers
+        // Seed the content clock at seq 0 / version 0 for every node so the
+        // read-path liveness filter (`is_active`) treats these trusted nodes as
+        // live; without this `get_active_links` would drop every edge.
+        let node_init = layers
             .iter()
             .flat_map(|l| l.links.keys())
-            .map(|&v| (v, 0u64))
+            .map(|&v| {
+                (
+                    v,
+                    NodeInit {
+                        seq_no: 0,
+                        version: 0,
+                    },
+                )
+            })
             .collect();
         let entry_points = entry_points
             .into_iter()
@@ -274,7 +308,7 @@ impl GraphMem {
                 layer: ep.1,
             })
             .collect::<Vec<_>>();
-        GraphMem::from_parts(entry_points, layers, 0, node_init_seq_no)
+        GraphMem::from_parts(entry_points, layers, 0, node_init)
     }
 
     pub fn get_layers(&self) -> Vec<Layer> {
@@ -352,7 +386,7 @@ impl GraphMem {
                         layer.remove_node(sid);
                     }
                     self.entry_points.retain(|ep| ep.point != sid);
-                    if let Some(old) = self.node_init_seq_no.remove(&sid) {
+                    if let Some(old) = self.node_init.remove(&sid) {
                         self.node_init_hash
                             .remove(Self::node_init_contribution(sid, old));
                     }
@@ -379,12 +413,16 @@ impl GraphMem {
                     for layer_idx in 0..*height {
                         self.layers[layer_idx].create_node(sid, tick);
                     }
-                    if let Some(old) = self.node_init_seq_no.insert(sid, seq_no) {
+                    let init = NodeInit {
+                        seq_no,
+                        version: id.version_id(),
+                    };
+                    if let Some(old) = self.node_init.insert(sid, init) {
                         self.node_init_hash
                             .remove(Self::node_init_contribution(sid, old));
                     }
                     self.node_init_hash
-                        .add_unordered(Self::node_init_contribution(sid, seq_no));
+                        .add_unordered(Self::node_init_contribution(sid, init));
                 }
                 MutationOp::AddEdges { .. } | MutationOp::RemoveEdges { .. } => {}
             }
@@ -412,7 +450,7 @@ impl GraphMem {
                     let base_sid = base.serial_id();
                     let neighbor_sids: Vec<SerialId> =
                         to_add.iter().map(|v| v.serial_id()).collect();
-                    let content = &self.node_init_seq_no;
+                    let content = &self.node_init;
                     // Causal-construction guard: an edge to a node not yet in the
                     // content clock is stamped at this tick while the target's
                     // clock is minted later, so `is_active` reads it as stale and
@@ -464,7 +502,7 @@ impl GraphMem {
                     let base_sid = base.serial_id();
                     let remove_sids: Vec<SerialId> =
                         to_remove.iter().map(|v| v.serial_id()).collect();
-                    let content = &self.node_init_seq_no;
+                    let content = &self.node_init;
                     let layer_mut = &mut self.layers[layer];
                     if matches!(edge_type, EdgeType::Base | EdgeType::All) {
                         if layer_mut.get_links(&base_sid).is_none() {
@@ -569,20 +607,34 @@ impl GraphMem {
             .unwrap_or(&[])
     }
 
-    /// Neighbors of `base` at layer `lc` valid for traversal: `z` is kept iff
-    /// [`is_active`] (live and not content-refreshed past this neighborhood's
-    /// certified `seq_no`), so traversal skips reauthed/removed edges even in
-    /// neighborhoods no write has physically cleaned yet. Returns an owned `Vec`;
-    /// empty if `base`/`lc` absent.
-    pub fn get_active_links(&self, base: &SerialId, lc: usize) -> Vec<SerialId> {
+    /// Current `VectorId` of an in-graph node, from the graph's own content
+    /// clock. `None` means not live in the graph (never inserted, or removed) —
+    /// callers must not fabricate a version for it.
+    pub fn vector_id_of(&self, serial: SerialId) -> Option<VectorId> {
+        self.node_init
+            .get(&serial)
+            .map(|ni| VectorId::new(serial, ni.version))
+    }
+
+    /// Neighbors of `base` at layer `lc` valid for traversal, resolved to their
+    /// current `VectorId`s from the content clock: `z` is kept iff [`is_active`]
+    /// (live and not content-refreshed past this neighborhood's certified
+    /// `seq_no`), so traversal skips reauthed/removed edges even in
+    /// neighborhoods no write has physically cleaned yet. Returns an owned
+    /// `Vec`; empty if `base`/`lc` absent.
+    pub fn get_active_links(&self, base: &SerialId, lc: usize) -> Vec<VectorId> {
         let Some(nbhd) = self.layers.get(lc).and_then(|layer| layer.get_links(base)) else {
             return Vec::new();
         };
         let old_seq = nbhd.seq_no;
         nbhd.neighbors
             .iter()
-            .copied()
-            .filter(|z| is_active(&self.node_init_seq_no, *z, old_seq))
+            .filter_map(|&z| {
+                self.node_init
+                    .get(&z)
+                    .filter(|ni| ni.active_at(old_seq))
+                    .map(|ni| VectorId::new(z, ni.version))
+            })
             .collect()
     }
 
@@ -784,8 +836,8 @@ impl Serialize for GraphMem {
         state.serialize_field("entry_points", &self.entry_points)?;
         state.serialize_field("layers", &self.layers)?;
         state.serialize_field("last_update_seq_no", &self.last_update_seq_no)?;
-        let sorted_node_init: BTreeMap<_, _> = self.node_init_seq_no.iter().collect();
-        state.serialize_field("node_init_seq_no", &sorted_node_init)?;
+        let sorted_node_init: BTreeMap<_, _> = self.node_init.iter().collect();
+        state.serialize_field("node_init", &sorted_node_init)?;
         state.end()
     }
 }
@@ -1060,9 +1112,9 @@ where
         .collect();
 
     let new_node_last_update_seq_no = graph
-        .node_init_seq_no
+        .node_init
         .into_iter()
-        .map(|(id, seq)| (vector_map(id), seq))
+        .map(|(id, init)| (vector_map(id), init))
         .collect();
 
     GraphMem::from_parts(
@@ -1095,13 +1147,28 @@ mod tests {
     /// different edges via `is_active` could agree on the checksum.
     #[test]
     fn checksum_folds_content_and_neighborhood_clocks() {
-        use super::{EntryPoint, Layer};
+        use super::{EntryPoint, Layer, NodeInit};
         // node1 neighborhood seq = `nbhd_seq`; node1 content clock = `content`.
-        let build = |nbhd_seq: u64, content: u64| -> GraphMem {
+        let build = |nbhd_seq: u64, content: u64, version: i16| -> GraphMem {
             let mut layer = Layer::new();
             layer.set_links_trusted(1u32, vec![2u32], nbhd_seq);
             layer.set_links_trusted(2u32, vec![], 0);
-            let node_init = HashMap::from([(1u32, content), (2u32, 0u64)]);
+            let node_init = HashMap::from([
+                (
+                    1u32,
+                    NodeInit {
+                        seq_no: content,
+                        version,
+                    },
+                ),
+                (
+                    2u32,
+                    NodeInit {
+                        seq_no: 0,
+                        version: 0,
+                    },
+                ),
+            ]);
             GraphMem::from_parts(
                 vec![EntryPoint { point: 1, layer: 0 }],
                 vec![layer],
@@ -1110,17 +1177,22 @@ mod tests {
             )
         };
 
-        let base = build(0, 0);
-        assert_eq!(base.checksum(), build(0, 0).checksum(), "deterministic");
+        let base = build(0, 0, 0);
+        assert_eq!(base.checksum(), build(0, 0, 0).checksum(), "deterministic");
         assert_ne!(
             base.checksum(),
-            build(5, 0).checksum(),
+            build(5, 0, 0).checksum(),
             "per-neighborhood seq_no must be folded into the checksum"
         );
         assert_ne!(
             base.checksum(),
-            build(0, 7).checksum(),
-            "node_init_seq_no (content clock) must be folded into the checksum"
+            build(0, 7, 0).checksum(),
+            "node_init (content clock) must be folded into the checksum"
+        );
+        assert_ne!(
+            base.checksum(),
+            build(0, 0, 3).checksum(),
+            "node version must be folded into the checksum"
         );
     }
 
@@ -1179,13 +1251,6 @@ mod tests {
             distance2: &Self::DistanceRef,
         ) -> Result<bool> {
             Ok(*distance1 < *distance2)
-        }
-
-        async fn only_valid_entry_points(
-            &mut self,
-            entry_points: Vec<(VectorId, usize)>,
-        ) -> Vec<(VectorId, usize)> {
-            entry_points
         }
 
         async fn serials_to_vector_ids(&self, serial_ids: &[SerialId]) -> Vec<Option<VectorId>> {
@@ -1515,7 +1580,7 @@ mod tests {
                 }],
             })
             .unwrap();
-        assert_eq!(graph.get_active_links(&1, 0), vec![2u32]);
+        assert_eq!(graph.get_active_links(&1, 0), vec![b]);
 
         // Reauth b (content[b] -> 3) without touching a.
         graph
@@ -1530,7 +1595,7 @@ mod tests {
             graph.layers[0].get_links(&1).unwrap().neighbors().to_vec(),
             vec![2u32]
         );
-        assert_eq!(graph.get_active_links(&1, 0), Vec::<SerialId>::new());
+        assert_eq!(graph.get_active_links(&1, 0), Vec::<VectorId>::new());
     }
 
     /// Read-path liveness: `get_active_links` drops a dangling edge to a removed
@@ -1579,19 +1644,20 @@ mod tests {
             graph.layers[0].get_links(&1).unwrap().neighbors().to_vec(),
             vec![2u32]
         );
-        assert_eq!(graph.get_active_links(&1, 0), Vec::<SerialId>::new());
+        assert_eq!(graph.get_active_links(&1, 0), Vec::<VectorId>::new());
     }
 
     /// Read-path selectivity: a live neighbor survives while a content-stale
     /// neighbor is dropped. Guards against `get_active_links` blanket-emptying
     /// (e.g. an inverted `is_active`), which the single-neighbor tests above
-    /// would not catch.
+    /// would not catch. `c` carries a non-zero version, pinning that the
+    /// surviving link resolves to the version its `AddNode` carried.
     #[test]
     fn get_active_links_keeps_live_drops_stale() {
         let mut graph = GraphMem::new();
         let a = VectorId::from_serial_id(1);
         let b = VectorId::from_serial_id(2);
-        let c = VectorId::from_serial_id(3);
+        let c = VectorId::new(3, 5);
         let node = |id| MutationOp::AddNode {
             id,
             height: 1,
@@ -1616,7 +1682,7 @@ mod tests {
                 }],
             })
             .unwrap();
-        assert_eq!(graph.get_active_links(&1, 0), vec![2u32, 3u32]);
+        assert_eq!(graph.get_active_links(&1, 0), vec![b, c]);
 
         // Reauth only b (content[b] -> 3); a and c untouched.
         graph
@@ -1626,8 +1692,11 @@ mod tests {
             })
             .unwrap();
 
-        // c (content[c]=1 <= 2) survives; b (content[b]=3 > 2) is skipped.
-        assert_eq!(graph.get_active_links(&1, 0), vec![3u32]);
+        // c (content[c]=1 <= 2) survives at its inserted version; b
+        // (content[b]=3 > 2) is skipped.
+        assert_eq!(graph.get_active_links(&1, 0), vec![c]);
+        assert_eq!(graph.vector_id_of(3), Some(c));
+        assert_eq!(graph.vector_id_of(4), None, "never-inserted serial");
     }
 
     /// `node_init_hash` is maintained incrementally by `insert_apply` but
@@ -1738,8 +1807,8 @@ mod tests {
             ],
         })
         .unwrap();
-        assert_eq!(g.get_active_links(&1, 0), vec![2, 3]);
-        assert_eq!(g.get_active_links(&2, 0), vec![1]);
+        assert_eq!(g.get_active_links(&1, 0), vec![v(2), v(3)]);
+        assert_eq!(g.get_active_links(&2, 0), vec![v(1)]);
 
         // Reauth node 3 (bumps its content clock) and delete node 4, so the aged
         // graph carries a non-uniform content clock and a removed node.
@@ -1813,7 +1882,7 @@ mod tests {
         })
         .unwrap();
         assert_eq!(g.get_raw_links(&1, 0), &[2u32, 3u32], "stale 3 still raw");
-        assert_eq!(g.get_active_links(&1, 0), vec![2], "3 masked as stale");
+        assert_eq!(g.get_active_links(&1, 0), vec![v(2)], "3 masked as stale");
 
         // RemoveEdges Base(1 -/-> 2): retain drops explicit 2 AND stale 3.
         g.insert_apply(&GraphMutation {
@@ -1901,7 +1970,7 @@ mod tests {
             ops: vec![node(v(1)), node(v(2)), node(v(3))],
         })
         .unwrap();
-        let clock_before = g.node_init_seq_no.clone();
+        let clock_before = g.node_init.clone();
 
         // All(1 <-> [2@v7, 3@v2]): versions dropped; 1's list keys on {2,3}, and
         // 1 is back-linked into 2 and 3 by bare serial.
@@ -1931,7 +2000,7 @@ mod tests {
             "back-edge keyed on serial 3"
         );
         assert_eq!(
-            g.node_init_seq_no, clock_before,
+            g.node_init, clock_before,
             "AddEdges must not perturb the content clock"
         );
 
@@ -2019,7 +2088,7 @@ mod tests {
         assert_eq!(g.get_entry_points(), None, "entry-point list emptied");
         // L1 now empty, so fall back to min serial of L0.
         assert_eq!(g.get_temporary_entry_point(), Some((2u32, 0)));
-        assert!(!g.node_init_seq_no.contains_key(&1), "content[1] dropped");
+        assert!(!g.node_init.contains_key(&1), "content[1] dropped");
     }
 
     #[test]

--- a/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
@@ -105,11 +105,72 @@ impl NodeInit {
 /// added) and a stamp `> old_seq` means content-refreshed (reauthed) since the
 /// edge was certified — either way the edge is dropped.
 ///
-/// Used both at write time (the filter-on-bump in `insert_apply`, which drops
-/// invalid edges before re-stamping a neighborhood) and at read time
-/// ([`GraphMem::get_active_links`], which skips them during traversal).
+/// Used at mint time (the filter-on-bump in [`GraphMem::apply_new`], which
+/// drops invalid edges before re-stamping a neighborhood and records each drop
+/// as an explicit `RemoveEdges`) and at read time
+/// ([`GraphMem::get_active_links`], which skips them during traversal). Replay
+/// ([`GraphMem::insert_apply`]) never evaluates it — recorded segments replay
+/// literally.
 fn is_active(content: &HashMap<SerialId, NodeInit>, z: SerialId, old_seq: u64) -> bool {
     content.get(&z).is_some_and(|ni| ni.active_at(old_seq))
+}
+
+/// One mint-side staleness drop: while applying the op at `op_index`, the
+/// filter re-stamping `node`'s neighborhood at `layer` dropped `dropped` as
+/// invalid (see [`is_active`]). Enrichment turns each record into a synthesized
+/// `RemoveEdges` so the drop is explicit in the persisted mutation.
+struct StaleDrop {
+    op_index: usize,
+    layer: usize,
+    node: SerialId,
+    dropped: Vec<SerialId>,
+}
+
+/// Record a neighborhood's filter drops when minting (`drops = Some`); no-op on
+/// replay or when nothing was dropped.
+fn record_drops(
+    drops: &mut Option<&mut Vec<StaleDrop>>,
+    op_index: usize,
+    layer: usize,
+    node: SerialId,
+    dropped: Vec<SerialId>,
+) {
+    if let Some(d) = drops.as_deref_mut() {
+        if !dropped.is_empty() {
+            d.push(StaleDrop {
+                op_index,
+                layer,
+                node,
+                dropped,
+            });
+        }
+    }
+}
+
+/// Splice recorded staleness drops into `ops` as explicit `RemoveEdges`, each
+/// placed immediately *before* the op whose apply performed the drop, so a
+/// literal replay drops the edge before that op can re-append the same serial.
+/// `drops` must be in op order (`op_index` non-decreasing), which the apply
+/// pass produces naturally.
+fn enrich_with_drops(ops: Vec<MutationOp>, drops: Vec<StaleDrop>) -> Vec<MutationOp> {
+    if drops.is_empty() {
+        return ops;
+    }
+    let mut out = Vec::with_capacity(ops.len() + drops.len());
+    let mut drops = drops.into_iter().peekable();
+    for (op_index, op) in ops.into_iter().enumerate() {
+        while drops.peek().is_some_and(|d| d.op_index == op_index) {
+            let d = drops.next().expect("peeked");
+            out.push(MutationOp::RemoveEdges {
+                base: d.node,
+                neighbors: d.dropped,
+                layer: d.layer,
+                edge_type: EdgeType::Base,
+            });
+        }
+        out.push(op);
+    }
+    out
 }
 
 /// Representation of the entry point of HNSW search in a layered graph.
@@ -139,8 +200,8 @@ pub struct GraphMem {
     pub layers: Vec<Layer>,
 
     /// The sequence number of the most recently applied `GraphMutation`. `0`
-    /// means no mutation has been applied. Advanced by `insert_apply` on
-    /// success.
+    /// means no mutation has been applied. Advanced on every successful apply
+    /// (`apply_new` / `insert_apply`).
     pub last_update_seq_no: u64,
 
     /// Content clock: for each live node, the seq_no at which it was last
@@ -154,8 +215,8 @@ pub struct GraphMem {
     /// into [`GraphMem::checksum`] so the content clock (liveness + version)
     /// is part of cross-party consensus. Derived state: not serialized;
     /// recomputed from `node_init` on construction and deserialization, kept
-    /// in sync by `insert_apply`. Private so all construction routes through
-    /// `from_parts`, which computes it.
+    /// in sync by the mutation apply. Private so all construction routes
+    /// through `from_parts`, which computes it.
     node_init_hash: SetHash,
 }
 
@@ -266,7 +327,7 @@ impl GraphMem {
 
     /// Single source of truth for how a content-clock entry is folded into
     /// `node_init_hash` — used by both the bulk build in `from_parts` and the
-    /// incremental updates in `insert_apply`, so the two can never drift.
+    /// incremental updates in the mutation apply, so the two can never drift.
     fn node_init_contribution(
         serial: SerialId,
         init: NodeInit,
@@ -345,40 +406,58 @@ impl GraphMem {
         }
     }
 
-    /// Applies a list of graph mutations to the in-memory graph.
+    /// Applies a replayed (WAL/checkpoint) mutation to the in-memory graph,
+    /// literally.
     ///
-    /// This updates the graph's entry points set and connects the new vector to
-    /// its neighbors as specified in the mutations.
+    /// Replay executes exactly the recorded ops: `AddEdges` appends the named
+    /// serials, `RemoveEdges` removes the named serials — no staleness
+    /// predicate runs. Stale-edge drops are explicit `RemoveEdges` ops in the
+    /// recorded stream, synthesized at mint time by [`Self::apply_new`], so a
+    /// segment replays to the minted state even under a binary whose staleness
+    /// predicate has since changed.
     ///
     /// The supplied `mutation.seq_no` must be strictly greater than
     /// `self.last_update_seq_no`; otherwise the call returns `Err` without
     /// touching the graph. On success `self.last_update_seq_no` advances to
     /// `mutation.seq_no`.
-    ///
-    /// Causal construction: an `AddEdges` op must not reference a target created
-    /// *later* — in a following mutation, or later in this same op list. The edge
-    /// is stamped at this tick while the target's content clock is minted at its
-    /// own (later) insertion, so [`is_active`] treats it as stale and drops it at
-    /// read time. Insert all endpoints before wiring edges between them; debug
-    /// builds assert it.
     pub fn insert_apply(&mut self, mutation: &GraphMutation) -> Result<()> {
-        if mutation.seq_no <= self.last_update_seq_no {
+        self.apply_ops(mutation.seq_no, &mutation.ops, None)
+    }
+
+    /// Shared two-pass apply. `drops = Some` is mint mode: every touched
+    /// neighborhood is filtered through [`is_active`] before the op's own edit
+    /// (filter-on-bump), and each dropped edge is recorded for enrichment.
+    /// `drops = None` is literal replay: no predicate runs.
+    ///
+    /// Causal construction (mint): an `AddEdges` op must not reference a target
+    /// created *later* — in a following mutation. The edge is stamped at this
+    /// tick while the target's content clock is minted at its own (later)
+    /// insertion, so [`is_active`] treats it as stale and drops it at read
+    /// time. Insert all endpoints before wiring edges between them; debug
+    /// builds assert it.
+    fn apply_ops(
+        &mut self,
+        seq_no: u64,
+        ops: &[MutationOp],
+        mut drops: Option<&mut Vec<StaleDrop>>,
+    ) -> Result<()> {
+        if seq_no <= self.last_update_seq_no {
             return Err(eyre::eyre!(
-                "GraphMem::insert_apply: mutation seq_no {} is not strictly greater than \
+                "GraphMem::apply_ops: mutation seq_no {} is not strictly greater than \
                  last_update_seq_no {}",
-                mutation.seq_no,
+                seq_no,
                 self.last_update_seq_no,
             ));
         }
 
-        let seq_no = mutation.seq_no;
+        let minting = drops.is_some();
         // One monotonic tick for this mutation: node creation (Pass 1) and edge
         // edits (Pass 2) both stamp neighborhoods with it, so every live seq_no
         // stamp is `Tick`-guarded.
         let tick = Tick::new(seq_no);
 
         // Pass 1: apply node-level mutations.
-        for op in mutation.ops.iter() {
+        for op in ops.iter() {
             match op {
                 MutationOp::RemoveNode { id } => {
                     let sid = id.serial_id();
@@ -428,13 +507,13 @@ impl GraphMem {
             }
         }
 
-        // Pass 2: apply edge-level mutations. Each touched neighborhood drops its
-        // invalid edges (see `is_active`) then is re-stamped in one step (see
-        // `Layer::edit_links`): the drop happens *before* any new edge is
-        // appended, so an append can't re-certify an already-invalid sibling as
-        // fresh. Edge ops never advance the content clock — only a node's own
-        // (re-)insertion does.
-        for op in mutation.ops.iter() {
+        // Pass 2: apply edge-level mutations. When minting, each touched
+        // neighborhood drops its invalid edges (see `is_active`) then is
+        // re-stamped in one step (see `Layer::edit_links`): the drop happens
+        // *before* any new edge is appended, so an append can't re-certify an
+        // already-invalid sibling as fresh. Edge ops never advance the content
+        // clock — only a node's own (re-)insertion does.
+        for (op_index, op) in ops.iter().enumerate() {
             match op {
                 MutationOp::AddNode { .. } | MutationOp::RemoveNode { .. } => {}
                 MutationOp::AddEdges {
@@ -447,41 +526,67 @@ impl GraphMem {
                     if self.layers.len() < layer + 1 {
                         self.layers.resize(layer + 1, Layer::new());
                     }
-                    let base_sid = base.serial_id();
-                    let neighbor_sids: Vec<SerialId> =
-                        to_add.iter().map(|v| v.serial_id()).collect();
                     let content = &self.node_init;
                     // Causal-construction guard: an edge to a node not yet in the
                     // content clock is stamped at this tick while the target's
                     // clock is minted later, so `is_active` reads it as stale and
                     // drops it. Insert endpoints before wiring edges to them.
                     debug_assert!(
-                        neighbor_sids.iter().all(|z| content.contains_key(z)),
+                        to_add.iter().all(|z| content.contains_key(z)),
                         "AddEdges: neighbor absent from content clock (edge added \
                          before its endpoint exists); the edge would be silently dropped"
                     );
                     let layer_mut = &mut self.layers[layer];
-                    // Forward half: append `neighbor_sids` to base's own list.
+                    // Forward half: append `to_add` to base's own list.
                     if matches!(edge_type, EdgeType::Base | EdgeType::All) {
-                        if layer_mut.get_links(&base_sid).is_none() {
-                            warn!("AddEdges({edge_type:?}): base={base:?} missing at layer {layer}; skipping outgoing half");
+                        if layer_mut.get_links(base).is_none() {
+                            warn!("AddEdges({edge_type:?}): base={base} missing at layer {layer}; skipping outgoing half");
                         } else {
-                            layer_mut.edit_links(base_sid, tick, |old_seq, nbrs| {
-                                nbrs.retain(|z| is_active(content, *z, old_seq));
-                                nbrs.extend_from_slice(&neighbor_sids);
+                            let mut dropped = Vec::new();
+                            layer_mut.edit_links(*base, tick, |old_seq, nbrs| {
+                                if minting {
+                                    nbrs.retain(|z| {
+                                        let keep = is_active(content, *z, old_seq);
+                                        if !keep {
+                                            dropped.push(*z);
+                                        }
+                                        keep
+                                    });
+                                }
+                                nbrs.extend_from_slice(to_add);
+                                debug_assert!(
+                                    !minting || nbrs.iter().all(|z| is_active(content, *z, seq_no)),
+                                    "mint left an invalid edge in a re-stamped neighborhood"
+                                );
                             });
+                            record_drops(&mut drops, op_index, layer, *base, dropped);
                         }
                     }
                     // Back half: append base into each target's list.
                     if matches!(edge_type, EdgeType::Neighbors | EdgeType::All) {
-                        for (target, target_sid) in to_add.iter().zip(neighbor_sids.iter()) {
-                            if layer_mut.get_links(target_sid).is_none() {
-                                warn!("AddEdges({edge_type:?}): target={target:?} missing at layer {layer} (base={base:?}); skipping back-edge");
+                        for target in to_add.iter() {
+                            if layer_mut.get_links(target).is_none() {
+                                warn!("AddEdges({edge_type:?}): target={target} missing at layer {layer} (base={base}); skipping back-edge");
                             } else {
-                                layer_mut.edit_links(*target_sid, tick, |old_seq, nbrs| {
-                                    nbrs.retain(|z| is_active(content, *z, old_seq));
-                                    nbrs.push(base_sid);
+                                let mut dropped = Vec::new();
+                                layer_mut.edit_links(*target, tick, |old_seq, nbrs| {
+                                    if minting {
+                                        nbrs.retain(|z| {
+                                            let keep = is_active(content, *z, old_seq);
+                                            if !keep {
+                                                dropped.push(*z);
+                                            }
+                                            keep
+                                        });
+                                    }
+                                    nbrs.push(*base);
+                                    debug_assert!(
+                                        !minting
+                                            || nbrs.iter().all(|z| is_active(content, *z, seq_no)),
+                                        "mint left an invalid edge in a re-stamped neighborhood"
+                                    );
                                 });
+                                record_drops(&mut drops, op_index, layer, *target, dropped);
                             }
                         }
                     }
@@ -494,37 +599,58 @@ impl GraphMem {
                 } => {
                     let layer = *layer;
                     if self.layers.len() < layer + 1 {
-                        warn!(
-                            "RemoveEdges: layer {layer} does not exist (base={base:?}); skipping"
-                        );
+                        warn!("RemoveEdges: layer {layer} does not exist (base={base}); skipping");
                         continue;
                     }
-                    let base_sid = base.serial_id();
-                    let remove_sids: Vec<SerialId> =
-                        to_remove.iter().map(|v| v.serial_id()).collect();
                     let content = &self.node_init;
                     let layer_mut = &mut self.layers[layer];
                     if matches!(edge_type, EdgeType::Base | EdgeType::All) {
-                        if layer_mut.get_links(&base_sid).is_none() {
-                            warn!("RemoveEdges({edge_type:?}): base={base:?} missing at layer {layer}; skipping outgoing half");
+                        if layer_mut.get_links(base).is_none() {
+                            warn!("RemoveEdges({edge_type:?}): base={base} missing at layer {layer}; skipping outgoing half");
                         } else {
-                            layer_mut.edit_links(base_sid, tick, |old_seq, nbrs| {
+                            let mut dropped = Vec::new();
+                            layer_mut.edit_links(*base, tick, |old_seq, nbrs| {
                                 nbrs.retain(|z| {
-                                    is_active(content, *z, old_seq) && !remove_sids.contains(z)
+                                    // Named serials replay from this op itself;
+                                    // only predicate drops need recording.
+                                    if to_remove.contains(z) {
+                                        return false;
+                                    }
+                                    if !minting {
+                                        return true;
+                                    }
+                                    let keep = is_active(content, *z, old_seq);
+                                    if !keep {
+                                        dropped.push(*z);
+                                    }
+                                    keep
                                 });
                             });
+                            record_drops(&mut drops, op_index, layer, *base, dropped);
                         }
                     }
                     if matches!(edge_type, EdgeType::Neighbors | EdgeType::All) {
-                        for (target, target_sid) in to_remove.iter().zip(remove_sids.iter()) {
-                            if layer_mut.get_links(target_sid).is_none() {
-                                warn!("RemoveEdges({edge_type:?}): target={target:?} missing at layer {layer} (base={base:?}); skipping");
+                        for target in to_remove.iter() {
+                            if layer_mut.get_links(target).is_none() {
+                                warn!("RemoveEdges({edge_type:?}): target={target} missing at layer {layer} (base={base}); skipping");
                             } else {
-                                layer_mut.edit_links(*target_sid, tick, |old_seq, nbrs| {
+                                let mut dropped = Vec::new();
+                                layer_mut.edit_links(*target, tick, |old_seq, nbrs| {
                                     nbrs.retain(|z| {
-                                        is_active(content, *z, old_seq) && *z != base_sid
+                                        if *z == *base {
+                                            return false;
+                                        }
+                                        if !minting {
+                                            return true;
+                                        }
+                                        let keep = is_active(content, *z, old_seq);
+                                        if !keep {
+                                            dropped.push(*z);
+                                        }
+                                        keep
                                     });
                                 });
+                                record_drops(&mut drops, op_index, layer, *target, dropped);
                             }
                         }
                     }
@@ -532,12 +658,20 @@ impl GraphMem {
             }
         }
 
-        self.last_update_seq_no = mutation.seq_no;
+        self.last_update_seq_no = seq_no;
         Ok(())
     }
 
     /// Stamp a locally-built [`UnstampedMutation`] with the next sequence
-    /// number, apply it, and return the resulting [`GraphMutation`].
+    /// number, apply it with the staleness filter active, and return the
+    /// resulting [`GraphMutation`] with every filter drop made explicit: a
+    /// synthesized `RemoveEdges` (base-half, bare serials) is spliced in
+    /// immediately *before* the op whose apply performed the drop, so a literal
+    /// replay ([`Self::insert_apply`]) reproduces this graph's state — the
+    /// drop-before-append order matters when the same serial is dropped as
+    /// stale and re-appended within one op (a reauth back-edge). The enriched
+    /// op list is state-equivalent, not op-identical, to what was applied here;
+    /// the checksum covers state only.
     ///
     /// This is the sole minter of sequence numbers for in-process mutations:
     /// the number is assigned from `next_sequence_number()` and consumed by the
@@ -547,12 +681,13 @@ impl GraphMem {
     /// go through `insert_apply`/`insert_apply_all` instead, where the strict
     /// monotonicity check guards the externally-supplied `seq_no`.
     pub fn apply_new(&mut self, mutation: UnstampedMutation) -> Result<GraphMutation> {
-        let stamped = GraphMutation {
-            seq_no: self.next_sequence_number(),
-            ops: mutation.ops,
-        };
-        self.insert_apply(&stamped)?;
-        Ok(stamped)
+        let seq_no = self.next_sequence_number();
+        let mut drops = Vec::new();
+        self.apply_ops(seq_no, &mutation.ops, Some(&mut drops))?;
+        Ok(GraphMutation {
+            seq_no,
+            ops: enrich_with_drops(mutation.ops, drops),
+        })
     }
 
     pub fn insert_apply_all(&mut self, mutations: &[GraphMutation]) -> Result<()> {
@@ -940,9 +1075,10 @@ impl Layer {
     /// Remove `id`'s own neighborhood. Backlinks (`other -> id`) are intentionally
     /// left in place: `id` is dropped from the content clock at the same
     /// `RemoveNode`, so [`is_active`] masks every dangling edge to it at read time,
-    /// and filter-on-bump drops it physically the next time that neighbor is
-    /// touched. This keeps `RemoveNode` a pure node removal — no implicit,
-    /// WAL-invisible mutation of other nodes' neighborhoods.
+    /// and the next mint-time touch of that neighbor drops it physically —
+    /// recording the drop as an explicit `RemoveEdges` in that later mutation.
+    /// This keeps `RemoveNode` a pure node removal — no implicit mutation of
+    /// other nodes' neighborhoods.
     pub fn remove_node(&mut self, id: SerialId) {
         if let Some(nbhd) = self.links.remove(&id) {
             self.set_hash.remove_hash(Self::neighborhood_contribution(
@@ -1363,7 +1499,9 @@ mod tests {
         Ok(())
     }
 
-    use crate::hnsw::graph::mutation::{EdgeType, GraphMutation, MutationOp, UpdateEntryPoint};
+    use crate::hnsw::graph::mutation::{
+        EdgeType, GraphMutation, MutationOp, UnstampedMutation, UpdateEntryPoint,
+    };
 
     #[test]
     fn add_edges_outgoing_writes_only_to_id_list() {
@@ -1398,9 +1536,9 @@ mod tests {
             .insert_apply(&GraphMutation {
                 seq_no: 2,
                 ops: vec![MutationOp::AddEdges {
-                    base: a,
+                    base: 1,
                     layer: 0,
-                    neighbors: vec![b, c],
+                    neighbors: vec![2, 3],
                     edge_type: EdgeType::Base,
                 }],
             })
@@ -1451,9 +1589,9 @@ mod tests {
             .insert_apply(&GraphMutation {
                 seq_no: 2,
                 ops: vec![MutationOp::AddEdges {
-                    base: a,
+                    base: 1,
                     layer: 0,
-                    neighbors: vec![b, c],
+                    neighbors: vec![2, 3],
                     edge_type: EdgeType::Neighbors,
                 }],
             })
@@ -1466,10 +1604,13 @@ mod tests {
         assert_eq!(graph.layers[0].get_links(&3).unwrap().neighbors, vec![1u32]);
     }
 
-    /// Filter-on-bump: an asymmetric stale edge `a -> b` (no `b -> a` back-edge,
-    /// as arises after compaction) is dropped the next time `a`'s neighborhood
-    /// is touched once `b`'s content clock has advanced via reauth. This is the
-    /// v5 replacement for main's per-edge version-skip.
+    /// Filter-on-bump at mint: an asymmetric stale edge `a -> b` (no `b -> a`
+    /// back-edge, as arises after compaction) is dropped the next time `a`'s
+    /// neighborhood is touched once `b`'s content clock has advanced via
+    /// reauth — and the drop is recorded in the minted mutation as an explicit
+    /// `RemoveEdges` placed before the triggering op, so a literal replay
+    /// reproduces it. This is the v5 replacement for main's per-edge
+    /// version-skip.
     #[test]
     fn stale_edge_dropped_on_neighborhood_touch_after_reauth() {
         let mut graph = GraphMem::new();
@@ -1484,19 +1625,17 @@ mod tests {
 
         // seq 1: insert a and b.
         graph
-            .insert_apply(&GraphMutation {
-                seq_no: 1,
+            .apply_new(UnstampedMutation {
                 ops: vec![node(a), node(b)],
             })
             .unwrap();
         // seq 2: asymmetric forward edge a -> b only; b's list stays empty.
         graph
-            .insert_apply(&GraphMutation {
-                seq_no: 2,
+            .apply_new(UnstampedMutation {
                 ops: vec![MutationOp::AddEdges {
-                    base: a,
+                    base: 1,
                     layer: 0,
-                    neighbors: vec![b],
+                    neighbors: vec![2],
                     edge_type: EdgeType::Base,
                 }],
             })
@@ -1509,8 +1648,7 @@ mod tests {
         // seq 3: reauth b. RemoveNode(b) no longer touches a's list (no backlink
         // cleanup), so a -> b survives — then AddNode(b) advances content[b] to 3.
         graph
-            .insert_apply(&GraphMutation {
-                seq_no: 3,
+            .apply_new(UnstampedMutation {
                 ops: vec![MutationOp::RemoveNode { id: b }, node(b)],
             })
             .unwrap();
@@ -1525,25 +1663,36 @@ mod tests {
         // runs against a's prior seq (2) and drops a -> b (content[b] = 3 > 2)
         // before appending d.
         graph
-            .insert_apply(&GraphMutation {
-                seq_no: 4,
-                ops: vec![node(d)],
-            })
+            .apply_new(UnstampedMutation { ops: vec![node(d)] })
             .unwrap();
-        graph
-            .insert_apply(&GraphMutation {
-                seq_no: 5,
-                ops: vec![MutationOp::AddEdges {
-                    base: a,
-                    layer: 0,
-                    neighbors: vec![d],
-                    edge_type: EdgeType::Base,
-                }],
+        let touch = MutationOp::AddEdges {
+            base: 1,
+            layer: 0,
+            neighbors: vec![3],
+            edge_type: EdgeType::Base,
+        };
+        let minted = graph
+            .apply_new(UnstampedMutation {
+                ops: vec![touch.clone()],
             })
             .unwrap();
         assert_eq!(
             graph.layers[0].get_links(&1).unwrap().neighbors().to_vec(),
             vec![3u32]
+        );
+
+        // The minted mutation carries the drop explicitly, before the touch.
+        assert_eq!(
+            minted.ops,
+            vec![
+                MutationOp::RemoveEdges {
+                    base: 1,
+                    neighbors: vec![2],
+                    layer: 0,
+                    edge_type: EdgeType::Base,
+                },
+                touch,
+            ]
         );
     }
 
@@ -1573,9 +1722,9 @@ mod tests {
             .insert_apply(&GraphMutation {
                 seq_no: 2,
                 ops: vec![MutationOp::AddEdges {
-                    base: a,
+                    base: 1,
                     layer: 0,
-                    neighbors: vec![b],
+                    neighbors: vec![2],
                     edge_type: EdgeType::Base,
                 }],
             })
@@ -1624,9 +1773,9 @@ mod tests {
             .insert_apply(&GraphMutation {
                 seq_no: 2,
                 ops: vec![MutationOp::AddEdges {
-                    base: a,
+                    base: 1,
                     layer: 0,
-                    neighbors: vec![b],
+                    neighbors: vec![2],
                     edge_type: EdgeType::Base,
                 }],
             })
@@ -1675,9 +1824,9 @@ mod tests {
             .insert_apply(&GraphMutation {
                 seq_no: 2,
                 ops: vec![MutationOp::AddEdges {
-                    base: a,
+                    base: 1,
                     layer: 0,
-                    neighbors: vec![b, c],
+                    neighbors: vec![2, 3],
                     edge_type: EdgeType::Base,
                 }],
             })
@@ -1725,9 +1874,9 @@ mod tests {
             .insert_apply(&GraphMutation {
                 seq_no: 2,
                 ops: vec![MutationOp::AddEdges {
-                    base: a,
+                    base: 1,
                     layer: 0,
-                    neighbors: vec![b],
+                    neighbors: vec![2],
                     edge_type: EdgeType::All,
                 }],
             })
@@ -1793,14 +1942,14 @@ mod tests {
             seq_no: 2,
             ops: vec![
                 MutationOp::AddEdges {
-                    base: v(1),
-                    neighbors: vec![v(2), v(3)],
+                    base: 1,
+                    neighbors: vec![2, 3],
                     layer: 0,
                     edge_type: EdgeType::All,
                 },
                 MutationOp::AddEdges {
-                    base: v(3),
-                    neighbors: vec![v(4)],
+                    base: 3,
+                    neighbors: vec![4],
                     layer: 0,
                     edge_type: EdgeType::Base,
                 },
@@ -1842,10 +1991,12 @@ mod tests {
         }
     }
 
-    /// The `MutationOp::RemoveEdges` fused retain: one teardown drops the
-    /// explicitly-named edge AND sweeps a sibling that went content-stale, in a
-    /// single neighborhood re-stamp — covering both the base-list retain
+    /// The `MutationOp::RemoveEdges` fused retain at mint: one teardown drops
+    /// the explicitly-named edge AND sweeps a sibling that went content-stale,
+    /// in a single neighborhood re-stamp — covering both the base-list retain
     /// (EdgeType::Base) and the target-loop back-half retain (EdgeType::All).
+    /// The swept sibling (and only it — the named edge replays from the op
+    /// itself) is recorded as a synthesized `RemoveEdges` before the op.
     /// Stale edges survive RemoveNode cleanup by staying asymmetric: the
     /// reauthed target's own list never names the holder, so bidirectional
     /// cleanup doesn't visit it.
@@ -1858,88 +2009,99 @@ mod tests {
         };
         let v = VectorId::from_serial_id;
         let mut g = GraphMem::new();
-        g.insert_apply(&GraphMutation {
-            seq_no: 1,
+        g.apply_new(UnstampedMutation {
             ops: (1..=6).map(|i| node(v(i))).collect(),
         })
         .unwrap();
 
         // ── EdgeType::Base, forward-half retain. 1 -> {2,3} forward-only, then
         // reauth 3 so 1->3 is content-stale while 1's list is untouched.
-        g.insert_apply(&GraphMutation {
-            seq_no: 2,
+        g.apply_new(UnstampedMutation {
             ops: vec![MutationOp::AddEdges {
-                base: v(1),
-                neighbors: vec![v(2), v(3)],
+                base: 1,
+                neighbors: vec![2, 3],
                 layer: 0,
                 edge_type: EdgeType::Base,
             }],
         })
         .unwrap();
-        g.insert_apply(&GraphMutation {
-            seq_no: 3,
+        g.apply_new(UnstampedMutation {
             ops: vec![MutationOp::RemoveNode { id: v(3) }, node(v(3))],
         })
         .unwrap();
         assert_eq!(g.get_raw_links(&1, 0), &[2u32, 3u32], "stale 3 still raw");
         assert_eq!(g.get_active_links(&1, 0), vec![v(2)], "3 masked as stale");
 
-        // RemoveEdges Base(1 -/-> 2): retain drops explicit 2 AND stale 3.
-        g.insert_apply(&GraphMutation {
-            seq_no: 4,
-            ops: vec![MutationOp::RemoveEdges {
-                base: v(1),
-                neighbors: vec![v(2)],
-                layer: 0,
-                edge_type: EdgeType::Base,
-            }],
-        })
-        .unwrap();
+        // RemoveEdges Base(1 -/-> 2): retain drops explicit 2 AND stale 3; only
+        // the stale sweep is synthesized into the minted op list.
+        let teardown = MutationOp::RemoveEdges {
+            base: 1,
+            neighbors: vec![2],
+            layer: 0,
+            edge_type: EdgeType::Base,
+        };
+        let minted = g
+            .apply_new(UnstampedMutation {
+                ops: vec![teardown.clone()],
+            })
+            .unwrap();
         assert_eq!(
             g.get_raw_links(&1, 0),
             &[] as &[u32],
             "explicit 2 removed AND content-stale 3 swept in one retain"
         );
+        assert_eq!(
+            minted.ops,
+            vec![
+                MutationOp::RemoveEdges {
+                    base: 1,
+                    neighbors: vec![3],
+                    layer: 0,
+                    edge_type: EdgeType::Base,
+                },
+                teardown,
+            ],
+            "stale sweep recorded before the op; named edge not re-recorded"
+        );
 
         // ── EdgeType::All, back-half (target-loop) retain. 4<->5 symmetric plus
         // asymmetric 5->6; reauth 6 so 5->6 is stale.
-        g.insert_apply(&GraphMutation {
-            seq_no: 5,
+        g.apply_new(UnstampedMutation {
             ops: vec![
                 MutationOp::AddEdges {
-                    base: v(4),
-                    neighbors: vec![v(5)],
+                    base: 4,
+                    neighbors: vec![5],
                     layer: 0,
                     edge_type: EdgeType::All,
                 },
                 MutationOp::AddEdges {
-                    base: v(5),
-                    neighbors: vec![v(6)],
+                    base: 5,
+                    neighbors: vec![6],
                     layer: 0,
                     edge_type: EdgeType::Base,
                 },
             ],
         })
         .unwrap();
-        g.insert_apply(&GraphMutation {
-            seq_no: 6,
+        g.apply_new(UnstampedMutation {
             ops: vec![MutationOp::RemoveNode { id: v(6) }, node(v(6))],
         })
         .unwrap();
         assert_eq!(g.get_raw_links(&5, 0), &[4u32, 6u32], "stale 6 still raw");
 
         // RemoveEdges All(4 -/- 5): forward half empties 4; back-half retain on
-        // target 5 drops explicit 4 AND stale 6.
-        g.insert_apply(&GraphMutation {
-            seq_no: 7,
-            ops: vec![MutationOp::RemoveEdges {
-                base: v(4),
-                neighbors: vec![v(5)],
-                layer: 0,
-                edge_type: EdgeType::All,
-            }],
-        })
-        .unwrap();
+        // target 5 drops explicit 4 AND stale 6 — the latter synthesized.
+        let teardown = MutationOp::RemoveEdges {
+            base: 4,
+            neighbors: vec![5],
+            layer: 0,
+            edge_type: EdgeType::All,
+        };
+        let minted = g
+            .apply_new(UnstampedMutation {
+                ops: vec![teardown.clone()],
+            })
+            .unwrap();
         assert_eq!(
             g.get_raw_links(&4, 0),
             &[] as &[u32],
@@ -1950,14 +2112,202 @@ mod tests {
             &[] as &[u32],
             "back-half retain drops explicit 4 AND content-stale 6"
         );
+        assert_eq!(
+            minted.ops,
+            vec![
+                MutationOp::RemoveEdges {
+                    base: 5,
+                    neighbors: vec![6],
+                    layer: 0,
+                    edge_type: EdgeType::Base,
+                },
+                teardown,
+            ],
+            "back-half stale sweep recorded against the touched target's list"
+        );
     }
 
-    /// v5's defining invariant: edges are version-free. A `VectorId{serial,
-    /// version != 0}` fed through a mutation op lands under the bare serial on
-    /// both the add and remove paths, and edge ops never perturb the content
-    /// clock.
+    /// The WAL contract: a mutation stream minted by `apply_new` (staleness
+    /// filter active, drops recorded) replays LITERALLY via `insert_apply_all`
+    /// onto a fresh graph to the identical state — checksum included. Every
+    /// filter drop must therefore appear as a synthesized `RemoveEdges` in the
+    /// minted ops, correctly placed. The history exercises: reauth whose
+    /// re-wiring touches a neighborhood holding its own stale back-edge
+    /// (drop-then-re-add of the same serial in one op — ordering load-bearing),
+    /// deletion followed by a touch sweeping the dangling edge, both
+    /// `RemoveEdges` fused-retain halves (Base forward, All back), a
+    /// compaction-shaped `RemoveEdges`, multi-layer edges, and entry-point
+    /// churn.
+    #[test]
+    fn minted_stream_replays_literally_to_identical_graph() {
+        fn mint(g: &mut GraphMem, wal: &mut Vec<GraphMutation>, ops: Vec<MutationOp>) {
+            wal.push(g.apply_new(UnstampedMutation { ops }).unwrap());
+        }
+        let node = |s: u32| MutationOp::AddNode {
+            id: VectorId::from_serial_id(s),
+            height: 1,
+            update_ep: UpdateEntryPoint::False,
+        };
+        // Node 1 spans layers 0,1 and is the entry point; re-minted on reauth.
+        let node1 = || MutationOp::AddNode {
+            id: VectorId::from_serial_id(1),
+            height: 2,
+            update_ep: UpdateEntryPoint::Append { layer: 1 },
+        };
+        let all = |base: u32, neighbors: Vec<u32>, layer: usize| MutationOp::AddEdges {
+            base,
+            neighbors,
+            layer,
+            edge_type: EdgeType::All,
+        };
+
+        let mut l = GraphMem::new();
+        let mut wal = Vec::new();
+
+        // seq 1: nodes 1..=7 (1 and 5 span layer 1).
+        let mut ops = vec![node1()];
+        ops.extend((2..=7).map(node));
+        ops[4] = MutationOp::AddNode {
+            id: VectorId::from_serial_id(5),
+            height: 2,
+            update_ep: UpdateEntryPoint::False,
+        };
+        mint(&mut l, &mut wal, ops);
+        // seq 2: 1<->2 at layer 0, 1<->5 at layer 1.
+        mint(
+            &mut l,
+            &mut wal,
+            vec![all(1, vec![2], 0), all(1, vec![5], 1)],
+        );
+        // seq 3: reauth 1, phase one — node teardown (2 and 5 keep stale
+        // back-edges to 1; the entry point is dropped).
+        mint(
+            &mut l,
+            &mut wal,
+            vec![MutationOp::RemoveNode {
+                id: VectorId::from_serial_id(1),
+            }],
+        );
+        // seq 4: reauth 1, phase two — KEY fixture: the re-wiring back-halves
+        // touch 2 (layer 0) and 5 (layer 1), each holding the stale edge to 1
+        // that the same op re-adds. The synthesized drop must precede the op.
+        mint(
+            &mut l,
+            &mut wal,
+            vec![node1(), all(1, vec![2], 0), all(1, vec![5], 1)],
+        );
+        assert_eq!(
+            wal[3].ops,
+            vec![
+                node1(),
+                MutationOp::RemoveEdges {
+                    base: 2,
+                    neighbors: vec![1],
+                    layer: 0,
+                    edge_type: EdgeType::Base,
+                },
+                all(1, vec![2], 0),
+                MutationOp::RemoveEdges {
+                    base: 5,
+                    neighbors: vec![1],
+                    layer: 1,
+                    edge_type: EdgeType::Base,
+                },
+                all(1, vec![5], 1),
+            ],
+            "reauth drops synthesized per layer, each before its re-adding op"
+        );
+
+        // seq 5: pure deletion of 2 — node 1 keeps a dangling 1->2 edge.
+        mint(
+            &mut l,
+            &mut wal,
+            vec![MutationOp::RemoveNode {
+                id: VectorId::from_serial_id(2),
+            }],
+        );
+        // seq 6: 3<->1 — the back-half touch of 1 sweeps the dangling 2.
+        mint(&mut l, &mut wal, vec![all(3, vec![1], 0)]);
+        // seq 7: forward-only fan-out 5 -> {6,7} at layer 0.
+        mint(
+            &mut l,
+            &mut wal,
+            vec![MutationOp::AddEdges {
+                base: 5,
+                neighbors: vec![6, 7],
+                layer: 0,
+                edge_type: EdgeType::Base,
+            }],
+        );
+        // seq 8: reauth 6 in one mutation (no edges reference 6 here).
+        mint(
+            &mut l,
+            &mut wal,
+            vec![
+                MutationOp::RemoveNode {
+                    id: VectorId::from_serial_id(6),
+                },
+                node(6),
+            ],
+        );
+        // seq 9: compaction-shaped RemoveEdges (Base): drops named 7 and sweeps
+        // stale 6 from 5's list in the fused forward retain.
+        mint(
+            &mut l,
+            &mut wal,
+            vec![MutationOp::RemoveEdges {
+                base: 5,
+                neighbors: vec![7],
+                layer: 0,
+                edge_type: EdgeType::Base,
+            }],
+        );
+        // seq 10: 4<->3.
+        mint(&mut l, &mut wal, vec![all(4, vec![3], 0)]);
+        // seq 11: reauth 1 again — 3's list (certified at seq 10) holds a now
+        // stale edge to 1.
+        mint(
+            &mut l,
+            &mut wal,
+            vec![
+                MutationOp::RemoveNode {
+                    id: VectorId::from_serial_id(1),
+                },
+                node1(),
+            ],
+        );
+        // seq 12: RemoveEdges All 4 -/- 3: the back-half target retain on 3
+        // drops named 4 and sweeps stale 1.
+        mint(
+            &mut l,
+            &mut wal,
+            vec![MutationOp::RemoveEdges {
+                base: 4,
+                neighbors: vec![3],
+                layer: 0,
+                edge_type: EdgeType::All,
+            }],
+        );
+
+        // The stream really carries synthesized drops beyond the asserted ones.
+        let synthesized_drops = wal
+            .iter()
+            .flat_map(|m| m.ops.iter())
+            .filter(|op| matches!(op, MutationOp::RemoveEdges { .. }))
+            .count();
+        assert!(synthesized_drops >= 6, "got {synthesized_drops}");
+
+        let mut r = GraphMem::new();
+        r.insert_apply_all(&wal).unwrap();
+        assert_eq!(l.checksum(), r.checksum(), "replay diverged from mint");
+        assert_eq!(l, r, "replay diverged from mint");
+    }
+
+    /// v5's defining invariant: edges are version-free (edge ops carry bare
+    /// serials by type), and edge ops never perturb the content clock — a
+    /// node's `NodeInit` moves only on its own `AddNode`/`RemoveNode`.
     #[tokio::test]
-    async fn remove_edges_op_multi_version_collapse() {
+    async fn edge_ops_do_not_perturb_content_clock() {
         let node = |id: VectorId| MutationOp::AddNode {
             id,
             height: 1,
@@ -1965,61 +2315,49 @@ mod tests {
         };
         let v = VectorId::from_serial_id;
         let mut g = GraphMem::new();
+        // Node 2 carries a non-zero version so the clock has real content.
         g.insert_apply(&GraphMutation {
             seq_no: 1,
-            ops: vec![node(v(1)), node(v(2)), node(v(3))],
+            ops: vec![node(v(1)), node(VectorId::new(2, 7)), node(v(3))],
         })
         .unwrap();
         let clock_before = g.node_init.clone();
 
-        // All(1 <-> [2@v7, 3@v2]): versions dropped; 1's list keys on {2,3}, and
-        // 1 is back-linked into 2 and 3 by bare serial.
         g.insert_apply(&GraphMutation {
             seq_no: 2,
             ops: vec![MutationOp::AddEdges {
-                base: v(1),
-                neighbors: vec![VectorId::new(2, 7), VectorId::new(3, 2)],
+                base: 1,
+                neighbors: vec![2, 3],
                 layer: 0,
                 edge_type: EdgeType::All,
             }],
         })
         .unwrap();
-        assert_eq!(
-            g.get_raw_links(&1, 0),
-            &[2u32, 3u32],
-            "versions collapsed to serials"
-        );
+        assert_eq!(g.get_raw_links(&1, 0), &[2u32, 3u32]);
         assert_eq!(
             g.get_raw_links(&2, 0),
             &[1u32],
             "back-edge keyed on serial 2"
         );
         assert_eq!(
-            g.get_raw_links(&3, 0),
-            &[1u32],
-            "back-edge keyed on serial 3"
-        );
-        assert_eq!(
             g.node_init, clock_before,
             "AddEdges must not perturb the content clock"
         );
 
-        // RemoveEdges Base(1 -/- 2@v99): a different version of serial 2 still
-        // matches the serial-2 edge.
         g.insert_apply(&GraphMutation {
             seq_no: 3,
             ops: vec![MutationOp::RemoveEdges {
-                base: v(1),
-                neighbors: vec![VectorId::new(2, 99)],
+                base: 1,
+                neighbors: vec![2],
                 layer: 0,
                 edge_type: EdgeType::Base,
             }],
         })
         .unwrap();
+        assert_eq!(g.get_raw_links(&1, 0), &[3u32]);
         assert_eq!(
-            g.get_raw_links(&1, 0),
-            &[3u32],
-            "versioned RemoveEdges matched the serial-2 edge"
+            g.node_init, clock_before,
+            "RemoveEdges must not perturb the content clock"
         );
     }
 
@@ -2055,8 +2393,8 @@ mod tests {
         g.insert_apply(&GraphMutation {
             seq_no: 2,
             ops: vec![MutationOp::AddEdges {
-                base: v(1),
-                neighbors: vec![v(2), v(3)],
+                base: 1,
+                neighbors: vec![2, 3],
                 layer: 0,
                 edge_type: EdgeType::All,
             }],
@@ -2123,9 +2461,9 @@ mod tests {
             .insert_apply(&GraphMutation {
                 seq_no: 2,
                 ops: vec![MutationOp::AddEdges {
-                    base: a,
+                    base: 1,
                     layer: 0,
-                    neighbors: vec![b, c],
+                    neighbors: vec![2, 3],
                     edge_type: EdgeType::All,
                 }],
             })
@@ -2154,9 +2492,9 @@ mod tests {
                         update_ep: UpdateEntryPoint::Append { layer: 1 },
                     },
                     MutationOp::AddEdges {
-                        base: a,
+                        base: 1,
                         layer: 0,
-                        neighbors: vec![b, c],
+                        neighbors: vec![2, 3],
                         edge_type: EdgeType::Base,
                     },
                     MutationOp::AddNode {
@@ -2165,9 +2503,9 @@ mod tests {
                         update_ep: UpdateEntryPoint::False,
                     },
                     MutationOp::AddEdges {
-                        base: b,
+                        base: 2,
                         layer: 0,
-                        neighbors: vec![a],
+                        neighbors: vec![1],
                         edge_type: EdgeType::Base,
                     },
                     MutationOp::AddNode {
@@ -2176,9 +2514,9 @@ mod tests {
                         update_ep: UpdateEntryPoint::False,
                     },
                     MutationOp::AddEdges {
-                        base: c,
+                        base: 3,
                         layer: 0,
-                        neighbors: vec![a],
+                        neighbors: vec![1],
                         edge_type: EdgeType::Base,
                     },
                 ],
@@ -2188,9 +2526,9 @@ mod tests {
             .insert_apply(&GraphMutation {
                 seq_no: 2,
                 ops: vec![MutationOp::RemoveEdges {
-                    base: a,
+                    base: 1,
                     layer: 0,
-                    neighbors: vec![b],
+                    neighbors: vec![2],
                     edge_type: EdgeType::Base,
                 }],
             })
@@ -2213,9 +2551,9 @@ mod tests {
                 ops: vec![
                     // Listed first: an edge op that references a node not yet created.
                     MutationOp::AddEdges {
-                        base: a,
+                        base: 1,
                         layer: 0,
-                        neighbors: vec![b],
+                        neighbors: vec![2],
                         edge_type: EdgeType::Base,
                     },
                     // Listed second: the node creation.

--- a/iris-mpc-cpu/src/hnsw/graph/mutation.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/mutation.rs
@@ -1,4 +1,4 @@
-use iris_mpc_common::VectorId;
+use iris_mpc_common::{SerialId, VectorId};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -41,19 +41,23 @@ pub enum MutationOp {
     RemoveNode {
         id: VectorId,
     },
-    /// Every `base` and `neighbors` node must already exist (its `AddNode` applied
-    /// in an earlier mutation or earlier in this op list). An edge to a
-    /// not-yet-created node is dropped as stale — see `GraphMem::insert_apply`
-    /// (causal construction).
+    /// Every `base` and `neighbors` node must already exist: its `AddNode`
+    /// applied in an earlier mutation, or anywhere in this op list (node ops
+    /// apply before edge ops). An edge to a not-yet-created node is treated as
+    /// stale at read time — see `GraphMem::apply_new` (causal construction).
+    ///
+    /// Edge ops carry bare serials: node identity/version lives in `AddNode`/
+    /// `RemoveNode` (the content-clock source), and edges only select
+    /// neighborhood members.
     AddEdges {
-        base: VectorId,
-        neighbors: Vec<VectorId>,
+        base: SerialId,
+        neighbors: Vec<SerialId>,
         layer: usize,
         edge_type: EdgeType,
     },
     RemoveEdges {
-        base: VectorId,
-        neighbors: Vec<VectorId>,
+        base: SerialId,
+        neighbors: Vec<SerialId>,
         layer: usize,
         edge_type: EdgeType,
     },
@@ -104,7 +108,7 @@ impl UnstampedMutation {
     /// in this mutation. Used as the candidate set for batch compaction. The
     /// returned Vec is the raw walk and may contain duplicates; callers fold
     /// into a set to dedup.
-    pub fn expanded_neighborhoods(&self) -> Vec<(VectorId, usize)> {
+    pub fn expanded_neighborhoods(&self) -> Vec<(SerialId, usize)> {
         let mut out = Vec::new();
         for op in &self.ops {
             if let MutationOp::AddEdges {
@@ -314,11 +318,6 @@ mod tests {
 
     use super::{EdgeType, MutationOp, UnstampedMutation, UpdateEntryPoint};
 
-    #[allow(dead_code)]
-    fn mk_vector_id(id: u32) -> VectorId {
-        VectorId::from_serial_id(id)
-    }
-
     fn mk_add_edges(
         base: u32,
         neighbors: Vec<u32>,
@@ -326,8 +325,8 @@ mod tests {
         edge_type: EdgeType,
     ) -> MutationOp {
         MutationOp::AddEdges {
-            base: mk_vector_id(base),
-            neighbors: neighbors.into_iter().map(mk_vector_id).collect(),
+            base,
+            neighbors,
             layer,
             edge_type,
         }
@@ -340,14 +339,7 @@ mod tests {
         };
         let mut got = mutation.expanded_neighborhoods();
         got.sort();
-        assert_eq!(
-            got,
-            vec![
-                (mk_vector_id(1), 0),
-                (mk_vector_id(2), 0),
-                (mk_vector_id(3), 0)
-            ]
-        );
+        assert_eq!(got, vec![(1, 0), (2, 0), (3, 0)]);
     }
 
     #[test]
@@ -355,10 +347,7 @@ mod tests {
         let mutation = UnstampedMutation {
             ops: vec![mk_add_edges(1, vec![2, 3], 1, EdgeType::Base)],
         };
-        assert_eq!(
-            mutation.expanded_neighborhoods(),
-            vec![(mk_vector_id(1), 1)]
-        );
+        assert_eq!(mutation.expanded_neighborhoods(), vec![(1, 1)]);
     }
 
     #[test]
@@ -368,7 +357,7 @@ mod tests {
         };
         let mut got = mutation.expanded_neighborhoods();
         got.sort();
-        assert_eq!(got, vec![(mk_vector_id(2), 2), (mk_vector_id(3), 2)]);
+        assert_eq!(got, vec![(2, 2), (3, 2)]);
     }
 
     #[test]
@@ -376,16 +365,16 @@ mod tests {
         let mutation = UnstampedMutation {
             ops: vec![
                 MutationOp::AddNode {
-                    id: mk_vector_id(1),
+                    id: VectorId::from_serial_id(1),
                     height: 1,
                     update_ep: UpdateEntryPoint::False,
                 },
                 MutationOp::RemoveNode {
-                    id: mk_vector_id(2),
+                    id: VectorId::from_serial_id(2),
                 },
                 MutationOp::RemoveEdges {
-                    base: mk_vector_id(3),
-                    neighbors: vec![mk_vector_id(4), mk_vector_id(5)],
+                    base: 3,
+                    neighbors: vec![4, 5],
                     layer: 0,
                     edge_type: EdgeType::All,
                 },
@@ -394,6 +383,6 @@ mod tests {
         };
         let mut got = mutation.expanded_neighborhoods();
         got.sort();
-        assert_eq!(got, vec![(mk_vector_id(6), 0), (mk_vector_id(7), 0)]);
+        assert_eq!(got, vec![(6, 0), (7, 0)]);
     }
 }

--- a/iris-mpc-cpu/src/hnsw/graph/test_utils.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/test_utils.rs
@@ -400,9 +400,9 @@ impl DbContext {
                     update_ep: UpdateEntryPoint::False,
                 },
                 MutationOp::AddEdges {
-                    base: vectors[i],
+                    base: vectors[i].serial_id(),
                     layer: 0,
-                    neighbors,
+                    neighbors: neighbors.iter().map(|v| v.serial_id()).collect(),
                     edge_type: EdgeType::Base,
                 },
             ];

--- a/iris-mpc-cpu/src/hnsw/searcher.rs
+++ b/iris-mpc-cpu/src/hnsw/searcher.rs
@@ -1536,15 +1536,20 @@ impl HnswSearcher {
         &self,
         store: &mut V,
         graph: &GraphMem,
-        candidates: &BTreeSet<(VectorId, usize)>,
+        candidates: &BTreeSet<(SerialId, usize)>,
     ) -> Result<Vec<MutationOp>> {
         // Read the current neighborhood for each candidate; keep only those
         // exceeding M_limit on their layer.
         let mut oversized: Vec<(VectorId, usize, Vec<VectorId>)> = Vec::new();
-        for (id, layer) in candidates {
-            let nbhd: Vec<VectorId> = graph.get_active_links(&id.serial_id(), *layer);
+        for (serial, layer) in candidates {
+            let nbhd: Vec<VectorId> = graph.get_active_links(serial, *layer);
             if nbhd.len() > self.params.get_M_limit(*layer) {
-                oversized.push((*id, *layer, nbhd));
+                // A node in a layer always has a content-clock entry; resolve
+                // its current VectorId for the MPC ranking.
+                let id = graph
+                    .vector_id_of(*serial)
+                    .expect("oversized neighborhood without a content-clock entry");
+                oversized.push((id, *layer, nbhd));
             }
         }
 
@@ -1577,14 +1582,14 @@ impl HnswSearcher {
             izip!(&base_nodes, &layers, &neighborhoods, compacted_nbhds)
         {
             let compacted_set: HashSet<_> = compacted.iter().collect();
-            let to_remove: Vec<VectorId> = original
+            let to_remove: Vec<SerialId> = original
                 .iter()
                 .filter(|v| !compacted_set.contains(v))
-                .cloned()
+                .map(|v| v.serial_id())
                 .collect();
             if !to_remove.is_empty() {
                 ops.push(MutationOp::RemoveEdges {
-                    base: *id,
+                    base: id.serial_id(),
                     layer: *layer,
                     neighbors: to_remove,
                     edge_type: EdgeType::Base,
@@ -1629,9 +1634,9 @@ impl HnswSearcher {
         }];
         for (layer_idx, layer_links) in links_unstructured.into_iter().enumerate() {
             ops.push(MutationOp::AddEdges {
-                base: inserted_vector,
+                base: inserted_vector.serial_id(),
                 layer: layer_idx,
-                neighbors: layer_links,
+                neighbors: layer_links.iter().map(|v| v.serial_id()).collect(),
                 edge_type: EdgeType::All,
             });
         }
@@ -1836,8 +1841,8 @@ mod tests {
             update_ep: UpdateEntryPoint::False,
         }));
         ops.push(MutationOp::AddEdges {
-            base,
-            neighbors: nbrs.clone(),
+            base: base.serial_id(),
+            neighbors: nbrs.iter().map(|v| v.serial_id()).collect(),
             layer: 0,
             edge_type: EdgeType::Base,
         });
@@ -1848,7 +1853,7 @@ mod tests {
         graph.insert_apply(&setup)?;
 
         let mut candidates = BTreeSet::new();
-        candidates.insert((base, 0));
+        candidates.insert((base.serial_id(), 0));
 
         let ops = searcher
             .compact_batch(&mut store, &graph, &candidates)
@@ -1862,13 +1867,13 @@ mod tests {
                 neighbors,
                 edge_type,
             } => {
-                assert_eq!(*b, base);
+                assert_eq!(*b, base.serial_id());
                 assert_eq!(layer, &0);
                 assert_eq!(edge_type, &EdgeType::Base);
                 let expected_trim = oversized_count - searcher.params.get_M_max(0);
                 assert_eq!(neighbors.len(), expected_trim);
                 // Every removed neighbor came from the original set.
-                let orig: HashSet<_> = nbrs.iter().collect();
+                let orig: HashSet<_> = nbrs.iter().map(|v| v.serial_id()).collect();
                 for n in neighbors {
                     assert!(
                         orig.contains(n),
@@ -1915,8 +1920,8 @@ mod tests {
                     update_ep: UpdateEntryPoint::False,
                 },
                 MutationOp::AddEdges {
-                    base: a,
-                    neighbors: vec![b],
+                    base: a.serial_id(),
+                    neighbors: vec![b.serial_id()],
                     layer: 0,
                     edge_type: EdgeType::Base,
                 },
@@ -1925,7 +1930,7 @@ mod tests {
         graph.insert_apply(&setup)?;
 
         let mut candidates = BTreeSet::new();
-        candidates.insert((a, 0));
+        candidates.insert((a.serial_id(), 0));
 
         let ops = searcher
             .compact_batch(&mut store, &graph, &candidates)

--- a/iris-mpc-cpu/src/hnsw/searcher.rs
+++ b/iris-mpc-cpu/src/hnsw/searcher.rs
@@ -396,16 +396,20 @@ impl HnswSearcher {
     ) -> Result<(SortedNeighborhood<V>, usize, usize, UpdateEntryPoint)> {
         let max_graph_layer = self.max_graph_layer;
 
-        // Get all valid entry points
-        let ep_serials: Vec<_> = graph.entry_points.iter().map(|ep| ep.point).collect();
-        let entry_points: Vec<(VectorId, usize)> = store
-            .serials_to_vector_ids(&ep_serials)
-            .await
-            .into_iter()
-            .zip(graph.entry_points.iter().map(|ep| ep.layer))
-            .filter_map(|(vid, layer)| vid.map(|v| (v, layer)))
+        // Entry points resolve from the graph's own content clock: a serial
+        // without a clock entry is not live (removed, or pruned at migration)
+        // and is skipped rather than resolved to a fabricated version.
+        let entry_points: Vec<(VectorId, usize)> = graph
+            .entry_points
+            .iter()
+            .filter_map(|ep| graph.vector_id_of(ep.point).map(|v| (v, ep.layer)))
             .collect();
-        let entry_points = store.only_valid_entry_points(entry_points).await;
+        #[cfg(debug_assertions)]
+        Self::debug_assert_graph_resolution_matches_store(
+            store,
+            entry_points.iter().map(|(v, _)| *v),
+        )
+        .await;
         let (ep_vectors, ep_layers): (Vec<VectorId>, Vec<usize>) = entry_points.into_iter().unzip();
         metrics::gauge!("entry_points_count").set(ep_vectors.len() as f64);
 
@@ -417,7 +421,9 @@ impl HnswSearcher {
         }
 
         let (W, n_layers) = if ep_vectors.is_empty() {
-            let ep = graph.get_temporary_entry_point();
+            let ep = graph
+                .get_temporary_entry_point()
+                .and_then(|(serial, layer)| graph.vector_id_of(serial).map(|v| (v, layer)));
             let (W, layer) = self.init_nbhd_from_ep(store, ep, query).await?;
 
             // Layers are 0-indexed, so number of graph layers is one greater than the entry point layer
@@ -450,35 +456,46 @@ impl HnswSearcher {
         Ok((W, n_layers, bounded_insertion_layer, update_ep))
     }
 
-    /// For a specified entry point, returns an initialized singleton candidate
-    /// neighborhood containing the entry point, and the graph layer of this
-    /// neighborhood.
+    /// For a specified entry point (already resolved via the graph's content
+    /// clock), returns an initialized singleton candidate neighborhood
+    /// containing the entry point, and the graph layer of this neighborhood.
     ///
     /// If `ep` is specified as `None` (no entry point available), then returns
     /// an empty neighborhood and `None` for its layer.
     async fn init_nbhd_from_ep<V: VectorStore>(
         &self,
         store: &mut V,
-        ep: Option<(SerialId, usize)>,
+        ep: Option<(VectorId, usize)>,
         query: &V::QueryRef,
     ) -> Result<(SortedNeighborhood<V>, Option<usize>)> {
-        if let Some((entry_point, layer)) = ep {
-            // A resolver `None` means the entry point is no longer live; treat it
-            // as no entry point rather than fabricating a version.
-            if let Some(vector_id) = store
-                .serials_to_vector_ids(&[entry_point])
-                .await
-                .pop()
-                .flatten()
-            {
-                let distance = store.eval_distance(query, &vector_id).await?;
-                let W = SortedNeighborhood::from_singleton((vector_id, distance));
-                Ok((W, Some(layer)))
-            } else {
-                Ok((SortedNeighborhood::new(), None))
-            }
+        if let Some((vector_id, layer)) = ep {
+            let distance = store.eval_distance(query, &vector_id).await?;
+            let W = SortedNeighborhood::from_singleton((vector_id, distance));
+            Ok((W, Some(layer)))
         } else {
             Ok((SortedNeighborhood::new(), None))
+        }
+    }
+
+    /// Debug-only cross-check of the graph's content-clock resolution against
+    /// the store registry. The registry may run *ahead* of the graph clock
+    /// within a batch or during genesis delta replay (registry writes land
+    /// before the corresponding graph mutation), so the invariant is
+    /// asymmetric: a graph-live serial must be registry-present, and the graph
+    /// version must never exceed the registry's.
+    #[cfg(debug_assertions)]
+    async fn debug_assert_graph_resolution_matches_store<V: VectorStore>(
+        store: &V,
+        resolved: impl Iterator<Item = VectorId>,
+    ) {
+        let resolved: Vec<VectorId> = resolved.collect();
+        let serials: Vec<SerialId> = resolved.iter().map(|v| v.serial_id()).collect();
+        let from_store = store.serials_to_vector_ids(&serials).await;
+        for (graph_v, store_v) in resolved.iter().zip(from_store) {
+            debug_assert!(
+                store_v.is_some_and(|s| s.version_id() >= graph_v.version_id()),
+                "graph content clock ahead of the store registry: graph {graph_v:?}, store {store_v:?}"
+            );
         }
     }
 
@@ -999,13 +1016,11 @@ impl HnswSearcher {
         let mut init_nodes = Vec::from_iter(W.as_ref().iter().map(|(e, _eq)| *e));
         let mut open_idx = 0;
         while open_idx < init_nodes.len() && init_nodes.len() < ef {
-            // get valid, unvisited neighbors of current node at `open_idx`
-            let active = graph.get_active_links(&init_nodes[open_idx].serial_id(), lc);
-            let nbhd: Vec<VectorId> = store
-                .serials_to_vector_ids(&active)
-                .await
+            // get valid, unvisited neighbors of current node at `open_idx`,
+            // resolved to current VectorIds by the graph's content clock
+            let nbhd: Vec<VectorId> = graph
+                .get_active_links(&init_nodes[open_idx].serial_id(), lc)
                 .into_iter()
-                .flatten()
                 .filter(|x| !init_nodes.contains(x))
                 .collect();
 
@@ -1285,13 +1300,9 @@ impl HnswSearcher {
         query: &V::QueryRef,
         visited: &mut HashSet<VectorId>,
     ) -> Result<Vec<(VectorId, V::DistanceRef)>> {
-        let neighbors = graph.get_active_links(&node.serial_id(), lc);
-
-        let unvisited_neighbors: Vec<VectorId> = store
-            .serials_to_vector_ids(&neighbors)
-            .await
+        let unvisited_neighbors: Vec<VectorId> = graph
+            .get_active_links(&node.serial_id(), lc)
             .into_iter()
-            .flatten()
             .filter(|e| visited.insert(*e))
             .collect();
 
@@ -1328,15 +1339,18 @@ impl HnswSearcher {
         let mut opened_nodes = Vec::with_capacity(nodes.len());
 
         for node in nodes {
-            let neighbors = graph.get_active_links(&node.serial_id(), lc);
-
-            let unvisited_neighbors: Vec<VectorId> = store
-                .serials_to_vector_ids(&neighbors)
-                .await
+            let unvisited_neighbors: Vec<VectorId> = graph
+                .get_active_links(&node.serial_id(), lc)
                 .into_iter()
-                .flatten()
                 .filter(|e| visited.insert(*e))
                 .collect();
+
+            #[cfg(debug_assertions)]
+            Self::debug_assert_graph_resolution_matches_store(
+                store,
+                unvisited_neighbors.iter().copied(),
+            )
+            .await;
 
             valid_neighbors.extend(unvisited_neighbors);
             opened_nodes.push(*node);
@@ -1515,8 +1529,9 @@ impl HnswSearcher {
     /// Ranks over active neighborhoods (`get_active_links`), not raw: compaction
     /// evicts physically and an evicted live edge cannot be recovered, so
     /// selection must never see a content-stale or removed edge (read-time masking
-    /// wouldn't undo the eviction). Registry-absent serials are dropped by the
-    /// resolver. This reproduces main's pre-compaction `only_valid_vectors` clean.
+    /// wouldn't undo the eviction). Clock-absent serials are dropped by the
+    /// active filter. This reproduces main's pre-compaction `only_valid_vectors`
+    /// clean.
     pub async fn compact_batch<V: VectorStore>(
         &self,
         store: &mut V,
@@ -1527,13 +1542,7 @@ impl HnswSearcher {
         // exceeding M_limit on their layer.
         let mut oversized: Vec<(VectorId, usize, Vec<VectorId>)> = Vec::new();
         for (id, layer) in candidates {
-            let active = graph.get_active_links(&id.serial_id(), *layer);
-            let nbhd: Vec<VectorId> = store
-                .serials_to_vector_ids(&active)
-                .await
-                .into_iter()
-                .flatten()
-                .collect();
+            let nbhd: Vec<VectorId> = graph.get_active_links(&id.serial_id(), *layer);
             if nbhd.len() > self.params.get_M_limit(*layer) {
                 oversized.push((*id, *layer, nbhd));
             }

--- a/iris-mpc-cpu/src/hnsw/vector_store.rs
+++ b/iris-mpc-cpu/src/hnsw/vector_store.rs
@@ -67,12 +67,6 @@ pub trait VectorStore: Debug {
     /// to help comparison to other vectors.
     async fn vectors_as_queries(&mut self, vectors: Vec<VectorId>) -> Result<Vec<Self::QueryRef>>;
 
-    /// Retain entrypoints (vector id, layer) whose vector id is valid
-    async fn only_valid_entry_points(
-        &mut self,
-        entry_points: Vec<(VectorId, usize)>,
-    ) -> Vec<(VectorId, usize)>;
-
     /// Evaluate the distance between pairs of (query, vector), in batch.
     /// The default implementation is a loop over `eval_distance`.
     /// Override for more efficient batch distance evaluations.
@@ -210,9 +204,11 @@ pub trait VectorStore: Debug {
     /// or `None` if the serial is not currently live in the registry/storage.
     /// Returns one entry per input serial, positionally aligned. Registry-backed
     /// stores take the version lock via an awaited read (never `try_read`), so
-    /// resolution reflects the true current version. A serial absent from the
-    /// registry resolves to `None` (dropped by the caller), matching the old
-    /// `only_valid_vectors` semantics — never fabricated at version 0.
+    /// resolution reflects the true current version.
+    ///
+    /// Traversal resolves from the graph's own content clock
+    /// (`GraphMem::vector_id_of` / `get_active_links`); this method is the
+    /// registry side of the debug-build cross-check that the two sources agree.
     async fn serials_to_vector_ids(&self, serial_ids: &[SerialId]) -> Vec<Option<VectorId>>;
 }
 

--- a/iris-mpc-cpu/src/utils/serialization/graph.rs
+++ b/iris-mpc-cpu/src/utils/serialization/graph.rs
@@ -12,7 +12,7 @@ use iris_mpc_common::VectorId;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    hnsw::graph::layered_graph::{self, GraphMem, Layer},
+    hnsw::graph::layered_graph::{self, GraphMem, Layer, NodeInit},
     utils::serialization::types::{
         graph_v0::{self, read_graph_v0, GraphV0},
         graph_v1::{self, read_graph_v1, GraphV1},
@@ -394,11 +394,11 @@ pub fn read_graph_pair_pruned<R: std::io::Read + ?Sized>(
     }
 }
 
-/// Build pruned `Layer`s and a clock-0 `node_init_seq_no` from a legacy graph.
-/// `$layers`/`$entry_points` are moved out (distinct fields → partial move).
-/// At most one version per serial matches `version_map`, so multi-version
-/// stragglers collapse deterministically onto the live entry. `set_links_trusted`
-/// recomputes each layer's `set_hash`.
+/// Build pruned `Layer`s and a `node_init` clock (seq 0, version from
+/// `version_map`) from a legacy graph. `$layers`/`$entry_points` are moved out
+/// (distinct fields → partial move). At most one version per serial matches
+/// `version_map`, so multi-version stragglers collapse deterministically onto
+/// the live entry. `set_links_trusted` recomputes each layer's `set_hash`.
 macro_rules! legacy_prune_to_mem {
     ($layers:expr, $entry_points:expr, $last_update_seq_no:expr, $prune:expr) => {{
         let src_layers = $layers;
@@ -423,16 +423,24 @@ macro_rules! legacy_prune_to_mem {
             }
             layers.push(out);
         }
-        let node_init_seq_no = layers
+        // A kept node's key version equals its registry-current version (that's
+        // what `live_at` checked), so it seeds the graph's version truth.
+        let node_init = layers
             .iter()
             .flat_map(|l| l.links.keys())
-            .map(|&v| (v, 0u64))
+            .map(|&v| {
+                let version = *prune
+                    .version_map
+                    .get(&v)
+                    .expect("pruned node must be in version_map");
+                (v, NodeInit { seq_no: 0, version })
+            })
             .collect();
         GraphMem::from_parts(
             $entry_points.into_iter().map(|e| e.into()).collect(),
             layers,
             $last_update_seq_no,
-            node_init_seq_no,
+            node_init,
         )
     }};
 }
@@ -535,10 +543,10 @@ impl From<graph_v0::Layer> for Layer {
 impl From<graph_v0::GraphV0> for GraphMem {
     fn from(value: GraphV0) -> Self {
         let layers: Vec<Layer> = value.layers.into_iter().map(|layer| layer.into()).collect();
-        let node_init_seq_no = layers
+        let node_init = layers
             .iter()
             .flat_map(|l| l.links.keys())
-            .map(|&v| (v, 0u64))
+            .map(|&v| (v, NodeInit::default()))
             .collect();
         GraphMem::from_parts(
             value
@@ -548,7 +556,7 @@ impl From<graph_v0::GraphV0> for GraphMem {
                 .collect::<Vec<_>>(),
             layers,
             0,
-            node_init_seq_no,
+            node_init,
         )
     }
 }
@@ -583,10 +591,10 @@ impl From<graph_v1::Layer> for Layer {
 impl From<graph_v1::GraphV1> for GraphMem {
     fn from(value: GraphV1) -> Self {
         let layers: Vec<Layer> = value.layers.into_iter().map(|layer| layer.into()).collect();
-        let node_init_seq_no = layers
+        let node_init = layers
             .iter()
             .flat_map(|l| l.links.keys())
-            .map(|&v| (v, 0u64))
+            .map(|&v| (v, NodeInit::default()))
             .collect();
         GraphMem::from_parts(
             value
@@ -596,7 +604,7 @@ impl From<graph_v1::GraphV1> for GraphMem {
                 .collect::<Vec<_>>(),
             layers,
             0,
-            node_init_seq_no,
+            node_init,
         )
     }
 }
@@ -634,10 +642,10 @@ impl From<graph_v2::Layer> for Layer {
 impl From<graph_v2::GraphV2> for GraphMem {
     fn from(value: graph_v2::GraphV2) -> Self {
         let layers: Vec<Layer> = value.layers.into_iter().map(|layer| layer.into()).collect();
-        let node_init_seq_no = layers
+        let node_init = layers
             .iter()
             .flat_map(|l| l.links.keys())
-            .map(|&v| (v, 0u64))
+            .map(|&v| (v, NodeInit::default()))
             .collect();
         // GraphMem uses a Vec<EntryPoint>, V2 uses Option<EntryPoint>.
         GraphMem::from_parts(
@@ -648,7 +656,7 @@ impl From<graph_v2::GraphV2> for GraphMem {
                 .collect::<Vec<_>>(),
             layers,
             0,
-            node_init_seq_no,
+            node_init,
         )
     }
 }
@@ -686,17 +694,17 @@ impl From<graph_v3::Layer> for Layer {
 impl From<graph_v3::GraphV3> for GraphMem {
     fn from(value: graph_v3::GraphV3) -> Self {
         let layers: Vec<Layer> = value.layers.into_iter().map(|layer| layer.into()).collect();
-        let node_init_seq_no = layers
+        let node_init = layers
             .iter()
             .flat_map(|l| l.links.keys())
-            .map(|&v| (v, 0u64))
+            .map(|&v| (v, NodeInit::default()))
             .collect();
         // V3 uses a Vec<EntryPoint>, which matches GraphMem
         GraphMem::from_parts(
             value.entry_point.into_iter().map(|e| e.into()).collect(),
             layers,
             0,
-            node_init_seq_no,
+            node_init,
         )
     }
 }
@@ -733,16 +741,16 @@ impl From<graph_v4::Layer> for Layer {
 impl From<graph_v4::GraphV4> for GraphMem {
     fn from(value: graph_v4::GraphV4) -> Self {
         let layers: Vec<Layer> = value.layers.into_iter().map(|layer| layer.into()).collect();
-        let node_init_seq_no = layers
+        let node_init = layers
             .iter()
             .flat_map(|l| l.links.keys())
-            .map(|&v| (v, 0u64))
+            .map(|&v| (v, NodeInit::default()))
             .collect();
         GraphMem::from_parts(
             value.entry_points.into_iter().map(|e| e.into()).collect(),
             layers,
             value.last_update_seq_no,
-            node_init_seq_no,
+            node_init,
         )
     }
 }
@@ -826,13 +834,26 @@ impl From<graph_v5::Layer> for Layer {
     }
 }
 
+impl From<graph_v5::NodeInit> for NodeInit {
+    fn from(value: graph_v5::NodeInit) -> Self {
+        NodeInit {
+            seq_no: value.seq_no,
+            version: value.version,
+        }
+    }
+}
+
 impl From<graph_v5::GraphV5> for GraphMem {
     fn from(value: GraphV5) -> Self {
         GraphMem::from_parts(
             value.entry_points.into_iter().map(|e| e.into()).collect(),
             value.layers.into_iter().map(|layer| layer.into()).collect(),
             value.last_update_seq_no,
-            value.node_init_seq_no,
+            value
+                .node_init
+                .into_iter()
+                .map(|(k, v)| (k, v.into()))
+                .collect(),
         )
     }
 }
@@ -870,12 +891,25 @@ impl From<Layer> for graph_v5::Layer {
     }
 }
 
+impl From<NodeInit> for graph_v5::NodeInit {
+    fn from(value: NodeInit) -> Self {
+        graph_v5::NodeInit {
+            seq_no: value.seq_no,
+            version: value.version,
+        }
+    }
+}
+
 impl From<GraphMem> for graph_v5::GraphV5 {
     fn from(value: GraphMem) -> Self {
         graph_v5::GraphV5 {
             entry_points: value.entry_points.into_iter().map(|ep| ep.into()).collect(),
             layers: value.layers.into_iter().map(|layer| layer.into()).collect(),
-            node_init_seq_no: value.node_init_seq_no,
+            node_init: value
+                .node_init
+                .into_iter()
+                .map(|(k, v)| (k, v.into()))
+                .collect(),
             last_update_seq_no: value.last_update_seq_no,
         }
     }
@@ -911,10 +945,14 @@ mod tests {
         }
         // Seed the content clock at 0 for every node, matching how the From<GraphVN>
         // converters build a real graph; otherwise the checksum (which now folds
-        // node_init_seq_no) would differ from a round-tripped graph's.
-        let node_init_seq_no = layer.get_links_map().keys().map(|&k| (k, 0u64)).collect();
+        // node_init) would differ from a round-tripped graph's.
+        let node_init = layer
+            .get_links_map()
+            .keys()
+            .map(|&k| (k, NodeInit::default()))
+            .collect();
         let entry_points = vec![layered_graph::EntryPoint { point: 1, layer: 0 }];
-        GraphMem::from_parts(entry_points, vec![layer], 0, node_init_seq_no)
+        GraphMem::from_parts(entry_points, vec![layer], 0, node_init)
     }
 
     /// Round-trip a `GraphMem` through the current (V5) serialization format and
@@ -936,22 +974,31 @@ mod tests {
     /// wire layouts must be byte-identical, else the cutover graph is corrupt.
     /// The clocks are non-zero and DISTINCT over out-of-order keys: a non-zero
     /// `last_update_seq_no` makes a scalar field-order drift misalign the next
-    /// map-length prefix, and distinct `node_init`/`seq_no` values make the
+    /// map-length prefix, and distinct `node_init` seq/version values make the
     /// BTreeMap-sort vs HashMap-iteration arm of `GraphV5::Serialize` observable
     /// (uniform-zero clocks would alias the two orderings and pass regardless).
+    /// Distinct versions also pin the per-entry (seq_no, version) field order.
     #[test]
     fn graphmem_direct_write_matches_current_and_reads_back() {
         let mut layer = Layer::new();
         for (i, &n) in [7u32, 3, 9, 1, 5, 8, 2, 6, 4].iter().enumerate() {
             layer.set_links_trusted(n, vec![n + 1, n + 2], i as u64 + 1);
         }
-        let node_init_seq_no = layer
+        let node_init = layer
             .get_links_map()
             .keys()
-            .map(|&k| (k, k as u64 * 10 + 1))
+            .map(|&k| {
+                (
+                    k,
+                    NodeInit {
+                        seq_no: k as u64 * 10 + 1,
+                        version: k as i16 + 1,
+                    },
+                )
+            })
             .collect();
         let entry_points = vec![layered_graph::EntryPoint { point: 1, layer: 0 }];
-        let g = GraphMem::from_parts(entry_points, vec![layer], 42, node_init_seq_no);
+        let g = GraphMem::from_parts(entry_points, vec![layer], 42, node_init);
 
         let direct = bincode::serialize(&[g.clone(), g.clone()]).unwrap();
         let mut via_current = Vec::new();
@@ -1085,8 +1132,8 @@ mod tests {
 
     /// Prune-at-read drops edges whose stored target version differs from the
     /// target's current key version, plus edges to absent targets, reproducing
-    /// the runtime version-skip that v5 serial-only edges can't perform. Clock
-    /// is seeded to 0 for every surviving node.
+    /// the runtime version-skip that v5 serial-only edges can't perform. Every
+    /// surviving node's clock seeds at seq 0 with its registry-current version.
     #[test]
     fn prune_drops_version_drifted_and_dangling_edges() {
         use crate::utils::serialization::types::graph_v4;
@@ -1115,8 +1162,12 @@ mod tests {
         assert_eq!(m[&2u32].neighbors(), [3u32], "fresh edge kept");
         assert!(m[&3u32].neighbors().is_empty());
         assert_eq!(mem.last_update_seq_no, 7);
-        for k in [1u32, 2, 3] {
-            assert_eq!(mem.node_init_seq_no.get(&k), Some(&0u64));
+        for (k, version) in [(1u32, 0i16), (2, 0), (3, 2)] {
+            assert_eq!(
+                mem.node_init.get(&k),
+                Some(&NodeInit { seq_no: 0, version }),
+                "clock seeds at seq 0 with the registry-current version"
+            );
         }
     }
 
@@ -1157,7 +1208,13 @@ mod tests {
             "inbound edge to 3@1 dropped"
         );
         assert_eq!(m[&2u32].neighbors(), [3u32], "inbound edge to 3@2 kept");
-        assert_eq!(mem.node_init_seq_no.get(&3u32), Some(&0u64));
+        assert_eq!(
+            mem.node_init.get(&3u32),
+            Some(&NodeInit {
+                seq_no: 0,
+                version: 2
+            })
+        );
     }
 
     /// A deleted serial is dropped outright even when the registry version still
@@ -1191,7 +1248,7 @@ mod tests {
         assert_eq!(m[&1u32].neighbors(), [2u32], "edge to deleted 3 dropped");
         assert!(m[&2u32].neighbors().is_empty());
         assert!(
-            !mem.node_init_seq_no.contains_key(&3u32),
+            !mem.node_init.contains_key(&3u32),
             "deleted serial absent from clock"
         );
     }

--- a/iris-mpc-cpu/src/utils/serialization/graph_mutation.rs
+++ b/iris-mpc-cpu/src/utils/serialization/graph_mutation.rs
@@ -4,7 +4,7 @@ use crate::{
         mutation::{EdgeType, MutationOp, UpdateEntryPoint},
         GraphMutation,
     },
-    utils::serialization::types::graph_mutation_v0::{self, GraphMutationV0},
+    utils::serialization::types::graph_mutation_v1::{self, GraphMutationV1},
 };
 use eyre::{Result, WrapErr};
 use iris_mpc_common::VectorId;
@@ -17,23 +17,27 @@ use serde::{Deserialize, Serialize};
 ///
 /// The active version is persisted in `hawk_graph_mutations.mutation_format_version`
 /// so that the deserializer can dispatch without inspecting the blob bytes.
+///
+/// V0 (edge ops carrying `VectorId`, no drop enrichment) is intentionally not
+/// readable: its segments were recorded under predicate-apply semantics and do
+/// not replay literally. The WAL is reset at the v5 cutover, so a version-0 row
+/// reaching this code is an operational error and fails loudly in `try_from`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum GraphMutationFormat {
-    /// V0: plain `bincode::serialize(BothEyes<Vec<GraphMutation>>)`.
-    ///
-    /// This is the format that existed before versioning was introduced.
-    /// All previously-written rows are implicitly V0.
-    V0,
+    /// V1: plain `bincode::serialize(BothEyes<Vec<GraphMutation>>)` with edge
+    /// ops carrying bare serial ids and mint-time staleness drops recorded as
+    /// explicit `RemoveEdges` (literal replay).
+    V1,
 }
 
 impl GraphMutationFormat {
     /// The format new writes are emitted in.
-    pub const CURRENT: Self = Self::V0;
+    pub const CURRENT: Self = Self::V1;
 
     /// Integer stored in `mutation_format_version` DB column.
     pub fn version(&self) -> i16 {
         match self {
-            GraphMutationFormat::V0 => 0,
+            GraphMutationFormat::V1 => 1,
         }
     }
 }
@@ -43,7 +47,7 @@ impl TryFrom<i16> for GraphMutationFormat {
 
     fn try_from(v: i16) -> Result<Self> {
         match v {
-            0 => Ok(GraphMutationFormat::V0),
+            1 => Ok(GraphMutationFormat::V1),
             _ => Err(eyre::eyre!(
                 "unsupported GraphMutation format version: {}",
                 v
@@ -56,7 +60,7 @@ impl TryFrom<i16> for GraphMutationFormat {
 
 /// Serialize using the current stable format.
 pub fn serialize_mutations_current(data: &BothEyes<Vec<GraphMutation>>) -> Result<Vec<u8>> {
-    // V0: plain bincode — no prefix bytes in the blob itself; version is tracked
+    // V1: plain bincode — no prefix bytes in the blob itself; version is tracked
     // in the DB column `mutation_format_version`.
     Ok(bincode::serialize(data)?)
 }
@@ -71,58 +75,58 @@ pub fn deserialize_mutations(
     bytes: &[u8],
 ) -> Result<BothEyes<Vec<GraphMutation>>> {
     match format {
-        GraphMutationFormat::V0 => deserialize_v0_to_current(bytes),
-        // When a V1 is added: add arm here, define a types/graph_mutation_v1.rs
-        // intermediate struct with From<GraphMutationV1> → BothEyes<Vec<GraphMutation>>,
-        // and call bincode::deserialize::<GraphMutationV1>(bytes)?.into()
+        GraphMutationFormat::V1 => deserialize_v1_to_current(bytes),
+        // When a V2 is added: add arm here, define a types/graph_mutation_v2.rs
+        // intermediate struct with From<GraphMutationV2> → BothEyes<Vec<GraphMutation>>,
+        // and call bincode::deserialize::<GraphMutationV2>(bytes)?.into()
     }
 }
 
 /* ------------- Deserialize Helpers ------------- */
 
-fn deserialize_v0_to_current(bytes: &[u8]) -> Result<BothEyes<Vec<GraphMutation>>> {
-    let v0: BothEyes<Vec<GraphMutationV0>> = bincode::deserialize(bytes).wrap_err_with(|| {
+fn deserialize_v1_to_current(bytes: &[u8]) -> Result<BothEyes<Vec<GraphMutation>>> {
+    let v1: BothEyes<Vec<GraphMutationV1>> = bincode::deserialize(bytes).wrap_err_with(|| {
         format!(
-            "deserializing GraphMutation V0 blob ({} bytes)",
+            "deserializing GraphMutation V1 blob ({} bytes)",
             bytes.len()
         )
     })?;
-    Ok(v0.map(|eye| eye.into_iter().map(|m| m.into()).collect()))
+    Ok(v1.map(|eye| eye.into_iter().map(|m| m.into()).collect()))
 }
 
-/* ----------- Conversion GraphMutationV0 -> GraphMutation ----------- */
+/* ----------- Conversion GraphMutationV1 -> GraphMutation ----------- */
 
-impl From<graph_mutation_v0::VectorId> for VectorId {
-    fn from(value: graph_mutation_v0::VectorId) -> Self {
+impl From<graph_mutation_v1::VectorId> for VectorId {
+    fn from(value: graph_mutation_v1::VectorId) -> Self {
         VectorId::new(value.id, value.version)
     }
 }
 
-impl From<graph_mutation_v0::EdgeType> for EdgeType {
-    fn from(value: graph_mutation_v0::EdgeType) -> Self {
+impl From<graph_mutation_v1::EdgeType> for EdgeType {
+    fn from(value: graph_mutation_v1::EdgeType) -> Self {
         match value {
-            graph_mutation_v0::EdgeType::Base => EdgeType::Base,
-            graph_mutation_v0::EdgeType::Neighbors => EdgeType::Neighbors,
-            graph_mutation_v0::EdgeType::All => EdgeType::All,
+            graph_mutation_v1::EdgeType::Base => EdgeType::Base,
+            graph_mutation_v1::EdgeType::Neighbors => EdgeType::Neighbors,
+            graph_mutation_v1::EdgeType::All => EdgeType::All,
         }
     }
 }
 
-impl From<graph_mutation_v0::UpdateEntryPoint> for UpdateEntryPoint {
-    fn from(value: graph_mutation_v0::UpdateEntryPoint) -> Self {
+impl From<graph_mutation_v1::UpdateEntryPoint> for UpdateEntryPoint {
+    fn from(value: graph_mutation_v1::UpdateEntryPoint) -> Self {
         match value {
-            graph_mutation_v0::UpdateEntryPoint::False => UpdateEntryPoint::False,
-            graph_mutation_v0::UpdateEntryPoint::Append { layer } => {
+            graph_mutation_v1::UpdateEntryPoint::False => UpdateEntryPoint::False,
+            graph_mutation_v1::UpdateEntryPoint::Append { layer } => {
                 UpdateEntryPoint::Append { layer }
             }
         }
     }
 }
 
-impl From<graph_mutation_v0::MutationOp> for MutationOp {
-    fn from(value: graph_mutation_v0::MutationOp) -> Self {
+impl From<graph_mutation_v1::MutationOp> for MutationOp {
+    fn from(value: graph_mutation_v1::MutationOp) -> Self {
         match value {
-            graph_mutation_v0::MutationOp::AddNode {
+            graph_mutation_v1::MutationOp::AddNode {
                 id,
                 height,
                 update_ep,
@@ -131,28 +135,28 @@ impl From<graph_mutation_v0::MutationOp> for MutationOp {
                 height,
                 update_ep: update_ep.into(),
             },
-            graph_mutation_v0::MutationOp::RemoveNode { id } => {
+            graph_mutation_v1::MutationOp::RemoveNode { id } => {
                 MutationOp::RemoveNode { id: id.into() }
             }
-            graph_mutation_v0::MutationOp::AddEdges {
+            graph_mutation_v1::MutationOp::AddEdges {
                 base,
                 neighbors,
                 layer,
                 edge_type,
             } => MutationOp::AddEdges {
-                base: base.into(),
-                neighbors: neighbors.into_iter().map(|n| n.into()).collect(),
+                base,
+                neighbors,
                 layer,
                 edge_type: edge_type.into(),
             },
-            graph_mutation_v0::MutationOp::RemoveEdges {
+            graph_mutation_v1::MutationOp::RemoveEdges {
                 base,
                 neighbors,
                 layer,
                 edge_type,
             } => MutationOp::RemoveEdges {
-                base: base.into(),
-                neighbors: neighbors.into_iter().map(|n| n.into()).collect(),
+                base,
+                neighbors,
                 layer,
                 edge_type: edge_type.into(),
             },
@@ -160,8 +164,8 @@ impl From<graph_mutation_v0::MutationOp> for MutationOp {
     }
 }
 
-impl From<GraphMutationV0> for GraphMutation {
-    fn from(value: GraphMutationV0) -> Self {
+impl From<GraphMutationV1> for GraphMutation {
+    fn from(value: GraphMutationV1) -> Self {
         GraphMutation {
             seq_no: value.seq_no,
             ops: value.ops.into_iter().map(|op| op.into()).collect(),
@@ -174,39 +178,44 @@ mod tests {
     use super::*;
 
     #[test]
-    fn validate_v0_deserialize() {
-        // Input in the V0 wire types: one mutation on the first eye, none on the
+    fn validate_v1_deserialize() {
+        // Input in the V1 wire types: one mutation on the first eye, none on the
         // second.
-        let vid1 = graph_mutation_v0::VectorId { id: 42, version: 1 };
-        let vid2 = graph_mutation_v0::VectorId { id: 99, version: 2 };
-        let vid3 = graph_mutation_v0::VectorId {
+        let vid1 = graph_mutation_v1::VectorId { id: 42, version: 1 };
+        let vid3 = graph_mutation_v1::VectorId {
             id: 100,
             version: 3,
         };
 
-        let both_eyes: BothEyes<Vec<graph_mutation_v0::GraphMutationV0>> = [
-            vec![graph_mutation_v0::GraphMutationV0 {
+        let both_eyes: BothEyes<Vec<graph_mutation_v1::GraphMutationV1>> = [
+            vec![graph_mutation_v1::GraphMutationV1 {
                 seq_no: 12345,
                 ops: vec![
-                    graph_mutation_v0::MutationOp::AddNode {
+                    graph_mutation_v1::MutationOp::AddNode {
                         id: vid1.clone(),
                         height: 3,
-                        update_ep: graph_mutation_v0::UpdateEntryPoint::Append { layer: 2 },
+                        update_ep: graph_mutation_v1::UpdateEntryPoint::Append { layer: 2 },
                     },
-                    graph_mutation_v0::MutationOp::AddEdges {
-                        base: vid2.clone(),
-                        neighbors: vec![vid1.clone(), vid3.clone()],
+                    graph_mutation_v1::MutationOp::AddEdges {
+                        base: 99,
+                        neighbors: vec![42, 100],
                         layer: 1,
-                        edge_type: graph_mutation_v0::EdgeType::All,
+                        edge_type: graph_mutation_v1::EdgeType::All,
                     },
-                    graph_mutation_v0::MutationOp::RemoveNode { id: vid3.clone() },
+                    graph_mutation_v1::MutationOp::RemoveEdges {
+                        base: 42,
+                        neighbors: vec![100],
+                        layer: 0,
+                        edge_type: graph_mutation_v1::EdgeType::Base,
+                    },
+                    graph_mutation_v1::MutationOp::RemoveNode { id: vid3.clone() },
                 ],
             }],
             vec![],
         ];
 
         // Hand-built target in the *current* types. Deliberately constructed
-        // literally rather than via `.into()`, so the V0 -> current conversion is
+        // literally rather than via `.into()`, so the V1 -> current conversion is
         // actually under test instead of being asserted against itself.
         let expected: BothEyes<Vec<GraphMutation>> = [
             vec![GraphMutation {
@@ -218,10 +227,16 @@ mod tests {
                         update_ep: UpdateEntryPoint::Append { layer: 2 },
                     },
                     MutationOp::AddEdges {
-                        base: VectorId::new(99, 2),
-                        neighbors: vec![VectorId::new(42, 1), VectorId::new(100, 3)],
+                        base: 99,
+                        neighbors: vec![42, 100],
                         layer: 1,
                         edge_type: EdgeType::All,
+                    },
+                    MutationOp::RemoveEdges {
+                        base: 42,
+                        neighbors: vec![100],
+                        layer: 0,
+                        edge_type: EdgeType::Base,
                     },
                     MutationOp::RemoveNode {
                         id: VectorId::new(100, 3),
@@ -232,9 +247,16 @@ mod tests {
         ];
 
         let serialized = bincode::serialize(&both_eyes).expect("serialization failed");
-        let deserialized = deserialize_mutations(GraphMutationFormat::V0, &serialized)
+        let deserialized = deserialize_mutations(GraphMutationFormat::V1, &serialized)
             .expect("deserialization failed");
 
         assert_eq!(deserialized, expected);
+    }
+
+    /// V0 rows (pre-enrichment, edge ops carrying VectorId) must fail loudly:
+    /// they cannot be replayed literally, and the WAL is reset at cutover.
+    #[test]
+    fn version_0_is_rejected() {
+        assert!(GraphMutationFormat::try_from(0).is_err());
     }
 }

--- a/iris-mpc-cpu/src/utils/serialization/types/graph_mutation_v1.rs
+++ b/iris-mpc-cpu/src/utils/serialization/types/graph_mutation_v1.rs
@@ -1,7 +1,14 @@
 use serde::{Deserialize, Serialize};
 
+/// V1 wire format for one WAL graph mutation.
+///
+/// Differences from V0: edge ops carry bare serial ids (node identity/version
+/// rides only `AddNode`/`RemoveNode`), and recorded op lists are drop-enriched
+/// for literal replay — every mint-time staleness drop appears as an explicit
+/// `RemoveEdges`. V0 segments predate enrichment, so they cannot be replayed
+/// literally and are not readable; the WAL is reset at the v5 cutover.
 #[derive(Clone, Serialize, Deserialize)]
-pub struct GraphMutationV0 {
+pub struct GraphMutationV1 {
     pub seq_no: u64,
     pub ops: Vec<MutationOp>,
 }
@@ -46,14 +53,14 @@ pub enum MutationOp {
         id: VectorId,
     },
     AddEdges {
-        base: VectorId,
-        neighbors: Vec<VectorId>,
+        base: u32,
+        neighbors: Vec<u32>,
         layer: usize,
         edge_type: EdgeType,
     },
     RemoveEdges {
-        base: VectorId,
-        neighbors: Vec<VectorId>,
+        base: u32,
+        neighbors: Vec<u32>,
         layer: usize,
         edge_type: EdgeType,
     },

--- a/iris-mpc-cpu/src/utils/serialization/types/graph_v5.rs
+++ b/iris-mpc-cpu/src/utils/serialization/types/graph_v5.rs
@@ -6,17 +6,25 @@ use std::collections::{BTreeMap, HashMap};
 /// serialization type, kept for long-term compatibility and portability of
 /// serialized data.
 ///
-/// `Serialize` is hand-written: both field order AND the `node_init_seq_no`
+/// `Serialize` is hand-written: both field order AND the `node_init`
 /// map ordering must match `GraphMem`'s own serializer, because genesis writes
 /// `[GraphMem; 2]` directly while the materializer and hawk restart read it
-/// back as `GraphV5`. A derived impl would emit `node_init_seq_no` in HashMap
+/// back as `GraphV5`. A derived impl would emit `node_init` in HashMap
 /// iteration order, diverging from `GraphMem` and breaking checkpoint BLAKE3.
 #[derive(Default, Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct GraphV5 {
     pub entry_points: Vec<EntryPoint>,
     pub layers: Vec<Layer>,
     pub last_update_seq_no: u64,
-    pub node_init_seq_no: HashMap<SerialId, u64>,
+    pub node_init: HashMap<SerialId, NodeInit>,
+}
+
+/// Type associated with the `GraphV5` serialization type. Wire layout must
+/// match `layered_graph::NodeInit` (u64 seq_no, then i16 version).
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NodeInit {
+    pub seq_no: u64,
+    pub version: i16,
 }
 
 impl Serialize for GraphV5 {
@@ -25,8 +33,8 @@ impl Serialize for GraphV5 {
         state.serialize_field("entry_points", &self.entry_points)?;
         state.serialize_field("layers", &self.layers)?;
         state.serialize_field("last_update_seq_no", &self.last_update_seq_no)?;
-        let sorted_node_init: BTreeMap<_, _> = self.node_init_seq_no.iter().collect();
-        state.serialize_field("node_init_seq_no", &sorted_node_init)?;
+        let sorted_node_init: BTreeMap<_, _> = self.node_init.iter().collect();
+        state.serialize_field("node_init", &sorted_node_init)?;
         state.end()
     }
 }

--- a/iris-mpc-cpu/src/utils/serialization/types/mod.rs
+++ b/iris-mpc-cpu/src/utils/serialization/types/mod.rs
@@ -5,7 +5,7 @@
 //! possible exceptions for lower-level data types related to serialization
 //! formats of external libraries.
 
-pub mod graph_mutation_v0;
+pub mod graph_mutation_v1;
 pub mod graph_v0;
 pub mod graph_v1;
 pub mod graph_v2;

--- a/iris-mpc/tests/utils/wal_builder.rs
+++ b/iris-mpc/tests/utils/wal_builder.rs
@@ -74,10 +74,9 @@ impl WalMutationBuilder {
         for idx in starting_idx..new_len {
             let node_id = idx + 1;
             // All nodes added before this one become neighbors.
-            let neighbors: Vec<VectorId> = (1..=node_id)
+            let neighbors: Vec<u32> = (1..=node_id)
                 .filter(|x| x != &node_id)
                 .map(|x| x as u32)
-                .map(VectorId::from_serial_id)
                 .collect();
 
             let mut mutation = GraphMutation {
@@ -92,7 +91,7 @@ impl WalMutationBuilder {
 
             if !neighbors.is_empty() {
                 mutation.ops.push(MutationOp::AddEdges {
-                    base: VectorId::from_serial_id(node_id as _),
+                    base: node_id as u32,
                     neighbors,
                     layer: 0,
                     edge_type: EdgeType::All,
@@ -129,19 +128,15 @@ impl WalMutationBuilder {
     pub fn add_node_with_neighbors(&mut self, neighbor_ids: &[u32]) -> &mut Self {
         let node_id = (self.entries.len() + 1) as u32;
         let modification_id = node_id as i64;
-        let neighbors: Vec<VectorId> = neighbor_ids
-            .iter()
-            .map(|&id| VectorId::from_serial_id(id))
-            .collect();
         let mut ops = vec![MutationOp::AddNode {
             id: VectorId::from_serial_id(node_id),
             height: 1,
             update_ep: UpdateEntryPoint::False,
         }];
-        if !neighbors.is_empty() {
+        if !neighbor_ids.is_empty() {
             ops.push(MutationOp::AddEdges {
-                base: VectorId::from_serial_id(node_id),
-                neighbors,
+                base: node_id,
+                neighbors: neighbor_ids.to_vec(),
                 layer: 0,
                 edge_type: EdgeType::All,
             });
@@ -203,7 +198,7 @@ impl WalMutationBuilder {
             let modification_id = m.seq_no as i64;
             let serial_id: i64 = match m.ops.first() {
                 Some(MutationOp::AddNode { id, .. }) => id.serial_id() as i64,
-                Some(MutationOp::AddEdges { base, .. }) => base.serial_id() as i64,
+                Some(MutationOp::AddEdges { base, .. }) => *base as i64,
                 _ => 0,
             };
             let s3_url = uuid::Uuid::from_u128(modification_id as u128).to_string();


### PR DESCRIPTION
Stacked on #2232.

**Content clock carries the iris version** (`NodeInit{seq_no, version}`): the graph is the self-contained serial→`VectorId` truth for traversal; `only_valid_entry_points` removed; registry kept as a debug-build cross-check.

**WAL-explicit stale drops**: minting (`apply_new`) still runs the staleness filter, but now records every drop and splices it into the returned mutation as an explicit `RemoveEdges` placed before the triggering op. Replay (`insert_apply`) is literal — no predicate — so recorded segments reproduce the minted state even if the staleness predicate changes across deploys. Edge ops carry bare serials (identity/version rides `AddNode`/`RemoveNode` only). Mutation wire format bumps to V1; V0 is rejected — the WAL is reset at the v5 cutover.

Equivalence is pinned by `minted_stream_replays_literally_to_identical_graph` (reauth re-adding its own stale back-edge, deletion sweeps, both `RemoveEdges` fused-retain halves, compaction-shaped ops) and a real-`insert()`-path replay test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)