### PR TITLE
fix for when there are more sessions than requests

### DIFF
--- a/iris-mpc-cpu/src/execution/hawk_main/scheduler.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/scheduler.rs
@@ -77,8 +77,9 @@ impl Schedule {
     /// as it is optimized for its logic
     pub fn intra_match_batches(&self) -> Vec<Batch> {
         let n_tasks = self.n_requests * self.n_rotations;
-        let batch_size = n_tasks / self.n_sessions;
-        let rest_size = n_tasks % self.n_sessions;
+        let n_sessions = self.n_sessions.min(n_tasks).max(1);
+        let batch_size = n_tasks / n_sessions;
+        let rest_size = n_tasks % n_sessions;
 
         (0..N_EYES)
             .flat_map(|i_eye| {
@@ -112,8 +113,9 @@ impl Schedule {
     /// This method is search-aware and weighs central rotations as higher workloads than non-central ones
     pub fn search_batches(&self) -> Vec<Batch> {
         let n_tasks = self.n_requests * self.n_rotations;
-        let batch_size = n_tasks / self.n_sessions;
-        let rest_size = n_tasks % self.n_sessions;
+        let n_sessions = self.n_sessions.min(n_tasks).max(1);
+        let batch_size = n_tasks / n_sessions;
+        let rest_size = n_tasks % n_sessions;
 
         (0..N_EYES)
             .flat_map(|i_eye| {

--- a/iris-mpc-cpu/src/execution/hawk_main/scheduler.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/scheduler.rs
@@ -92,7 +92,7 @@ impl Schedule {
                     })
                 });
 
-                (0..self.n_sessions).map(move |i_session| {
+                (0..n_sessions).map(move |i_session| {
                     // Some sessions get one more task if n_sessions does not divide n_tasks.
                     let one_more = (i_session < rest_size) as usize;
 
@@ -132,7 +132,7 @@ impl Schedule {
                     })
                 });
 
-                (0..self.n_sessions).map(move |i_session| {
+                (0..n_sessions).map(move |i_session| {
                     // Some sessions get one more task if n_sessions does not divide n_tasks.
                     let one_more = (i_session < rest_size) as usize;
 
@@ -231,8 +231,8 @@ mod test {
 
     fn test_intra_match_schedule_impl(n_sessions: usize, n_requests: usize, n_rotations: usize) {
         let n_eyes = N_EYES;
-        let n_batches = n_eyes * n_sessions;
         let n_tasks = n_eyes * n_requests * n_rotations;
+        let n_batches = n_eyes * n_sessions.min(n_requests * n_rotations).max(1);
 
         let batches = Schedule::new(n_sessions, n_requests, n_rotations).intra_match_batches();
         assert_eq!(batches.len(), n_batches);
@@ -281,8 +281,8 @@ mod test {
 
     fn test_search_schedule_impl(n_sessions: usize, n_requests: usize, n_rotations: usize) {
         let n_eyes = N_EYES;
-        let n_batches = n_eyes * n_sessions;
         let n_tasks = n_eyes * n_requests * n_rotations;
+        let n_batches = n_eyes * n_sessions.min(n_requests * n_rotations).max(1);
 
         let batches = Schedule::new(n_sessions, n_requests, n_rotations).search_batches();
         assert_eq!(batches.len(), n_batches);

--- a/iris-mpc-cpu/src/execution/hawk_main/scheduler.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/scheduler.rs
@@ -30,9 +30,6 @@ where
 }
 
 /// A schedule is a collections of batches to process in parallel.
-/// n_tasks is n_requests * n_rotations. these get distributed over
-/// n_sessions. Schedule::new() must ensure that n_sessions does not exceed
-/// n_requests * n_rotations.
 pub struct Schedule {
     n_sessions: usize,
     n_requests: usize,
@@ -68,7 +65,7 @@ pub type TaskId = (usize, usize, usize);
 impl Schedule {
     pub fn new(n_sessions: usize, n_requests: usize, n_rotations: usize) -> Self {
         Self {
-            n_sessions: n_sessions.min(n_requests * n_rotations),
+            n_sessions,
             n_requests,
             n_rotations,
         }
@@ -232,9 +229,7 @@ mod test {
 
     fn test_intra_match_schedule_impl(n_sessions: usize, n_requests: usize, n_rotations: usize) {
         let n_eyes = N_EYES;
-        // n_sessions is capped to n_tasks in Schedule::new; reflect that here.
-        let effective_sessions = n_sessions.min(n_requests * n_rotations);
-        let n_batches = n_eyes * effective_sessions;
+        let n_batches = n_eyes * n_sessions;
         let n_tasks = n_eyes * n_requests * n_rotations;
 
         let batches = Schedule::new(n_sessions, n_requests, n_rotations).intra_match_batches();
@@ -254,7 +249,7 @@ mod test {
             .iter()
             .flat_map(|b| {
                 assert!(b.i_eye < n_eyes);
-                assert!(b.i_session < effective_sessions);
+                assert!(b.i_session < n_sessions);
 
                 b.tasks.iter().map(|t| {
                     assert!(t.i_request < n_requests);
@@ -284,9 +279,7 @@ mod test {
 
     fn test_search_schedule_impl(n_sessions: usize, n_requests: usize, n_rotations: usize) {
         let n_eyes = N_EYES;
-        // n_sessions is capped to n_tasks in Schedule::new; reflect that here.
-        let effective_sessions = n_sessions.min(n_requests * n_rotations);
-        let n_batches = n_eyes * effective_sessions;
+        let n_batches = n_eyes * n_sessions;
         let n_tasks = n_eyes * n_requests * n_rotations;
 
         let batches = Schedule::new(n_sessions, n_requests, n_rotations).search_batches();
@@ -306,7 +299,7 @@ mod test {
             .iter()
             .flat_map(|b| {
                 assert!(b.i_eye < n_eyes);
-                assert!(b.i_session < effective_sessions);
+                assert!(b.i_session < n_sessions);
 
                 b.tasks.iter().map(|t| {
                     assert!(t.i_request < n_requests);

--- a/iris-mpc-cpu/src/execution/hawk_main/scheduler.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/scheduler.rs
@@ -30,6 +30,9 @@ where
 }
 
 /// A schedule is a collections of batches to process in parallel.
+/// n_tasks is n_requests * n_rotations. these get distributed over
+/// n_sessions. Schedule::new() must ensure that n_sessions does not exceed
+/// n_requests * n_rotations.
 pub struct Schedule {
     n_sessions: usize,
     n_requests: usize,
@@ -65,7 +68,7 @@ pub type TaskId = (usize, usize, usize);
 impl Schedule {
     pub fn new(n_sessions: usize, n_requests: usize, n_rotations: usize) -> Self {
         Self {
-            n_sessions,
+            n_sessions: n_sessions.min(n_requests * n_rotations),
             n_requests,
             n_rotations,
         }
@@ -229,7 +232,9 @@ mod test {
 
     fn test_intra_match_schedule_impl(n_sessions: usize, n_requests: usize, n_rotations: usize) {
         let n_eyes = N_EYES;
-        let n_batches = n_eyes * n_sessions;
+        // n_sessions is capped to n_tasks in Schedule::new; reflect that here.
+        let effective_sessions = n_sessions.min(n_requests * n_rotations);
+        let n_batches = n_eyes * effective_sessions;
         let n_tasks = n_eyes * n_requests * n_rotations;
 
         let batches = Schedule::new(n_sessions, n_requests, n_rotations).intra_match_batches();
@@ -249,7 +254,7 @@ mod test {
             .iter()
             .flat_map(|b| {
                 assert!(b.i_eye < n_eyes);
-                assert!(b.i_session < n_sessions);
+                assert!(b.i_session < effective_sessions);
 
                 b.tasks.iter().map(|t| {
                     assert!(t.i_request < n_requests);
@@ -279,7 +284,9 @@ mod test {
 
     fn test_search_schedule_impl(n_sessions: usize, n_requests: usize, n_rotations: usize) {
         let n_eyes = N_EYES;
-        let n_batches = n_eyes * n_sessions;
+        // n_sessions is capped to n_tasks in Schedule::new; reflect that here.
+        let effective_sessions = n_sessions.min(n_requests * n_rotations);
+        let n_batches = n_eyes * effective_sessions;
         let n_tasks = n_eyes * n_requests * n_rotations;
 
         let batches = Schedule::new(n_sessions, n_requests, n_rotations).search_batches();
@@ -299,7 +306,7 @@ mod test {
             .iter()
             .flat_map(|b| {
                 assert!(b.i_eye < n_eyes);
-                assert!(b.i_session < n_sessions);
+                assert!(b.i_session < effective_sessions);
 
                 b.tasks.iter().map(|t| {
                     assert!(t.i_request < n_requests);


### PR DESCRIPTION
Prevent the number of sessions used for scheduling searches to exceed the number of requests. Otherwise, in `search_batches()`, `batch_size` can be zero. This results in idle tokio tasks; the `rest_size` still got distributed over the sessions - the requests were still processed.