### PR TITLE
test: local 3-party repro harness proving the POP-4051 stall and the bounded-abort fix

### DIFF
--- a/docker-compose.pop4051-repro.yaml
+++ b/docker-compose.pop4051-repro.yaml
@@ -1,0 +1,13 @@
+# POP-4051 repro overlay: enables the bounded batch-poll abort on all parties.
+# Baseline stall repro: omit this file (or ABORT_SECS=0).
+# Fix validation:      ABORT_SECS=10 docker compose -f docker-compose.hawk.yaml -f docker-compose.pop4051-repro.yaml up
+services:
+  hawk_participant_0:
+    environment:
+      SMPC__BATCH_POLL_ABORT_AFTER_SECS: "${ABORT_SECS:-0}"
+  hawk_participant_1:
+    environment:
+      SMPC__BATCH_POLL_ABORT_AFTER_SECS: "${ABORT_SECS:-0}"
+  hawk_participant_2:
+    environment:
+      SMPC__BATCH_POLL_ABORT_AFTER_SECS: "${ABORT_SECS:-0}"

--- a/scripts/tools/pop4051-repro.sh
+++ b/scripts/tools/pop4051-repro.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# POP-4051 local repro: force one party into the unbounded poll_exact_messages
+# wait (the silent batch-loop stall) against the local 3-party hawk stack.
+#
+# Mechanism (deterministic, no log-races):
+#   1. All parties idle, queues empty.
+#   2. Pause party 1. Party 0's next sync round will block retrying peer-state
+#      fetches against the paused party — a seconds-wide window.
+#   3. Send one uniqueness request (unique --rng-seed to defeat FIFO
+#      content-based deduplication). Copies land on all three queues.
+#   4. Party 0 reads its own count (1) and latches messages_to_poll=1 in its
+#      peer-visible sticky state, then blocks on party 1's sync endpoint.
+#   5. Steal party 0's queue copy (external ReceiveMessage, long visibility).
+#   6. Unpause party 1 (total pause < 8s, under the 10s sync timeout).
+#   7. Party 0 completes the sync round with target=1 latched and an EMPTY
+#      queue -> waits in poll_exact_messages. Parties 1/2 poll their copies,
+#      form the batch, and wait (loudly) in the batch-entries SHA sync.
+#
+# Verdicts:
+#   STALL_REPRODUCED  party 0 entered poll (target 1) and did not finish within STALL_WAIT
+#   ABORT_OBSERVED    fix fired: "aborting empty batch poll attempt" (EXPECT_ABORT=1)
+#   RECOVERED         after releasing the stolen copy, party 0 finished the batch
+#   NO_REPRO          timing lost — retried automatically
+#
+# Usage:
+#   Baseline (fix disabled -> silent stall):
+#     docker compose -f docker-compose.hawk.yaml up -d
+#     ./scripts/tools/pop4051-repro.sh
+#   Fix validation (bounded abort):
+#     ABORT_SECS=10 docker compose -f docker-compose.hawk.yaml -f docker-compose.pop4051-repro.yaml up -d
+#     EXPECT_ABORT=1 ./scripts/tools/pop4051-repro.sh
+set -uo pipefail
+
+export AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test AWS_REGION=us-east-1
+ENDPOINT=(--endpoint-url http://localhost:4566)
+Q0="http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/smpcv2-0-dev.fifo"
+COMPOSE="docker compose -f docker-compose.hawk.yaml"
+P0=hawk_participant_0
+P1=hawk_participant_1
+HOLD_SECS="${HOLD_SECS:-600}"      # visibility timeout while holding party 0's stolen copy
+STALL_WAIT="${STALL_WAIT:-25}"     # seconds of silence in poll that count as the stall
+EXPECT_ABORT="${EXPECT_ABORT:-0}"  # 1 = expect the fix's abort instead of the silent stall
+ATTEMPTS="${ATTEMPTS:-4}"
+RECEIPT=""
+CLIENT_PID=""
+
+say() { printf '\n== [%s] %s ==\n' "$(date -u +%H:%M:%S)" "$*"; }
+p_logs() { $COMPOSE logs --no-log-prefix --since "$1" "$2" 2>/dev/null; }
+
+cleanup() {
+  [ -n "$CLIENT_PID" ] && kill "$CLIENT_PID" 2>/dev/null
+  docker unpause "$($COMPOSE ps -q $P1)" >/dev/null 2>&1
+  release_message
+}
+trap cleanup EXIT
+
+release_message() {
+  [ -z "$RECEIPT" ] && return 0
+  aws "${ENDPOINT[@]}" sqs change-message-visibility --queue-url "$Q0" \
+    --receipt-handle "$RECEIPT" --visibility-timeout 0 >/dev/null 2>&1 || true
+  RECEIPT=""
+}
+
+steal_message() {
+  RECEIPT=""
+  for _ in $(seq 1 8); do
+    local out
+    out=$(aws "${ENDPOINT[@]}" sqs receive-message --queue-url "$Q0" \
+      --wait-time-seconds 1 --visibility-timeout "$HOLD_SECS" \
+      --max-number-of-messages 1 --query 'Messages[0].ReceiptHandle' --output text 2>/dev/null)
+    if [ -n "$out" ] && [ "$out" != "None" ]; then RECEIPT="$out"; return 0; fi
+  done
+  return 1
+}
+
+send_request() {
+  # Unique rng seed per send: FIFO topic/queues use content-based deduplication,
+  # so identical client payloads within 5 min are silently dropped.
+  AWS_ENDPOINT_URL="http://127.0.0.1:4566" ./target/release/client \
+    --request-topic-arn arn:aws:sns:us-east-1:000000000000:iris-mpc-input.fifo \
+    --requests-bucket-name wf-smpcv2-dev-sns-requests \
+    --public-key-base-url "http://localhost:4566/wf-dev-public-keys" \
+    --response-queue-url http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/iris-mpc-results-us-east-1.fifo \
+    --region us-east-1 \
+    --n-batches 1 --batch-size 1 \
+    --rng-seed "$(( (RANDOM << 15) ^ RANDOM ^ $(date +%s) ))" \
+    >"/tmp/pop4051-client-$1.log" 2>&1 &
+  CLIENT_PID=$!
+}
+
+end_client() { [ -n "$CLIENT_PID" ] && kill "$CLIENT_PID" 2>/dev/null; wait "$CLIENT_PID" 2>/dev/null; CLIENT_PID=""; }
+
+attempt() {
+  local n="$1" t0
+  t0=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  say "attempt $n: pausing $P1 to widen party 0's sync window"
+  docker pause "$($COMPOSE ps -q $P1)" >/dev/null || return 2
+  local pause_started; pause_started=$(date +%s)
+
+  say "sending one uniqueness request (unique rng seed)"
+  send_request "$n"
+
+  # Wait for party 0 to READ its queue count and latch the non-zero target in
+  # its peer-visible sticky state — it logs this at info. Only then steal: with
+  # party 1 paused, party 0 is now blocked in peer-sync, so the steal cannot
+  # lose a race against its ReceiveMessage.
+  say "waiting for party 0 to latch messages_to_poll=1"
+  local latched=0
+  for _ in $(seq 1 14); do
+    if p_logs "$t0" $P0 | grep -q "messages_to_poll=1"; then latched=1; break; fi
+    sleep 0.5
+  done
+  if [ "$latched" -ne 1 ]; then
+    say "party 0 did not latch within window (was mid-round at pause); NO_REPRO"
+    docker unpause "$($COMPOSE ps -q $P1)" >/dev/null
+    end_client; return 1
+  fi
+
+  say "party 0 latched; stealing its queue copy (visibility ${HOLD_SECS}s)"
+  if ! steal_message; then
+    say "steal failed — party 0 grabbed its copy first; NO_REPRO"
+    docker unpause "$($COMPOSE ps -q $P1)" >/dev/null
+    end_client; return 1
+  fi
+
+  local pause_elapsed=$(( $(date +%s) - pause_started ))
+  say "stole party 0's copy after ${pause_elapsed}s of pause; unpausing $P1"
+  docker unpause "$($COMPOSE ps -q $P1)" >/dev/null
+  if [ "$pause_elapsed" -ge 8 ]; then
+    say "pause window ${pause_elapsed}s >= 8s — peers may have torn down; treating as NO_REPRO"
+    release_message; end_client; return 1
+  fi
+
+  say "party 0 should now be in poll_exact_messages with an empty queue; observing ${STALL_WAIT}s"
+  sleep "$STALL_WAIT"
+  local p0; p0=$(p_logs "$t0" $P0)
+
+  if ! echo "$p0" | grep -q "Polling SQS for up to 1"; then
+    say "party 0 never entered the poll (agreement round missed); NO_REPRO"
+    release_message; end_client; return 1
+  fi
+
+  if [ "$EXPECT_ABORT" = "1" ]; then
+    if echo "$p0" | grep -q "aborting empty batch poll attempt"; then
+      say "VERDICT: ABORT_OBSERVED — the fix bounded the wait"
+    else
+      say "VERDICT: FIX_MISS — party 0 in poll but no abort (ABORT_SECS set? < STALL_WAIT?)"
+      echo "$p0" | tail -5; release_message; end_client; return 2
+    fi
+  else
+    if echo "$p0" | grep -q "Finished polling SQS. Processed 1"; then
+      say "party 0 finished its poll — steal lost the race; NO_REPRO"
+      release_message; end_client; return 1
+    fi
+    say "VERDICT: STALL_REPRODUCED — party 0 silent in poll_exact_messages (target latched, queue empty)"
+    echo "-- party 0 last lines:"; echo "$p0" | tail -3
+    echo "-- peer 1 (formed batch, waiting in entries-sync):"
+    p_logs "$t0" $P1 | grep -E "Finished polling|Batch sync entries|sync .*fail" | tail -3
+  fi
+
+  say "releasing party 0's copy (visibility -> 0); watching recovery"
+  release_message
+  for _ in $(seq 1 45); do
+    if p_logs "$t0" $P0 | grep -q "Finished polling SQS. Processed 1"; then
+      say "VERDICT: RECOVERED — party 0 consumed the released copy and completed the batch"
+      end_client; return 0
+    fi
+    sleep 2
+  done
+  say "VERDICT: NO_RECOVERY within 90s — inspect logs manually"
+  end_client; return 2
+}
+
+say "preflight: stack health + client binary"
+$COMPOSE ps --format '{{.Service}} {{.Health}}' | grep -v healthy | grep -v '^$' && { echo "unhealthy services above — aborting"; exit 1; }
+[ -x ./target/release/client ] || cargo build --release -q -p iris-mpc-bins --bin client || exit 1
+
+for i in $(seq 1 "$ATTEMPTS"); do
+  attempt "$i"; rc=$?
+  [ "$rc" -eq 0 ] && { say "SUCCESS"; exit 0; }
+  [ "$rc" -eq 2 ] && { say "FAILED (hard)"; exit 2; }
+  say "retrying after cleanup"; sleep 8
+done
+say "no repro in $ATTEMPTS attempts"
+exit 1


### PR DESCRIPTION
Stacked on #2258. This PR adds a deterministic local reproduction of the silent batch-poll stall ([POP-4051](https://linear.app/worldcoin/issue/POP-4051/iris-mpc-batch-loop-can-deadlock-silently-liveness-probe-cant-detect)) and records the evidence that #2258's abort semantics work end-to-end on the real 3-party protocol — so review of the fix doesn't have to rest on code reasoning alone.

## What it proves (observed locally, image built from #2258's branch)

**1. Baseline — fix disabled (default): the stall reproduces on the first attempt.**
Party 0 enters `poll_exact_messages` with `target=1` latched and an empty queue and goes fully silent — its only log lines during the stall are healthcheck 200s. This is the exact signature of the 2026-06-23 stage wedge (all parties 1/1 Ready, logs quiet). The peer meanwhile shows the loud half:

```
Batch ID: 5. Finished polling SQS. Processed 1 messages for this batch attempt (target: 1).
Batch sync entries attempt 1 failed after 23.2s: Timeout waiting for party
http://hawk_participant_0:3000/batch-sync-entries to reach batch hash 97a05d20
(last observed: peer batch_hash b6da345d differs from own 97a05d20). Retrying...
```

Releasing the stolen queue copy (`ChangeMessageVisibility → 0`) recovers the batch within ~2s — the freezes-then-continues behavior seen on stage.

**2. Fix — `SMPC__BATCH_POLL_ABORT_AFTER_SECS=10` via the compose overlay: the wait is bounded and reconvergence works.**

```
Batch ID: 1. aborting empty batch poll attempt after 11s waiting for target 1; re-entering batch sync
...release stolen copy...
Batch ID: 1. Finished polling SQS. Processed 1 messages for this batch attempt (target: 1).
```

After the abort, party 0 resets its peer-visible target, re-agrees, consumes the released copy, forms the **identical** batch, the entries-SHA sync converges, and the batch completes. That exercises all three invariants #2258 asks reviewers to verify: empty-abort-only, peer-visible reset, SHA-sync reconvergence.

**3. Incidental: the peer-teardown coupling, observed live.** An earlier harness iteration paused one party >10s (`batch_sync_polling_timeout_secs`); both *healthy* peers exited (`Server exited normally`) via the batch-sync `Err` path. That's the follow-up item on the ticket demonstrated in miniature — one stalled party takes down its healthy peers.

## How the repro works (why it's deterministic)

Racing an external queue-steal against the party's own `ReceiveMessage` loses (localstack delivers in ~13ms). Instead:

1. `docker pause` party 1 — party 0's next sync round now blocks retrying peer-state fetches (a seconds-wide window).
2. Send one uniqueness request via the `client` bin (**unique `--rng-seed` per send** — the FIFO topic/queues use content-based deduplication and silently drop identical payloads for 5 min).
3. Wait for party 0 to log its latched `messages_to_poll=1` (it's now blocked in peer-sync, so the steal can't lose a race).
4. Steal party 0's queue copy with an external `ReceiveMessage` (600s visibility).
5. Unpause party 1 within 8s (under the 10s sync timeout — see finding 3 for what happens otherwise).

Party 0 completes the sync round with the target latched and an empty queue → the stall, every time.

## Run it

```bash
docker build -f Dockerfile.dev.hawk -t hawk-server-local-build:latest .

# Baseline (expect STALL_REPRODUCED, then RECOVERED after release):
docker compose -f docker-compose.hawk.yaml up -d
./scripts/tools/pop4051-repro.sh

# Fix validation (expect ABORT_OBSERVED, then RECOVERED):
ABORT_SECS=10 docker compose -f docker-compose.hawk.yaml -f docker-compose.pop4051-repro.yaml up -d
EXPECT_ABORT=1 ./scripts/tools/pop4051-repro.sh
```

Manual harness, not wired into CI. Happy to fold it into a CI job later if we want regression coverage, but that's scope for a follow-up.