### PR TITLE
fix(store): gate version_id writes behind an explicit-version flag

### DIFF
--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -30,21 +30,17 @@ pub use s3_importer::{
 use sqlx::{PgPool, Postgres, Row, Transaction};
 use std::ops::DerefMut;
 
-/// Proof that `app.explicit_version_id = 'on'` is active on the borrowed
-/// transaction, permitting an authoritative `version_id` write.
+/// Proof that `app.explicit_version_id = 'on'` is set on the borrowed transaction,
+/// permitting a verbatim `version_id` write.
 ///
-/// Obtainable only via [`ExplicitVersion::enable`], which sets the flag on the
-/// exact transaction it borrows. The flag is `SET LOCAL`, so it clears when the
-/// transaction commits or rolls back. The `irises` `BEFORE UPDATE` trigger
-/// rejects any hand-set `version_id` while the flag is off, so an explicit write
-/// without a handle fails at the database instead of being silently
-/// auto-incremented.
+/// Obtainable only via [`ExplicitVersion::enable`]. The flag is `SET LOCAL`, so it
+/// clears at commit/rollback; without it the trigger rejects any hand-set `version_id`.
 pub struct ExplicitVersion<'t, 'c> {
     tx: &'t mut Transaction<'c, Postgres>,
 }
 
 impl<'t, 'c> ExplicitVersion<'t, 'c> {
-    /// Enable authoritative `version_id` writes for the remainder of `tx`.
+    /// Enable verbatim `version_id` writes for the rest of `tx`.
     pub async fn enable(tx: &'t mut Transaction<'c, Postgres>) -> Result<Self> {
         sqlx::query("SET LOCAL app.explicit_version_id = 'on'")
             .execute(tx.deref_mut())
@@ -453,10 +449,8 @@ WHERE id = $1;
         Ok(())
     }
 
-    /// Update an existing iris's shares and write `version_id` authoritatively.
-    ///
-    /// The [`ExplicitVersion`] handle bypasses the auto-increment trigger, so
-    /// `version_id` is stored verbatim (any value, including a lower one).
+    /// Update an iris's shares, writing `version_id` verbatim (the [`ExplicitVersion`]
+    /// handle bypasses the auto-increment trigger).
     pub async fn update_iris_with_version_id(
         &self,
         tx: &mut ExplicitVersion<'_, '_>,
@@ -1217,7 +1211,7 @@ pub mod tests {
         Ok(())
     }
 
-    // update_iris (no explicit version) with changed content auto-increments version_id.
+    // update_iris auto-increments version_id on content change.
     #[tokio::test]
     async fn test_update_iris_auto_increments_version() -> Result<()> {
         let schema_name = temporary_name();
@@ -1267,8 +1261,7 @@ pub mod tests {
         Ok(())
     }
 
-    // update_iris_with_version_id with changed content and an explicit version different from the
-    // current one writes exactly the explicit version (trigger does not override it).
+    // A differing explicit version is written verbatim.
     #[tokio::test]
     async fn test_update_iris_with_version_id_respects_explicit_version() -> Result<()> {
         let schema_name = temporary_name();
@@ -1296,11 +1289,12 @@ pub mod tests {
             right_mask: &[999_u16; 6400],
         };
         let mut tx = store.tx().await?;
-        let mut ev = ExplicitVersion::enable(&mut tx).await?;
-        store
-            .update_iris_with_version_id(&mut ev, 5, &updated)
-            .await?;
-        drop(ev);
+        {
+            let mut ev = ExplicitVersion::enable(&mut tx).await?;
+            store
+                .update_iris_with_version_id(&mut ev, 5, &updated)
+                .await?;
+        }
         tx.commit().await?;
 
         let got = store.get_iris_data_by_id(1).await?;
@@ -1314,8 +1308,7 @@ pub mod tests {
         Ok(())
     }
 
-    // With the flag on, an explicit version equal to the current one is honored verbatim (no
-    // auto-increment), even when content changes.
+    // An explicit version equal to the current one is honored verbatim, even on content change.
     #[tokio::test]
     async fn test_update_iris_with_version_id_equal_version_is_honored() -> Result<()> {
         let schema_name = temporary_name();
@@ -1344,11 +1337,12 @@ pub mod tests {
             right_mask: &[999_u16; 6400],
         };
         let mut tx = store.tx().await?;
-        let mut ev = ExplicitVersion::enable(&mut tx).await?;
-        store
-            .update_iris_with_version_id(&mut ev, 0, &updated)
-            .await?;
-        drop(ev);
+        {
+            let mut ev = ExplicitVersion::enable(&mut tx).await?;
+            store
+                .update_iris_with_version_id(&mut ev, 0, &updated)
+                .await?;
+        }
         tx.commit().await?;
 
         let got = store.get_iris_data_by_id(1).await?;
@@ -1358,8 +1352,7 @@ pub mod tests {
         Ok(())
     }
 
-    // With the flag on, version_id may be set to an arbitrary value, including a lower one (for
-    // manual repair).
+    // version_id may be set to an arbitrary value, including a lower one.
     #[tokio::test]
     async fn test_update_iris_with_version_id_allows_arbitrary_version() -> Result<()> {
         let schema_name = temporary_name();
@@ -1389,21 +1382,23 @@ pub mod tests {
 
         // Bump to 5.
         let mut tx = store.tx().await?;
-        let mut ev = ExplicitVersion::enable(&mut tx).await?;
-        store
-            .update_iris_with_version_id(&mut ev, 5, &updated)
-            .await?;
-        drop(ev);
+        {
+            let mut ev = ExplicitVersion::enable(&mut tx).await?;
+            store
+                .update_iris_with_version_id(&mut ev, 5, &updated)
+                .await?;
+        }
         tx.commit().await?;
         assert_eq!(store.get_iris_data_by_id(1).await?.version_id(), 5);
 
         // Set back to 2 (lower).
         let mut tx = store.tx().await?;
-        let mut ev = ExplicitVersion::enable(&mut tx).await?;
-        store
-            .update_iris_with_version_id(&mut ev, 2, &updated)
-            .await?;
-        drop(ev);
+        {
+            let mut ev = ExplicitVersion::enable(&mut tx).await?;
+            store
+                .update_iris_with_version_id(&mut ev, 2, &updated)
+                .await?;
+        }
         tx.commit().await?;
         assert_eq!(store.get_iris_data_by_id(1).await?.version_id(), 2);
 
@@ -1411,8 +1406,7 @@ pub mod tests {
         Ok(())
     }
 
-    // A hand-set version_id without the flag is rejected by the trigger instead of being silently
-    // overwritten.
+    // A hand-set version_id without the flag is rejected.
     #[tokio::test]
     async fn test_update_version_id_without_flag_is_rejected() -> Result<()> {
         let schema_name = temporary_name();

--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -35,6 +35,7 @@ use std::ops::DerefMut;
 ///
 /// Obtainable only via [`ExplicitVersion::enable`]. The flag is `SET LOCAL`, so it
 /// clears at commit/rollback; without it the trigger rejects any hand-set `version_id`.
+#[must_use]
 pub struct ExplicitVersion<'t, 'c> {
     tx: &'t mut Transaction<'c, Postgres>,
 }

--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -1195,6 +1195,135 @@ pub mod tests {
         Ok(())
     }
 
+    // update_iris (no explicit version) with changed content auto-increments version_id.
+    #[tokio::test]
+    async fn test_update_iris_auto_increments_version() -> Result<()> {
+        let schema_name = temporary_name();
+        let postgres_client =
+            PostgresClient::new(test_db_url()?.as_str(), &schema_name, AccessMode::ReadWrite)
+                .await?;
+        let store = Store::new(&postgres_client).await?;
+
+        let iris = StoredIrisRef {
+            id: 1,
+            left_code: &[123_u16; 12800],
+            left_mask: &[456_u16; 6400],
+            right_code: &[789_u16; 12800],
+            right_mask: &[101_u16; 6400],
+        };
+        let mut tx = store.tx().await?;
+        store.insert_irises(&mut tx, &[iris]).await?;
+        tx.commit().await?;
+
+        store
+            .update_iris(
+                None,
+                1,
+                &GaloisRingIrisCodeShare {
+                    id: 1,
+                    coefs: [666_u16; 12800],
+                },
+                &GaloisRingTrimmedMaskCodeShare {
+                    id: 1,
+                    coefs: [777_u16; 6400],
+                },
+                &GaloisRingIrisCodeShare {
+                    id: 1,
+                    coefs: [888_u16; 12800],
+                },
+                &GaloisRingTrimmedMaskCodeShare {
+                    id: 1,
+                    coefs: [999_u16; 6400],
+                },
+            )
+            .await?;
+
+        let got = store.get_iris_data_by_id(1).await?;
+        assert_eq!(got.version_id(), 1);
+
+        cleanup(&postgres_client, &schema_name).await?;
+        Ok(())
+    }
+
+    // update_iris_with_version_id with changed content and an explicit version different from the
+    // current one writes exactly the explicit version (trigger does not override it).
+    #[tokio::test]
+    async fn test_update_iris_with_version_id_respects_explicit_version() -> Result<()> {
+        let schema_name = temporary_name();
+        let postgres_client =
+            PostgresClient::new(test_db_url()?.as_str(), &schema_name, AccessMode::ReadWrite)
+                .await?;
+        let store = Store::new(&postgres_client).await?;
+
+        let iris = StoredIrisRef {
+            id: 1,
+            left_code: &[123_u16; 12800],
+            left_mask: &[456_u16; 6400],
+            right_code: &[789_u16; 12800],
+            right_mask: &[101_u16; 6400],
+        };
+        let mut tx = store.tx().await?;
+        store.insert_irises(&mut tx, &[iris]).await?;
+        tx.commit().await?;
+
+        let updated = StoredIrisRef {
+            id: 1,
+            left_code: &[666_u16; 12800],
+            left_mask: &[777_u16; 6400],
+            right_code: &[888_u16; 12800],
+            right_mask: &[999_u16; 6400],
+        };
+        store.update_iris_with_version_id(None, 5, &updated).await?;
+
+        let got = store.get_iris_data_by_id(1).await?;
+        assert_eq!(got.version_id(), 5);
+        assert_eq!(cast_u8_to_u16(&got.left_code), updated.left_code);
+        assert_eq!(cast_u8_to_u16(&got.left_mask), updated.left_mask);
+        assert_eq!(cast_u8_to_u16(&got.right_code), updated.right_code);
+        assert_eq!(cast_u8_to_u16(&got.right_mask), updated.right_mask);
+
+        cleanup(&postgres_client, &schema_name).await?;
+        Ok(())
+    }
+
+    // Residual: an explicit version equal to the current one is indistinguishable from "unchanged",
+    // so content changes still auto-increment it.
+    #[tokio::test]
+    async fn test_update_iris_with_version_id_equal_version_still_increments() -> Result<()> {
+        let schema_name = temporary_name();
+        let postgres_client =
+            PostgresClient::new(test_db_url()?.as_str(), &schema_name, AccessMode::ReadWrite)
+                .await?;
+        let store = Store::new(&postgres_client).await?;
+
+        let iris = StoredIrisRef {
+            id: 1,
+            left_code: &[123_u16; 12800],
+            left_mask: &[456_u16; 6400],
+            right_code: &[789_u16; 12800],
+            right_mask: &[101_u16; 6400],
+        };
+        let mut tx = store.tx().await?;
+        store.insert_irises(&mut tx, &[iris]).await?;
+        tx.commit().await?;
+
+        // Inserted row has version_id 0; re-request 0 with changed content.
+        let updated = StoredIrisRef {
+            id: 1,
+            left_code: &[666_u16; 12800],
+            left_mask: &[777_u16; 6400],
+            right_code: &[888_u16; 12800],
+            right_mask: &[999_u16; 6400],
+        };
+        store.update_iris_with_version_id(None, 0, &updated).await?;
+
+        let got = store.get_iris_data_by_id(1).await?;
+        assert_eq!(got.version_id(), 1);
+
+        cleanup(&postgres_client, &schema_name).await?;
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_insert_modification() -> Result<()> {
         let schema_name = temporary_name();

--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -30,6 +30,34 @@ pub use s3_importer::{
 use sqlx::{PgPool, Postgres, Row, Transaction};
 use std::ops::DerefMut;
 
+/// Proof that `app.explicit_version_id = 'on'` is active on the borrowed
+/// transaction, permitting an authoritative `version_id` write.
+///
+/// Obtainable only via [`ExplicitVersion::enable`], which sets the flag on the
+/// exact transaction it borrows. The flag is `SET LOCAL`, so it clears when the
+/// transaction commits or rolls back. The `irises` `BEFORE UPDATE` trigger
+/// rejects any hand-set `version_id` while the flag is off, so an explicit write
+/// without a handle fails at the database instead of being silently
+/// auto-incremented.
+pub struct ExplicitVersion<'t, 'c> {
+    tx: &'t mut Transaction<'c, Postgres>,
+}
+
+impl<'t, 'c> ExplicitVersion<'t, 'c> {
+    /// Enable authoritative `version_id` writes for the remainder of `tx`.
+    pub async fn enable(tx: &'t mut Transaction<'c, Postgres>) -> Result<Self> {
+        sqlx::query("SET LOCAL app.explicit_version_id = 'on'")
+            .execute(tx.deref_mut())
+            .await?;
+        Ok(Self { tx })
+    }
+
+    /// The underlying transaction, for other statements in the same unit of work.
+    pub fn tx(&mut self) -> &mut Transaction<'c, Postgres> {
+        &mut *self.tx
+    }
+}
+
 /// The unified type that can hold either DB or S3 variants.
 pub enum StoredIris {
     // DB stores the shares in their original form
@@ -425,16 +453,19 @@ WHERE id = $1;
         Ok(())
     }
 
-    // Update existing iris with given shares.
+    /// Update an existing iris's shares and write `version_id` authoritatively.
+    ///
+    /// The [`ExplicitVersion`] handle bypasses the auto-increment trigger, so
+    /// `version_id` is stored verbatim (any value, including a lower one).
     pub async fn update_iris_with_version_id(
         &self,
-        external_tx: Option<&mut Transaction<'_, Postgres>>,
+        tx: &mut ExplicitVersion<'_, '_>,
         version_id: i16,
         codes_and_masks: &StoredIrisRef<'_>,
     ) -> Result<()> {
-        let query = sqlx::query(
+        sqlx::query(
             r#"
-UPDATE irises SET (version_id, left_code, left_mask, right_code, right_mask) = ($2, $3, $4, $5  , $6)
+UPDATE irises SET (version_id, left_code, left_mask, right_code, right_mask) = ($2, $3, $4, $5, $6)
 WHERE id = $1;
 "#,
         )
@@ -443,18 +474,9 @@ WHERE id = $1;
         .bind(cast_slice::<u16, u8>(codes_and_masks.left_code))
         .bind(cast_slice::<u16, u8>(codes_and_masks.left_mask))
         .bind(cast_slice::<u16, u8>(codes_and_masks.right_code))
-        .bind(cast_slice::<u16, u8>(codes_and_masks.right_mask));
-
-        match external_tx {
-            Some(external_tx) => {
-                query.execute(external_tx.deref_mut()).await?;
-            }
-            None => {
-                let mut new_tx = self.pool.begin().await?;
-                query.execute(&mut *new_tx).await?;
-                new_tx.commit().await?;
-            }
-        }
+        .bind(cast_slice::<u16, u8>(codes_and_masks.right_mask))
+        .execute(tx.tx().deref_mut())
+        .await?;
 
         Ok(())
     }
@@ -1273,7 +1295,13 @@ pub mod tests {
             right_code: &[888_u16; 12800],
             right_mask: &[999_u16; 6400],
         };
-        store.update_iris_with_version_id(None, 5, &updated).await?;
+        let mut tx = store.tx().await?;
+        let mut ev = ExplicitVersion::enable(&mut tx).await?;
+        store
+            .update_iris_with_version_id(&mut ev, 5, &updated)
+            .await?;
+        drop(ev);
+        tx.commit().await?;
 
         let got = store.get_iris_data_by_id(1).await?;
         assert_eq!(got.version_id(), 5);
@@ -1286,10 +1314,10 @@ pub mod tests {
         Ok(())
     }
 
-    // Residual: an explicit version equal to the current one is indistinguishable from "unchanged",
-    // so content changes still auto-increment it.
+    // With the flag on, an explicit version equal to the current one is honored verbatim (no
+    // auto-increment), even when content changes.
     #[tokio::test]
-    async fn test_update_iris_with_version_id_equal_version_still_increments() -> Result<()> {
+    async fn test_update_iris_with_version_id_equal_version_is_honored() -> Result<()> {
         let schema_name = temporary_name();
         let postgres_client =
             PostgresClient::new(test_db_url()?.as_str(), &schema_name, AccessMode::ReadWrite)
@@ -1315,10 +1343,106 @@ pub mod tests {
             right_code: &[888_u16; 12800],
             right_mask: &[999_u16; 6400],
         };
-        store.update_iris_with_version_id(None, 0, &updated).await?;
+        let mut tx = store.tx().await?;
+        let mut ev = ExplicitVersion::enable(&mut tx).await?;
+        store
+            .update_iris_with_version_id(&mut ev, 0, &updated)
+            .await?;
+        drop(ev);
+        tx.commit().await?;
 
         let got = store.get_iris_data_by_id(1).await?;
-        assert_eq!(got.version_id(), 1);
+        assert_eq!(got.version_id(), 0);
+
+        cleanup(&postgres_client, &schema_name).await?;
+        Ok(())
+    }
+
+    // With the flag on, version_id may be set to an arbitrary value, including a lower one (for
+    // manual repair).
+    #[tokio::test]
+    async fn test_update_iris_with_version_id_allows_arbitrary_version() -> Result<()> {
+        let schema_name = temporary_name();
+        let postgres_client =
+            PostgresClient::new(test_db_url()?.as_str(), &schema_name, AccessMode::ReadWrite)
+                .await?;
+        let store = Store::new(&postgres_client).await?;
+
+        let iris = StoredIrisRef {
+            id: 1,
+            left_code: &[123_u16; 12800],
+            left_mask: &[456_u16; 6400],
+            right_code: &[789_u16; 12800],
+            right_mask: &[101_u16; 6400],
+        };
+        let mut tx = store.tx().await?;
+        store.insert_irises(&mut tx, &[iris]).await?;
+        tx.commit().await?;
+
+        let updated = StoredIrisRef {
+            id: 1,
+            left_code: &[666_u16; 12800],
+            left_mask: &[777_u16; 6400],
+            right_code: &[888_u16; 12800],
+            right_mask: &[999_u16; 6400],
+        };
+
+        // Bump to 5.
+        let mut tx = store.tx().await?;
+        let mut ev = ExplicitVersion::enable(&mut tx).await?;
+        store
+            .update_iris_with_version_id(&mut ev, 5, &updated)
+            .await?;
+        drop(ev);
+        tx.commit().await?;
+        assert_eq!(store.get_iris_data_by_id(1).await?.version_id(), 5);
+
+        // Set back to 2 (lower).
+        let mut tx = store.tx().await?;
+        let mut ev = ExplicitVersion::enable(&mut tx).await?;
+        store
+            .update_iris_with_version_id(&mut ev, 2, &updated)
+            .await?;
+        drop(ev);
+        tx.commit().await?;
+        assert_eq!(store.get_iris_data_by_id(1).await?.version_id(), 2);
+
+        cleanup(&postgres_client, &schema_name).await?;
+        Ok(())
+    }
+
+    // A hand-set version_id without the flag is rejected by the trigger instead of being silently
+    // overwritten.
+    #[tokio::test]
+    async fn test_update_version_id_without_flag_is_rejected() -> Result<()> {
+        let schema_name = temporary_name();
+        let postgres_client =
+            PostgresClient::new(test_db_url()?.as_str(), &schema_name, AccessMode::ReadWrite)
+                .await?;
+        let store = Store::new(&postgres_client).await?;
+
+        let iris = StoredIrisRef {
+            id: 1,
+            left_code: &[123_u16; 12800],
+            left_mask: &[456_u16; 6400],
+            right_code: &[789_u16; 12800],
+            right_mask: &[101_u16; 6400],
+        };
+        let mut tx = store.tx().await?;
+        store.insert_irises(&mut tx, &[iris]).await?;
+        tx.commit().await?;
+
+        let res = sqlx::query("UPDATE irises SET version_id = 42 WHERE id = $1")
+            .bind(1_i64)
+            .execute(&store.pool)
+            .await;
+        assert!(
+            res.is_err(),
+            "hand-set version_id without the flag must be rejected"
+        );
+
+        // Row is unchanged.
+        assert_eq!(store.get_iris_data_by_id(1).await?.version_id(), 0);
 
         cleanup(&postgres_client, &schema_name).await?;
         Ok(())

--- a/iris-mpc-upgrade-hawk/src/genesis/mod.rs
+++ b/iris-mpc-upgrade-hawk/src/genesis/mod.rs
@@ -1292,8 +1292,7 @@ async fn get_results_thread(
                                     right_code: &right_iris.code.coefs,
                                     right_mask: &right_iris.mask.coefs,
                                 };
-                    // We should ensure that the vector_id_to_persist is matching the inserted serial id.
-                    // The handle bypasses the auto-increment trigger so the replayed version is written verbatim.
+                    // Replay the modification's version verbatim; the handle bypasses the auto-increment trigger.
                     {
                         let mut ev = ExplicitVersion::enable(&mut graph_tx.tx).await?;
                         hnsw_iris_store

--- a/iris-mpc-upgrade-hawk/src/genesis/mod.rs
+++ b/iris-mpc-upgrade-hawk/src/genesis/mod.rs
@@ -47,7 +47,7 @@ use iris_mpc_cpu::{
     hawkers::aby3::aby3_store::{Aby3Store, VectorIdRegistryRef},
     hnsw::{graph::graph_store::GraphPg, GraphMem},
 };
-use iris_mpc_store::{Store as IrisStore, StoredIrisRef};
+use iris_mpc_store::{ExplicitVersion, Store as IrisStore, StoredIrisRef};
 use std::{
     sync::Arc,
     time::{Duration, Instant},
@@ -1292,13 +1292,18 @@ async fn get_results_thread(
                                     right_code: &right_iris.code.coefs,
                                     right_mask: &right_iris.mask.coefs,
                                 };
-                    // We should ensure that the vector_id_to_persist is matching the inserted serial id
-                    hnsw_iris_store.update_iris_with_version_id(
-                            Some(&mut graph_tx.tx),
-                            vector_id_to_persist.version_id(),
-                            &iris_data,
-                        )
-                        .await?;
+                    // We should ensure that the vector_id_to_persist is matching the inserted serial id.
+                    // The handle bypasses the auto-increment trigger so the replayed version is written verbatim.
+                    {
+                        let mut ev = ExplicitVersion::enable(&mut graph_tx.tx).await?;
+                        hnsw_iris_store
+                            .update_iris_with_version_id(
+                                &mut ev,
+                                vector_id_to_persist.version_id(),
+                                &iris_data,
+                            )
+                            .await?;
+                    }
 
                     let mut db_tx = graph_tx.tx;
                     set_last_indexed_modification_id(&mut db_tx, modification_id).await?;

--- a/iris-mpc-upgrade-hawk/src/genesis/mod.rs
+++ b/iris-mpc-upgrade-hawk/src/genesis/mod.rs
@@ -1285,13 +1285,13 @@ async fn get_results_thread(
                     let right_iris = &right_irises[0];
 
                     let mut graph_tx = graph_store_bg.tx().await?;
-                    let iris_data =StoredIrisRef {
-                                    id: vector_id_to_persist.serial_id() as i64,
-                                    left_code: &left_iris.code.coefs,
-                                    left_mask: &left_iris.mask.coefs,
-                                    right_code: &right_iris.code.coefs,
-                                    right_mask: &right_iris.mask.coefs,
-                                };
+                    let iris_data = StoredIrisRef {
+                        id: vector_id_to_persist.serial_id() as i64,
+                        left_code: &left_iris.code.coefs,
+                        left_mask: &left_iris.mask.coefs,
+                        right_code: &right_iris.code.coefs,
+                        right_mask: &right_iris.mask.coefs,
+                    };
                     // Replay the modification's version verbatim; the handle bypasses the auto-increment trigger.
                     {
                         let mut ev = ExplicitVersion::enable(&mut graph_tx.tx).await?;

--- a/iris-mpc-upgrade-hawk/tests/utils/mpc_node.rs
+++ b/iris-mpc-upgrade-hawk/tests/utils/mpc_node.rs
@@ -19,7 +19,7 @@ use iris_mpc_cpu::{
     hawkers::plaintext_store::PlaintextStore,
     hnsw::{graph::graph_store::GraphPg as GraphStore, GraphMem},
 };
-use iris_mpc_store::{Store, StoredIrisRef};
+use iris_mpc_store::{ExplicitVersion, Store, StoredIrisRef};
 use itertools::Itertools;
 use tokio::task::JoinSet;
 
@@ -245,8 +245,11 @@ impl MpcNode {
         }
 
         let update_serial_ids = modifications::modifications_extension_updates(last_mods, cur_mods);
-        for serial_id in update_serial_ids {
-            db_ops::increment_iris_version(&mut tx, serial_id).await?;
+        {
+            let mut ev = ExplicitVersion::enable(&mut tx).await?;
+            for serial_id in update_serial_ids {
+                db_ops::increment_iris_version(&mut ev, serial_id).await?;
+            }
         }
 
         tx.commit().await?;
@@ -257,7 +260,10 @@ impl MpcNode {
     #[allow(dead_code)]
     pub async fn increment_iris_version(&self, serial_id: i64) -> Result<()> {
         let mut tx = self.gpu_stores.iris.tx().await?;
-        db_ops::increment_iris_version(&mut tx, serial_id).await?;
+        {
+            let mut ev = ExplicitVersion::enable(&mut tx).await?;
+            db_ops::increment_iris_version(&mut ev, serial_id).await?;
+        }
         tx.commit().await?;
 
         Ok(())
@@ -495,23 +501,24 @@ pub mod db_ops {
 
     use eyre::Result;
     use iris_mpc_common::{helpers::sync::Modification, VectorId};
-    use iris_mpc_store::Store;
+    use iris_mpc_store::{ExplicitVersion, Store};
     use sqlx::{Postgres, Transaction};
 
     /// Test functionality which updates an iris only by incrementing its version,
     /// without changing the underlying iris code.
     pub async fn increment_iris_version(
-        tx: &mut Transaction<'_, Postgres>,
+        tx: &mut ExplicitVersion<'_, '_>,
         serial_id: i64,
     ) -> Result<()> {
-        let query = sqlx::query(
+        sqlx::query(
             r#"
             UPDATE irises SET version_id = version_id + 1
             WHERE id = $1;
             "#,
         )
-        .bind(serial_id);
-        query.execute(tx.deref_mut()).await?;
+        .bind(serial_id)
+        .execute(tx.tx().deref_mut())
+        .await?;
 
         Ok(())
     }

--- a/iris-mpc-utils/src/pgres/ops.rs
+++ b/iris-mpc-utils/src/pgres/ops.rs
@@ -1,23 +1,23 @@
 use eyre::Result;
 use iris_mpc_common::{helpers::sync::Modification, VectorId};
-use iris_mpc_store::Store;
+use iris_mpc_store::{ExplicitVersion, Store};
 use sqlx::{Postgres, Transaction};
 use std::ops::DerefMut;
 
 /// Increments an Iris's version.
 pub async fn increment_iris_version(
-    tx: &mut Transaction<'_, Postgres>,
+    tx: &mut ExplicitVersion<'_, '_>,
     serial_id: i64,
 ) -> Result<()> {
-    let query = sqlx::query(
+    sqlx::query(
         r#"
             UPDATE irises SET version_id = version_id + 1
             WHERE id = $1;
             "#,
     )
-    .bind(serial_id);
-
-    query.execute(tx.deref_mut()).await?;
+    .bind(serial_id)
+    .execute(tx.tx().deref_mut())
+    .await?;
 
     Ok(())
 }

--- a/migrations/20260710120000_version_id_trigger_respect_explicit.down.sql
+++ b/migrations/20260710120000_version_id_trigger_respect_explicit.down.sql
@@ -1,0 +1,13 @@
+CREATE OR REPLACE FUNCTION increment_version_id()
+RETURNS TRIGGER AS $$
+BEGIN
+    -- Only increment version_id if actual data columns changed
+    IF (OLD.left_code IS DISTINCT FROM NEW.left_code OR
+        OLD.left_mask IS DISTINCT FROM NEW.left_mask OR
+        OLD.right_code IS DISTINCT FROM NEW.right_code OR
+        OLD.right_mask IS DISTINCT FROM NEW.right_mask) THEN
+        NEW.version_id = COALESCE(OLD.version_id, 0) + 1;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/migrations/20260710120000_version_id_trigger_respect_explicit.up.sql
+++ b/migrations/20260710120000_version_id_trigger_respect_explicit.up.sql
@@ -1,11 +1,10 @@
--- version_id is trigger-managed: content changes auto-increment it. A hand-set
--- version_id is rejected unless the caller opts in for the transaction via
--- `SET LOCAL app.explicit_version_id = 'on'` (the ExplicitVersion store API),
--- in which case the value is written verbatim.
+-- Content changes auto-increment version_id. A hand-set version_id is rejected
+-- unless the transaction sets app.explicit_version_id (the ExplicitVersion store
+-- API), which writes it verbatim.
 CREATE OR REPLACE FUNCTION increment_version_id()
 RETURNS TRIGGER AS $$
 BEGIN
-    -- Authoritative write: honor version_id verbatim (any value).
+    -- Flag on: write version_id verbatim.
     IF current_setting('app.explicit_version_id', true) = 'on' THEN
         RETURN NEW;
     END IF;

--- a/migrations/20260710120000_version_id_trigger_respect_explicit.up.sql
+++ b/migrations/20260710120000_version_id_trigger_respect_explicit.up.sql
@@ -1,9 +1,24 @@
--- An explicitly changed version_id takes precedence; otherwise content changes auto-increment it.
+-- version_id is trigger-managed: content changes auto-increment it. A hand-set
+-- version_id is rejected unless the caller opts in for the transaction via
+-- `SET LOCAL app.explicit_version_id = 'on'` (the ExplicitVersion store API),
+-- in which case the value is written verbatim.
 CREATE OR REPLACE FUNCTION increment_version_id()
 RETURNS TRIGGER AS $$
 BEGIN
-    IF (NEW.version_id IS NOT DISTINCT FROM OLD.version_id) AND
-       (OLD.left_code IS DISTINCT FROM NEW.left_code OR
+    -- Authoritative write: honor version_id verbatim (any value).
+    IF current_setting('app.explicit_version_id', true) = 'on' THEN
+        RETURN NEW;
+    END IF;
+
+    -- Flag off: version_id must not be set by hand.
+    IF NEW.version_id IS DISTINCT FROM OLD.version_id THEN
+        RAISE EXCEPTION 'version_id changed (% -> %) without the explicit-version flag',
+            OLD.version_id, NEW.version_id
+            USING HINT = 'SET LOCAL app.explicit_version_id = ''on''; first, or use the ExplicitVersion store API';
+    END IF;
+
+    -- Default: auto-increment on content change.
+    IF (OLD.left_code IS DISTINCT FROM NEW.left_code OR
         OLD.left_mask IS DISTINCT FROM NEW.left_mask OR
         OLD.right_code IS DISTINCT FROM NEW.right_code OR
         OLD.right_mask IS DISTINCT FROM NEW.right_mask) THEN

--- a/migrations/20260710120000_version_id_trigger_respect_explicit.up.sql
+++ b/migrations/20260710120000_version_id_trigger_respect_explicit.up.sql
@@ -1,0 +1,14 @@
+-- An explicitly changed version_id takes precedence; otherwise content changes auto-increment it.
+CREATE OR REPLACE FUNCTION increment_version_id()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF (NEW.version_id IS NOT DISTINCT FROM OLD.version_id) AND
+       (OLD.left_code IS DISTINCT FROM NEW.left_code OR
+        OLD.left_mask IS DISTINCT FROM NEW.left_mask OR
+        OLD.right_code IS DISTINCT FROM NEW.right_code OR
+        OLD.right_mask IS DISTINCT FROM NEW.right_mask) THEN
+        NEW.version_id = COALESCE(OLD.version_id, 0) + 1;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/migrations/20260710120000_version_id_trigger_respect_explicit.up.sql
+++ b/migrations/20260710120000_version_id_trigger_respect_explicit.up.sql
@@ -13,7 +13,7 @@ BEGIN
     IF NEW.version_id IS DISTINCT FROM OLD.version_id THEN
         RAISE EXCEPTION 'version_id changed (% -> %) without the explicit-version flag',
             OLD.version_id, NEW.version_id
-            USING HINT = 'SET LOCAL app.explicit_version_id = ''on''; first, or use the ExplicitVersion store API';
+            USING HINT = 'Enable app.explicit_version_id for the transaction (via the ExplicitVersion store API) before changing version_id.';
     END IF;
 
     -- Default: auto-increment on content change.


### PR DESCRIPTION
The `irises` `BEFORE UPDATE` trigger auto-incremented `version_id` on any content change, overriding a `version_id` set by the `UPDATE` itself — so `update_iris_with_version_id` could not write an authoritative version.

The trigger now:
- honors a hand-set `version_id` verbatim (any value, including a lower one) when the transaction enables `app.explicit_version_id`;
- rejects a hand-set `version_id` otherwise, instead of silently overwriting it;
- auto-increments on content change when `version_id` is untouched — unchanged behavior, so the `update_iris` path is unaffected.

`ExplicitVersion` enables the flag for a transaction and is required by the version-writing APIs (`update_iris_with_version_id`, `increment_iris_version`), so the flag is a compile-time requirement rather than a convention; the trigger is the runtime backstop for raw SQL. The migration replaces the trigger function in place (bound by name).

Tests cover: auto-increment when untouched, verbatim explicit version (differing, equal, and lower), and rejection of a hand-set `version_id` without the flag.
