### PR TITLE
chore(POP-4092): Run sidecar at 1pm CEST

### DIFF
--- a/deploy/prod/common-values-ampc-hnsw-graph-persistence-job.yaml
+++ b/deploy/prod/common-values-ampc-hnsw-graph-persistence-job.yaml
@@ -1,7 +1,7 @@
 image: "ghcr.io/worldcoin/iris-mpc-cpu:v0.32.5@sha256:9d61c8672ad6bed5e1591dcf9ff57584b4d5dd265bad2961cbd55ce04d7b1ac8"
 
 environment: prod
-schedule: "10 0 * * *"
+schedule: "0 11 * * *"
 
 env:
   ENV: "prod"


### PR DESCRIPTION
This pull request makes a small change to the scheduling of a job in the `deploy/prod/common-values-ampc-hnsw-graph-persistence-job.yaml` file. The job's cron schedule has been updated.

- Changed the `schedule` value from `"10 0 * * *"` to `"0 11 * * *"` to adjust the time the job runs.