### PR TITLE
feat(iris-mpc): surface batch-poll wait progress + duration metric (POP-4051)

### DIFF
--- a/iris-mpc/src/services/processors/batch.rs
+++ b/iris-mpc/src/services/processors/batch.rs
@@ -388,8 +388,25 @@ impl<'a> BatchProcessor<'a> {
             num_to_poll
         );
         let queue_url = &self.config.requests_queue_url;
+        // This wait is unbounded (the batch only forms once the cross-party-agreed
+        // target is received) and its per-attempt retry logs are debug-level, so a
+        // stalled poll is invisible at info level — the 2026-06-23 stage wedge sat
+        // silent for 2.5h (POP-4051). Surface progress periodically at info.
+        let poll_start = std::time::Instant::now();
+        let mut last_progress_log = poll_start;
 
         while self.msg_counter < num_to_poll as usize {
+            if last_progress_log.elapsed() >= std::time::Duration::from_secs(30) {
+                tracing::info!(
+                    "Batch ID: {}. Batch poll still waiting after {}s with {} out of {} messages processed.",
+                    current_batch_id,
+                    poll_start.elapsed().as_secs(),
+                    self.msg_counter,
+                    num_to_poll
+                );
+                metrics::counter!("batch_poll_waiting").increment(1);
+                last_progress_log = std::time::Instant::now();
+            }
             if self.shutdown_handler.is_shutting_down() {
                 tracing::info!(
                     "Stopping batch receive during polling exact messages due to shutdown signal..."
@@ -446,6 +463,7 @@ impl<'a> BatchProcessor<'a> {
             self.msg_counter,
             num_to_poll
         );
+        metrics::histogram!("batch_poll_duration").record(poll_start.elapsed().as_secs_f64());
         Ok(())
     }
 


### PR DESCRIPTION
Observability only — **zero behavior change**, +18 lines, one file.

`poll_exact_messages` waits unbounded for the cross-party-agreed message target, and its per-attempt retry logs are `debug`-level. A stalled poll is therefore invisible at info level: on 2026-06-23 all three stage parties sat wedged in this exact wait for 2.5h with pods 1/1 Ready and silent logs ([POP-4051](https://linear.app/worldcoin/issue/POP-4051/iris-mpc-batch-loop-can-deadlock-silently-liveness-probe-cant-detect)). The same waits show up on stage daily at 8-9 min scale (analysis on the ticket).

Adds:
- an **info log every 30s** while the poll is waiting (`processed/target` + elapsed) — the silence is what let the wedge hide
- `batch_poll_waiting` counter (one increment per 30s tick) and `batch_poll_duration` histogram on completion, complementing the existing `receive_batch_duration`

Follow-up (separate): a Datadog monitor on `batch_poll_waiting` rate / `batch_poll_duration` tail, so a stalled batch loop pages instead of hiding behind green pods — the detection gap stays closed regardless of when the batch-ingestion redesign (#2264) lands.

Extracted from the POP-4051 fix branch; the behavioral half (bounded abort) is deliberately NOT included — it regressed on stage (target re-agreement while a peer held partial progress; details on the ticket) and the direction decision moved to the redesign.