### PR TITLE
Make ignore unknown migrations flag configurable, move db migrations out of store constructor

### DIFF
--- a/.github/workflows/temp-branch-build-and-push.yaml
+++ b/.github/workflows/temp-branch-build-and-push.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - "dev"
-      - "allow-unknown-migrations"
+      - "elenagryaznova/pop-4114-introduce-feature-flag-for-ignoring-unknown-migrations-iris"
 
 concurrency:
   group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:a3c82c7a29578a3f3cea9791de6065990980b6bf"
+image: "ghcr.io/worldcoin/iris-mpc:f4acd2f9e51dfa635d9b3ebfafbb34dd0b30b901"
 
 environment: stage
 replicaCount: 1

--- a/iris-mpc-bins/bin/iris-mpc-cpu/sidecar.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/sidecar.rs
@@ -49,17 +49,15 @@ pub struct SidecarArgs {
     #[clap(long, env = "SMPC__CPU_DATABASE__SCHEMA")]
     pub db_schema: String,
 
-    /// Ignore migration versions recorded in the database but absent from this
-    /// binary. Defaults to `false` so a rolled-back sidecar tolerates a newer
-    /// schema instead of aborting with `VersionMissing`; set to `false` to
-    /// strictly validate migrations.
+    /// Ignore missing migration versions recorded in the database but absent from this
+    /// binary. Defaults to `false` so a rolled-back sidecar doesn't tolerate a newer
+    /// schema and abort with `VersionMissing`; set to `true` to allow missing migrations.
     #[clap(
         long,
-        env = "SMPC__CPU_DATABASE__MIGRATE_IGNORE_MISSING",
-        default_value_t = false,
-        action = clap::ArgAction::Set
+        env = "SMPC__CPU_DATABASE__IGNORE_MISSING_MIGRATIONS",
+        default_value_t = false
     )]
-    pub migrate_ignore_missing: bool,
+    pub ignore_missing_migrations: bool,
 
     /// S3 bucket holding graph checkpoint objects.
     #[clap(long, env = "SMPC__GRAPH_CHECKPOINT_BUCKET_NAME")]
@@ -198,7 +196,7 @@ async fn main() -> Result<()> {
 
     let postgres =
         PostgresClient::new(&args.db_url, &args.db_schema, AccessMode::ReadWrite).await?;
-    run_migrations(&postgres.pool, args.migrate_ignore_missing).await?;
+    run_migrations(&postgres.pool, args.ignore_missing_migrations).await?;
     let graph_store: GraphPg<iris_mpc_cpu::hawkers::aby3::aby3_store::Aby3Store> =
         GraphPg::new(&postgres).await?;
 

--- a/iris-mpc-bins/bin/iris-mpc-cpu/sidecar.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/sidecar.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 
 use ampc_actor_utils::network::tcp::TlsConfig;
 use iris_mpc_common::config::Config;
-use iris_mpc_common::postgres::{AccessMode, PostgresClient};
+use iris_mpc_common::postgres::{run_migrations, AccessMode, PostgresClient};
 use iris_mpc_common::tracing::initialize_tracing;
 use iris_mpc_cpu::{
     checkpoint_protocol::{sidecar_main, SidecarConfig},
@@ -186,6 +186,7 @@ async fn main() -> Result<()> {
 
     let postgres =
         PostgresClient::new(&args.db_url, &args.db_schema, AccessMode::ReadWrite).await?;
+    run_migrations(&postgres.pool, false).await?;
     let graph_store: GraphPg<iris_mpc_cpu::hawkers::aby3::aby3_store::Aby3Store> =
         GraphPg::new(&postgres).await?;
 

--- a/iris-mpc-bins/bin/iris-mpc-cpu/sidecar.rs
+++ b/iris-mpc-bins/bin/iris-mpc-cpu/sidecar.rs
@@ -49,6 +49,18 @@ pub struct SidecarArgs {
     #[clap(long, env = "SMPC__CPU_DATABASE__SCHEMA")]
     pub db_schema: String,
 
+    /// Ignore migration versions recorded in the database but absent from this
+    /// binary. Defaults to `false` so a rolled-back sidecar tolerates a newer
+    /// schema instead of aborting with `VersionMissing`; set to `false` to
+    /// strictly validate migrations.
+    #[clap(
+        long,
+        env = "SMPC__CPU_DATABASE__MIGRATE_IGNORE_MISSING",
+        default_value_t = false,
+        action = clap::ArgAction::Set
+    )]
+    pub migrate_ignore_missing: bool,
+
     /// S3 bucket holding graph checkpoint objects.
     #[clap(long, env = "SMPC__GRAPH_CHECKPOINT_BUCKET_NAME")]
     pub bucket: String,
@@ -186,7 +198,7 @@ async fn main() -> Result<()> {
 
     let postgres =
         PostgresClient::new(&args.db_url, &args.db_schema, AccessMode::ReadWrite).await?;
-    run_migrations(&postgres.pool, false).await?;
+    run_migrations(&postgres.pool, args.migrate_ignore_missing).await?;
     let graph_store: GraphPg<iris_mpc_cpu::hawkers::aby3::aby3_store::Aby3Store> =
         GraphPg::new(&postgres).await?;
 

--- a/iris-mpc-bins/bin/iris-mpc-upgrade/rerandomize_db.rs
+++ b/iris-mpc-bins/bin/iris-mpc-upgrade/rerandomize_db.rs
@@ -18,7 +18,7 @@ use iris_mpc_common::galois_engine::degree4::{
     GaloisRingIrisCodeShare, GaloisRingTrimmedMaskCodeShare,
 };
 use iris_mpc_common::id::PartyID;
-use iris_mpc_common::postgres::{AccessMode, PostgresClient};
+use iris_mpc_common::postgres::{run_migrations, AccessMode, PostgresClient};
 use iris_mpc_store::{DbStoredIris, Store, StoredIrisRef};
 use iris_mpc_upgrade::config::{
     KeyGenConfig, ReRandomizeCheckConfig, ReRandomizeConfig, ReRandomizeDbSubCommand,
@@ -207,6 +207,7 @@ async fn rerandomize_db_main(config: ReRandomizeConfig) -> Result<()> {
         AccessMode::ReadWrite,
     )
     .await?;
+    run_migrations(&postgres_client_write.pool, false).await?;
     let read_store = Store::new(&postgres_client_read).await?;
     let write_store = Store::new(&postgres_client_write).await?;
 

--- a/iris-mpc-bins/bin/iris-mpc-upgrade/reshare-client.rs
+++ b/iris-mpc-bins/bin/iris-mpc-upgrade/reshare-client.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use eyre::Result;
 use futures::StreamExt;
 use hkdf::Hkdf;
-use iris_mpc_common::postgres::{AccessMode, PostgresClient};
+use iris_mpc_common::postgres::{run_migrations, AccessMode, PostgresClient};
 use iris_mpc_common::{
     galois_engine::degree4::{GaloisRingIrisCodeShare, GaloisRingTrimmedMaskCodeShare},
     helpers::kms_dh::derive_shared_secret,
@@ -59,6 +59,7 @@ async fn main() -> Result<()> {
     let schema_name = format!("{}_{}_{}", APP_NAME, config.environment, config.party_id);
     let postgres_client =
         PostgresClient::new(&config.db_url, &schema_name, AccessMode::ReadWrite).await?;
+    run_migrations(&postgres_client.pool, false).await?;
     let store = Store::new(&postgres_client).await?;
 
     let iris_stream = store.stream_irises_in_range(config.db_start..config.db_end);

--- a/iris-mpc-bins/bin/iris-mpc-upgrade/reshare-server.rs
+++ b/iris-mpc-bins/bin/iris-mpc-upgrade/reshare-server.rs
@@ -1,7 +1,7 @@
 use ampc_server_utils::TaskMonitor;
 use clap::Parser;
 use eyre::Result;
-use iris_mpc_common::postgres::{AccessMode, PostgresClient};
+use iris_mpc_common::postgres::{run_migrations, AccessMode, PostgresClient};
 use iris_mpc_store::Store;
 use iris_mpc_upgrade::{
     config::ReShareServerConfig,
@@ -40,6 +40,7 @@ async fn main() -> Result<()> {
     let schema_name = format!("{}_{}_{}", APP_NAME, config.environment, config.party_id);
     let postgres_client =
         PostgresClient::new(&config.db_url, &schema_name, AccessMode::ReadWrite).await?;
+    run_migrations(&postgres_client.pool, false).await?;
     let store = Store::new(&postgres_client).await?;
 
     let receiver_helper = IrisCodeReshareReceiverHelper::new(

--- a/iris-mpc-bins/bin/iris-mpc-upgrade/seed_v2_dbs.rs
+++ b/iris-mpc-bins/bin/iris-mpc-upgrade/seed_v2_dbs.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use eyre::Result;
-use iris_mpc_common::postgres::{AccessMode, PostgresClient};
+use iris_mpc_common::postgres::{run_migrations, AccessMode, PostgresClient};
 use iris_mpc_common::{
     galois_engine::degree4::FullGaloisRingIrisCodeShare, iris_db::iris::IrisCode,
 };
@@ -74,6 +74,10 @@ async fn main() -> Result<()> {
         AccessMode::ReadWrite,
     )
     .await?;
+
+    run_migrations(&party_1_pg_client.pool, false).await?;
+    run_migrations(&party_2_pg_client.pool, false).await?;
+    run_migrations(&party_3_pg_client.pool, false).await?;
 
     let store1 = Store::new(&party_1_pg_client).await?;
     let store2 = Store::new(&party_2_pg_client).await?;

--- a/iris-mpc-bins/bin/iris-mpc/server.rs
+++ b/iris-mpc-bins/bin/iris-mpc/server.rs
@@ -33,7 +33,7 @@ use iris_mpc_common::config::CommonConfig;
 use iris_mpc_common::galois_engine::degree4::GaloisShares;
 use iris_mpc_common::helpers::sync::ModificationKey::{RequestId, RequestSerialId};
 use iris_mpc_common::job::{GaloisSharesBothSides, RequestIndex};
-use iris_mpc_common::postgres::{AccessMode, PostgresClient};
+use iris_mpc_common::postgres::{run_migrations, AccessMode, PostgresClient};
 use iris_mpc_common::tracing::initialize_tracing;
 use iris_mpc_common::{
     config::{Config, Opt},
@@ -160,6 +160,7 @@ async fn server_main(config: Config) -> Result<()> {
     );
     let postgres_client =
         PostgresClient::new(&db_config.url, schema_name.as_str(), AccessMode::ReadWrite).await?;
+    run_migrations(&postgres_client.pool, db_config.migrate_ignore_missing).await?;
     let store = Store::new(&postgres_client).await?;
 
     tracing::info!("Initialising AWS services");

--- a/iris-mpc-bins/bin/iris-mpc/server.rs
+++ b/iris-mpc-bins/bin/iris-mpc/server.rs
@@ -183,7 +183,7 @@ async fn server_main(config: Config) -> Result<()> {
     );
     let postgres_client =
         PostgresClient::new(&db_config.url, schema_name.as_str(), AccessMode::ReadWrite).await?;
-    run_migrations(&postgres_client.pool, db_config.migrate_ignore_missing).await?;
+    run_migrations(&postgres_client.pool, db_config.ignore_missing_migrations).await?;
     let store = Store::new(&postgres_client).await?;
 
     tracing::info!("Initialising AWS services");

--- a/iris-mpc-common/src/config/mod.rs
+++ b/iris-mpc-common/src/config/mod.rs
@@ -631,6 +631,10 @@ pub struct DbConfig {
     /// Degree of parallelism for loading data.
     #[serde(default = "default_load_parallelism")]
     pub load_parallelism: usize,
+
+    /// Flag indicating whether to ignore missing migrations.
+    #[serde(default)]
+    pub migrate_ignore_missing: bool,
 }
 
 fn default_load_parallelism() -> usize {
@@ -643,6 +647,7 @@ impl fmt::Debug for DbConfig {
             .field("url", &"********") // Mask the URL
             .field("migrate", &self.migrate)
             .field("create", &self.create)
+            .field("migrate_ignore_missing", &self.migrate_ignore_missing)
             .finish()
     }
 }

--- a/iris-mpc-common/src/config/mod.rs
+++ b/iris-mpc-common/src/config/mod.rs
@@ -662,7 +662,7 @@ pub struct DbConfig {
 
     /// Flag indicating whether to ignore missing migrations.
     #[serde(default)]
-    pub migrate_ignore_missing: bool,
+    pub ignore_missing_migrations: bool,
 }
 
 fn default_load_parallelism() -> usize {
@@ -675,7 +675,7 @@ impl fmt::Debug for DbConfig {
             .field("url", &"********") // Mask the URL
             .field("migrate", &self.migrate)
             .field("create", &self.create)
-            .field("migrate_ignore_missing", &self.migrate_ignore_missing)
+            .field("ignore_missing_migrations", &self.ignore_missing_migrations)
             .finish()
     }
 }

--- a/iris-mpc-common/src/postgres/mod.rs
+++ b/iris-mpc-common/src/postgres/mod.rs
@@ -7,7 +7,6 @@ const MAX_CONNECTIONS: u32 = 100;
 pub struct PostgresClient {
     pub pool: PgPool,
     pub schema_name: String,
-    pub access_mode: AccessMode,
 }
 
 // Helper type: name of a PostgreSQL schema.
@@ -68,23 +67,29 @@ impl PostgresClient {
 
         Ok(PostgresClient {
             pool,
-            access_mode,
             schema_name: schema_name.to_string(),
         })
     }
+}
 
-    pub async fn migrate(&self) {
-        tracing::info!("Running migrations...");
+/// Runs pending database migrations against the schema associated with `client`.
+///
+/// When `ignore_missing_migrations` is true,
+/// migrations applied to the database but missing from the local migrations
+/// directory are ignored instead of causing the migration to fail.
+///
+/// This is intentionally decoupled from connection/store construction so that
+/// migrations run explicitly, once, at application startup.
+pub async fn run_migrations(pool: &PgPool, ignore_missing_migrations: bool) -> Result<()> {
+    tracing::info!(
+        "Running migrations (ignore_missing_migrations={})...",
+        ignore_missing_migrations
+    );
 
-        if self.access_mode == AccessMode::ReadOnly {
-            tracing::info!("Not migrating client in read-only mode");
-            return;
-        }
+    sqlx::migrate!("./../migrations")
+        .set_ignore_missing(ignore_missing_migrations)
+        .run(pool)
+        .await?;
 
-        sqlx::migrate!("./../migrations")
-            .set_ignore_missing(true)
-            .run(&self.pool)
-            .await
-            .expect("Failed to run migrations");
-    }
+    Ok(())
 }

--- a/iris-mpc-cpu/src/genesis/state_accessor.rs
+++ b/iris-mpc-cpu/src/genesis/state_accessor.rs
@@ -296,7 +296,9 @@ mod tests {
         hnsw::graph::graph_store::GraphPg,
     };
     use eyre::Result;
-    use iris_mpc_common::postgres::{AccessMode, PostgresClient, PostgresSchemaName};
+    use iris_mpc_common::postgres::{
+        run_migrations, AccessMode, PostgresClient, PostgresSchemaName,
+    };
     use iris_mpc_store::{
         test_utils::{cleanup, temporary_name, test_db_url},
         Store as IrisStore,
@@ -319,6 +321,7 @@ mod tests {
         let pg_schema = temporary_name();
         let pg_client =
             PostgresClient::new(&test_db_url()?, &pg_schema, AccessMode::ReadWrite).await?;
+        run_migrations(&pg_client.pool, false).await?;
         // Set graph store
         let graph_store = GraphPg::new(&pg_client).await?;
         let graph_store_arc = Arc::new(graph_store);

--- a/iris-mpc-cpu/src/hnsw/graph/graph_store.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/graph_store.rs
@@ -50,8 +50,6 @@ impl<V: VectorStore> GraphPg<V> {
             postgres_client.schema_name,
         );
 
-        postgres_client.migrate().await;
-
         Ok(Self {
             pool: postgres_client.pool.clone(),
             schema_name: postgres_client.schema_name.clone(),
@@ -509,7 +507,7 @@ impl<'b, V: VectorStore> GraphTx<'b, V> {
 
 pub mod test_utils {
     use super::*;
-    use iris_mpc_common::postgres::{AccessMode, PostgresClient};
+    use iris_mpc_common::postgres::{run_migrations, AccessMode, PostgresClient};
     use iris_mpc_store::test_utils::{cleanup, temporary_name, test_db_url};
     use std::ops::{Deref, DerefMut};
 
@@ -527,6 +525,7 @@ pub mod test_utils {
             let schema_name = temporary_name();
             let postgres_client =
                 PostgresClient::new(&test_db_url()?, &schema_name, AccessMode::ReadWrite).await?;
+            run_migrations(&postgres_client.pool, false).await?;
             let graph = GraphPg::new(&postgres_client).await?;
             Ok(TestGraphPg {
                 postgres_client,

--- a/iris-mpc-cpu/src/hnsw/graph/test_utils.rs
+++ b/iris-mpc-cpu/src/hnsw/graph/test_utils.rs
@@ -35,7 +35,7 @@ use aws_sdk_s3::Client as S3Client;
 use clap::ValueEnum;
 use eyre::Result;
 use iris_mpc_common::iris_db::db::IrisDB;
-use iris_mpc_common::postgres::{AccessMode, PostgresClient};
+use iris_mpc_common::postgres::{run_migrations, AccessMode, PostgresClient};
 use iris_mpc_store::{Store, StoredIrisRef};
 use itertools::Itertools;
 use rand::SeedableRng;
@@ -74,6 +74,7 @@ impl DbContext {
         let client = PostgresClient::new(url, schema, AccessMode::ReadWrite)
             .await
             .unwrap();
+        run_migrations(&client.pool, false).await.unwrap();
         let store = Store::new(&client).await.unwrap();
         let graph_pg = GraphPg::new(&client).await.unwrap();
         Self {

--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -1624,6 +1624,7 @@ pub mod tests {
         let postgres_client =
             PostgresClient::new(test_db_url()?.as_str(), &schema_name, AccessMode::ReadWrite)
                 .await?;
+        run_migrations(&postgres_client.pool, false).await?;
         let store = Store::new(&postgres_client).await?;
 
         let iris = StoredIrisRef {
@@ -1674,6 +1675,7 @@ pub mod tests {
         let postgres_client =
             PostgresClient::new(test_db_url()?.as_str(), &schema_name, AccessMode::ReadWrite)
                 .await?;
+        run_migrations(&postgres_client.pool, false).await?;
         let store = Store::new(&postgres_client).await?;
 
         let iris = StoredIrisRef {
@@ -1721,6 +1723,7 @@ pub mod tests {
         let postgres_client =
             PostgresClient::new(test_db_url()?.as_str(), &schema_name, AccessMode::ReadWrite)
                 .await?;
+        run_migrations(&postgres_client.pool, false).await?;
         let store = Store::new(&postgres_client).await?;
 
         let iris = StoredIrisRef {
@@ -1765,6 +1768,7 @@ pub mod tests {
         let postgres_client =
             PostgresClient::new(test_db_url()?.as_str(), &schema_name, AccessMode::ReadWrite)
                 .await?;
+        run_migrations(&postgres_client.pool, false).await?;
         let store = Store::new(&postgres_client).await?;
 
         let iris = StoredIrisRef {
@@ -1819,6 +1823,7 @@ pub mod tests {
         let postgres_client =
             PostgresClient::new(test_db_url()?.as_str(), &schema_name, AccessMode::ReadWrite)
                 .await?;
+        run_migrations(&postgres_client.pool, false).await?;
         let store = Store::new(&postgres_client).await?;
 
         let iris = StoredIrisRef {

--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -1130,6 +1130,7 @@ pub mod tests {
         let postgres_client =
             PostgresClient::new(test_db_url()?.as_str(), &schema_name, AccessMode::ReadWrite)
                 .await?;
+        run_migrations(&postgres_client.pool, false).await?;
         let store = Store::new(&postgres_client).await?;
 
         let sequence_number = "42";
@@ -1170,6 +1171,7 @@ pub mod tests {
         let postgres_client =
             PostgresClient::new(test_db_url()?.as_str(), &schema_name, AccessMode::ReadWrite)
                 .await?;
+        run_migrations(&postgres_client.pool, false).await?;
         let store = Store::new(&postgres_client).await?;
 
         assert!(
@@ -1223,6 +1225,7 @@ pub mod tests {
         let postgres_client =
             PostgresClient::new(test_db_url()?.as_str(), &schema_name, AccessMode::ReadWrite)
                 .await?;
+        run_migrations(&postgres_client.pool, false).await?;
         let store = Store::new(&postgres_client).await?;
 
         for seq in ["20", "21", "22"] {
@@ -1263,6 +1266,7 @@ pub mod tests {
         let postgres_client =
             PostgresClient::new(test_db_url()?.as_str(), &schema_name, AccessMode::ReadWrite)
                 .await?;
+        run_migrations(&postgres_client.pool, false).await?;
         let store = Store::new(&postgres_client).await?;
 
         // The C2 state: rows 10,11 persisted somewhere in the fleet (this

--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -8,6 +8,7 @@ use futures::{
     Stream, StreamExt, TryStreamExt,
 };
 use iris_mpc_common::helpers::sync::MOD_STATUS_IN_PROGRESS;
+use iris_mpc_common::postgres::PostgresClient;
 use iris_mpc_common::{
     config::Config,
     galois_engine::degree4::{GaloisRingIrisCodeShare, GaloisRingTrimmedMaskCodeShare},
@@ -19,7 +20,6 @@ use iris_mpc_common::{
         sync::Modification,
     },
     iris_db::iris::IrisCode,
-    postgres::PostgresClient,
     SerialId, VectorId,
 };
 use itertools::izip;
@@ -164,11 +164,9 @@ impl Store {
             postgres_client.schema_name
         );
 
-        postgres_client.migrate().await;
-
         Ok(Store {
             pool: postgres_client.pool.clone(),
-            schema_name: postgres_client.schema_name.to_string(),
+            schema_name: postgres_client.schema_name.clone(),
         })
     }
 
@@ -820,7 +818,7 @@ pub mod tests {
             },
             sync::ModificationStatus,
         },
-        postgres::AccessMode,
+        postgres::{run_migrations, AccessMode},
     };
 
     // Max connections default to 100 for Postgres, but can't test at quite this level when running
@@ -834,6 +832,7 @@ pub mod tests {
         let postgres_client =
             PostgresClient::new(test_db_url()?.as_str(), &schema_name, AccessMode::ReadWrite)
                 .await?;
+        run_migrations(&postgres_client.pool, false).await?;
         let store = Store::new(&postgres_client).await?;
 
         let got: Vec<DbStoredIris> = store.stream_irises().await.try_collect().await?;
@@ -911,6 +910,7 @@ pub mod tests {
         let postgres_client =
             PostgresClient::new(test_db_url()?.as_str(), &schema_name, AccessMode::ReadWrite)
                 .await?;
+        run_migrations(&postgres_client.pool, false).await?;
         let store = Store::new(&postgres_client).await?;
 
         let mut tx = store.tx().await?;
@@ -929,6 +929,7 @@ pub mod tests {
         let postgres_client =
             PostgresClient::new(test_db_url()?.as_str(), &schema_name, AccessMode::ReadWrite)
                 .await?;
+        run_migrations(&postgres_client.pool, false).await?;
         let store = Store::new(&postgres_client).await?;
 
         let mut codes_and_masks = vec![];
@@ -973,6 +974,7 @@ pub mod tests {
         let postgres_client =
             PostgresClient::new(test_db_url()?.as_str(), &schema_name, AccessMode::ReadWrite)
                 .await?;
+        run_migrations(&postgres_client.pool, false).await?;
         let store = Store::new(&postgres_client).await?;
 
         let codes_and_masks = &[
@@ -1023,6 +1025,7 @@ pub mod tests {
         let postgres_client =
             PostgresClient::new(test_db_url()?.as_str(), &schema_name, AccessMode::ReadWrite)
                 .await?;
+        run_migrations(&postgres_client.pool, false).await?;
         let store = Store::new(&postgres_client).await?;
 
         let expected_generated_irises_num = 10;
@@ -1042,6 +1045,7 @@ pub mod tests {
         let postgres_client =
             PostgresClient::new(test_db_url()?.as_str(), &schema_name, AccessMode::ReadWrite)
                 .await?;
+        run_migrations(&postgres_client.pool, false).await?;
         let store = Store::new(&postgres_client).await?;
 
         let mut irises = vec![];
@@ -1075,6 +1079,7 @@ pub mod tests {
         let postgres_client =
             PostgresClient::new(test_db_url()?.as_str(), &schema_name, AccessMode::ReadWrite)
                 .await?;
+        run_migrations(&postgres_client.pool, false).await?;
         let store = Store::new(&postgres_client).await?;
 
         // insert two irises into db
@@ -1201,6 +1206,7 @@ pub mod tests {
         let postgres_client =
             PostgresClient::new(test_db_url()?.as_str(), &schema_name, AccessMode::ReadWrite)
                 .await?;
+        run_migrations(&postgres_client.pool, false).await?;
         let store = Store::new(&postgres_client).await?;
 
         // 1. Insert a new modification
@@ -1248,6 +1254,7 @@ pub mod tests {
         let postgres_client =
             PostgresClient::new(test_db_url()?.as_str(), &schema_name, AccessMode::ReadWrite)
                 .await?;
+        run_migrations(&postgres_client.pool, false).await?;
         let store = Store::new(&postgres_client).await?;
 
         // Insert a few modifications
@@ -1315,6 +1322,7 @@ pub mod tests {
         let postgres_client =
             PostgresClient::new(test_db_url()?.as_str(), &schema_name, AccessMode::ReadWrite)
                 .await?;
+        run_migrations(&postgres_client.pool, false).await?;
         let store = Store::new(&postgres_client).await?;
 
         // Insert five modifications
@@ -1416,6 +1424,7 @@ pub mod tests {
         let postgres_client =
             PostgresClient::new(test_db_url()?.as_str(), &schema_name, AccessMode::ReadWrite)
                 .await?;
+        run_migrations(&postgres_client.pool, false).await?;
         let store = Store::new(&postgres_client).await?;
 
         // Insert three modifications.
@@ -1464,6 +1473,7 @@ pub mod tests {
         let postgres_client =
             PostgresClient::new(test_db_url()?.as_str(), &schema_name, AccessMode::ReadWrite)
                 .await?;
+        run_migrations(&postgres_client.pool, false).await?;
         let store = Store::new(&postgres_client).await?;
 
         // Insert several modifications.
@@ -1488,6 +1498,7 @@ pub mod tests {
 
         // Clean up the temporary schema.
         cleanup(&postgres_client, &schema_name).await?;
+
         Ok(())
     }
 
@@ -1506,6 +1517,7 @@ pub mod tests {
         let postgres_client =
             PostgresClient::new(test_db_url()?.as_str(), &schema_name, AccessMode::ReadWrite)
                 .await?;
+        run_migrations(&postgres_client.pool, false).await?;
         let store = Store::new(&postgres_client).await?;
 
         // Insert a variety of modifications with different request types
@@ -1677,6 +1689,7 @@ pub mod tests {
         let postgres_client =
             PostgresClient::new(test_db_url()?.as_str(), &schema_name, AccessMode::ReadWrite)
                 .await?;
+        run_migrations(&postgres_client.pool, false).await?;
         let store = Store::new(&postgres_client).await?;
 
         // Insert 3 modifications with the SAME serial_id (200)

--- a/iris-mpc-upgrade-hawk/src/genesis/mod.rs
+++ b/iris-mpc-upgrade-hawk/src/genesis/mod.rs
@@ -18,7 +18,7 @@ use eyre::{bail, eyre, Report, Result};
 use iris_mpc_common::{
     config::{CommonConfig, Config, ENV_PROD, ENV_STAGE},
     helpers::{smpc_request, sync::Modification},
-    postgres::{AccessMode, PostgresClient},
+    postgres::{run_migrations, AccessMode, PostgresClient},
     SerialId,
 };
 pub use iris_mpc_cpu::genesis::BatchSizeConfig;
@@ -1170,6 +1170,7 @@ async fn get_service_clients(
             let db_client =
                 PostgresClient::new(&db_config.url, db_schema.as_str(), AccessMode::ReadWrite)
                     .await?;
+            run_migrations(&db_client.pool, db_config.migrate_ignore_missing).await?;
 
             Ok((
                 IrisStore::new(&db_client).await?,

--- a/iris-mpc-upgrade-hawk/src/genesis/mod.rs
+++ b/iris-mpc-upgrade-hawk/src/genesis/mod.rs
@@ -1170,7 +1170,7 @@ async fn get_service_clients(
             let db_client =
                 PostgresClient::new(&db_config.url, db_schema.as_str(), AccessMode::ReadWrite)
                     .await?;
-            run_migrations(&db_client.pool, db_config.migrate_ignore_missing).await?;
+            run_migrations(&db_client.pool, db_config.ignore_missing_migrations).await?;
 
             Ok((
                 IrisStore::new(&db_client).await?,

--- a/iris-mpc-upgrade-hawk/tests/utils/mpc_node.rs
+++ b/iris-mpc-upgrade-hawk/tests/utils/mpc_node.rs
@@ -9,7 +9,7 @@ use crate::utils::{
 use eyre::{bail, Result};
 use iris_mpc_common::{
     config::Config,
-    postgres::{AccessMode, PostgresClient},
+    postgres::{run_migrations, AccessMode, PostgresClient},
     SerialId, VectorId,
 };
 use iris_mpc_cpu::{
@@ -44,7 +44,7 @@ impl DbStores {
         let client = PostgresClient::new(url, schema_name, access_mode)
             .await
             .unwrap();
-        client.migrate().await;
+        run_migrations(&client.pool, false).await.unwrap();
         let iris = Store::new(&client).await.unwrap();
         let graph = GraphStore::new(&client).await.unwrap();
 

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -37,7 +37,7 @@ use iris_mpc_common::helpers::smpc_response::create_message_type_attribute_map;
 use iris_mpc_common::helpers::sqs_s3_helper::upload_file_to_s3;
 use iris_mpc_common::helpers::sync::{SyncResult, SyncState};
 use iris_mpc_common::job::JobSubmissionHandle;
-use iris_mpc_common::postgres::{AccessMode, PostgresClient};
+use iris_mpc_common::postgres::{run_migrations, AccessMode, PostgresClient};
 use iris_mpc_cpu::checkpoint_protocol::runner::SidecarConfigWrapper;
 use iris_mpc_cpu::execution::hawk_main::worker_pool_initializer::{
     DbLoadParams, LocalWorkerPoolInitializer, WorkerPoolInitializer,
@@ -333,6 +333,11 @@ async fn prepare_stores(config: &Config) -> Result<(Store, GraphPg<Aby3Store<Haw
         &hawk_db_config.url,
         &hawk_schema_name,
         AccessMode::ReadWrite,
+    )
+    .await?;
+    run_migrations(
+        &hawk_postgres_client.pool,
+        hawk_db_config.migrate_ignore_missing,
     )
     .await?;
 

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -424,7 +424,7 @@ async fn prepare_stores(config: &Config) -> Result<(Store, GraphPg<Aby3Store<Haw
     .await?;
     run_migrations(
         &hawk_postgres_client.pool,
-        hawk_db_config.migrate_ignore_missing,
+        hawk_db_config.ignore_missing_migrations,
     )
     .await?;
 

--- a/iris-mpc/tests/utils/configs.rs
+++ b/iris-mpc/tests/utils/configs.rs
@@ -53,6 +53,7 @@ pub fn make_hawk_config(
         url: cpu_cfg.db_url.clone(),
         migrate: true,
         create: true,
+        migrate_ignore_missing: false,
         load_parallelism: 8,
     };
     let healthcheck_ports: Vec<String> = all_configs

--- a/iris-mpc/tests/utils/configs.rs
+++ b/iris-mpc/tests/utils/configs.rs
@@ -53,7 +53,7 @@ pub fn make_hawk_config(
         url: cpu_cfg.db_url.clone(),
         migrate: true,
         create: true,
-        migrate_ignore_missing: false,
+        ignore_missing_migrations: false,
         load_parallelism: 8,
     };
     let healthcheck_ports: Vec<String> = all_configs

--- a/iris-mpc/tests/utils/cpu_node.rs
+++ b/iris-mpc/tests/utils/cpu_node.rs
@@ -4,7 +4,7 @@ use super::CpuConfigs;
 
 use eyre::eyre;
 use iris_mpc_common::{
-    postgres::{AccessMode, PostgresClient},
+    postgres::{run_migrations, AccessMode, PostgresClient},
     VectorId, MASK_CODE_LENGTH,
 };
 use iris_mpc_cpu::hawkers::plaintext_store::PlaintextStore;
@@ -31,11 +31,11 @@ pub struct DbStores {
 
 impl DbStores {
     pub async fn new(config: &CpuNodeConfig) -> eyre::Result<Self> {
-        let pg =
+        let pg_client =
             PostgresClient::new(&config.db_url, &config.db_schema, AccessMode::ReadWrite).await?;
-        pg.migrate().await;
-        let graph = GraphPg::new(&pg).await?;
-        let iris_store = IrisStore::new(&pg).await?;
+        run_migrations(&pg_client.pool, false).await?;
+        let graph = GraphPg::new(&pg_client).await?;
+        let iris_store = IrisStore::new(&pg_client).await?;
         Ok(Self { graph, iris_store })
     }
 

--- a/iris-mpc/tests/workflows/mod.rs
+++ b/iris-mpc/tests/workflows/mod.rs
@@ -8,7 +8,7 @@ pub mod wal_109;
 pub mod wal_110;
 
 use ampc_actor_utils::network::tcp::TlsConfig;
-use iris_mpc_common::postgres::{AccessMode, PostgresClient};
+use iris_mpc_common::postgres::{run_migrations, AccessMode, PostgresClient};
 use iris_mpc_cpu::{
     checkpoint_protocol::{sidecar_main, SidecarConfig},
     execution::hawk_main::{build_hawk_network_handle, HawkArgs},
@@ -121,6 +121,7 @@ pub fn run_sidecar(
             let postgres =
                 PostgresClient::new(&config.db_url, &config.db_schema, AccessMode::ReadWrite)
                     .await?;
+            run_migrations(&postgres.pool, false).await?;
             // Aby3Store type param is phantom for WAL/checkpoint ops; store-agnostic.
             let graph_store: GraphPg<Aby3Store> = GraphPg::new(&postgres).await?;
 


### PR DESCRIPTION
Introduced a feature flag to ignore unknown migrations: This provides a safe rollback path. If we need to revert to a previous application version, the older code won’t crash when encountering newer (but backwards-compatible) database schemas.

Decoupled migrations from the Postgres client: Previously, running migrations was an unexpected side effect of instantiating the store. Moving this logic out of the constructor prevents migrations from running unnecessarily when multiple store instances are created.


**Database migration handling:**

* Introduced a standalone `run_migrations` function that must be called explicitly to apply pending migrations, replacing the previous implicit migration logic in `PostgresClient` and related store constructors. This function supports an option to ignore missing migrations. (`iris-mpc-common/src/postgres/mod.rs`, `iris-mpc-common/src/config/mod.rs`, various bin and test files) [[1]](diffhunk://#diff-b358159b7c1e1177d320b40e3d5c9b22c80638f6a0d889bb867fcd4bc5d4abcfL71-R94) [[2]](diffhunk://#diff-b358159b7c1e1177d320b40e3d5c9b22c80638f6a0d889bb867fcd4bc5d4abcfL10) [[3]](diffhunk://#diff-8f1d98b79d8be3af2dae2cb8a616a57b38c7eabe28e8f84a8da121cd836db38dR634-R637) [[4]](diffhunk://#diff-8f1d98b79d8be3af2dae2cb8a616a57b38c7eabe28e8f84a8da121cd836db38dR650) [[5]](diffhunk://#diff-ce487da4b837e22aba6b9a76fe4930f91613617bc4e0df40937a8f335e9169f2L36-R36) [[6]](diffhunk://#diff-ce487da4b837e22aba6b9a76fe4930f91613617bc4e0df40937a8f335e9169f2R163) [[7]](diffhunk://#diff-57f551d8a53b8f7183fce9823754277879109ad63b9298830ce0f2a957c4c990L15-R15) [[8]](diffhunk://#diff-57f551d8a53b8f7183fce9823754277879109ad63b9298830ce0f2a957c4c990R189) [[9]](diffhunk://#diff-eee6c43d7501fd6184995f036533ee8d21c6ecc1908131a72a39c3d4ed023c46L21-R21) [[10]](diffhunk://#diff-eee6c43d7501fd6184995f036533ee8d21c6ecc1908131a72a39c3d4ed023c46R210) [[11]](diffhunk://#diff-8d80046ed4e3c89747ec868ee41b02997e150174188edb1549eb4c91a6f2b020L5-R5) [[12]](diffhunk://#diff-8d80046ed4e3c89747ec868ee41b02997e150174188edb1549eb4c91a6f2b020R62) [[13]](diffhunk://#diff-52d6040dd81a4db25e0592692988764daf6e576784849f13b595b957112e736fL4-R4) [[14]](diffhunk://#diff-52d6040dd81a4db25e0592692988764daf6e576784849f13b595b957112e736fR43) [[15]](diffhunk://#diff-177ce3be1eab0299d3d4abed268902baef55c70f287e03cfd734bf6d7e3f9a2fL3-R3) [[16]](diffhunk://#diff-177ce3be1eab0299d3d4abed268902baef55c70f287e03cfd734bf6d7e3f9a2fL78-R84) [[17]](diffhunk://#diff-56b5c7060b4cae6c051650f29b8e9a50e174d04922038d897687cc1be855bc6bL299-R301) [[18]](diffhunk://#diff-56b5c7060b4cae6c051650f29b8e9a50e174d04922038d897687cc1be855bc6bR324) [[19]](diffhunk://#diff-73ddde6a5a8c8a9782dce540ea62c8ef737a15b6d156a45cecff17313c6cef6dL9-R9) [[20]](diffhunk://#diff-73ddde6a5a8c8a9782dce540ea62c8ef737a15b6d156a45cecff17313c6cef6dL53-L54) [[21]](diffhunk://#diff-73ddde6a5a8c8a9782dce540ea62c8ef737a15b6d156a45cecff17313c6cef6dL512-R510) [[22]](diffhunk://#diff-73ddde6a5a8c8a9782dce540ea62c8ef737a15b6d156a45cecff17313c6cef6dL521-R520) [[23]](diffhunk://#diff-73ddde6a5a8c8a9782dce540ea62c8ef737a15b6d156a45cecff17313c6cef6dR529-R539) [[24]](diffhunk://#diff-f994ba708689fd2f1aabc551c6f622484a758c82a8d63f87527f744f8f4a1cafL38-R38) [[25]](diffhunk://#diff-f994ba708689fd2f1aabc551c6f622484a758c82a8d63f87527f744f8f4a1cafR77) [[26]](diffhunk://#diff-563dd6519cb36fa6faad90201d22eb2c5519770ac44fdc03296dc41101da90e4R11) [[27]](diffhunk://#diff-563dd6519cb36fa6faad90201d22eb2c5519770ac44fdc03296dc41101da90e4L22) [[28]](diffhunk://#diff-563dd6519cb36fa6faad90201d22eb2c5519770ac44fdc03296dc41101da90e4L167-R169) [[29]](diffhunk://#diff-563dd6519cb36fa6faad90201d22eb2c5519770ac44fdc03296dc41101da90e4L823-R821)

* Added a `migrate_ignore_missing` field to `DbConfig`, allowing deployments to opt into ignoring missing migrations during migration runs. (`iris-mpc-common/src/config/mod.rs`) [[1]](diffhunk://#diff-8f1d98b79d8be3af2dae2cb8a616a57b38c7eabe28e8f84a8da121cd836db38dR634-R637) [[2]](diffhunk://#diff-8f1d98b79d8be3af2dae2cb8a616a57b38c7eabe28e8f84a8da121cd836db38dR650)

**API and constructor changes:**

* Updated `Store::new` and `GraphPg::new` to no longer run migrations during construction; callers are now responsible for running migrations before using these types. (`iris-mpc-store/src/lib.rs`, `iris-mpc-cpu/src/hnsw/graph/graph_store.rs`) [[1]](diffhunk://#diff-563dd6519cb36fa6faad90201d22eb2c5519770ac44fdc03296dc41101da90e4L167-R169) [[2]](diffhunk://#diff-73ddde6a5a8c8a9782dce540ea62c8ef737a15b6d156a45cecff17313c6cef6dL53-L54)

* Updated test utilities and test code to explicitly call `run_migrations` before using database-backed stores. (`iris-mpc-cpu/src/genesis/state_accessor.rs`, `iris-mpc-cpu/src/hnsw/graph/graph_store.rs`, `iris-mpc-cpu/src/hnsw/graph/test_utils.rs`) [[1]](diffhunk://#diff-56b5c7060b4cae6c051650f29b8e9a50e174d04922038d897687cc1be855bc6bR324) [[2]](diffhunk://#diff-56b5c7060b4cae6c051650f29b8e9a50e174d04922038d897687cc1be855bc6bL373-R376) [[3]](diffhunk://#diff-56b5c7060b4cae6c051650f29b8e9a50e174d04922038d897687cc1be855bc6bL424-R427) [[4]](diffhunk://#diff-73ddde6a5a8c8a9782dce540ea62c8ef737a15b6d156a45cecff17313c6cef6dR529-R539) [[5]](diffhunk://#diff-f994ba708689fd2f1aabc551c6f622484a758c82a8d63f87527f744f8f4a1cafR77)

**Signature and usage updates:**

* Adjusted function signatures and usages throughout the codebase to pass explicit `PgPool` and schema names where needed, reflecting the decoupling of migration logic from client/store construction. (`iris-mpc-bins/bin/iris-mpc-cpu/db_sanity_check.rs`, `iris-mpc-bins/bin/iris-mpc-upgrade/seed_v2_dbs.rs`) [[1]](diffhunk://#diff-0c5af88515b034757578b545f9e81eeafc760a95c83edb3a01615006c7597cefL1079-R1080) [[2]](diffhunk://#diff-177ce3be1eab0299d3d4abed268902baef55c70f287e03cfd734bf6d7e3f9a2fL78-R84)

These changes provide more explicit control over database migrations, improve code clarity, and make database initialization more robust and configurable.