### PR TITLE
Roll out POP-3931 to stage: hawk image bump + modifications reaper dry-run

### DIFF
--- a/deploy/stage/common-values-ampc-hnsw-modifications-retention.yaml
+++ b/deploy/stage/common-values-ampc-hnsw-modifications-retention.yaml
@@ -9,13 +9,18 @@
 # coordination exists or is needed. The GPU MPCV2 DB's copy grows the same way; its
 # reaper instance FOLLOWS SHORTLY (same binary, values + cluster-apps entry only).
 #
-# NOTE: bump the pin to a post-POP-3931 build before enabling — the batch-pause and
-# bounded-health-probe behavior land with this PR's image.
-image: "ghcr.io/worldcoin/retention-reaper:d9a3d33342dfd9e95c7b11e8ef4e4101a3e6ed80"
+image: "ghcr.io/worldcoin/retention-reaper:f8cb55547b1833ef2ccb0a84c5bd37c9e06b2408"
 
-# Disabled by default (RETENTION__ENABLED unset → false): deploys as a no-op. The enable
-# path is the same as anon-stats: bump image → RETENTION__ENABLED+DRY_RUN → inspect
-# previewed counts + health gauges → flip DRY_RUN off, one party first.
+# STAGE ENABLE, DRY-RUN: the hawk image bump in this same PR applies the created_at
+# migration to the HNSW DB at boot; the reaper then previews the exact delete predicate
+# (read-only COUNT) daily. Expected counts: 0 for the first 30 days (backfill stamps all
+# rows at migration time) — the dry run proves the query is valid against the migrated
+# schema (created_at present, guard incl. the newest-10k subselect executes). Flip
+# DRY_RUN to "false" after the first clean previews; nothing becomes deletable before
+# the 30d clock matures anyway.
+env:
+  RETENTION__ENABLED: "true"
+  RETENTION__DRY_RUN: "true"
 
 replicaCount: 1
 

--- a/deploy/stage/common-values-ampc-hnsw.yaml
+++ b/deploy/stage/common-values-ampc-hnsw.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc-cpu:d9a3d33342dfd9e95c7b11e8ef4e4101a3e6ed80-arm64"
+image: "ghcr.io/worldcoin/iris-mpc-cpu:f8cb55547b1833ef2ccb0a84c5bd37c9e06b2408-arm64"
 
 environment: stage
 replicaCount: 1


### PR DESCRIPTION
Rolls the merged #2262 out to stage HNSW.

## What

1. **Stage hawk fleet → `f8cb55547`** (`common-values-ampc-hnsw.yaml`, arm64 image — verified present on ghcr). Hawk boot applies the `modifications` `created_at` migration (transactional ADD COLUMN + index; brief SHARE lock on writers, per the #2262 design discussion) to the HNSW DB on all 3 stage parties.
2. **Modifications reaper → ENABLED + DRY_RUN** on the stage HNSW clusters, pin bumped to the post-POP-3931 binary (`batch_pause_ms`, bounded health probes, `current_schema` pin). The CronJobs are already deployed and verified as disabled no-ops (2026-07-09: all 3 apps Synced/Healthy, forced run exited 0 with the disabled log line).

## Expected behavior after merge

- Hawk pods roll and migrate at boot; watch for `Running migrations` + clean startup on all 3 parties.
- Next 04:00Z reaper run (or a forced job) logs `DRY RUN: would delete 0 rows from modifications …` — 0 because `created_at` backfills to migration time; **the value of the dry run is proving the full predicate (incl. the newest-10k guard subselect) executes against the migrated schema.**
- `oldest_retained_seconds` / `dead_tuple_ratio` gauges start reporting for the `modifications` table.

## Next (after clean previews)

Flip `DRY_RUN` off (nothing becomes deletable before the 30d clock matures anyway), then the GPU/MPCV2 copy's reaper instance (values + cluster-apps entry + GPU image bump for its migration) — still stage-only. Prod ships inert via #2267 + cluster-apps#312 at the downtime.

Note: deploy requires an Argo nudge — the hnsw `iris-mpc` app values sync state should be checked post-merge (apps-bootstrap auto-sync is still off; the retention app itself auto-syncs from main and picks the reaper changes up immediately).