### PR TITLE
graph_v5: resolve mutation intents at stamping (linearization alternative)

### DIFF
--- a/iris-mpc-bins/bin/iris-mpc-cpu/init_test_dbs.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/init_test_dbs.rs
@@ -397,7 +397,7 @@ async fn main() -> Result<()> {
                 vector_store.insert_with_id(inserted_id, query.clone());
 
                 let insertion_layer = searcher.gen_layer_prf(&prf_seed, &(inserted_id, side))?;
-                let (neighbors, update_ep) = searcher
+                let (neighbors, update_ep, as_of) = searcher
                     .search_to_insert(&mut vector_store, &graph, &query, insertion_layer)
                     .await?;
                 searcher
@@ -407,6 +407,7 @@ async fn main() -> Result<()> {
                         inserted_id,
                         neighbors,
                         update_ep,
+                        as_of,
                     )
                     .await?;
 

--- a/iris-mpc-cpu/src/execution/hawk_main/insert.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/insert.rs
@@ -35,6 +35,9 @@ pub struct InsertPlanV<V: VectorStore> {
     pub query: V::QueryRef,
     pub links: Vec<Vec<VectorId>>,
     pub update_ep: UpdateEntryPoint,
+    /// Graph state `links` was identified against (see
+    /// `UnstampedMutation::as_of`); comes from the search that produced them.
+    pub as_of: u64,
 }
 
 // Manual implementation of Clone for InsertPlanV, since derive(Clone) does not
@@ -45,6 +48,7 @@ impl<V: VectorStore> Clone for InsertPlanV<V> {
             query: self.query.clone(),
             links: self.links.clone(),
             update_ep: self.update_ep.clone(),
+            as_of: self.as_of,
         }
     }
 }
@@ -65,8 +69,8 @@ impl<V: VectorStore> Clone for InsertPlanV<V> {
 ///
 /// Returns a parallel pair of `VecRequests`:
 /// - the per-slot `Vec<ConnectPlanV>` carrying the graph mutations to persist (a slot
-///   may produce 0 to 3 mutations from the per-slot steps, and the last non-empty slot may
-///   additionally carry the batch's single global compaction mutation);
+///   may produce several mutations from the per-slot steps, and the last non-empty slot
+///   may additionally carry the batch's single global compaction mutation);
 /// - the per-slot `Option<VectorId>` identifying the newly inserted vector, or `None`
 ///   for pure deletions and no-op slots.
 pub async fn insert<V: VectorStoreMut>(
@@ -96,7 +100,7 @@ pub async fn insert<V: VectorStoreMut>(
     let insert_plans = join_plans(plans);
     validate_ep_updates(&insert_plans, searcher.max_graph_layer)?;
 
-    let mut intra_batch_inserted = vec![];
+    let mut intra_batch_inserted: Vec<VectorId> = vec![];
     let m = searcher.params.get_M(0);
 
     let mut slot_outputs: Vec<Vec<ConnectPlanV>> = vec![vec![]; insert_plans.len()];
@@ -109,6 +113,7 @@ pub async fn insert<V: VectorStoreMut>(
         // (a) Delete first: own GraphMutation with the lower seq_no.
         if let Some(rid) = replace_id {
             let mutation = graph.apply_new(UnstampedMutation {
+                as_of: graph.last_update_seq_no,
                 ops: vec![MutationOp::RemoveNode { id: *rid }],
             })?;
             slot_outputs[idx].push(mutation);
@@ -118,23 +123,19 @@ pub async fn insert<V: VectorStoreMut>(
         // neighborhoods for the batch compaction.
         if let Some(InsertPlanV {
             query,
-            mut links,
+            links,
             update_ep,
+            as_of,
         }) = plan
         {
-            if let Some(bottom_layer) = links.first_mut() {
-                if bottom_layer.len() < m {
-                    bottom_layer.extend_from_slice(&intra_batch_inserted);
-                }
-            }
-
             // Vector id actually inserted by this update
             let inserted_id = match insert_id {
                 None => store.insert(&query).await,
                 Some(id) => store.insert_at(id, &query).await?,
             };
-            intra_batch_inserted.push(inserted_id);
             slot_inserted_ids[idx] = Some(inserted_id);
+
+            let bottom_needs_links = links.first().is_some_and(|l| l.len() < m);
 
             let mut ops: Vec<MutationOp> = vec![MutationOp::AddNode {
                 id: inserted_id,
@@ -149,23 +150,46 @@ pub async fn insert<V: VectorStoreMut>(
                     edge_type: EdgeType::All,
                 });
             }
-            let unstamped = UnstampedMutation { ops };
+            let unstamped = UnstampedMutation { as_of, ops };
             for pair in unstamped.expanded_neighborhoods() {
                 batch_expanded.insert(pair);
             }
             let mutation = graph.apply_new(unstamped)?;
             slot_outputs[idx].push(mutation);
+
+            // Bootstrap connectivity: a small bottom layer additionally links
+            // to this batch's earlier inserts. Those references are identified
+            // now, not by the plan's search, so they ride their own mutation
+            // at the current seq.
+            if bottom_needs_links && !intra_batch_inserted.is_empty() {
+                let ops = vec![MutationOp::AddEdges {
+                    base: inserted_id.serial_id(),
+                    layer: 0,
+                    neighbors: intra_batch_inserted.iter().map(|v| v.serial_id()).collect(),
+                    edge_type: EdgeType::All,
+                }];
+                let unstamped = UnstampedMutation {
+                    as_of: graph.last_update_seq_no,
+                    ops,
+                };
+                for pair in unstamped.expanded_neighborhoods() {
+                    batch_expanded.insert(pair);
+                }
+                let mutation = graph.apply_new(unstamped)?;
+                slot_outputs[idx].push(mutation);
+            }
+            intra_batch_inserted.push(inserted_id);
         }
     }
 
     // (c) Global compaction across the batch, attributed to the last
     // non-empty slot.
     if !batch_expanded.is_empty() {
-        let ops = searcher
+        let (ops, as_of) = searcher
             .compact_batch(store, graph, &batch_expanded)
             .await?;
         if !ops.is_empty() {
-            let mutation = graph.apply_new(UnstampedMutation { ops })?;
+            let mutation = graph.apply_new(UnstampedMutation { as_of, ops })?;
             let last_idx = slot_outputs
                 .iter()
                 .rposition(|v| !v.is_empty())
@@ -227,6 +251,7 @@ mod tests {
             query: Arc::new(IrisCode::default()),
             links: vec![Vec::new(); ins_layer],
             update_ep: ep_update,
+            as_of: 0,
         }
     }
 
@@ -235,11 +260,13 @@ mod tests {
     fn dummy_insert_plan_with_links(
         ep_update: UpdateEntryPoint,
         links: Vec<Vec<VectorId>>,
+        as_of: u64,
     ) -> InsertPlanV<PlaintextStore> {
         InsertPlanV {
             query: Arc::new(IrisCode::default()),
             links,
             update_ep: ep_update,
+            as_of,
         }
     }
 
@@ -551,6 +578,70 @@ mod tests {
         );
     }
 
+    /// A plan whose searched bottom layer comes back small links to the
+    /// batch's earlier inserts through a follow-up mutation minted at the
+    /// current seq — those references are identified at apply time, not by
+    /// the plan's search.
+    #[tokio::test]
+    async fn test_insert_small_bottom_layer_links_to_intra_batch_inserts() {
+        let mut store = PlaintextStore::default();
+        let mut graph: GraphMem = GraphMem::new();
+        let searcher = HnswSearcher::new_with_test_parameters();
+
+        // Two inserts into an empty graph; both searches found nothing.
+        let plans = vec![
+            Some(dummy_insert_plan_with_links(
+                UpdateEntryPoint::False,
+                vec![vec![]],
+                0,
+            )),
+            Some(dummy_insert_plan_with_links(
+                UpdateEntryPoint::False,
+                vec![vec![]],
+                0,
+            )),
+        ];
+        let insert_ids: VecRequests<Option<VectorId>> = vec![None, None];
+        let replace_ids: VecRequests<Option<VectorId>> = vec![None, None];
+
+        let (grouped, inserted_ids) = insert(
+            &mut store,
+            &mut graph,
+            &searcher,
+            plans,
+            &insert_ids,
+            &replace_ids,
+        )
+        .await
+        .expect("insert should succeed");
+
+        let a = inserted_ids[0].expect("slot 0 inserted");
+        let b = inserted_ids[1].expect("slot 1 inserted");
+
+        // Slot 0 had no earlier inserts to link to; slot 1 carries the
+        // bootstrap AddEdges as its own mutation after the insert.
+        assert_eq!(grouped[0].len(), 1);
+        assert_eq!(grouped[1].len(), 2);
+        assert_eq!(
+            grouped[1][1].ops,
+            vec![MutationOp::AddEdges {
+                base: b.serial_id(),
+                neighbors: vec![a.serial_id()],
+                layer: 0,
+                edge_type: EdgeType::All,
+            }]
+        );
+        assert_eq!(graph.get_active_links(&b.serial_id(), 0), vec![a]);
+        assert_eq!(graph.get_active_links(&a.serial_id(), 0), vec![b]);
+
+        // The recorded stream replays to the identical graph.
+        let mut fresh: GraphMem = GraphMem::new();
+        for m in grouped.iter().flatten() {
+            fresh.insert_apply(m).expect("replay");
+        }
+        assert_eq!(graph.checksum(), fresh.checksum());
+    }
+
     #[tokio::test]
     async fn test_insert_stamps_strictly_increasing_seq_nos_per_slot() {
         let mut store = PlaintextStore::default();
@@ -691,8 +782,11 @@ mod tests {
         // With EdgeType::All, each seed's neighborhood gains the new node,
         // pushing each from m_limit → m_limit + 1, which exceeds M_limit and
         // triggers compaction.
-        let new_plan =
-            dummy_insert_plan_with_links(UpdateEntryPoint::False, vec![seed_ids.clone()]);
+        let new_plan = dummy_insert_plan_with_links(
+            UpdateEntryPoint::False,
+            vec![seed_ids.clone()],
+            graph.last_update_seq_no,
+        );
         let plans = vec![Some(new_plan), None];
         let insert_ids: VecRequests<Option<VectorId>> = vec![None, None];
         let replace_ids: VecRequests<Option<VectorId>> = vec![None, None];
@@ -782,6 +876,7 @@ mod tests {
         wal.push(
             graph
                 .apply_new(UnstampedMutation {
+                    as_of: graph.last_update_seq_no,
                     ops: vec![
                         MutationOp::AddNode {
                             id: a,
@@ -800,6 +895,7 @@ mod tests {
         wal.push(
             graph
                 .apply_new(UnstampedMutation {
+                    as_of: graph.last_update_seq_no,
                     ops: vec![MutationOp::AddEdges {
                         base: a.serial_id(),
                         neighbors: vec![b.serial_id()],
@@ -815,6 +911,7 @@ mod tests {
         let plans = vec![Some(dummy_insert_plan_with_links(
             UpdateEntryPoint::False,
             vec![vec![b]],
+            graph.last_update_seq_no,
         ))];
         let insert_ids: VecRequests<Option<VectorId>> = vec![None];
         let replace_ids: VecRequests<Option<VectorId>> = vec![Some(a)];

--- a/iris-mpc-cpu/src/execution/hawk_main/matching.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/matching.rs
@@ -839,6 +839,7 @@ mod tests {
                     query: Aby3Query::new(QueryId::new()),
                     links: links_unstructured,
                     update_ep: UpdateEntryPoint::False,
+                    as_of: 0,
                 },
             };
             VecRotations::from(vec![

--- a/iris-mpc-cpu/src/execution/hawk_main/search.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/search.rs
@@ -321,7 +321,7 @@ async fn per_insert_query(
 ) -> Result<HawkInsertPlan> {
     let start = Instant::now();
 
-    let (links, update_ep) = search_params
+    let (links, update_ep, as_of) = search_params
         .hnsw
         .search_to_insert(aby3_store, graph_store, &query, insertion_layer)
         .await?;
@@ -360,6 +360,7 @@ async fn per_insert_query(
             query,
             links: links_unstructured,
             update_ep,
+            as_of,
         },
         classified,
     })
@@ -375,6 +376,7 @@ async fn per_search_query(
     let start = Instant::now();
 
     let ef_search = search_params.hnsw.params.get_ef_search(0);
+    let as_of = graph_store.last_update_seq_no;
     let layer_0_neighbors = search_params
         .hnsw
         .search(aby3_store, graph_store, &query, ef_search)
@@ -402,6 +404,7 @@ async fn per_search_query(
             query,
             links: links_unstructured,
             update_ep: UpdateEntryPoint::False,
+            as_of,
         },
         classified,
     })
@@ -424,7 +427,7 @@ pub async fn search_single_query_no_match_count<H: std::hash::Hash>(
 
     let insertion_layer = searcher.gen_layer_prf(&session.hnsw_prf_key, identifier)?;
 
-    let (links, update_ep) = searcher
+    let (links, update_ep, as_of) = searcher
         .search_to_insert(&mut *store, &graph, &query, insertion_layer)
         .await?;
 
@@ -442,6 +445,7 @@ pub async fn search_single_query_no_match_count<H: std::hash::Hash>(
         query,
         links: links_unstructured,
         update_ep,
+        as_of,
     })
 }
 

--- a/iris-mpc-cpu/src/genesis/plaintext.rs
+++ b/iris-mpc-cpu/src/genesis/plaintext.rs
@@ -239,7 +239,7 @@ pub async fn run_plaintext_genesis(mut state: GenesisState) -> Result<GenesisSta
                     let identifier = (vector_id, side);
                     let insertion_layer = searcher.gen_layer_prf(&prf_key, &identifier)?;
 
-                    let (links, update_ep) = searcher
+                    let (links, update_ep, as_of) = searcher
                         .search_to_insert(store, graph, &query, insertion_layer)
                         .await?;
 
@@ -255,6 +255,7 @@ pub async fn run_plaintext_genesis(mut state: GenesisState) -> Result<GenesisSta
                         query,
                         links: links_unstructured,
                         update_ep,
+                        as_of,
                     };
 
                     insert::insert(
@@ -339,7 +340,7 @@ pub async fn run_plaintext_genesis(mut state: GenesisState) -> Result<GenesisSta
                 let identifier = (vector_id, side);
                 let insertion_layer = searcher.gen_layer_prf(&prf_key, &identifier)?;
 
-                let (links, update_ep) = searcher
+                let (links, update_ep, as_of) = searcher
                     .search_to_insert(store, graph, &query, insertion_layer)
                     .await?;
 
@@ -355,6 +356,7 @@ pub async fn run_plaintext_genesis(mut state: GenesisState) -> Result<GenesisSta
                     query,
                     links: links_unstructured,
                     update_ep,
+                    as_of,
                 };
 
                 results.push(Some(insert_plan));

--- a/iris-mpc-cpu/src/hawkers/build_plaintext.rs
+++ b/iris-mpc-cpu/src/hawkers/build_plaintext.rs
@@ -71,7 +71,7 @@ pub async fn plaintext_parallel_batch_insert<D: DistanceOps>(
             jobs.spawn(async move {
                 let insertion_layer = searcher.gen_layer_prf(&prf_seed, &(vector_id))?;
 
-                let (links, update_ep) = searcher
+                let (links, update_ep, as_of) = searcher
                     .search_to_insert(&mut store, &graph, &query, insertion_layer)
                     .await?;
 
@@ -87,6 +87,7 @@ pub async fn plaintext_parallel_batch_insert<D: DistanceOps>(
                     query,
                     links: links_unstructured,
                     update_ep,
+                    as_of,
                 };
                 Ok((vector_id, insert_plan))
             });
@@ -156,7 +157,7 @@ pub async fn deep_id_parallel_batch_insert(
             jobs.spawn(async move {
                 let insertion_layer = searcher.gen_layer_prf(&prf_seed, &(vector_id))?;
 
-                let (links, update_ep) = searcher
+                let (links, update_ep, as_of) = searcher
                     .search_to_insert(&mut store, &graph, &query, insertion_layer)
                     .await?;
 
@@ -172,6 +173,7 @@ pub async fn deep_id_parallel_batch_insert(
                     query,
                     links: links_unstructured,
                     update_ep,
+                    as_of,
                 };
                 Ok((vector_id, insert_plan))
             });

--- a/iris-mpc-cpu/src/hawkers/plaintext_deep_id_store.rs
+++ b/iris-mpc-cpu/src/hawkers/plaintext_deep_id_store.rs
@@ -242,11 +242,11 @@ impl PlaintextDeepIDStore {
                 .map(|version| VectorId::new(serial_id, version))
                 .unwrap_or_else(|| VectorId::from_serial_id(serial_id));
             let insertion_layer = searcher.gen_layer_rng(&mut rng)?;
-            let (neighbors, update_ep) = searcher
+            let (neighbors, update_ep, as_of) = searcher
                 .search_to_insert(self, &graph, &query, insertion_layer)
                 .await?;
             searcher
-                .insert_from_search_results(self, &mut graph, query_id, neighbors, update_ep)
+                .insert_from_search_results(self, &mut graph, query_id, neighbors, update_ep, as_of)
                 .await?;
         }
 

--- a/iris-mpc-cpu/src/hawkers/plaintext_store.rs
+++ b/iris-mpc-cpu/src/hawkers/plaintext_store.rs
@@ -127,11 +127,11 @@ impl<D: DistanceOps> PlaintextStore<D> {
                 .clone();
             let query_id = VectorId::from_serial_id(serial_id);
             let insertion_layer = searcher.gen_layer_rng(&mut rng)?;
-            let (neighbors, update_ep) = searcher
+            let (neighbors, update_ep, as_of) = searcher
                 .search_to_insert(self, &graph, &query, insertion_layer)
                 .await?;
             searcher
-                .insert_from_search_results(self, &mut graph, query_id, neighbors, update_ep)
+                .insert_from_search_results(self, &mut graph, query_id, neighbors, update_ep, as_of)
                 .await?;
         }
 

--- a/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
@@ -588,6 +588,13 @@ impl GraphMem {
     /// already invalid, and a fresh edge to the target's new content is not
     /// this intent's to evict.
     ///
+    /// `AddEdges` additionally drops self-references (`z == base`): a
+    /// self-edge is never meaningful, and in a minting mutation it can only
+    /// be a stale echo of a search that ran against the node's replaced
+    /// content — the carve-out must not re-admit it. Dropped silently
+    /// (routine on reauth, not a drift signal). `RemoveEdges` keeps
+    /// self-references, so removing an existing self-edge stays expressible.
+    ///
     /// Node ops pass through untouched. The surviving ops all satisfy the
     /// spec preconditions (`model.rs`) at apply time.
     fn linearize(&self, mutation: UnstampedMutation) -> Vec<MutationOp> {
@@ -608,15 +615,23 @@ impl GraphMem {
         let fresh = |z: &SerialId| minted.contains(z) || is_active(&self.node_init, *z, as_of);
 
         let mut dropped = 0usize;
-        // The surviving refs of one op half, or `None` if the op is void.
-        let mut filter_refs = |base: &SerialId, neighbors: Vec<SerialId>| {
+        // The surviving refs of one op, or `None` if the op is void.
+        let mut filter_refs = |base: &SerialId, neighbors: Vec<SerialId>, keep_self: bool| {
             if !fresh(base) {
                 dropped += neighbors.len();
                 return None;
             }
-            let before = neighbors.len();
-            let kept: Vec<SerialId> = neighbors.into_iter().filter(|z| fresh(z)).collect();
-            dropped += before - kept.len();
+            let mut kept = Vec::with_capacity(neighbors.len());
+            for z in neighbors {
+                if !keep_self && z == *base {
+                    continue;
+                }
+                if fresh(&z) {
+                    kept.push(z);
+                } else {
+                    dropped += 1;
+                }
+            }
             (!kept.is_empty()).then_some(kept)
         };
 
@@ -629,7 +644,7 @@ impl GraphMem {
                     neighbors,
                     layer,
                     edge_type,
-                } => filter_refs(&base, neighbors).map(|neighbors| MutationOp::AddEdges {
+                } => filter_refs(&base, neighbors, false).map(|neighbors| MutationOp::AddEdges {
                     base,
                     neighbors,
                     layer,
@@ -640,7 +655,7 @@ impl GraphMem {
                     neighbors,
                     layer,
                     edge_type,
-                } => filter_refs(&base, neighbors).map(|neighbors| MutationOp::RemoveEdges {
+                } => filter_refs(&base, neighbors, true).map(|neighbors| MutationOp::RemoveEdges {
                     base,
                     neighbors,
                     layer,
@@ -1827,6 +1842,83 @@ mod tests {
         assert_eq!(graph.get_active_links(&1, 0), Vec::<VectorId>::new());
         assert_eq!(graph.get_active_links(&3, 0), Vec::<VectorId>::new());
         assert_eq!(minted.ops, vec![]);
+    }
+
+    /// Linearization: a reauth plan's search almost always finds the node's
+    /// own old version, and the serial collapse turns it into a
+    /// self-reference. It was identified against the content the reauth
+    /// replaces, so it must not survive as a self-edge — while legitimate
+    /// neighbors do; the record carries only the survivors.
+    #[test]
+    fn linearization_drops_reauth_self_reference() {
+        let mut graph = GraphMem::new();
+        let s0 = VectorId::new(1, 0);
+        let s1 = VectorId::new(1, 1);
+        let a = VectorId::from_serial_id(2);
+        let node = |id| MutationOp::AddNode {
+            id,
+            height: 1,
+            update_ep: UpdateEntryPoint::False,
+        };
+
+        // seq 1: S and anchor A, linked.
+        graph
+            .apply_new(UnstampedMutation {
+                as_of: graph.last_update_seq_no,
+                ops: vec![
+                    node(s0),
+                    node(a),
+                    MutationOp::AddEdges {
+                        base: 1,
+                        neighbors: vec![2],
+                        layer: 0,
+                        edge_type: EdgeType::All,
+                    },
+                ],
+            })
+            .unwrap();
+        // The reauth's search identified [S(old), A] here.
+        let as_of = graph.last_update_seq_no;
+        // seq 2: teardown, its own mutation (the production shape).
+        graph
+            .apply_new(UnstampedMutation {
+                as_of: graph.last_update_seq_no,
+                ops: vec![MutationOp::RemoveNode { id: s1 }],
+            })
+            .unwrap();
+        // seq 3: re-insert wiring the searched links, self-echo included.
+        let minted = graph
+            .apply_new(UnstampedMutation {
+                as_of,
+                ops: vec![
+                    node(s1),
+                    MutationOp::AddEdges {
+                        base: 1,
+                        neighbors: vec![1, 2],
+                        layer: 0,
+                        edge_type: EdgeType::All,
+                    },
+                ],
+            })
+            .unwrap();
+
+        // No self-edge, physically or actively; the real neighbor survives
+        // in both directions; the record carries only the survivors.
+        assert_eq!(graph.get_raw_links(&1, 0), &[2u32]);
+        assert_eq!(graph.get_active_links(&1, 0), vec![a]);
+        assert_eq!(graph.get_active_links(&2, 0), vec![s1]);
+        assert_eq!(
+            minted.ops,
+            vec![
+                node(s1),
+                MutationOp::AddEdges {
+                    base: 1,
+                    neighbors: vec![2],
+                    layer: 0,
+                    edge_type: EdgeType::All,
+                },
+            ]
+        );
     }
 
     /// Read-path skip: `get_active_links` omits a content-stale neighbor even

--- a/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/layered_graph.rs
@@ -25,7 +25,7 @@ use serde::{
     Deserialize, Serialize,
 };
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, HashSet},
     fmt::Display,
     iter::once,
     path::PathBuf,
@@ -105,10 +105,13 @@ impl NodeInit {
 /// added) and a stamp `> old_seq` means content-refreshed (reauthed) since the
 /// edge was certified — either way the edge is dropped.
 ///
-/// Used on every apply (the filter-on-bump in `GraphMem::edit_neighborhood`)
-/// and at read time ([`GraphMem::get_active_links`]) — the lazy realization of the
-/// abstract semantics that removing or re-inserting a node invalidates every
-/// edge incident to it (see `model.rs`).
+/// One discipline, three anchors: edits filter against the neighborhood's old
+/// certificate (the filter-on-bump in `GraphMem::edit_neighborhood`), reads
+/// against its current one ([`GraphMem::get_active_links`]), and stamping
+/// against the minting intent's `as_of` (the linearization in
+/// `GraphMem::apply_new`) — the lazy realization of the abstract semantics
+/// that removing or re-inserting a node invalidates every edge incident to it
+/// (see `model.rs`).
 ///
 /// Replay re-evaluates this predicate. Changes that preserve the abstract
 /// graph (`model.rs`) replay old segments safely and need no WAL migration —
@@ -553,9 +556,10 @@ impl GraphMem {
     }
 
     /// Stamp a locally-built [`UnstampedMutation`] with the next sequence
-    /// number, apply it, and return the resulting [`GraphMutation`] with the
-    /// ops unchanged; replaying it ([`Self::insert_apply`]) runs the
-    /// identical apply.
+    /// number, linearize it against the current graph (see
+    /// [`Self::linearize`]), apply it, and return the resulting
+    /// [`GraphMutation`] carrying the surviving ops; replaying it
+    /// ([`Self::insert_apply`]) runs the identical apply.
     ///
     /// This is the sole minter of sequence numbers for in-process mutations:
     /// the number is assigned from `next_sequence_number()` and consumed by the
@@ -566,11 +570,94 @@ impl GraphMem {
     /// monotonicity check guards the externally-supplied `seq_no`.
     pub fn apply_new(&mut self, mutation: UnstampedMutation) -> Result<GraphMutation> {
         let seq_no = self.next_sequence_number();
-        self.apply_ops(seq_no, &mutation.ops)?;
-        Ok(GraphMutation {
-            seq_no,
-            ops: mutation.ops,
-        })
+        let ops = self.linearize(mutation);
+        self.apply_ops(seq_no, &ops)?;
+        Ok(GraphMutation { seq_no, ops })
+    }
+
+    /// Linearize an intent whose edge references were identified at
+    /// `mutation.as_of`: the same staleness discipline as reads
+    /// ([`Self::get_active_links`]) and edits ([`Self::edit_neighborhood`]),
+    /// applied to the mutation itself at its stamping point. A referenced
+    /// serial is *void* if it is not [`is_active`] at `as_of` — removed, or
+    /// content-refreshed after identification — unless this mutation's own
+    /// `AddNode` creates it (freshness-at-creation). Void `neighbors` are
+    /// dropped from their op; an op whose `base` is void is dropped entirely,
+    /// since its ranking belonged to content that no longer exists. For
+    /// `RemoveEdges` a void target's removal is skipped: the ranked edge is
+    /// already invalid, and a fresh edge to the target's new content is not
+    /// this intent's to evict.
+    ///
+    /// Node ops pass through untouched. The surviving ops all satisfy the
+    /// spec preconditions (`model.rs`) at apply time.
+    fn linearize(&self, mutation: UnstampedMutation) -> Vec<MutationOp> {
+        let UnstampedMutation { as_of, ops } = mutation;
+        debug_assert!(
+            as_of <= self.last_update_seq_no,
+            "intent as_of {} is ahead of the graph at {}",
+            as_of,
+            self.last_update_seq_no,
+        );
+        let minted: HashSet<SerialId> = ops
+            .iter()
+            .filter_map(|op| match op {
+                MutationOp::AddNode { id, .. } => Some(id.serial_id()),
+                _ => None,
+            })
+            .collect();
+        let fresh = |z: &SerialId| minted.contains(z) || is_active(&self.node_init, *z, as_of);
+
+        let mut dropped = 0usize;
+        // The surviving refs of one op half, or `None` if the op is void.
+        let mut filter_refs = |base: &SerialId, neighbors: Vec<SerialId>| {
+            if !fresh(base) {
+                dropped += neighbors.len();
+                return None;
+            }
+            let before = neighbors.len();
+            let kept: Vec<SerialId> = neighbors.into_iter().filter(|z| fresh(z)).collect();
+            dropped += before - kept.len();
+            (!kept.is_empty()).then_some(kept)
+        };
+
+        let mut resolved = Vec::with_capacity(ops.len());
+        for op in ops {
+            let resolved_op = match op {
+                MutationOp::AddNode { .. } | MutationOp::RemoveNode { .. } => Some(op),
+                MutationOp::AddEdges {
+                    base,
+                    neighbors,
+                    layer,
+                    edge_type,
+                } => filter_refs(&base, neighbors).map(|neighbors| MutationOp::AddEdges {
+                    base,
+                    neighbors,
+                    layer,
+                    edge_type,
+                }),
+                MutationOp::RemoveEdges {
+                    base,
+                    neighbors,
+                    layer,
+                    edge_type,
+                } => filter_refs(&base, neighbors).map(|neighbors| MutationOp::RemoveEdges {
+                    base,
+                    neighbors,
+                    layer,
+                    edge_type,
+                }),
+            };
+            resolved.extend(resolved_op);
+        }
+        if dropped > 0 {
+            metrics::counter!("graph_linearization_dropped_refs").increment(dropped as u64);
+            warn!(
+                "linearization dropped {dropped} edge ref(s) identified at seq {as_of} \
+                 (graph at {})",
+                self.last_update_seq_no,
+            );
+        }
+        resolved
     }
 
     pub fn insert_apply_all(&mut self, mutations: &[GraphMutation]) -> Result<()> {
@@ -1328,7 +1415,7 @@ mod tests {
         for raw_query in IrisDB::new_random_rng(20, &mut rng).db {
             let query = Arc::new(raw_query);
             let insertion_layer = searcher.gen_layer_rng(&mut rng)?;
-            let (neighbors, update_ep) = searcher
+            let (neighbors, update_ep, as_of) = searcher
                 .search_to_insert(&mut vector_store, &graph_store, &query, insertion_layer)
                 .await?;
             let inserted = vector_store.insert(&query).await;
@@ -1339,6 +1426,7 @@ mod tests {
                     inserted,
                     neighbors,
                     update_ep,
+                    as_of,
                 )
                 .await?;
 
@@ -1505,12 +1593,14 @@ mod tests {
         // seq 1: insert a and b.
         graph
             .apply_new(UnstampedMutation {
+                as_of: graph.last_update_seq_no,
                 ops: vec![node(a), node(b)],
             })
             .unwrap();
         // seq 2: asymmetric forward edge a -> b only; b's list stays empty.
         graph
             .apply_new(UnstampedMutation {
+                as_of: graph.last_update_seq_no,
                 ops: vec![MutationOp::AddEdges {
                     base: 1,
                     layer: 0,
@@ -1528,6 +1618,7 @@ mod tests {
         // cleanup), so a -> b survives — then AddNode(b) advances content[b] to 3.
         graph
             .apply_new(UnstampedMutation {
+                as_of: graph.last_update_seq_no,
                 ops: vec![MutationOp::RemoveNode { id: b }, node(b)],
             })
             .unwrap();
@@ -1542,7 +1633,10 @@ mod tests {
         // runs against a's prior seq (2) and drops a -> b (content[b] = 3 > 2)
         // before appending d.
         graph
-            .apply_new(UnstampedMutation { ops: vec![node(d)] })
+            .apply_new(UnstampedMutation {
+                as_of: graph.last_update_seq_no,
+                ops: vec![node(d)],
+            })
             .unwrap();
         let touch = MutationOp::AddEdges {
             base: 1,
@@ -1552,6 +1646,7 @@ mod tests {
         };
         let minted = graph
             .apply_new(UnstampedMutation {
+                as_of: graph.last_update_seq_no,
                 ops: vec![touch.clone()],
             })
             .unwrap();
@@ -1562,6 +1657,176 @@ mod tests {
 
         // The drop is not reflected in the op list; it re-derives on replay.
         assert_eq!(minted.ops, vec![touch]);
+    }
+
+    /// Linearization: an `AddEdges` intent identified before its target's
+    /// reauth must not re-point at — and certify — the target's new content.
+    #[test]
+    fn linearization_drops_edge_ref_to_target_reauthed_after_identification() {
+        let mut graph = GraphMem::new();
+        let x0 = VectorId::new(1, 0);
+        let x1 = VectorId::new(1, 1);
+        let y = VectorId::from_serial_id(2);
+        let node = |id| MutationOp::AddNode {
+            id,
+            height: 1,
+            update_ep: UpdateEntryPoint::False,
+        };
+
+        // seq 1: X enters the graph.
+        graph
+            .apply_new(UnstampedMutation {
+                as_of: graph.last_update_seq_no,
+                ops: vec![node(x0)],
+            })
+            .unwrap();
+        // Y's insert search identified X here.
+        let as_of = graph.last_update_seq_no;
+        // seq 2: X reauths — its content is no longer what the search saw.
+        graph
+            .apply_new(UnstampedMutation {
+                as_of: graph.last_update_seq_no,
+                ops: vec![MutationOp::RemoveNode { id: x1 }, node(x1)],
+            })
+            .unwrap();
+        // seq 3: Y's insert lands with the pre-reauth identification.
+        let minted = graph
+            .apply_new(UnstampedMutation {
+                as_of,
+                ops: vec![
+                    node(y),
+                    MutationOp::AddEdges {
+                        base: 2,
+                        neighbors: vec![1],
+                        layer: 0,
+                        edge_type: EdgeType::All,
+                    },
+                ],
+            })
+            .unwrap();
+
+        // The stale reference is dropped at stamping: no edge in either
+        // direction, and the record carries only the surviving ops.
+        assert_eq!(graph.get_active_links(&2, 0), Vec::<VectorId>::new());
+        assert_eq!(graph.get_active_links(&1, 0), Vec::<VectorId>::new());
+        assert_eq!(minted.ops, vec![node(y)]);
+    }
+
+    /// Linearization: a `RemoveEdges` intent ranked before its target's reauth
+    /// must not evict the fresh edge the reauth re-added — the removal names
+    /// the old edge, which is already gone.
+    #[test]
+    fn linearization_skips_removal_of_edge_readded_after_identification() {
+        let mut graph = GraphMem::new();
+        let x0 = VectorId::new(1, 0);
+        let x1 = VectorId::new(1, 1);
+        let y = VectorId::from_serial_id(2);
+        let node = |id| MutationOp::AddNode {
+            id,
+            height: 1,
+            update_ep: UpdateEntryPoint::False,
+        };
+
+        // seq 1: Y -> X.
+        graph
+            .apply_new(UnstampedMutation {
+                as_of: graph.last_update_seq_no,
+                ops: vec![
+                    node(x0),
+                    node(y),
+                    MutationOp::AddEdges {
+                        base: 2,
+                        neighbors: vec![1],
+                        layer: 0,
+                        edge_type: EdgeType::Base,
+                    },
+                ],
+            })
+            .unwrap();
+        // Compaction ranked Y's neighborhood and chose to evict X here.
+        let as_of = graph.last_update_seq_no;
+        // seq 2: X reauths and re-links to Y — Y -> X now points at vetted
+        // fresh content.
+        graph
+            .apply_new(UnstampedMutation {
+                as_of: graph.last_update_seq_no,
+                ops: vec![
+                    MutationOp::RemoveNode { id: x1 },
+                    node(x1),
+                    MutationOp::AddEdges {
+                        base: 1,
+                        neighbors: vec![2],
+                        layer: 0,
+                        edge_type: EdgeType::All,
+                    },
+                ],
+            })
+            .unwrap();
+        assert_eq!(graph.get_active_links(&2, 0), vec![x1]);
+
+        // seq 3: the stale-ranked eviction lands; the fresh edge survives.
+        graph
+            .apply_new(UnstampedMutation {
+                as_of,
+                ops: vec![MutationOp::RemoveEdges {
+                    base: 2,
+                    neighbors: vec![1],
+                    layer: 0,
+                    edge_type: EdgeType::Base,
+                }],
+            })
+            .unwrap();
+        assert_eq!(graph.get_active_links(&2, 0), vec![x1]);
+    }
+
+    /// Linearization: an edge intent whose *base* was reauthed after
+    /// identification is void — the ranking belonged to content that no
+    /// longer exists, so both halves are dropped (matching main, where the
+    /// VectorId-keyed neighborhood no-ops).
+    #[test]
+    fn linearization_drops_op_whose_base_reauthed_after_identification() {
+        let mut graph = GraphMem::new();
+        let x0 = VectorId::new(1, 0);
+        let x1 = VectorId::new(1, 1);
+        let z = VectorId::from_serial_id(3);
+        let node = |id| MutationOp::AddNode {
+            id,
+            height: 1,
+            update_ep: UpdateEntryPoint::False,
+        };
+
+        // seq 1: X and Z.
+        graph
+            .apply_new(UnstampedMutation {
+                as_of: graph.last_update_seq_no,
+                ops: vec![node(x0), node(z)],
+            })
+            .unwrap();
+        // An edge touch X <-> Z was identified here.
+        let as_of = graph.last_update_seq_no;
+        // seq 2: X reauths.
+        graph
+            .apply_new(UnstampedMutation {
+                as_of: graph.last_update_seq_no,
+                ops: vec![MutationOp::RemoveNode { id: x1 }, node(x1)],
+            })
+            .unwrap();
+        // seq 3: the stale-based touch lands and is void.
+        let minted = graph
+            .apply_new(UnstampedMutation {
+                as_of,
+                ops: vec![MutationOp::AddEdges {
+                    base: 1,
+                    neighbors: vec![3],
+                    layer: 0,
+                    edge_type: EdgeType::All,
+                }],
+            })
+            .unwrap();
+
+        assert_eq!(graph.get_active_links(&1, 0), Vec::<VectorId>::new());
+        assert_eq!(graph.get_active_links(&3, 0), Vec::<VectorId>::new());
+        assert_eq!(minted.ops, vec![]);
     }
 
     /// Read-path skip: `get_active_links` omits a content-stale neighbor even
@@ -1877,6 +2142,7 @@ mod tests {
         let v = VectorId::from_serial_id;
         let mut g = GraphMem::new();
         g.apply_new(UnstampedMutation {
+            as_of: g.last_update_seq_no,
             ops: (1..=6).map(|i| node(v(i))).collect(),
         })
         .unwrap();
@@ -1884,6 +2150,7 @@ mod tests {
         // ── EdgeType::Base, forward-half retain. 1 -> {2,3} forward-only, then
         // reauth 3 so 1->3 is content-stale while 1's list is untouched.
         g.apply_new(UnstampedMutation {
+            as_of: g.last_update_seq_no,
             ops: vec![MutationOp::AddEdges {
                 base: 1,
                 neighbors: vec![2, 3],
@@ -1893,6 +2160,7 @@ mod tests {
         })
         .unwrap();
         g.apply_new(UnstampedMutation {
+            as_of: g.last_update_seq_no,
             ops: vec![MutationOp::RemoveNode { id: v(3) }, node(v(3))],
         })
         .unwrap();
@@ -1909,6 +2177,7 @@ mod tests {
         };
         let minted = g
             .apply_new(UnstampedMutation {
+                as_of: g.last_update_seq_no,
                 ops: vec![teardown.clone()],
             })
             .unwrap();
@@ -1922,6 +2191,7 @@ mod tests {
         // ── EdgeType::All, back-half (target-loop) retain. 4<->5 symmetric plus
         // asymmetric 5->6; reauth 6 so 5->6 is stale.
         g.apply_new(UnstampedMutation {
+            as_of: g.last_update_seq_no,
             ops: vec![
                 MutationOp::AddEdges {
                     base: 4,
@@ -1939,6 +2209,7 @@ mod tests {
         })
         .unwrap();
         g.apply_new(UnstampedMutation {
+            as_of: g.last_update_seq_no,
             ops: vec![MutationOp::RemoveNode { id: v(6) }, node(v(6))],
         })
         .unwrap();
@@ -1954,6 +2225,7 @@ mod tests {
         };
         let minted = g
             .apply_new(UnstampedMutation {
+                as_of: g.last_update_seq_no,
                 ops: vec![teardown.clone()],
             })
             .unwrap();
@@ -1980,7 +2252,13 @@ mod tests {
     #[test]
     fn minted_stream_replays_to_identical_graph() {
         fn mint(g: &mut GraphMem, wal: &mut Vec<GraphMutation>, ops: Vec<MutationOp>) {
-            wal.push(g.apply_new(UnstampedMutation { ops }).unwrap());
+            wal.push(
+                g.apply_new(UnstampedMutation {
+                    as_of: g.last_update_seq_no,
+                    ops,
+                })
+                .unwrap(),
+            );
         }
         let node = |s: u32| MutationOp::AddNode {
             id: VectorId::from_serial_id(s),

--- a/iris-mpc-cpu/src/hnsw/graph/model.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/model.rs
@@ -7,9 +7,10 @@
 //! semantics lazily; the refinement test drives both with generated mutation
 //! streams and asserts their observations agree after every mutation.
 //!
-//! Spec preconditions (asserted here, upheld by production mints): `AddEdges`
-//! endpoints are live at apply time (causal construction); `AddNode` targets
-//! a non-live serial (reauth = `RemoveNode` + `AddNode` in one mutation).
+//! Spec preconditions (asserted here, established by the linearization in
+//! `GraphMem::apply_new`): `AddEdges` endpoints are live at apply time
+//! (causal construction); `AddNode` targets a non-live serial (reauth =
+//! `RemoveNode` + `AddNode` in one mutation).
 
 use super::mutation::{EdgeType, MutationOp, UpdateEntryPoint};
 use iris_mpc_common::{SerialId, VersionId};
@@ -279,18 +280,25 @@ mod tests {
 
             for step in 0..300 {
                 let live: Vec<SerialId> = UNIVERSE.filter(|s| m.version_of(*s).is_some()).collect();
-                let ops: Vec<MutationOp> = match rng.gen_range(0..100) {
+                let now = g.last_update_seq_no;
+                // `forbidden`: a serial whose content changed after the arm's
+                // as_of — the minted record must not reference it.
+                let mut forbidden: Option<SerialId> = None;
+                let (as_of, ops): (u64, Vec<MutationOp>) = match rng.gen_range(0..100) {
                     // Insert a non-live serial (fresh or resurrected).
                     0..=29 => {
                         let free: Vec<SerialId> =
                             UNIVERSE.filter(|s| m.version_of(*s).is_none()).collect();
                         match free.choose(rng) {
-                            Some(&s) => insert_ops(
-                                &m,
-                                s,
-                                rng.gen_range(0..4),
-                                rng.gen_range(1..=MAX_HEIGHT),
-                                rng,
+                            Some(&s) => (
+                                now,
+                                insert_ops(
+                                    &m,
+                                    s,
+                                    rng.gen_range(0..4),
+                                    rng.gen_range(1..=MAX_HEIGHT),
+                                    rng,
+                                ),
                             ),
                             None => continue,
                         }
@@ -309,15 +317,18 @@ mod tests {
                                 rng.gen_range(1..=MAX_HEIGHT),
                                 rng,
                             ));
-                            ops
+                            (now, ops)
                         }
                         None => continue,
                     },
                     // Deletion.
                     50..=64 => match live.choose(rng) {
-                        Some(&s) => vec![MutationOp::RemoveNode {
-                            id: VectorId::new(s, m.version_of(s).unwrap()),
-                        }],
+                        Some(&s) => (
+                            now,
+                            vec![MutationOp::RemoveNode {
+                                id: VectorId::new(s, m.version_of(s).unwrap()),
+                            }],
+                        ),
                         None => continue,
                     },
                     // Edge touch: wire a live base to live targets.
@@ -333,16 +344,19 @@ mod tests {
                             .choose(rng)
                             .unwrap()
                             .clone();
-                        vec![MutationOp::AddEdges {
-                            base,
-                            neighbors: targets,
-                            layer,
-                            edge_type,
-                        }]
+                        (
+                            now,
+                            vec![MutationOp::AddEdges {
+                                base,
+                                neighbors: targets,
+                                layer,
+                                edge_type,
+                            }],
+                        )
                     }
                     // Compaction-shaped RemoveEdges (named serials need not be
                     // present or live).
-                    _ => {
+                    85..=91 => {
                         let layer = rng.gen_range(0..MAX_HEIGHT);
                         let bases = pick_members(&m, layer, 0, 1, rng);
                         let Some(&base) = bases.first() else { continue };
@@ -362,17 +376,129 @@ mod tests {
                         }
                         let edge_type =
                             [EdgeType::Base, EdgeType::All].choose(rng).unwrap().clone();
-                        vec![MutationOp::RemoveEdges {
-                            base,
-                            neighbors: targets,
-                            layer,
-                            edge_type,
-                        }]
+                        (
+                            now,
+                            vec![MutationOp::RemoveEdges {
+                                base,
+                                neighbors: targets,
+                                layer,
+                                edge_type,
+                            }],
+                        )
+                    }
+                    // Drifted intent: identify refs now, let an intervening
+                    // reauth or deletion land, then mint with the stale as_of.
+                    // Linearization must resolve the void refs so the record
+                    // satisfies the spec preconditions (the model panics
+                    // otherwise).
+                    _ => {
+                        let layer = rng.gen_range(0..MAX_HEIGHT);
+                        let bases = pick_members(&m, layer, 0, 1, rng);
+                        let Some(&base) = bases.first() else { continue };
+                        let targets = pick_members(&m, layer, base, rng.gen_range(1..=3), rng);
+                        if targets.is_empty() {
+                            continue;
+                        }
+
+                        // Intervening reauth or deletion of one identified
+                        // serial.
+                        let mut pool = targets.clone();
+                        pool.push(base);
+                        let victim = *pool.choose(rng).unwrap();
+                        let version = m.version_of(victim).unwrap() + 1;
+                        let mut intervening = vec![MutationOp::RemoveNode {
+                            id: VectorId::new(victim, version),
+                        }];
+                        if rng.gen_bool(0.5) {
+                            intervening.extend(insert_ops(
+                                &m,
+                                victim,
+                                version,
+                                rng.gen_range(1..=MAX_HEIGHT),
+                                rng,
+                            ));
+                        }
+                        let minted = g
+                            .apply_new(UnstampedMutation {
+                                as_of: g.last_update_seq_no,
+                                ops: intervening,
+                            })
+                            .unwrap();
+                        m.apply(&minted.ops);
+                        wal.push(minted);
+                        assert_refines(&g, &m, step);
+                        forbidden = Some(victim);
+
+                        // The drifted intent: an insert wiring to the stale
+                        // refs, an edge touch, or a compaction-shaped removal.
+                        let free: Vec<SerialId> = UNIVERSE
+                            .filter(|s| *s != victim && m.version_of(*s).is_none())
+                            .collect();
+                        let ops = match (rng.gen_range(0..3), free.choose(rng)) {
+                            (0, Some(&s)) => {
+                                let height = layer + 1;
+                                let update_ep = if height > m.num_layers() {
+                                    UpdateEntryPoint::Append { layer }
+                                } else {
+                                    UpdateEntryPoint::False
+                                };
+                                vec![
+                                    MutationOp::AddNode {
+                                        id: VectorId::new(s, rng.gen_range(0..4)),
+                                        height,
+                                        update_ep,
+                                    },
+                                    MutationOp::AddEdges {
+                                        base: s,
+                                        neighbors: targets,
+                                        layer,
+                                        edge_type: EdgeType::All,
+                                    },
+                                ]
+                            }
+                            (1, _) => vec![MutationOp::AddEdges {
+                                base,
+                                neighbors: targets,
+                                layer,
+                                edge_type: [EdgeType::Base, EdgeType::Neighbors, EdgeType::All]
+                                    .choose(rng)
+                                    .unwrap()
+                                    .clone(),
+                            }],
+                            _ => vec![MutationOp::RemoveEdges {
+                                base,
+                                neighbors: targets,
+                                layer,
+                                edge_type: [EdgeType::Base, EdgeType::All]
+                                    .choose(rng)
+                                    .unwrap()
+                                    .clone(),
+                            }],
+                        };
+                        (now, ops)
                     }
                 };
 
-                wal.push(g.apply_new(UnstampedMutation { ops: ops.clone() }).unwrap());
-                m.apply(&ops);
+                let minted = g.apply_new(UnstampedMutation { as_of, ops }).unwrap();
+                if let Some(victim) = forbidden {
+                    for op in &minted.ops {
+                        if let MutationOp::AddEdges {
+                            base, neighbors, ..
+                        }
+                        | MutationOp::RemoveEdges {
+                            base, neighbors, ..
+                        } = op
+                        {
+                            assert!(
+                                *base != victim && !neighbors.contains(&victim),
+                                "step {step}: record references serial {victim}, whose content \
+                                 changed after the intent's as_of"
+                            );
+                        }
+                    }
+                }
+                m.apply(&minted.ops);
+                wal.push(minted);
                 assert_refines(&g, &m, step);
             }
 

--- a/iris-mpc-cpu/src/hnsw/graph/mutation.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/mutation.rs
@@ -17,6 +17,17 @@ pub struct GraphMutation {
 /// graph.
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
 pub struct UnstampedMutation {
+    /// Sequence number of the graph state the edge references in `ops` were
+    /// identified against (the search snapshot). Consumed at stamping: a
+    /// reference whose target changed after `as_of` is void and is dropped
+    /// (see `GraphMem::apply_new`). Never persisted — the stamped record
+    /// carries only the surviving ops.
+    ///
+    /// Must come from the graph read that produced the references (search or
+    /// neighborhood-ranking APIs return it alongside their results); minting
+    /// with a later seq re-certifies references against content they never
+    /// saw.
+    pub as_of: u64,
     pub ops: Vec<MutationOp>,
 }
 
@@ -335,6 +346,7 @@ mod tests {
     #[test]
     fn expanded_neighborhoods_addedges_all_yields_base_and_neighbors() {
         let mutation = UnstampedMutation {
+            as_of: 0,
             ops: vec![mk_add_edges(1, vec![2, 3], 0, EdgeType::All)],
         };
         let mut got = mutation.expanded_neighborhoods();
@@ -345,6 +357,7 @@ mod tests {
     #[test]
     fn expanded_neighborhoods_addedges_base_yields_only_base() {
         let mutation = UnstampedMutation {
+            as_of: 0,
             ops: vec![mk_add_edges(1, vec![2, 3], 1, EdgeType::Base)],
         };
         assert_eq!(mutation.expanded_neighborhoods(), vec![(1, 1)]);
@@ -353,6 +366,7 @@ mod tests {
     #[test]
     fn expanded_neighborhoods_addedges_neighbors_yields_only_neighbors() {
         let mutation = UnstampedMutation {
+            as_of: 0,
             ops: vec![mk_add_edges(1, vec![2, 3], 2, EdgeType::Neighbors)],
         };
         let mut got = mutation.expanded_neighborhoods();
@@ -363,6 +377,7 @@ mod tests {
     #[test]
     fn expanded_neighborhoods_ignores_non_addedges_ops() {
         let mutation = UnstampedMutation {
+            as_of: 0,
             ops: vec![
                 MutationOp::AddNode {
                     id: VectorId::from_serial_id(1),

--- a/iris-mpc-cpu/src/hnsw/searcher.rs
+++ b/iris-mpc-cpu/src/hnsw/searcher.rs
@@ -1424,11 +1424,11 @@ impl HnswSearcher {
         query: &V::QueryRef,
         insertion_layer: usize,
     ) -> Result<VectorId> {
-        let (neighbors, update_ep) = self
+        let (neighbors, update_ep, as_of) = self
             .search_to_insert(store, graph, query, insertion_layer)
             .await?;
         let inserted = store.insert(query).await;
-        self.insert_from_search_results(store, graph, inserted, neighbors, update_ep)
+        self.insert_from_search_results(store, graph, inserted, neighbors, update_ep, as_of)
             .await?;
         Ok(inserted)
     }
@@ -1465,7 +1465,12 @@ impl HnswSearcher {
         graph: &GraphMem,
         query: &V::QueryRef,
         insertion_layer: usize,
-    ) -> Result<(Vec<SortedNeighborhood<V>>, UpdateEntryPoint)> {
+    ) -> Result<(Vec<SortedNeighborhood<V>>, UpdateEntryPoint, u64)> {
+        // The graph state this search's results are identified against;
+        // returned so the mutation minted from them carries its provenance
+        // (`UnstampedMutation::as_of`).
+        let as_of = graph.last_update_seq_no;
+
         // Initialize candidate neighborhood, index of highest search layer,
         // finalized layer of node insertion, and entry point update outcome.
         let init_start = std::time::Instant::now();
@@ -1516,7 +1521,7 @@ impl HnswSearcher {
 
         assert_eq!(links.len(), insertion_layer + 1);
 
-        Ok((links, update_ep))
+        Ok((links, update_ep, as_of))
     }
 
     /// Computes RemoveEdges ops for any of the `candidates` neighborhoods that
@@ -1537,7 +1542,11 @@ impl HnswSearcher {
         store: &mut V,
         graph: &GraphMem,
         candidates: &BTreeSet<(SerialId, usize)>,
-    ) -> Result<Vec<MutationOp>> {
+    ) -> Result<(Vec<MutationOp>, u64)> {
+        // The ranking below is identified against this graph state; minted
+        // removals carry it as their `UnstampedMutation::as_of`.
+        let as_of = graph.last_update_seq_no;
+
         // Read the current neighborhood for each candidate; keep only those
         // exceeding M_limit on their layer.
         let mut oversized: Vec<(VectorId, usize, Vec<VectorId>)> = Vec::new();
@@ -1560,7 +1569,7 @@ impl HnswSearcher {
         );
 
         if oversized.is_empty() {
-            return Ok(Vec::new());
+            return Ok((Vec::new(), as_of));
         }
 
         // Build parallel slices for the batched MPC compaction call.
@@ -1597,7 +1606,7 @@ impl HnswSearcher {
             }
         }
 
-        Ok(ops)
+        Ok((ops, as_of))
     }
 
     /// Insert a vector using the search results from `search_to_insert`,
@@ -1615,6 +1624,7 @@ impl HnswSearcher {
         inserted_vector: VectorId,
         links: Vec<SortedNeighborhood<V>>,
         update_ep: UpdateEntryPoint,
+        as_of: u64,
     ) -> Result<()> {
         // Trim and extract unstructured vector lists.
         let mut links_unstructured: Vec<Vec<VectorId>> = Vec::new();
@@ -1640,15 +1650,15 @@ impl HnswSearcher {
                 edge_type: EdgeType::All,
             });
         }
-        let plan = UnstampedMutation { ops };
+        let plan = UnstampedMutation { as_of, ops };
         let expanded: BTreeSet<_> = plan.expanded_neighborhoods().into_iter().collect();
         graph.apply_new(plan)?;
 
         // Single-insert compaction.
         if !expanded.is_empty() {
-            let ops = self.compact_batch(store, graph, &expanded).await?;
+            let (ops, as_of) = self.compact_batch(store, graph, &expanded).await?;
             if !ops.is_empty() {
-                graph.apply_new(UnstampedMutation { ops })?;
+                graph.apply_new(UnstampedMutation { as_of, ops })?;
             }
         }
 
@@ -1709,7 +1719,7 @@ mod tests {
         // Insert the codes.
         for query in queries1.iter() {
             let insertion_layer = db.gen_layer_rng(rng)?;
-            let (neighbors, update_ep) = db
+            let (neighbors, update_ep, as_of) = db
                 .search_to_insert(vector_store, graph_store, query, insertion_layer)
                 .await?;
             assert!(!db.is_match(vector_store, &neighbors).await?);
@@ -1722,6 +1732,7 @@ mod tests {
                 inserted,
                 neighbors,
                 update_ep,
+                as_of,
             )
             .await?;
         }
@@ -1787,7 +1798,7 @@ mod tests {
             // Same queries used above
             let query = queries_copy.next().unwrap();
 
-            let (neighbors, update_ep) = searcher_linear
+            let (neighbors, update_ep, _as_of) = searcher_linear
                 .search_to_insert(
                     vector_store_linear,
                     graph_store_linear,
@@ -1855,7 +1866,7 @@ mod tests {
         let mut candidates = BTreeSet::new();
         candidates.insert((base.serial_id(), 0));
 
-        let ops = searcher
+        let (ops, _as_of) = searcher
             .compact_batch(&mut store, &graph, &candidates)
             .await?;
 
@@ -1932,7 +1943,7 @@ mod tests {
         let mut candidates = BTreeSet::new();
         candidates.insert((a.serial_id(), 0));
 
-        let ops = searcher
+        let (ops, _as_of) = searcher
             .compact_batch(&mut store, &graph, &candidates)
             .await?;
         assert!(ops.is_empty());


### PR DESCRIPTION
Alternative boundary for reference resolution, against the base branch's resolve-at-every-apply (#2232); one of the two lands. Shared with the base: `as_of` provenance through the search/ranking APIs, the resolution predicate itself (void refs, void base, dropped `AddEdges` self-references), the executable spec, and the pinned regression tests.

**What differs — resolution happens once, at stamping.** `UnstampedMutation { as_of, ops }` is linearized inside `apply_new` before the first apply; the stamped `GraphMutation` carries only the surviving ops, and `as_of` is not persisted (wire records carry no `as_of` field). Replay applies records as recorded, so replayed segments are independent of the resolution predicate: predicate evolution never reinterprets history. The trade: records don't carry their identification context, and linearization must be atomic with the first apply — enforced structurally (`linearize` is private to `apply_new`, same exclusive borrow).

**Oracle.** Because the model consumes resolved records, the refinement test alone cannot observe a broken mint-side filter; the generator's drift arm therefore additionally pins that minted records never reference a serial whose content changed after the intent's `as_of` (mutation-tested: a neutered filter fails both this pin and the pinned unit tests).

348 cpu lib tests green; workspace clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
