### PR TITLE
Go live with stage anon-stats retention at 5 days (POP-3905)

### DIFF
--- a/deploy/monitors/anon-stats-retention-monitors.md
+++ b/deploy/monitors/anon-stats-retention-monitors.md
@@ -19,7 +19,7 @@ The CronJob runs daily; no success in >26h means it failed, didn't schedule, or 
 
 ## 2. Oldest-retained exceeds the window  (retention falling behind)
 If the reaper stops deleting (bug, lock contention, guard mistake), the oldest row ages past the window — the direct symptom.
-- **Metric monitor**: `max(last_6h):max:retention.oldest_retained_seconds{env:stage} by {service,table} > 1900800` (= 22 days = the 14-day window + a generous margin for backfilled legacy rows + slack). Page. Tune the margin after observing the first weeks (legacy rows are stamped at migration time and drain over the first window).
+- **Metric monitor**: threshold = **active retention window + 2 days** slack (matching the cross-party tolerance in #5). Stage runs a 5-day window → `max(last_6h):max:retention.oldest_retained_seconds{env:stage} by {service,table} > 604800` (= 7 days). Prod (when enabled, 14-day window) → `> 1382400` (= 16 days). Page. The old backfilled-legacy-rows margin is obsolete once the first live run drains the migration-stamped cohort; if the first run hasn't happened yet, expect this to read ~window-of-backfill until it does.
 
 ## 3. Bloat — dead-tuple ratio climbing  (the DELETE-approach risk)
 The one real failure mode of batched DELETE: autovacuum not keeping up with delete churn → table/index bloat.

--- a/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw-anon-stats-retention.yaml
+++ b/deploy/stage/ampc-hnsw-0-stage/values-ampc-hnsw-anon-stats-retention.yaml
@@ -20,7 +20,7 @@ env:
     valueFrom:
       fieldRef:
         fieldPath: status.hostIP
-  RETENTION_JOBS: '[{"table":"anon_stats_1d","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_1d_lifted","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_2d","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_2d_lifted","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_face","retention":"14 days","guard":"processed = TRUE"}]'
+  RETENTION_JOBS: '[{"table":"anon_stats_1d","retention":"5 days","guard":"processed = TRUE"},{"table":"anon_stats_1d_lifted","retention":"5 days","guard":"processed = TRUE"},{"table":"anon_stats_2d","retention":"5 days","guard":"processed = TRUE"},{"table":"anon_stats_2d_lifted","retention":"5 days","guard":"processed = TRUE"},{"table":"anon_stats_face","retention":"5 days","guard":"processed = TRUE"}]'
 
 # Lets the pod reach the anon-stats Aurora — mirrors ampc-hnsw-anon-stats-server (same DB, same SG).
 attachSecurityGroupPolicy:

--- a/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw-anon-stats-retention.yaml
+++ b/deploy/stage/ampc-hnsw-1-stage/values-ampc-hnsw-anon-stats-retention.yaml
@@ -20,7 +20,7 @@ env:
     valueFrom:
       fieldRef:
         fieldPath: status.hostIP
-  RETENTION_JOBS: '[{"table":"anon_stats_1d","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_1d_lifted","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_2d","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_2d_lifted","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_face","retention":"14 days","guard":"processed = TRUE"}]'
+  RETENTION_JOBS: '[{"table":"anon_stats_1d","retention":"5 days","guard":"processed = TRUE"},{"table":"anon_stats_1d_lifted","retention":"5 days","guard":"processed = TRUE"},{"table":"anon_stats_2d","retention":"5 days","guard":"processed = TRUE"},{"table":"anon_stats_2d_lifted","retention":"5 days","guard":"processed = TRUE"},{"table":"anon_stats_face","retention":"5 days","guard":"processed = TRUE"}]'
 
 # Lets the pod reach the anon-stats Aurora — mirrors ampc-hnsw-anon-stats-server (same DB, same SG).
 attachSecurityGroupPolicy:

--- a/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw-anon-stats-retention.yaml
+++ b/deploy/stage/ampc-hnsw-2-stage/values-ampc-hnsw-anon-stats-retention.yaml
@@ -20,7 +20,7 @@ env:
     valueFrom:
       fieldRef:
         fieldPath: status.hostIP
-  RETENTION_JOBS: '[{"table":"anon_stats_1d","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_1d_lifted","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_2d","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_2d_lifted","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_face","retention":"14 days","guard":"processed = TRUE"}]'
+  RETENTION_JOBS: '[{"table":"anon_stats_1d","retention":"5 days","guard":"processed = TRUE"},{"table":"anon_stats_1d_lifted","retention":"5 days","guard":"processed = TRUE"},{"table":"anon_stats_2d","retention":"5 days","guard":"processed = TRUE"},{"table":"anon_stats_2d_lifted","retention":"5 days","guard":"processed = TRUE"},{"table":"anon_stats_face","retention":"5 days","guard":"processed = TRUE"}]'
 
 # Lets the pod reach the anon-stats Aurora — mirrors ampc-hnsw-anon-stats-server (same DB, same SG).
 attachSecurityGroupPolicy:

--- a/deploy/stage/common-values-ampc-hnsw-anon-stats-retention.yaml
+++ b/deploy/stage/common-values-ampc-hnsw-anon-stats-retention.yaml
@@ -4,13 +4,14 @@
 # anon-stats Aurora live per-node.
 image: "ghcr.io/worldcoin/retention-reaper:d9a3d33342dfd9e95c7b11e8ef4e4101a3e6ed80"
 
-# STAGE DRY-RUN VALIDATION: enable the reaper in dry-run mode — it logs what it WOULD
-# reap (read-only COUNT, no DELETE). Safe only because the image above is the dry-run
-# build; deep-merges with the per-cluster RETENTION__* env maps. Flip DRY_RUN to "false"
-# to go live once the previewed counts look right.
+# STAGE LIVE: dry-run validated 2026-07-03 → 2026-07-09 (daily runs, all parties, exact
+# delete predicate logged incl. the processed=TRUE guard; 0 rows eligible only because
+# created_at was backfilled at migration time, < 14d ago). Retention is 5 days on stage
+# (per-node RETENTION_JOBS) so the mechanism produces real deletions to validate against
+# rows_deleted / oldest_retained_seconds before prod enablement.
 env:
   RETENTION__ENABLED: "true"
-  RETENTION__DRY_RUN: "true"
+  RETENTION__DRY_RUN: "false"
 
 replicaCount: 1
 

--- a/deploy/stage/common-values-anon-stats-retention.yaml
+++ b/deploy/stage/common-values-anon-stats-retention.yaml
@@ -3,13 +3,14 @@
 # iris-mpc-db-exporter. Per-cluster env (RETENTION__*, map format) lives in the per-node values files.
 image: "ghcr.io/worldcoin/retention-reaper:d9a3d33342dfd9e95c7b11e8ef4e4101a3e6ed80"
 
-# STAGE DRY-RUN VALIDATION: enable the reaper in dry-run mode — it logs what it WOULD
-# reap (read-only COUNT, no DELETE). Safe only because the image above is the dry-run
-# build; deep-merges with the per-cluster RETENTION__* env maps. Flip DRY_RUN to "false"
-# to go live once the previewed counts look right.
+# STAGE LIVE: dry-run validated 2026-07-03 → 2026-07-09 (daily runs, all parties, exact
+# delete predicate logged incl. the processed=TRUE guard; 0 rows eligible only because
+# created_at was backfilled at migration time, < 14d ago). Retention is 5 days on stage
+# (per-node RETENTION_JOBS) so the mechanism produces real deletions to validate against
+# rows_deleted / oldest_retained_seconds before prod enablement.
 env:
   RETENTION__ENABLED: "true"
-  RETENTION__DRY_RUN: "true"
+  RETENTION__DRY_RUN: "false"
 
 replicaCount: 1
 

--- a/deploy/stage/smpcv2-0-stage/values-anon-stats-retention.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-anon-stats-retention.yaml
@@ -21,4 +21,4 @@ env:
     valueFrom:
       fieldRef:
         fieldPath: status.hostIP
-  RETENTION_JOBS: '[{"table":"anon_stats_1d","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_1d_lifted","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_2d","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_2d_lifted","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_face","retention":"14 days","guard":"processed = TRUE"}]'
+  RETENTION_JOBS: '[{"table":"anon_stats_1d","retention":"5 days","guard":"processed = TRUE"},{"table":"anon_stats_1d_lifted","retention":"5 days","guard":"processed = TRUE"},{"table":"anon_stats_2d","retention":"5 days","guard":"processed = TRUE"},{"table":"anon_stats_2d_lifted","retention":"5 days","guard":"processed = TRUE"},{"table":"anon_stats_face","retention":"5 days","guard":"processed = TRUE"}]'

--- a/deploy/stage/smpcv2-1-stage/values-anon-stats-retention.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-anon-stats-retention.yaml
@@ -21,4 +21,4 @@ env:
     valueFrom:
       fieldRef:
         fieldPath: status.hostIP
-  RETENTION_JOBS: '[{"table":"anon_stats_1d","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_1d_lifted","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_2d","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_2d_lifted","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_face","retention":"14 days","guard":"processed = TRUE"}]'
+  RETENTION_JOBS: '[{"table":"anon_stats_1d","retention":"5 days","guard":"processed = TRUE"},{"table":"anon_stats_1d_lifted","retention":"5 days","guard":"processed = TRUE"},{"table":"anon_stats_2d","retention":"5 days","guard":"processed = TRUE"},{"table":"anon_stats_2d_lifted","retention":"5 days","guard":"processed = TRUE"},{"table":"anon_stats_face","retention":"5 days","guard":"processed = TRUE"}]'

--- a/deploy/stage/smpcv2-2-stage/values-anon-stats-retention.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-anon-stats-retention.yaml
@@ -21,4 +21,4 @@ env:
     valueFrom:
       fieldRef:
         fieldPath: status.hostIP
-  RETENTION_JOBS: '[{"table":"anon_stats_1d","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_1d_lifted","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_2d","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_2d_lifted","retention":"14 days","guard":"processed = TRUE"},{"table":"anon_stats_face","retention":"14 days","guard":"processed = TRUE"}]'
+  RETENTION_JOBS: '[{"table":"anon_stats_1d","retention":"5 days","guard":"processed = TRUE"},{"table":"anon_stats_1d_lifted","retention":"5 days","guard":"processed = TRUE"},{"table":"anon_stats_2d","retention":"5 days","guard":"processed = TRUE"},{"table":"anon_stats_2d_lifted","retention":"5 days","guard":"processed = TRUE"},{"table":"anon_stats_face","retention":"5 days","guard":"processed = TRUE"}]'


### PR DESCRIPTION
Flips the stage retention-reaper from dry-run to live and shortens retention to 5 days so the deletion mechanics can be validated with real side effects before prod enablement.

## Why now

Dry-run has been green since 2026-07-03 (daily 03:30Z runs, all 6 stage clusters). Every run logs the exact delete predicate — `created_at < now() - '14 days'::interval AND (processed = TRUE)` — but reports **0 eligible rows**: `created_at` was backfilled to the migration date, so nothing on stage is older than ~14 days yet. Waiting for rows to age past 14d validates nothing for another week; at 5 days the backfilled cohort becomes eligible immediately.

## What

- `"retention":"14 days"` → `"5 days"` in all 6 per-node `RETENTION_JOBS` (smpcv2-{0,1,2} + ampc-hnsw-{0,1,2}, 5 anon-stats tables each).
- `RETENTION__DRY_RUN: "true"` → `"false"` in both stage common values files.

## Guard (only processed rows are deleted)

`processed = TRUE` is verified at three levels: the values config (all 30 job entries), the binary (`retention-reaper/main.rs` ANDs the guard into both the dry-run COUNT and the ctid-batch DELETE sub-select — same predicate), and the live dry-run logs quoting the final SQL. Unprocessed rows are never touched regardless of age; the `oldest_retained_seconds` gauge also applies the guard so it won't false-alarm on old unprocessed rows.

## ⚠️ Deploy note — merge alone will NOT roll this out

Stage pods have been running image `c3b02487` since 2026-07-03 even though #2253 repinned main to `d9a3d333` the same day → these Argo apps have not synced from main since (the disabled apps-bootstrap auto-sync). After merge this needs either a manual `argocd app sync` per cluster or the owed auto-sync re-enable (SSO required). Syncing also moves the image to the main-provenance `d9a3d333` pin.

## Validation plan (post-sync)

Force one CronJob run (or wait for 03:30Z): expect nonzero `rows_deleted` per table in logs + `retention.rows_deleted` counter, `oldest_retained_seconds` ≤ ~5d among guarded rows, and unprocessed rows still present. Row counts before/after via PopStageDbAccess if desired.

Stage-only; prod has no retention manifests yet (gated on this proof). Ticket: POP-3905.