### PR TITLE
chore(deploy): repin stage images to main SHAs + remove temp-branch triggers

### DIFF
--- a/.github/workflows/build-and-push-retention-reaper.yaml
+++ b/.github/workflows/build-and-push-retention-reaper.yaml
@@ -7,9 +7,6 @@ on:
   push:
     branches:
       - main
-      # TEMPORARY: build a branch image pre-merge so it can be deployed to stage.
-      # Remove before merge.
-      - carlomazzaferro/pop-3905-retention-dry-run
     paths:
       - Dockerfile.retention-reaper
       - iris-mpc-bins/bin/retention-reaper/**

--- a/.github/workflows/temp-branch-build-and-push-anon-stats-server.yml
+++ b/.github/workflows/temp-branch-build-and-push-anon-stats-server.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "dev"
-      - "carlomazzaferro/pop-3905-retention-dry-run"
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'

--- a/.github/workflows/temp-branch-build-and-push-hawk-arm64.yaml
+++ b/.github/workflows/temp-branch-build-and-push-hawk-arm64.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "dev"
-      - "carlomazzaferro/pop-3905-retention-dry-run"
 
     paths-ignore:
       - "deploy/**"

--- a/.github/workflows/temp-branch-build-and-push.yaml
+++ b/.github/workflows/temp-branch-build-and-push.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "dev"
-      - "carlomazzaferro/pop-3905-retention-dry-run"
 
 concurrency:
   group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"

--- a/deploy/stage/common-values-ampc-hnsw-anon-stats-retention.yaml
+++ b/deploy/stage/common-values-ampc-hnsw-anon-stats-retention.yaml
@@ -2,7 +2,7 @@
 # worldcoin-foundation/common-cronjob) via wf-cluster-apps, mirroring ampc-hnsw-db-exporter.
 # Per-cluster env (map format) + the attachSecurityGroupPolicy that lets the pod reach the
 # anon-stats Aurora live per-node.
-image: "ghcr.io/worldcoin/retention-reaper:c3b02487b5ec98db4c5dcedbb4359fa82e02c3c2"
+image: "ghcr.io/worldcoin/retention-reaper:d9a3d33342dfd9e95c7b11e8ef4e4101a3e6ed80"
 
 # STAGE DRY-RUN VALIDATION: enable the reaper in dry-run mode — it logs what it WOULD
 # reap (read-only COUNT, no DELETE). Safe only because the image above is the dry-run

--- a/deploy/stage/common-values-ampc-hnsw-anon-stats-server.yaml
+++ b/deploy/stage/common-values-ampc-hnsw-anon-stats-server.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/anon-stats-server:f0a93f9708b2d356a33679abecdd9e13202a2147"
+image: "ghcr.io/worldcoin/anon-stats-server:d9a3d33342dfd9e95c7b11e8ef4e4101a3e6ed80"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/common-values-ampc-hnsw.yaml
+++ b/deploy/stage/common-values-ampc-hnsw.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc-cpu:f0a93f9708b2d356a33679abecdd9e13202a2147-arm64"
+image: "ghcr.io/worldcoin/iris-mpc-cpu:d9a3d33342dfd9e95c7b11e8ef4e4101a3e6ed80-arm64"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/common-values-anon-stats-retention.yaml
+++ b/deploy/stage/common-values-anon-stats-retention.yaml
@@ -1,7 +1,7 @@
 # POP-3905 — anon-stats retention CronJob (stage, smpcv2). Uses the common-cronjob chart
 # (chartVersion 1.11.0, worldcoin-foundation/common-cronjob) via wf-cluster-apps, mirroring
 # iris-mpc-db-exporter. Per-cluster env (RETENTION__*, map format) lives in the per-node values files.
-image: "ghcr.io/worldcoin/retention-reaper:c3b02487b5ec98db4c5dcedbb4359fa82e02c3c2"
+image: "ghcr.io/worldcoin/retention-reaper:d9a3d33342dfd9e95c7b11e8ef4e4101a3e6ed80"
 
 # STAGE DRY-RUN VALIDATION: enable the reaper in dry-run mode — it logs what it WOULD
 # reap (read-only COUNT, no DELETE). Safe only because the image above is the dry-run

--- a/deploy/stage/common-values-anon-stats-server.yaml
+++ b/deploy/stage/common-values-anon-stats-server.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/anon-stats-server:f0a93f9708b2d356a33679abecdd9e13202a2147"
+image: "ghcr.io/worldcoin/anon-stats-server:d9a3d33342dfd9e95c7b11e8ef4e4101a3e6ed80"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:8aac9a7953241268c16b97beab77732f6f802976"
+image: "ghcr.io/worldcoin/iris-mpc:d9a3d33342dfd9e95c7b11e8ef4e4101a3e6ed80"
 
 environment: stage
 replicaCount: 1


### PR DESCRIPTION
Post-merge cleanup after the POP-3905 retention / dry-run rollout (#2247, #2250, #2252 now on main).

## What
- **Repin the 4 deployed services to main-provenance images** at \`d9a3d33342dfd9e95c7b11e8ef4e4101a3e6ed80\` (they were pinned to ephemeral temp-branch build SHAs during the stage test):
  - \`iris-mpc\` (GPU) → \`:d9a3d3334\`
  - \`iris-mpc-cpu\` (HNSW) → \`:d9a3d3334-arm64\`
  - \`anon-stats-server\` (both fleets) → \`:d9a3d3334\`
  - \`retention-reaper\` (both fleets) → \`:d9a3d3334\`
- **Remove the leftover temp-branch build triggers** for the merged branch:
  - dropped \`carlomazzaferro/pop-3905-retention-dry-run\` from \`temp-branch-build-and-push.yaml\`, \`-hawk-arm64.yaml\`, \`-anon-stats-server.yml\` (standing \`dev\` entry kept)
  - removed the \"Remove before merge\" branch trigger from \`build-and-push-retention-reaper.yaml\` (\`main\` kept)

## Kept intentionally
- Retention stays in **dry-run** (\`RETENTION__ENABLED=true\` + \`RETENTION__DRY_RUN=true\`). Flipping to live is a follow-up once the previewed counts are validated (they read 0 until data ages 14d past the migration).

## Notes
- \`anon-stats-server\` didn't auto-build on \`d9a3d3334\` (path-filter miss on the merge); its main image was dispatched manually so the pinned SHA exists. It must carry the ampc \`e35cb4b\` bump (the \`created_at\` migration) — otherwise it hits sqlx \`VersionMissing\` against the already-migrated DB.
- No code/Cargo changes — deploy values + workflow triggers only.
- Live argo revert (apps still tracking the test branch + apps-bootstrap on manual) is a separate operational step, not in this PR.