### PR TITLE
feat: exact u16 GEMM via u16-gemm crate, versioned S3 snapshot format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3366,6 +3366,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "u16-gemm",
  "uuid",
 ]
 
@@ -6678,6 +6679,15 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "u16-gemm"
+version = "0.1.0"
+source = "git+https://github.com/philsippl/u16-gemm?branch=main#dfc55281eca60236e967b581ee3c45c471ab550d"
+dependencies = [
+ "cudarc",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "unicode-bidi"

--- a/iris-mpc-db-exporter/main.go
+++ b/iris-mpc-db-exporter/main.go
@@ -65,6 +65,7 @@ func exportCommand() *cobra.Command {
 	var parallelism int
 	var outputFolder string
 	var endIndex int
+	var formatVersion int
 
 	allowedOutputs := []string{"hdd", "s3"}
 
@@ -119,11 +120,12 @@ func exportCommand() *cobra.Command {
 			// Avoid blocking producers by defining a chan buffer in case consumers are slower
 			chanBufferLen := cfg.MaxItemsPerUploadPart * 2
 
-			commands.ExportCommand(ctx, exportMode, outputFolder, *store, converter.NewBinaryConverter(CodeSize, MaskSize, IdSize, VersionIdSize), writer, reader, batchSize, parallelism, endIndex, chanBufferLen)
+			commands.ExportCommand(ctx, exportMode, outputFolder, *store, converter.NewBinaryConverter(CodeSize, MaskSize, IdSize, VersionIdSize, formatVersion), writer, reader, batchSize, parallelism, endIndex, chanBufferLen)
 		},
 	}
 
 	exportCmd.Flags().StringVar(&exportMode, "export-mode", "INCREMENTAL_EXPORT", "Complete or incremental export")
+	exportCmd.Flags().IntVar(&formatVersion, "format-version", converter.FormatLegacyLimbs, "Snapshot record format: 1 = legacy limb planes, 2 = plain little-endian u16 shares")
 	exportCmd.Flags().StringVar(&exportFormat, "export-format", "csv", "Choose which format to convert the data to (csv/binary)")
 	exportCmd.Flags().StringVar(&exportOutput, "export-output", "hdd", "Choose which persistence to use (HDD/S3)")
 	exportCmd.Flags().StringVar(&outputFolder, "output-folder", "output", "Specify the output folder chunks will be written to")

--- a/iris-mpc-db-exporter/src/commands/exportCommand.go
+++ b/iris-mpc-db-exporter/src/commands/exportCommand.go
@@ -154,7 +154,8 @@ func ExportCommand(ctx context.Context, mode, outputFolder string, store iris.St
 
 	// Get current time in unix format. It's stored as BIGINT in postgres
 	unixTime := time.Now().Unix()
-	timestampFilePath := fmt.Sprintf("%s/%s/%d_%d_%d", outputFolder, persistence.TimestampsFolder, unixTime, batchSize, totalIrises)
+	timestampFilePath := fmt.Sprintf("%s/%s/%s", outputFolder, persistence.TimestampsFolder,
+		timestampMarkerName(unixTime, batchSize, totalIrises, converter.FormatVersion()))
 
 	o11y.S(ctx).Infof("Total irises: %d", totalIrises)
 
@@ -245,4 +246,17 @@ func ExportCommand(ctx context.Context, mode, outputFolder string, store iris.St
 
 	// Create the file with the date of the beginning of the export to mark the completion of the export
 	err = writer.Persist(timestampFilePath, []byte{})
+}
+
+// timestampMarkerName builds the snapshot marker file name. Format 1 keeps
+// the historical 3-part name ({unixTime}_{batchSize}_{lastSerialId}); newer
+// formats append the version as a 4th part so importers can select the right
+// record decoder. Record sizes are identical across formats, so the marker
+// name is the only format signal.
+func timestampMarkerName(unixTime int64, batchSize, totalIrises, formatVersion int) string {
+	name := fmt.Sprintf("%d_%d_%d", unixTime, batchSize, totalIrises)
+	if formatVersion != converter.FormatLegacyLimbs {
+		name = fmt.Sprintf("%s_%d", name, formatVersion)
+	}
+	return name
 }

--- a/iris-mpc-db-exporter/src/commands/exportCommand_test.go
+++ b/iris-mpc-db-exporter/src/commands/exportCommand_test.go
@@ -1,0 +1,14 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Format 1 keeps the historical 3-part marker name so existing importers are
+// unaffected; newer formats append the version as a 4th part.
+func TestTimestampMarkerName(t *testing.T) {
+	assert.Equal(t, "1720000000_1000_954", timestampMarkerName(1720000000, 1000, 954, 1))
+	assert.Equal(t, "1720000000_1000_954_2", timestampMarkerName(1720000000, 1000, 954, 2))
+}

--- a/iris-mpc-db-exporter/src/converter/binary.go
+++ b/iris-mpc-db-exporter/src/converter/binary.go
@@ -7,22 +7,55 @@ import (
 	"github.com/worldcoin/iris-mpc-db-exporter/src/iris"
 )
 
+const (
+	// FormatLegacyLimbs (format 1) stores each share as two byte planes with
+	// every u16 half encoded as (byte - 128) — the zero-point limb layout of
+	// the old GPU kernel. Implied by 3-part snapshot marker names.
+	FormatLegacyLimbs = 1
+	// FormatPlainU16 (format 2) stores each share verbatim as little-endian
+	// u16 bytes, identical to the database representation. Importers derive
+	// their compute encoding at load time.
+	FormatPlainU16 = 2
+)
+
 type BinaryConverter struct {
 	SingleRowTotalSize  int
 	SingleCodeSize      int
 	SingleMaskSize      int
 	SingleIdSize        int
 	SingleVersionIdSize int
+	formatVersion       int
 }
 
-func NewBinaryConverter(codeSize, maskSize, idSize, versionIdSize int) *BinaryConverter {
+func NewBinaryConverter(codeSize, maskSize, idSize, versionIdSize, formatVersion int) *BinaryConverter {
+	if formatVersion != FormatLegacyLimbs && formatVersion != FormatPlainU16 {
+		panic(fmt.Sprintf("unsupported export format version %d", formatVersion))
+	}
 	return &BinaryConverter{
 		SingleCodeSize:      codeSize,
 		SingleMaskSize:      maskSize,
 		SingleIdSize:        idSize,
 		SingleVersionIdSize: versionIdSize,
 		SingleRowTotalSize:  (codeSize * 2) + (maskSize * 2) + idSize + versionIdSize,
+		formatVersion:       formatVersion,
 	}
+}
+
+func (c *BinaryConverter) FormatVersion() int {
+	return c.formatVersion
+}
+
+// storeShare writes one share's bytes at `offset` in the layout selected by
+// the converter's format version and returns the next offset. Both layouts
+// occupy exactly len(input) bytes.
+func (c *BinaryConverter) storeShare(input []byte, output []byte, offset int) int {
+	if c.formatVersion == FormatPlainU16 {
+		// The database column already holds little-endian u16 shares; the
+		// plain format is a verbatim copy.
+		copy(output[offset:offset+len(input)], input)
+		return offset + len(input)
+	}
+	return storeAsEvenOddPairs(input, output, offset)
 }
 
 func (c *BinaryConverter) validateStoredIris(iris iris.StoredIris) error {
@@ -75,10 +108,10 @@ func (c *BinaryConverter) Convert(data []iris.StoredIris) ([]byte, error) {
 		// Step 2: Write masks and codes as even odd pairs
 		// Offset points where we left off in this row:
 		offset := start + c.SingleIdSize
-		offset = storeAsEvenOddPairs(item.LeftCode, outputArray, offset)
-		offset = storeAsEvenOddPairs(item.LeftMask, outputArray, offset)
-		offset = storeAsEvenOddPairs(item.RightCode, outputArray, offset)
-		offset = storeAsEvenOddPairs(item.RightMask, outputArray, offset)
+		offset = c.storeShare(item.LeftCode, outputArray, offset)
+		offset = c.storeShare(item.LeftMask, outputArray, offset)
+		offset = c.storeShare(item.RightCode, outputArray, offset)
+		offset = c.storeShare(item.RightMask, outputArray, offset)
 
 		// Step 3: Write version id
 		versionIdBytes := make([]byte, c.SingleVersionIdSize)
@@ -104,10 +137,10 @@ func (c *BinaryConverter) ConvertSingle(item iris.StoredIris) ([]byte, error) {
 	// Step 2: Write masks and codes as even odd pairs
 	// Offsets for subsequent data, observe that the helper is mutating the array in place
 	offset := c.SingleIdSize
-	offset = storeAsEvenOddPairs(item.LeftCode, outputArray, offset)
-	offset = storeAsEvenOddPairs(item.LeftMask, outputArray, offset)
-	offset = storeAsEvenOddPairs(item.RightCode, outputArray, offset)
-	offset = storeAsEvenOddPairs(item.RightMask, outputArray, offset)
+	offset = c.storeShare(item.LeftCode, outputArray, offset)
+	offset = c.storeShare(item.LeftMask, outputArray, offset)
+	offset = c.storeShare(item.RightCode, outputArray, offset)
+	offset = c.storeShare(item.RightMask, outputArray, offset)
 
 	// Step 3: Write version id
 	versionIdBytes := make([]byte, c.SingleVersionIdSize)

--- a/iris-mpc-db-exporter/src/converter/binary_test.go
+++ b/iris-mpc-db-exporter/src/converter/binary_test.go
@@ -16,7 +16,7 @@ import (
 //  2. ID is placed in the first 4 bytes in BigEndian format.
 //  3. Even-odd rearrangement is correct for code and mask data.
 func TestBinaryConverter_ConvertSingle(t *testing.T) {
-	c := NewBinaryConverter(8, 4, 4, 2)
+	c := NewBinaryConverter(8, 4, 4, 2, FormatLegacyLimbs)
 
 	// Build small test data for code/mask
 	leftCode := []byte{128, 129, 130, 131, 132, 133, 134, 135} // length=8, must be even
@@ -247,4 +247,51 @@ func TestStoreAsEvenOddPairs(t *testing.T) {
 	if !bytes.Equal(got, want) {
 		t.Errorf("storeAsEvenOddPairs mismatch.\nGot:  % X\nWant: % X", got, want)
 	}
+}
+
+// TestBinaryConverter_ConvertSingle_PlainU16 verifies that format 2 copies the
+// database bytes (little-endian u16 shares) verbatim, framed by the BE id and
+// version id, and that the record size is identical to format 1.
+func TestBinaryConverter_ConvertSingle_PlainU16(t *testing.T) {
+	c := NewBinaryConverter(8, 4, 4, 2, FormatPlainU16)
+
+	item := iris.StoredIris{
+		ID:        42,
+		LeftCode:  []byte{128, 129, 130, 131, 132, 133, 134, 135},
+		LeftMask:  []byte{140, 141, 142, 143},
+		RightCode: []byte{150, 151, 152, 153, 154, 155, 156, 157},
+		RightMask: []byte{160, 161, 162, 163},
+		VersionID: 55,
+	}
+
+	output, err := c.ConvertSingle(item)
+	assert.NoError(t, err)
+	assert.Equal(t, c.SingleRowTotalSize, len(output))
+
+	legacy := NewBinaryConverter(8, 4, 4, 2, FormatLegacyLimbs)
+	legacyOutput, err := legacy.ConvertSingle(item)
+	assert.NoError(t, err)
+	assert.Equal(t, len(legacyOutput), len(output), "formats must have identical record sizes")
+
+	assert.Equal(t, uint32(42), binary.BigEndian.Uint32(output[0:4]))
+
+	offset := 4
+	for _, share := range [][]byte{item.LeftCode, item.LeftMask, item.RightCode, item.RightMask} {
+		assert.Equal(t, share, output[offset:offset+len(share)], "plain u16 shares must be copied verbatim")
+		offset += len(share)
+	}
+
+	assert.Equal(t, uint16(55), binary.BigEndian.Uint16(output[offset:offset+2]))
+}
+
+// TestNewBinaryConverter_RejectsUnknownFormat ensures unknown format versions
+// cannot be constructed (a wrong format would silently write undecodable
+// snapshots, since record sizes match across formats).
+func TestNewBinaryConverter_RejectsUnknownFormat(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic for unknown format version, got no panic")
+		}
+	}()
+	NewBinaryConverter(8, 4, 4, 2, 3)
 }

--- a/iris-mpc-db-exporter/src/converter/interface.go
+++ b/iris-mpc-db-exporter/src/converter/interface.go
@@ -4,6 +4,9 @@ import "github.com/worldcoin/iris-mpc-db-exporter/src/iris"
 
 type Converter interface {
 	GetExtension() string
+	// FormatVersion identifies the on-disk record layout (see the Format*
+	// constants); it is appended to the snapshot marker name for versions > 1.
+	FormatVersion() int
 	Convert(data []iris.StoredIris) ([]byte, error)
 	ConvertSingle(data iris.StoredIris) ([]byte, error)
 }

--- a/iris-mpc-db-exporter/test/e2e_binary_hdd_export_test.go
+++ b/iris-mpc-db-exporter/test/e2e_binary_hdd_export_test.go
@@ -214,7 +214,7 @@ func TestDBExporting(t *testing.T) {
 	reader = &persistence.FilesystemReader{}
 	writer = &persistence.FilesystemWriter{}
 
-	commands.ExportCommand(ctx, "COMPLETE_EXPORT", "test_output", *store, converter.NewBinaryConverter(cfg.SingleCodeSize, cfg.SingleMaskSize, 4, 2), writer, reader, 503, 2, 0, 200)
+	commands.ExportCommand(ctx, "COMPLETE_EXPORT", "test_output", *store, converter.NewBinaryConverter(cfg.SingleCodeSize, cfg.SingleMaskSize, 4, 2, converter.FormatLegacyLimbs), writer, reader, 503, 2, 0, 200)
 
 	files, err := getFilesWithExtension("test_output", ".bin")
 	if err != nil {

--- a/iris-mpc-gpu/Cargo.toml
+++ b/iris-mpc-gpu/Cargo.toml
@@ -23,6 +23,7 @@ num-traits.workspace = true
 rand.workspace = true
 static_assertions.workspace = true
 iris-mpc-common = { path = "../iris-mpc-common" }
+u16-gemm = { git = "https://github.com/philsippl/u16-gemm", branch = "main" }
 iris-mpc-cpu = { path = "../iris-mpc-cpu" }
 metrics.workspace = true
 memmap2.workspace = true

--- a/iris-mpc-gpu/benches/matmul.rs
+++ b/iris-mpc-gpu/benches/matmul.rs
@@ -49,7 +49,6 @@ fn bench_memcpy(c: &mut Criterion) {
             let preprocessed_query = device_manager
                 .htod_transfer_query(&preprocessed_query, &streams, QUERY_SIZE, IRIS_CODE_LENGTH)
                 .unwrap();
-            let query_sums = engine.query_sums(&preprocessed_query, &streams, &blass);
             engine.dot(
                 &preprocessed_query,
                 &db_slices.code_gr,
@@ -58,7 +57,7 @@ fn bench_memcpy(c: &mut Criterion) {
                 &streams,
                 &blass,
             );
-            engine.dot_reduce(&query_sums, &db_slices.code_sums_gr, &db_sizes, 0, &streams);
+            engine.dot_reduce(&db_sizes, &streams);
             device_manager.await_streams(&streams);
         });
     });

--- a/iris-mpc-gpu/src/dot/kernel.cu
+++ b/iris-mpc-gpu/src/dot/kernel.cu
@@ -13,17 +13,15 @@ extern "C" __global__ void xor_assign_u8(U8 *lhs, U8 *rhs, size_t n)
     }
 }
 
-extern "C" __global__ void matmul_correct_and_reduce(int *c, unsigned short *output, int *a0Sums, int *a1Sums, int *b0Sums, int *b1Sums, size_t dbLength, size_t numElements, size_t offset, unsigned short multiplier, unsigned short *rngMasks0, unsigned short *rngMasks1)
+// The balanced-limb GEMM (see the u16-gemm crate) is exact mod 2^16, so the
+// epilogue is a plain truncation: two's-complement i32 -> u16 IS reduction
+// mod 2^16. No zero-point corrections, no sums.
+extern "C" __global__ void matmul_reduce(int *c, unsigned short *output, size_t numElements, unsigned short multiplier, unsigned short *rngMasks0, unsigned short *rngMasks1)
 {
     size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx < numElements)
     {
-        unsigned int queryIdx = idx / dbLength;
-        unsigned int dbIdx = idx % dbLength;
-        int s0 = a0Sums[offset + dbIdx] + b0Sums[queryIdx];
-        int s1 = a1Sums[offset + dbIdx] + b1Sums[queryIdx];
-        unsigned short result = c[idx] + (s0 << 7) + ((s0 + s1) << 15);
-        output[idx] = result * multiplier + rngMasks0[idx] - rngMasks1[idx];
+        output[idx] = (unsigned short)c[idx] * multiplier + rngMasks0[idx] - rngMasks1[idx];
     }
 }
 

--- a/iris-mpc-gpu/src/dot/share_db.rs
+++ b/iris-mpc-gpu/src/dot/share_db.rs
@@ -407,7 +407,7 @@ impl ShareDB {
             .device_manager
             .devices()
             .iter()
-            .map(|_device| unsafe {
+            .map(|_device| {
                 let host_mem0 = MmapMut::map_anon(max_size * self.code_length).unwrap();
                 let host_mem1 = MmapMut::map_anon(max_size * self.code_length).unwrap();
 

--- a/iris-mpc-gpu/src/dot/share_db.rs
+++ b/iris-mpc-gpu/src/dot/share_db.rs
@@ -3,28 +3,16 @@ use crate::{
     helpers::{
         comm::NcclComm,
         device_manager::DeviceManager,
-        dtod_at_offset, dtoh_at_offset, launch_config_from_elements_and_threads,
-        query_processor::{
-            CudaVec2DSlicer, CudaVec2DSlicerRawPointer, CudaVec2DSlicerU32, CudaVec2DSlicerU8,
-            StreamAwareCudaSlice,
-        },
+        dtoh_at_offset, launch_config_from_elements_and_threads,
+        query_processor::{CudaVec2DSlicer, CudaVec2DSlicerRawPointer, CudaVec2DSlicerU8},
         DEFAULT_LAUNCH_CONFIG_THREADS,
     },
     rng::chacha::ChaChaCudaRng,
     threshold_ring::protocol::ChunkShareView,
 };
-use core::panic;
 use cudarc::{
-    cublas::{
-        result::gemm_ex,
-        sys::{self, lib},
-        CudaBlas,
-    },
-    driver::{
-        result::{self, malloc_async},
-        sys::CUdeviceptr,
-        CudaFunction, CudaSlice, CudaStream, CudaView, DevicePtr, DeviceSlice, LaunchAsync,
-    },
+    cublas::CudaBlas,
+    driver::{CudaFunction, CudaSlice, CudaStream, CudaView, DevicePtr, DeviceSlice, LaunchAsync},
     nccl,
     nvrtc::compile_ptx,
 };
@@ -32,100 +20,37 @@ use itertools::{izip, Itertools};
 use memmap2::MmapMut;
 use rayon::prelude::*;
 use std::{
-    ffi::{c_void, CStr},
     mem::{self, forget},
     sync::Arc,
 };
+use u16_gemm::{encode_slice, gemm_i32_raw};
 
 const PTX_SRC: &str = include_str!("kernel.cu");
-const REDUCE_FUNCTION_NAME: &str = "matmul_correct_and_reduce";
+const REDUCE_FUNCTION_NAME: &str = "matmul_reduce";
 const XOR_ASSIGN_U8_NAME: &str = "xor_assign_u8";
-const LIMBS: usize = 2;
 
+/// Encode u16 values into the two balanced-limb i8 planes consumed by the
+/// GEMM engine (see the `u16-gemm` crate): `x ≡ s0 + 2^8·s1 (mod 2^16)` with
+/// `s0, s1 ∈ [-128, 127]`, which makes the three i8 limb GEMMs exact with no
+/// zero-point corrections.
 pub fn preprocess_query(query: &[u16]) -> Vec<Vec<u8>> {
-    let mut result = vec![];
-    for _ in 0..LIMBS {
-        result.push(vec![0u8; query.len()]);
-    }
-
-    for (idx, &entry) in query.iter().enumerate() {
-        for i in 0..LIMBS {
-            let tmp = (entry as u32 >> (i * 8)) as u8;
-            result[i][idx] = (tmp as i32 - 128) as u8;
-        }
-    }
-
-    result
-}
-
-#[allow(clippy::too_many_arguments)]
-pub fn gemm(
-    handle: &CudaBlas,
-    a: CUdeviceptr,
-    b: CUdeviceptr,
-    c: CUdeviceptr,
-    a_offset: u64,
-    b_offset: u64,
-    c_offset: u64,
-    m: usize,
-    n: usize,
-    k: usize,
-    alpha: i32,
-    beta: i32,
-) {
-    // https://docs.nvidia.com/cuda/cublas/#cublasgemmex:
-    // "CUBLAS_COMPUTE_32I and CUBLAS_COMPUTE_32I_PEDANTIC compute types are only supported with A, B being 4-byte aligned and lda, ldb being multiples of 4."
-    assert!(m.is_multiple_of(4), "m must be a multiple of 4");
-    // We don't enforce the following, since we use it for n=1 and emperial testing
-    // shows that it works. assert!(n.is_multiple_of(4), "n must be a multiple of 4");
-    assert!(a.is_multiple_of(4), "a must be aligned to 4 bytes");
-    assert!(b.is_multiple_of(4), "b must be aligned to 4 bytes");
-    unsafe {
-        let status = gemm_ex(
-            *handle.handle(),
-            sys::cublasOperation_t::CUBLAS_OP_T,
-            sys::cublasOperation_t::CUBLAS_OP_N,
-            m as i32,
-            n as i32,
-            k as i32,
-            &alpha as *const i32 as *const c_void,
-            (a + a_offset) as *const _,
-            sys::cublasDataType_t::CUDA_R_8I,
-            k as i32,
-            (b + b_offset) as *const _,
-            sys::cublasDataType_t::CUDA_R_8I,
-            k as i32,
-            &beta as *const i32 as *const c_void,
-            (c + c_offset) as *mut _,
-            sys::cublasDataType_t::CUDA_R_32I,
-            m as i32,
-            sys::cublasComputeType_t::CUBLAS_COMPUTE_32I_PEDANTIC,
-            sys::cublasGemmAlgo_t::CUBLAS_GEMM_DEFAULT,
-        );
-
-        // Try to fetch more information in case of an error
-        if let Err(e) = status {
-            let c_str = CStr::from_ptr(lib().cublasGetStatusString(e.0));
-            panic!("CUBLAS error: {:?}", c_str.to_str());
-        }
-    }
+    let (limb_0, limb_1) = encode_slice(query);
+    vec![limb_0, limb_1]
 }
 
 pub struct SlicedProcessedDatabase {
     pub code_gr: CudaVec2DSlicerRawPointer,
-    pub code_sums_gr: CudaVec2DSlicerU32,
 }
 
 pub struct DBChunkBuffers {
     pub limb_0: Vec<CudaSlice<u8>>,
     pub limb_1: Vec<CudaSlice<u8>>,
-    pub sums: CudaVec2DSlicer<u32>,
 }
 
-/// A single preprocessed database slice (code limbs + per-record sums) in a
-/// backing store. Encapsulates the record-movement operations on the slice:
-/// loading individual records, in-place updates, preprocessing, and prefetching
-/// into the matmul engine's chunk buffers.
+/// A single preprocessed database slice (code limb planes) in a backing
+/// store. Encapsulates the record-movement operations on the slice: loading
+/// individual records, in-place updates, and prefetching into the matmul
+/// engine's chunk buffers.
 ///
 /// The GPU/engine context (`code_length`, device manager, kernels, streams) is
 /// supplied via the `&ShareDB` `engine` parameter rather than owned by the
@@ -143,23 +68,18 @@ pub trait ProcessedDatabase {
         a1_host: &[u8],
     );
 
-    /// In-place update of an existing entry from device-resident query/sum
+    /// In-place update of an existing entry from device-resident query
     /// buffers (the insertion/reauth path).
     #[allow(clippy::too_many_arguments)]
     fn write_at_index(
         &self,
         engine: &ShareDB,
         query: &CudaVec2DSlicerU8,
-        sums: &CudaVec2DSlicerU32,
         src_index: usize,
         dst_index: usize,
         device_index: usize,
         streams: &[CudaStream],
     );
-
-    /// Compute and upload the per-record sums for `db_lens` records per device.
-    /// Called once after all records have been loaded.
-    fn preprocess(&mut self, engine: &ShareDB, db_lens: &[usize]);
 
     /// Copy a contiguous chunk of the store into device-side `buffers`.
     fn prefetch_chunk(
@@ -172,8 +92,7 @@ pub trait ProcessedDatabase {
         streams: &[CudaStream],
     );
 
-    /// Copy a selected subset (by index), together with their sums, into the
-    /// device-side `buffers`.
+    /// Copy a selected subset (by index) into the device-side `buffers`.
     fn prefetch_subset(
         &self,
         engine: &ShareDB,
@@ -216,7 +135,6 @@ impl ProcessedDatabase for SlicedProcessedDatabase {
         &self,
         engine: &ShareDB,
         query: &CudaVec2DSlicerU8,
-        sums: &CudaVec2DSlicerU32,
         src_index: usize,
         dst_index: usize,
         device_index: usize,
@@ -241,57 +159,6 @@ impl ProcessedDatabase for SlicedProcessedDatabase {
                 code_length,
                 streams[device_index].stream,
             );
-
-            dtod_at_offset(
-                *self.code_sums_gr.limb_0[device_index].device_ptr(),
-                dst_index * mem::size_of::<u32>(),
-                *sums.limb_0[device_index].device_ptr(),
-                mem::size_of::<u32>() * 15 + src_index * mem::size_of::<u32>() * ROTATIONS,
-                mem::size_of::<u32>(),
-                streams[device_index].stream,
-            );
-
-            dtod_at_offset(
-                *self.code_sums_gr.limb_1[device_index].device_ptr(),
-                dst_index * mem::size_of::<u32>(),
-                *sums.limb_1[device_index].device_ptr(),
-                mem::size_of::<u32>() * 15 + src_index * mem::size_of::<u32>() * ROTATIONS,
-                mem::size_of::<u32>(),
-                streams[device_index].stream,
-            );
-        }
-    }
-
-    fn preprocess(&mut self, engine: &ShareDB, db_lens: &[usize]) {
-        let code_len = engine.code_length;
-        for device_index in 0..engine.device_manager.device_count() {
-            for (limbs, sum_slices) in [
-                (&self.code_gr.limb_0, &mut self.code_sums_gr.limb_0),
-                (&self.code_gr.limb_1, &mut self.code_sums_gr.limb_1),
-            ] {
-                let sums = (0..db_lens[device_index])
-                    .into_par_iter()
-                    .map(|idx| {
-                        let slice: &[i8] = unsafe {
-                            std::slice::from_raw_parts(
-                                (limbs[device_index] + (idx * code_len) as u64) as *const _,
-                                code_len,
-                            )
-                        };
-                        slice.iter().map(|&x| x as u32).sum::<u32>()
-                    })
-                    .collect::<Vec<_>>();
-
-                engine
-                    .device_manager
-                    .device(device_index)
-                    .bind_to_thread()
-                    .unwrap();
-                unsafe {
-                    result::memcpy_htod_sync(sum_slices[device_index].cu_device_ptr, &sums)
-                        .unwrap();
-                }
-            }
         }
     }
 
@@ -379,28 +246,6 @@ impl ProcessedDatabase for SlicedProcessedDatabase {
                         )
                         .result()
                         .unwrap();
-                    cudarc::driver::sys::lib()
-                        .cuMemcpyDtoDAsync_v2(
-                            *buffers.sums.limb_0[idx].device_ptr()
-                                + (offset * size_of::<u32>()) as u64,
-                            self.code_sums_gr.limb_0[idx].device_ptr()
-                                + (*wanted_idx as usize * size_of::<u32>()) as u64,
-                            size_of::<u32>(),
-                            streams[idx].stream,
-                        )
-                        .result()
-                        .unwrap();
-                    cudarc::driver::sys::lib()
-                        .cuMemcpyDtoDAsync_v2(
-                            *buffers.sums.limb_1[idx].device_ptr()
-                                + (offset * size_of::<u32>()) as u64,
-                            self.code_sums_gr.limb_1[idx].device_ptr()
-                                + (*wanted_idx as usize * size_of::<u32>()) as u64,
-                            size_of::<u32>(),
-                            streams[idx].stream,
-                        )
-                        .result()
-                        .unwrap();
                 }
             }
         }
@@ -409,9 +254,8 @@ impl ProcessedDatabase for SlicedProcessedDatabase {
 
 impl SlicedProcessedDatabase {
     /// Load every record from `db_entries` (flat u16, length a multiple of the
-    /// engine's code length) into the store, then preprocess. Returns the
-    /// per-device record counts. Composes the per-record loads with
-    /// [`ProcessedDatabase::preprocess`].
+    /// engine's code length) into the store. Returns the per-device record
+    /// counts.
     #[allow(clippy::type_complexity)]
     pub fn load_full_db(&mut self, engine: &ShareDB, db_entries: &[u16]) -> Vec<usize> {
         assert!(db_entries.len().is_multiple_of(engine.code_length));
@@ -439,8 +283,6 @@ impl SlicedProcessedDatabase {
             }
         }
 
-        self.preprocess(engine, &db_lens);
-
         db_lens
     }
 }
@@ -454,7 +296,6 @@ pub struct ShareDB {
     xor_assign_u8_kernels: Vec<CudaFunction>,
     rngs: Vec<(ChaChaCudaRng, ChaChaCudaRng)>,
     comms: Vec<Arc<NcclComm>>,
-    ones: Vec<CudaSlice<u8>>,
     intermediate_results: Vec<CudaSlice<i32>>,
     pub results: Vec<CudaSlice<u8>>,
     pub results_peer: Vec<CudaSlice<u8>>,
@@ -498,11 +339,6 @@ impl ShareDB {
                     .unwrap()
             })
             .collect_vec();
-
-        let ones = vec![1u8; code_length];
-        let ones = (0..n_devices)
-            .map(|idx| device_manager.device(idx).htod_sync_copy(&ones).unwrap())
-            .collect::<Vec<_>>();
 
         // TODO: depending on the batch size, intermediate_results can get quite big, we
         // can perform the gemm in chunks to limit this
@@ -559,7 +395,6 @@ impl ShareDB {
             is_remote: !comms.is_empty(),
             comms,
             intermediate_results,
-            ones,
             results,
             results_peer,
             code_length,
@@ -568,11 +403,11 @@ impl ShareDB {
 
     pub fn alloc_db(&self, max_db_length: usize) -> SlicedProcessedDatabase {
         let max_size = max_db_length / self.device_manager.device_count();
-        let (db0_sums, (db1_sums, (db0, db1))) = self
+        let (db0, db1) = self
             .device_manager
             .devices()
             .iter()
-            .map(|device| unsafe {
+            .map(|_device| unsafe {
                 let host_mem0 = MmapMut::map_anon(max_size * self.code_length).unwrap();
                 let host_mem1 = MmapMut::map_anon(max_size * self.code_length).unwrap();
 
@@ -585,13 +420,7 @@ impl ShareDB {
                 forget(host_mem0);
                 forget(host_mem1);
 
-                (
-                    StreamAwareCudaSlice::from(device.alloc(max_size).unwrap()),
-                    (
-                        StreamAwareCudaSlice::from(device.alloc(max_size).unwrap()),
-                        (host_mem0_ptr, host_mem1_ptr),
-                    ),
-                )
+                (host_mem0_ptr, host_mem1_ptr)
             })
             .unzip();
 
@@ -603,10 +432,6 @@ impl ShareDB {
             code_gr: CudaVec2DSlicerRawPointer {
                 limb_0: db0,
                 limb_1: db1,
-            },
-            code_sums_gr: CudaVec2DSlicerU32 {
-                limb_0: db0_sums,
-                limb_1: db1_sums,
             },
         }
     }
@@ -620,15 +445,7 @@ impl ShareDB {
     ) {
         assert_eq!(record.len(), code_length);
 
-        let a0_host = record
-            .iter()
-            .map(|&x| ((x as i8) as i32 - 128) as i8)
-            .collect::<Vec<_>>();
-
-        let a1_host = record
-            .iter()
-            .map(|&x: &u16| ((x >> 8) as i32 - 128) as i8)
-            .collect::<Vec<_>>();
+        let (a0_host, a1_host) = encode_slice(record);
 
         let device_index = index % n_shards;
         let device_db_index = index / n_shards;
@@ -659,110 +476,38 @@ impl ShareDB {
         assert_eq!(a0_host.len(), code_length);
         assert_eq!(a1_host.len(), code_length);
 
+        // The S3 planes use the legacy offset encoding (each u16 half stored
+        // as `byte ^ 0x80`); remap them to the balanced limb encoding the
+        // GEMM engine expects: limb0 = low byte, limb1 = high byte + carry of
+        // limb0's sign bit (see `u16_gemm::encode_u16`).
+        let limb_0: Vec<u8> = a0_host.iter().map(|&b| b ^ 0x80).collect();
+        let limb_1: Vec<u8> = limb_0
+            .iter()
+            .zip(a1_host.iter())
+            .map(|(&lo, &hi)| (hi ^ 0x80).wrapping_add(lo >> 7))
+            .collect();
+
         let device_index = index % n_shards;
         let device_db_index = index / n_shards;
 
         unsafe {
             std::ptr::copy(
-                a0_host.as_ptr() as *const _,
+                limb_0.as_ptr() as *const _,
                 (db.limb_0[device_index] + (device_db_index * code_length) as u64) as *mut _,
                 code_length,
             );
 
             std::ptr::copy(
-                a1_host.as_ptr() as *const _,
+                limb_1.as_ptr() as *const _,
                 (db.limb_1[device_index] + (device_db_index * code_length) as u64) as *mut _,
                 code_length,
             );
         };
     }
 
-    pub fn query_sums(
-        &self,
-        query_ptrs: &CudaVec2DSlicerU8,
-        streams: &[CudaStream],
-        blass: &[CudaBlas],
-    ) -> CudaVec2DSlicerU32 {
-        let mut query1_sums = vec![];
-        let mut query0_sums = vec![];
-
-        for idx in 0..self.device_manager.device_count() {
-            let device = self.device_manager.device(idx);
-            device.bind_to_thread().unwrap();
-
-            let query0 = &query_ptrs.limb_0[idx];
-            let query1 = &query_ptrs.limb_1[idx];
-
-            let query0_sum = unsafe {
-                malloc_async(
-                    streams[idx].stream,
-                    self.query_length * mem::size_of::<u32>(),
-                )
-                .unwrap()
-            };
-            let slice0_sum = StreamAwareCudaSlice::<u32>::upgrade_ptr_stream(
-                query0_sum,
-                streams[idx].stream,
-                self.query_length,
-            );
-
-            let query1_sum = unsafe {
-                malloc_async(
-                    streams[idx].stream,
-                    self.query_length * mem::size_of::<u32>(),
-                )
-                .unwrap()
-            };
-
-            let slice1_sum = StreamAwareCudaSlice::<u32>::upgrade_ptr_stream(
-                query1_sum,
-                streams[idx].stream,
-                self.query_length,
-            );
-
-            gemm(
-                &blass[idx],
-                *query0.device_ptr(),
-                *self.ones[idx].device_ptr(),
-                query0_sum,
-                0,
-                0,
-                0,
-                self.query_length,
-                1,
-                self.code_length,
-                1,
-                0,
-            );
-            gemm(
-                &blass[idx],
-                *query1.device_ptr(),
-                *self.ones[idx].device_ptr(),
-                query1_sum,
-                0,
-                0,
-                0,
-                self.query_length,
-                1,
-                self.code_length,
-                1,
-                0,
-            );
-
-            query0_sums.push(slice0_sum);
-            query1_sums.push(slice1_sum);
-        }
-        CudaVec2DSlicer {
-            limb_0: query0_sums,
-            limb_1: query1_sums,
-        }
-    }
-
     pub fn alloc_db_chunk_buffer(&self, max_chunk_size: usize) -> DBChunkBuffers {
         let mut limb_0 = vec![];
         let mut limb_1 = vec![];
-        let mut sums_0 = vec![];
-        let mut sums_1 = vec![];
         for device in self.device_manager.devices() {
             limb_0.push(
                 device
@@ -774,21 +519,8 @@ impl ShareDB {
                     .alloc_zeros(max_chunk_size * self.code_length)
                     .unwrap(),
             );
-            sums_0.push(StreamAwareCudaSlice::from(
-                device.alloc_zeros(max_chunk_size).unwrap(),
-            ));
-            sums_1.push(StreamAwareCudaSlice::from(
-                device.alloc_zeros(max_chunk_size).unwrap(),
-            ));
         }
-        DBChunkBuffers {
-            limb_0,
-            limb_1,
-            sums: CudaVec2DSlicer {
-                limb_0: sums_0,
-                limb_1: sums_1,
-            },
-        }
+        DBChunkBuffers { limb_0, limb_1 }
     }
 
     pub fn dot<T>(
@@ -812,37 +544,27 @@ impl ShareDB {
                 self.rngs[idx].1.fill_rng_no_host_copy(len, &streams[idx]);
             }
 
-            for (i, d) in [db.limb_0[idx], db.limb_1[idx]].into_iter().enumerate() {
-                for (j, q) in [query0, query1].iter().enumerate() {
-                    if i + j >= LIMBS {
-                        continue;
-                    }
-                    gemm(
-                        &blass[idx],
-                        d,
-                        *q.device_ptr(),
-                        *self.intermediate_results[idx].device_ptr(),
-                        (offset * self.code_length) as u64,
-                        0,
-                        0,
-                        chunk_sizes[idx],
-                        self.query_length,
-                        self.code_length,
-                        1 << (8 * (i + j)),
-                        if i + j == 0 { 0 } else { 1 },
-                    );
-                }
+            let db_offset = (offset * self.code_length) as u64;
+            unsafe {
+                gemm_i32_raw(
+                    &blass[idx],
+                    db.limb_0[idx] + db_offset,
+                    db.limb_1[idx] + db_offset,
+                    *query0.device_ptr(),
+                    *query1.device_ptr(),
+                    *self.intermediate_results[idx].device_ptr(),
+                    chunk_sizes[idx],
+                    self.query_length,
+                    self.code_length,
+                )
+                .expect("u16 limb GEMM failed");
             }
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn dot_reduce_and_multiply(
         &mut self,
-        query_sums: &CudaVec2DSlicerU32,
-        db_sums: &CudaVec2DSlicerU32,
         chunk_sizes: &[usize],
-        offset: usize,
         streams: &[CudaStream],
         multiplier: u16,
     ) {
@@ -868,13 +590,7 @@ impl ShareDB {
                         (
                             &self.intermediate_results[idx],
                             &mut self.results[idx],
-                            *db_sums.limb_0[idx].device_ptr(),
-                            *db_sums.limb_1[idx].device_ptr(),
-                            *query_sums.limb_0[idx].device_ptr(),
-                            *query_sums.limb_1[idx].device_ptr(),
-                            chunk_sizes[idx] as u64,
                             (chunk_sizes[idx] * self.query_length) as u64,
-                            offset as u64,
                             multiplier,
                             self.rngs[idx].0.cuda_slice().unwrap(),
                             self.rngs[idx].1.cuda_slice().unwrap(),
@@ -885,15 +601,8 @@ impl ShareDB {
         }
     }
 
-    pub fn dot_reduce(
-        &mut self,
-        query_sums: &CudaVec2DSlicerU32,
-        db_sums: &CudaVec2DSlicerU32,
-        chunk_sizes: &[usize],
-        offset: usize,
-        streams: &[CudaStream],
-    ) {
-        self.dot_reduce_and_multiply(query_sums, db_sums, chunk_sizes, offset, streams, 1);
+    pub fn dot_reduce(&mut self, chunk_sizes: &[usize], streams: &[CudaStream]) {
+        self.dot_reduce_and_multiply(chunk_sizes, streams, 1);
     }
 
     fn single_xor_assign_u8(
@@ -1145,7 +854,6 @@ mod tests {
         let preprocessed_query = device_manager
             .htod_transfer_query(&preprocessed_query, &streams, QUERY_SIZE, IRIS_CODE_LENGTH)
             .unwrap();
-        let query_sums = engine.query_sums(&preprocessed_query, &streams, &blass);
         let mut db_slices = engine.alloc_db(DB_SIZE);
         device_manager.register_host_memory(&db_slices, DB_SIZE, IRIS_CODE_LENGTH);
         let db_sizes = db_slices.load_full_db(&engine, &db);
@@ -1158,7 +866,7 @@ mod tests {
             &streams,
             &blass,
         );
-        engine.dot_reduce(&query_sums, &db_slices.code_sums_gr, &db_sizes, 0, &streams);
+        engine.dot_reduce(&db_sizes, &streams);
         device_manager.await_streams(&streams);
 
         let a_nda = random_ndarray::<u16>(shard_db(&db, n_devices), DB_SIZE, WIDTH);
@@ -1247,7 +955,6 @@ mod tests {
             let preprocessed_query = device_manager
                 .htod_transfer_query(&preprocessed_query, &streams, QUERY_SIZE, IRIS_CODE_LENGTH)
                 .unwrap();
-            let query_sums = engine.query_sums(&preprocessed_query, &streams, &blass);
             let mut db_slices = engine.alloc_db(DB_SIZE);
             device_manager.register_host_memory(&db_slices, DB_SIZE, IRIS_CODE_LENGTH);
             let db_sizes = db_slices.load_full_db(&engine, &codes_db);
@@ -1260,7 +967,7 @@ mod tests {
                 &streams,
                 &blass,
             );
-            engine.dot_reduce(&query_sums, &db_slices.code_sums_gr, &db_sizes, 0, &streams);
+            engine.dot_reduce(&db_sizes, &streams);
             device_manager.await_streams(&streams);
             engine.fetch_results(&mut gpu_result[i], &db_sizes, 0);
         }
@@ -1377,8 +1084,6 @@ mod tests {
             let mask_query = device_manager
                 .htod_transfer_query(&mask_query, &streams, QUERY_SIZE, MASK_CODE_LENGTH)
                 .unwrap();
-            let code_query_sums = codes_engine.query_sums(&code_query, &streams, &blass);
-            let mask_query_sums = masks_engine.query_sums(&mask_query, &streams, &blass);
             let mut code_db_slices = codes_engine.alloc_db(DB_SIZE);
             let db_sizes = code_db_slices.load_full_db(&codes_engine, &codes_db);
             let mut mask_db_slices = masks_engine.alloc_db(DB_SIZE);
@@ -1405,21 +1110,8 @@ mod tests {
                 &blass,
             );
 
-            codes_engine.dot_reduce(
-                &code_query_sums,
-                &code_db_slices.code_sums_gr,
-                &db_sizes,
-                0,
-                &streams,
-            );
-            masks_engine.dot_reduce_and_multiply(
-                &mask_query_sums,
-                &mask_db_slices.code_sums_gr,
-                &db_sizes,
-                0,
-                &streams,
-                2,
-            );
+            codes_engine.dot_reduce(&db_sizes, &streams);
+            masks_engine.dot_reduce_and_multiply(&db_sizes, &streams, 2);
 
             device_manager.await_streams(&streams);
 

--- a/iris-mpc-gpu/src/helpers/query_processor.rs
+++ b/iris-mpc-gpu/src/helpers/query_processor.rs
@@ -1,6 +1,6 @@
 use crate::{
     dot::{
-        share_db::{DBChunkBuffers, ShareDB, SlicedProcessedDatabase},
+        share_db::{DBChunkBuffers, ShareDB},
         IRIS_CODE_LENGTH, MASK_CODE_LENGTH,
     },
     helpers::device_manager::DeviceManager,
@@ -102,7 +102,6 @@ pub struct CudaVec2DSlicer<T> {
     pub limb_1: Vec<StreamAwareCudaSlice<T>>,
 }
 
-pub type CudaVec2DSlicerU32 = CudaVec2DSlicer<u32>;
 pub type CudaVec2DSlicerU8 = CudaVec2DSlicer<u8>;
 pub type CudaVec2DSlicerI8 = CudaVec2DSlicer<i8>;
 
@@ -157,21 +156,6 @@ pub struct DeviceCompactQuery {
 }
 
 impl DeviceCompactQuery {
-    pub fn query_sums(
-        &self,
-        code_engine: &ShareDB,
-        mask_engine: &ShareDB,
-        streams: &[CudaStream],
-        blass: &[CudaBlas],
-    ) -> Result<DeviceCompactSums> {
-        Ok(DeviceCompactSums {
-            code_query: code_engine.query_sums(&self.code_query, streams, blass),
-            mask_query: mask_engine.query_sums(&self.mask_query, streams, blass),
-            code_query_insert: code_engine.query_sums(&self.code_query_insert, streams, blass),
-            mask_query_insert: mask_engine.query_sums(&self.mask_query_insert, streams, blass),
-        })
-    }
-
     pub fn compute_dot_products(
         &self,
         code_engine: &mut ShareDB,
@@ -233,85 +217,15 @@ impl DeviceCompactQuery {
         );
     }
 }
-pub struct DeviceCompactSums {
-    code_query: CudaVec2DSlicerU32,
-    mask_query: CudaVec2DSlicerU32,
-    pub code_query_insert: CudaVec2DSlicerU32,
-    pub mask_query_insert: CudaVec2DSlicerU32,
-}
 
-impl DeviceCompactSums {
-    pub fn compute_dot_reducers(
-        &self,
-        code_engine: &mut ShareDB,
-        mask_engine: &mut ShareDB,
-        db_sizes: &[usize],
-        offset: usize,
-        streams: &[CudaStream],
-    ) {
-        code_engine.dot_reduce(
-            &self.code_query,
-            &self.code_query_insert,
-            db_sizes,
-            offset,
-            streams,
-        );
-        mask_engine.dot_reduce_and_multiply(
-            &self.mask_query,
-            &self.mask_query_insert,
-            db_sizes,
-            offset,
-            streams,
-            2,
-        );
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    pub fn compute_dot_reducer_against_db(
-        &self,
-        code_engine: &mut ShareDB,
-        mask_engine: &mut ShareDB,
-        sliced_code_db: &SlicedProcessedDatabase,
-        sliced_mask_db: &SlicedProcessedDatabase,
-        database_sizes: &[usize],
-        offset: usize,
-        streams: &[CudaStream],
-    ) {
-        code_engine.dot_reduce(
-            &self.code_query,
-            &sliced_code_db.code_sums_gr,
-            database_sizes,
-            offset,
-            streams,
-        );
-        mask_engine.dot_reduce_and_multiply(
-            &self.mask_query,
-            &sliced_mask_db.code_sums_gr,
-            database_sizes,
-            offset,
-            streams,
-            2,
-        );
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    pub fn compute_dot_reducer_against_prepared_db(
-        &self,
-        code_engine: &mut ShareDB,
-        mask_engine: &mut ShareDB,
-        code_sums_gr: &CudaVec2DSlicer<u32>,
-        mask_sums_gr: &CudaVec2DSlicer<u32>,
-        database_sizes: &[usize],
-        streams: &[CudaStream],
-    ) {
-        code_engine.dot_reduce(&self.code_query, code_sums_gr, database_sizes, 0, streams);
-        mask_engine.dot_reduce_and_multiply(
-            &self.mask_query,
-            mask_sums_gr,
-            database_sizes,
-            0,
-            streams,
-            2,
-        );
-    }
+/// Reduce the accumulated dot products of both engines into u16 result
+/// shares (masks are multiplied by 2 as required by the protocol).
+pub fn compute_dot_reducers(
+    code_engine: &mut ShareDB,
+    mask_engine: &mut ShareDB,
+    db_sizes: &[usize],
+    streams: &[CudaStream],
+) {
+    code_engine.dot_reduce(db_sizes, streams);
+    mask_engine.dot_reduce_and_multiply(db_sizes, streams, 2);
 }

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -13,7 +13,7 @@ use crate::{
         device_manager::DeviceManager,
         htod_on_stream_sync,
         query_processor::{
-            CompactQuery, CudaVec2DSlicerRawPointer, DeviceCompactQuery, DeviceCompactSums,
+            compute_dot_reducers, CompactQuery, CudaVec2DSlicerRawPointer, DeviceCompactQuery,
         },
     },
     server::{
@@ -885,7 +885,7 @@ impl ServerActor {
                 .clone(),
         };
 
-        let (compact_device_queries_side1, compact_device_sums_side1) = record_stream_time!(
+        let compact_device_queries_side1 = record_stream_time!(
             &self.device_manager,
             &self.streams[0],
             events,
@@ -894,20 +894,11 @@ impl ServerActor {
             {
                 // This needs to be max_batch_size, even though the query can be shorter to have
                 // enough padding for GEMM
-                let compact_device_queries_side1 = compact_query_side1.htod_transfer(
+                compact_query_side1.htod_transfer(
                     &self.device_manager,
                     &self.streams[0],
                     self.max_batch_size,
-                )?;
-
-                let compact_device_sums_side1 = compact_device_queries_side1.query_sums(
-                    &self.codes_engine,
-                    &self.masks_engine,
-                    &self.streams[0],
-                    &self.cublas_handles[0],
-                )?;
-
-                (compact_device_queries_side1, compact_device_sums_side1)
+                )?
             }
         );
 
@@ -919,7 +910,6 @@ impl ServerActor {
         // prefilter the database with a higher threshold, also saving anon stats
         let one_sided_distance_cache_side1 = self.compare_query_against_db_and_self_prefiltering(
             &compact_device_queries_side1,
-            &compact_device_sums_side1,
             &mut events,
             self.full_scan_side,
             batch_size,
@@ -1008,7 +998,6 @@ impl ServerActor {
         let (partial_results_with_rotations_side1, _) = self
             .compare_query_against_db_subset_and_self(
                 &compact_device_queries_side1,
-                &compact_device_sums_side1,
                 &mut events,
                 self.full_scan_side,
                 batch_size,
@@ -1045,7 +1034,7 @@ impl ServerActor {
                 .clone(),
         };
 
-        let (compact_device_queries_side2, compact_device_sums_side2) = record_stream_time!(
+        let compact_device_queries_side2 = record_stream_time!(
             &self.device_manager,
             &self.streams[0],
             events,
@@ -1054,20 +1043,11 @@ impl ServerActor {
             {
                 // This needs to be MAX_BATCH_SIZE, even though the query can be shorter to have
                 // enough padding for GEMM
-                let compact_device_queries_side2 = compact_query_side2.htod_transfer(
+                compact_query_side2.htod_transfer(
                     &self.device_manager,
                     &self.streams[0],
                     self.max_batch_size,
-                )?;
-
-                let compact_device_sums_side2 = compact_device_queries_side2.query_sums(
-                    &self.codes_engine,
-                    &self.masks_engine,
-                    &self.streams[0],
-                    &self.cublas_handles[0],
-                )?;
-
-                (compact_device_queries_side2, compact_device_sums_side2)
+                )?
             }
         );
 
@@ -1075,7 +1055,6 @@ impl ServerActor {
         let (partial_results_with_rotations_side2, one_sided_distance_cache_side2) = self
             .compare_query_against_db_subset_and_self(
                 &compact_device_queries_side2,
-                &compact_device_sums_side2,
                 &mut events,
                 other_side,
                 batch_size,
@@ -1558,9 +1537,7 @@ impl ServerActor {
                                     Eye::Right => &self.left_mask_db_slices,
                                 },
                                 &compact_device_queries_side1,
-                                &compact_device_sums_side1,
                                 &compact_device_queries_side2,
-                                &compact_device_sums_side2,
                                 insertion_idx,
                                 self.current_db_sizes[i],
                                 i,
@@ -1615,9 +1592,7 @@ impl ServerActor {
                                     Eye::Right => &self.left_mask_db_slices,
                                 },
                                 &compact_device_queries_side1,
-                                &compact_device_sums_side1,
                                 &compact_device_queries_side2,
-                                &compact_device_sums_side2,
                                 reauth_pos,
                                 device_db_index as usize,
                                 i,
@@ -1789,7 +1764,6 @@ impl ServerActor {
     fn compare_query_against_self(
         &mut self,
         compact_device_queries: &DeviceCompactQuery,
-        compact_device_sums: &DeviceCompactSums,
         events: &mut HashMap<&str, Vec<Vec<CUevent>>>,
         eye_db: Eye,
     ) {
@@ -1823,11 +1797,10 @@ impl ServerActor {
                 );
                 tracing::info!(party_id = self.party_id, "compute_dot_reducers start");
 
-                compact_device_sums.compute_dot_reducers(
+                compute_dot_reducers(
                     &mut self.batch_codes_engine,
                     &mut self.batch_masks_engine,
                     &self.query_db_size,
-                    0,
                     batch_streams,
                 );
                 tracing::info!(party_id = self.party_id, "batch_dot end");
@@ -1900,7 +1873,6 @@ impl ServerActor {
     fn compare_query_against_db_subset_and_self(
         &mut self,
         compact_device_queries: &DeviceCompactQuery,
-        compact_device_sums: &DeviceCompactSums,
         events: &mut HashMap<&str, Vec<Vec<CUevent>>>,
         eye_db: Eye,
         batch_size: usize,
@@ -1921,12 +1893,7 @@ impl ServerActor {
         };
 
         // ---- START BATCH DEDUP ----
-        self.compare_query_against_self(
-            compact_device_queries,
-            compact_device_sums,
-            events,
-            eye_db,
-        );
+        self.compare_query_against_self(compact_device_queries, events, eye_db);
         // ---- END BATCH DEDUP ----
 
         // if the subset is completely empty, we can skip the whole process after we do the batch check
@@ -2014,11 +1981,9 @@ impl ServerActor {
                 "db_reduce",
                 self.enable_debug_timing,
                 {
-                    compact_device_sums.compute_dot_reducer_against_prepared_db(
+                    compute_dot_reducers(
                         &mut self.codes_engine,
                         &mut self.masks_engine,
-                        &self.code_chunk_buffers[0].sums,
-                        &self.mask_chunk_buffers[0].sums,
                         &dot_chunk_size,
                         &self.streams[0],
                     );
@@ -2246,7 +2211,6 @@ impl ServerActor {
     fn compare_query_against_db_and_self_prefiltering(
         &mut self,
         compact_device_queries: &DeviceCompactQuery,
-        compact_device_sums: &DeviceCompactSums,
         events: &mut HashMap<&str, Vec<Vec<CUevent>>>,
         eye_db: Eye,
         batch_size: usize,
@@ -2409,13 +2373,10 @@ impl ServerActor {
                 "db_reduce",
                 self.enable_debug_timing,
                 {
-                    compact_device_sums.compute_dot_reducer_against_db(
+                    compute_dot_reducers(
                         &mut self.codes_engine,
                         &mut self.masks_engine,
-                        code_db_slices,
-                        mask_db_slices,
                         &dot_chunk_size,
-                        offset,
                         request_streams,
                     );
                 }
@@ -2641,7 +2602,7 @@ impl ServerActor {
         if !batch.deletion_requests_indices.is_empty() {
             tracing::info!("Performing deletions");
             let (dummy_code_share, dummy_mask_share) = get_dummy_shares_for_deletion(self.party_id);
-            let (dummy_queries, dummy_sums) =
+            let dummy_queries =
                 self.prepare_device_query_for_shares(&dummy_code_share, &dummy_mask_share)?;
 
             for deletion_index in batch.deletion_requests_indices.clone() {
@@ -2667,9 +2628,7 @@ impl ServerActor {
                     &self.right_code_db_slices,
                     &self.right_mask_db_slices,
                     &dummy_queries,
-                    &dummy_sums,
                     &dummy_queries,
-                    &dummy_sums,
                     0,
                     device_db_index as usize,
                     device_index as usize,
@@ -2685,9 +2644,9 @@ impl ServerActor {
                 batch.identity_update_indices.clone(),
                 batch.identity_update_shares.clone()
             ) {
-                let (queries_left, sums_left) =
+                let queries_left =
                     self.prepare_device_query_for_shares(&shares.code_left, &shares.mask_left)?;
-                let (queries_right, sums_right) =
+                let queries_right =
                     self.prepare_device_query_for_shares(&shares.code_right, &shares.mask_right)?;
 
                 let device_index = update_index % self.device_manager.device_count() as u32;
@@ -2712,9 +2671,7 @@ impl ServerActor {
                     &self.right_code_db_slices,
                     &self.right_mask_db_slices,
                     &queries_left,
-                    &sums_left,
                     &queries_right,
-                    &sums_right,
                     0,
                     device_db_index as usize,
                     device_index as usize,
@@ -2803,7 +2760,7 @@ impl ServerActor {
         &self,
         code_share: &GaloisRingIrisCodeShare,
         mask_share: &GaloisRingTrimmedMaskCodeShare,
-    ) -> Result<(DeviceCompactQuery, DeviceCompactSums)> {
+    ) -> Result<DeviceCompactQuery> {
         let compact_query = {
             let code = preprocess_query(
                 &code_share
@@ -2832,14 +2789,7 @@ impl ServerActor {
             self.max_batch_size,
         )?;
 
-        let compact_device_sums = compact_device_queries.query_sums(
-            &self.codes_engine,
-            &self.masks_engine,
-            &self.streams[0],
-            &self.cublas_handles[0],
-        )?;
-
-        Ok((compact_device_queries, compact_device_sums))
+        Ok(compact_device_queries)
     }
 
     fn allocate_or_policy_bitmap(&mut self, bitmap: Vec<u64>) -> Vec<CudaSlice<u64>> {
@@ -3552,49 +3502,35 @@ fn write_db_at_index(
     right_code_db_slices: &SlicedProcessedDatabase,
     right_mask_db_slices: &SlicedProcessedDatabase,
     compact_device_queries_left: &DeviceCompactQuery,
-    compact_device_sums_left: &DeviceCompactSums,
     compact_device_queries_right: &DeviceCompactQuery,
-    compact_device_sums_right: &DeviceCompactSums,
     src_index: usize,
     dst_index: usize,
     device_index: usize,
     streams: &[CudaStream],
 ) {
-    for (engine, db, query, sums) in [
+    for (engine, db, query) in [
         (
             code_engine,
             left_code_db_slices,
             &compact_device_queries_left.code_query_insert,
-            &compact_device_sums_left.code_query_insert,
         ),
         (
             mask_engine,
             left_mask_db_slices,
             &compact_device_queries_left.mask_query_insert,
-            &compact_device_sums_left.mask_query_insert,
         ),
         (
             code_engine,
             right_code_db_slices,
             &compact_device_queries_right.code_query_insert,
-            &compact_device_sums_right.code_query_insert,
         ),
         (
             mask_engine,
             right_mask_db_slices,
             &compact_device_queries_right.mask_query_insert,
-            &compact_device_sums_right.mask_query_insert,
         ),
     ] {
-        db.write_at_index(
-            engine,
-            query,
-            sums,
-            src_index,
-            dst_index,
-            device_index,
-            streams,
-        );
+        db.write_at_index(engine, query, src_index, dst_index, device_index, streams);
     }
 }
 
@@ -3721,17 +3657,9 @@ impl InMemoryStore for ServerActor {
     }
 
     fn preprocess_db(&mut self) {
-        // we also register the memory allocated, page-locking it for more performance
+        // The balanced-limb encoding needs no precomputed sums; we only
+        // register the allocated memory, page-locking it for more performance.
         self.register_host_memory();
-
-        self.left_code_db_slices
-            .preprocess(&self.codes_engine, &self.current_db_sizes);
-        self.left_mask_db_slices
-            .preprocess(&self.masks_engine, &self.current_db_sizes);
-        self.right_code_db_slices
-            .preprocess(&self.codes_engine, &self.current_db_sizes);
-        self.right_mask_db_slices
-            .preprocess(&self.masks_engine, &self.current_db_sizes);
     }
 
     fn current_db_sizes(&self) -> impl std::fmt::Debug {

--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -25,7 +25,8 @@ use iris_mpc_common::{
 use itertools::izip;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 pub use s3_importer::{
-    fetch_and_parse_chunks, last_snapshot_timestamp, ObjectStore, S3Store, S3StoredIris,
+    fetch_and_parse_chunks, last_snapshot_timestamp, ObjectStore, S3IrisShares, S3Store,
+    S3StoredIris, SnapshotFormat,
 };
 use sqlx::{PgPool, Postgres, Row, Transaction};
 use std::ops::DerefMut;

--- a/iris-mpc-store/src/loader.rs
+++ b/iris-mpc-store/src/loader.rs
@@ -1,6 +1,7 @@
 use crate::s3_importer::create_db_chunks_s3_client;
 use crate::{
-    fetch_and_parse_chunks, last_snapshot_timestamp, DbStoredIris, S3Store, S3StoredIris, Store,
+    fetch_and_parse_chunks, last_snapshot_timestamp, DbStoredIris, S3IrisShares, S3Store,
+    S3StoredIris, Store,
 };
 use ampc_server_utils::shutdown_handler::ShutdownHandler;
 use aws_config::Region;
@@ -220,18 +221,46 @@ async fn load_iris_db_internal(
                 continue;
             }
 
-            actor.load_single_record_from_s3(
-                iris.serial_id() - 1,
-                iris.vector_id(),
-                iris.left_code_odd(),
-                iris.left_code_even(),
-                iris.right_code_odd(),
-                iris.right_code_even(),
-                iris.left_mask_odd(),
-                iris.left_mask_even(),
-                iris.right_mask_odd(),
-                iris.right_mask_even(),
-            );
+            match iris.shares() {
+                S3IrisShares::LegacyLimbs {
+                    left_code_odd,
+                    left_code_even,
+                    left_mask_odd,
+                    left_mask_even,
+                    right_code_odd,
+                    right_code_even,
+                    right_mask_odd,
+                    right_mask_even,
+                } => {
+                    actor.load_single_record_from_s3(
+                        iris.serial_id() - 1,
+                        iris.vector_id(),
+                        left_code_odd,
+                        left_code_even,
+                        right_code_odd,
+                        right_code_even,
+                        left_mask_odd,
+                        left_mask_even,
+                        right_mask_odd,
+                        right_mask_even,
+                    );
+                }
+                S3IrisShares::PlainU16 {
+                    left_code,
+                    left_mask,
+                    right_code,
+                    right_mask,
+                } => {
+                    actor.load_single_record_from_db(
+                        iris.serial_id() - 1,
+                        iris.vector_id(),
+                        left_code,
+                        left_mask,
+                        right_code,
+                        right_mask,
+                    );
+                }
+            }
             actor.increment_db_size(serial_id - 1);
 
             time_loading_into_memory += load_summary_ts.elapsed();

--- a/iris-mpc-store/src/s3_importer.rs
+++ b/iris-mpc-store/src/s3_importer.rs
@@ -13,26 +13,60 @@ use tokio::{io::AsyncReadExt, sync::mpsc::Sender};
 const SINGLE_ELEMENT_SIZE: usize = IRIS_CODE_LENGTH * mem::size_of::<u16>() * 2
     + MASK_CODE_LENGTH * mem::size_of::<u16>() * 2
     + mem::size_of::<u32>()
-    + mem::size_of::<u16>(); // 75 KB
+    + mem::size_of::<u16>(); // 75 KB, identical for both snapshot formats
 
 const MAX_RANGE_SIZE: usize = 200; // Download chunks in sub-chunks of 200 elements = 15 MB
+
+/// On-disk encoding of the share buffers inside a snapshot chunk. Both
+/// formats have identical record sizes, so the format cannot be inferred from
+/// the data — it is carried by the snapshot marker file name (see
+/// [`LastSnapshotDetails`]).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SnapshotFormat {
+    /// Format 1 (legacy, implied by 3-part marker names): each share is
+    /// stored as two byte planes with each u16 half encoded as `byte ^ 0x80`
+    /// — the zero-point limb encoding of the old GPU kernel.
+    V1LegacyLimbs,
+    /// Format 2: each share is a plain little-endian u16 array, identical to
+    /// the database representation. Consumers derive their compute encoding
+    /// at load time.
+    V2PlainU16,
+}
 
 pub struct S3StoredIris {
     #[allow(dead_code)]
     id: i64,
-    left_code_even: Vec<u8>,
-    left_code_odd: Vec<u8>,
-    left_mask_even: Vec<u8>,
-    left_mask_odd: Vec<u8>,
-    right_code_even: Vec<u8>,
-    right_code_odd: Vec<u8>,
-    right_mask_even: Vec<u8>,
-    right_mask_odd: Vec<u8>,
     version_id: i16,
+    shares: S3IrisShares,
+}
+
+/// The share buffers of one S3 record, in whichever encoding the snapshot
+/// uses.
+pub enum S3IrisShares {
+    /// [`SnapshotFormat::V1LegacyLimbs`]: `^ 0x80` byte planes
+    /// (odd = low bytes, even = high bytes of the u16 shares).
+    LegacyLimbs {
+        left_code_odd: Vec<u8>,
+        left_code_even: Vec<u8>,
+        left_mask_odd: Vec<u8>,
+        left_mask_even: Vec<u8>,
+        right_code_odd: Vec<u8>,
+        right_code_even: Vec<u8>,
+        right_mask_odd: Vec<u8>,
+        right_mask_even: Vec<u8>,
+    },
+    /// [`SnapshotFormat::V2PlainU16`]: plain u16 shares (database
+    /// representation).
+    PlainU16 {
+        left_code: Vec<u16>,
+        left_mask: Vec<u16>,
+        right_code: Vec<u16>,
+        right_mask: Vec<u16>,
+    },
 }
 
 impl S3StoredIris {
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, eyre::Error> {
+    pub fn from_bytes(bytes: &[u8], format: SnapshotFormat) -> Result<Self, eyre::Error> {
         let mut cursor = 0;
 
         // Helper closure to extract a slice of a given size
@@ -45,6 +79,19 @@ impl S3StoredIris {
                 *cursor += size;
                 Ok(slice.to_vec())
             };
+        // Helper closure to extract `len` little-endian u16s
+        let extract_u16s =
+            |bytes: &[u8], cursor: &mut usize, len: usize| -> Result<Vec<u16>, eyre::Error> {
+                if *cursor + len * 2 > bytes.len() {
+                    bail!("Exceeded total bytes while extracting u16 slice",);
+                }
+                let out = bytes[*cursor..*cursor + len * 2]
+                    .chunks_exact(2)
+                    .map(|b| u16::from_le_bytes([b[0], b[1]]))
+                    .collect();
+                *cursor += len * 2;
+                Ok(out)
+            };
 
         // Parse `id` (i64)
         let id_bytes = extract_slice(bytes, &mut cursor, 4)?;
@@ -54,15 +101,35 @@ impl S3StoredIris {
                 .map_err(|_| eyre!("Failed to convert id bytes to i64"))?,
         ) as i64;
 
-        // parse codes and masks for each limb separately
-        let left_code_odd = extract_slice(bytes, &mut cursor, IRIS_CODE_LENGTH)?;
-        let left_code_even = extract_slice(bytes, &mut cursor, IRIS_CODE_LENGTH)?;
-        let left_mask_odd = extract_slice(bytes, &mut cursor, MASK_CODE_LENGTH)?;
-        let left_mask_even = extract_slice(bytes, &mut cursor, MASK_CODE_LENGTH)?;
-        let right_code_odd = extract_slice(bytes, &mut cursor, IRIS_CODE_LENGTH)?;
-        let right_code_even = extract_slice(bytes, &mut cursor, IRIS_CODE_LENGTH)?;
-        let right_mask_odd = extract_slice(bytes, &mut cursor, MASK_CODE_LENGTH)?;
-        let right_mask_even = extract_slice(bytes, &mut cursor, MASK_CODE_LENGTH)?;
+        let shares = match format {
+            SnapshotFormat::V1LegacyLimbs => {
+                // parse codes and masks for each limb plane separately
+                let left_code_odd = extract_slice(bytes, &mut cursor, IRIS_CODE_LENGTH)?;
+                let left_code_even = extract_slice(bytes, &mut cursor, IRIS_CODE_LENGTH)?;
+                let left_mask_odd = extract_slice(bytes, &mut cursor, MASK_CODE_LENGTH)?;
+                let left_mask_even = extract_slice(bytes, &mut cursor, MASK_CODE_LENGTH)?;
+                let right_code_odd = extract_slice(bytes, &mut cursor, IRIS_CODE_LENGTH)?;
+                let right_code_even = extract_slice(bytes, &mut cursor, IRIS_CODE_LENGTH)?;
+                let right_mask_odd = extract_slice(bytes, &mut cursor, MASK_CODE_LENGTH)?;
+                let right_mask_even = extract_slice(bytes, &mut cursor, MASK_CODE_LENGTH)?;
+                S3IrisShares::LegacyLimbs {
+                    left_code_odd,
+                    left_code_even,
+                    left_mask_odd,
+                    left_mask_even,
+                    right_code_odd,
+                    right_code_even,
+                    right_mask_odd,
+                    right_mask_even,
+                }
+            }
+            SnapshotFormat::V2PlainU16 => S3IrisShares::PlainU16 {
+                left_code: extract_u16s(bytes, &mut cursor, IRIS_CODE_LENGTH)?,
+                left_mask: extract_u16s(bytes, &mut cursor, MASK_CODE_LENGTH)?,
+                right_code: extract_u16s(bytes, &mut cursor, IRIS_CODE_LENGTH)?,
+                right_mask: extract_u16s(bytes, &mut cursor, MASK_CODE_LENGTH)?,
+            },
+        };
 
         // Parse `version_id` (i16)
         let version_id_bytes = extract_slice(bytes, &mut cursor, 2)?;
@@ -74,15 +141,8 @@ impl S3StoredIris {
 
         Ok(S3StoredIris {
             id,
-            left_code_even,
-            left_code_odd,
-            left_mask_even,
-            left_mask_odd,
-            right_code_even,
-            right_code_odd,
-            right_mask_even,
-            right_mask_odd,
             version_id,
+            shares,
         })
     }
 
@@ -98,36 +158,8 @@ impl S3StoredIris {
         VectorId::new(self.id as u32, self.version_id)
     }
 
-    pub fn left_code_odd(&self) -> &Vec<u8> {
-        &self.left_code_odd
-    }
-
-    pub fn left_code_even(&self) -> &Vec<u8> {
-        &self.left_code_even
-    }
-
-    pub fn left_mask_odd(&self) -> &Vec<u8> {
-        &self.left_mask_odd
-    }
-
-    pub fn left_mask_even(&self) -> &Vec<u8> {
-        &self.left_mask_even
-    }
-
-    pub fn right_code_odd(&self) -> &Vec<u8> {
-        &self.right_code_odd
-    }
-
-    pub fn right_code_even(&self) -> &Vec<u8> {
-        &self.right_code_even
-    }
-
-    pub fn right_mask_odd(&self) -> &Vec<u8> {
-        &self.right_mask_odd
-    }
-
-    pub fn right_mask_even(&self) -> &Vec<u8> {
-        &self.right_mask_even
+    pub fn shares(&self) -> &S3IrisShares {
+        &self.shares
     }
 
     pub fn id(&self) -> i64 {
@@ -230,24 +262,44 @@ pub struct LastSnapshotDetails {
     pub timestamp: i64,
     pub last_serial_id: i64,
     pub chunk_size: i64,
+    pub format: SnapshotFormat,
 }
 
 impl LastSnapshotDetails {
     // Parse last snapshot from s3 file name.
-    // It is in {unixTime}_{batchSize}_{lastSerialId} format.
+    // It is in {unixTime}_{batchSize}_{lastSerialId} format, with an optional
+    // fourth {formatVersion} part ({unixTime}_{batchSize}_{lastSerialId}_{format}).
+    // A 3-part name implies format 1 (legacy limb planes). Marker files with an
+    // unknown format version are skipped, so an older importer never
+    // misinterprets snapshots it cannot decode (record sizes are identical
+    // across formats, so a wrong guess would silently load garbage shares).
     pub fn new_from_str(last_snapshot_str: &str) -> Option<Self> {
         let parts: Vec<&str> = last_snapshot_str.split('_').collect();
-        match parts.len() {
-            3 => Some(Self {
-                timestamp: parts[0].parse().unwrap(),
-                chunk_size: parts[1].parse().unwrap(),
-                last_serial_id: parts[2].parse().unwrap(),
-            }),
+        let format = match parts.len() {
+            3 => SnapshotFormat::V1LegacyLimbs,
+            4 => match parts[3] {
+                "1" => SnapshotFormat::V1LegacyLimbs,
+                "2" => SnapshotFormat::V2PlainU16,
+                other => {
+                    tracing::warn!(
+                        "Skipping snapshot with unsupported format version {}: {}",
+                        other,
+                        last_snapshot_str
+                    );
+                    return None;
+                }
+            },
             _ => {
                 tracing::warn!("Invalid export timestamp file name: {}", last_snapshot_str);
-                None
+                return None;
             }
-        }
+        };
+        Some(Self {
+            timestamp: parts[0].parse().unwrap(),
+            chunk_size: parts[1].parse().unwrap(),
+            last_serial_id: parts[2].parse().unwrap(),
+            format,
+        })
     }
 }
 
@@ -320,11 +372,12 @@ pub async fn fetch_and_parse_chunks(
         let tx = tx.clone();
         let shutdown = Arc::clone(&shutdown_handler);
         let key = format!("{}/{}.bin", prefix_name, chunk_id);
+        let format = last_snapshot_details.format;
 
         async move {
             tokio::spawn(async move {
                 tokio::select! {
-                    res = fetch_single_chunk(store, key, offset_within_chunk, requested_range_size, tx, max_retries, initial_backoff_ms) => res,
+                    res = fetch_single_chunk(store, key, offset_within_chunk, requested_range_size, format, tx, max_retries, initial_backoff_ms) => res,
                     _ = shutdown.wait_for_shutdown() => Err(eyre::eyre!("Shutdown requested")),
                 }
             })
@@ -342,11 +395,13 @@ pub async fn fetch_and_parse_chunks(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn fetch_single_chunk(
     store: Arc<impl ObjectStore>,
     key: String,
     offset: usize,
     size: usize,
+    format: SnapshotFormat,
     tx: Sender<S3StoredIris>,
     max_retries: usize,
     initial_backoff_ms: u64,
@@ -356,7 +411,8 @@ async fn fetch_single_chunk(
 
     loop {
         attempt += 1;
-        match read_range_in_chunk(Arc::clone(&store), &key, offset, size, tx.clone()).await {
+        match read_range_in_chunk(Arc::clone(&store), &key, offset, size, format, tx.clone()).await
+        {
             Ok(_) => {
                 return Ok(());
             }
@@ -394,6 +450,7 @@ async fn read_range_in_chunk(
     key: &str,
     offset_within_chunk: usize,
     range_size: usize,
+    format: SnapshotFormat,
     tx: Sender<S3StoredIris>,
 ) -> Result<()> {
     let mut stream = store
@@ -412,7 +469,7 @@ async fn read_range_in_chunk(
     loop {
         match stream.read_exact(&mut slice).await {
             Ok(_) => {
-                let iris = S3StoredIris::from_bytes(&slice)?;
+                let iris = S3StoredIris::from_bytes(&slice, format)?;
                 tx.send(iris).await?;
             }
             Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
@@ -567,6 +624,7 @@ mod tests {
             timestamp: 0,
             last_serial_id: n as i64,
             chunk_size: chunk_size as i64,
+            format: SnapshotFormat::V1LegacyLimbs,
         }
     }
 
@@ -583,6 +641,149 @@ mod tests {
         assert_eq!(last_snapshot.timestamp, 125);
         assert_eq!(last_snapshot.last_serial_id, 958);
         assert_eq!(last_snapshot.chunk_size, 100);
+        assert_eq!(last_snapshot.format, SnapshotFormat::V1LegacyLimbs);
+    }
+
+    #[tokio::test]
+    async fn test_last_snapshot_timestamp_versioned_markers() {
+        let mut store = MockStore::new();
+        store.add_timestamp_file("out/timestamps/123_100_954");
+        store.add_timestamp_file("out/timestamps/126_100_960_2");
+        // Unknown format versions must be skipped, not misread.
+        store.add_timestamp_file("out/timestamps/127_100_961_9");
+
+        let last_snapshot = last_snapshot_timestamp(&store, "out".to_string())
+            .await
+            .unwrap();
+        assert_eq!(last_snapshot.timestamp, 126);
+        assert_eq!(last_snapshot.last_serial_id, 960);
+        assert_eq!(last_snapshot.format, SnapshotFormat::V2PlainU16);
+    }
+
+    #[test]
+    fn test_snapshot_marker_format_parsing() {
+        let v1 = LastSnapshotDetails::new_from_str("123_100_954").unwrap();
+        assert_eq!(v1.format, SnapshotFormat::V1LegacyLimbs);
+        let v1_explicit = LastSnapshotDetails::new_from_str("123_100_954_1").unwrap();
+        assert_eq!(v1_explicit.format, SnapshotFormat::V1LegacyLimbs);
+        let v2 = LastSnapshotDetails::new_from_str("123_100_954_2").unwrap();
+        assert_eq!(v2.format, SnapshotFormat::V2PlainU16);
+        assert_eq!(v2.timestamp, 123);
+        assert_eq!(v2.chunk_size, 100);
+        assert_eq!(v2.last_serial_id, 954);
+        assert!(LastSnapshotDetails::new_from_str("123_100_954_3").is_none());
+        assert!(LastSnapshotDetails::new_from_str("123_100").is_none());
+    }
+
+    /// Serialize one record in v2 (plain LE u16) layout.
+    fn v2_record_bytes(
+        id: u32,
+        version_id: u16,
+        left_code: &[u16],
+        left_mask: &[u16],
+        right_code: &[u16],
+        right_mask: &[u16],
+    ) -> Vec<u8> {
+        let mut out = Vec::with_capacity(SINGLE_ELEMENT_SIZE);
+        out.extend_from_slice(&id.to_be_bytes());
+        for share in [left_code, left_mask, right_code, right_mask] {
+            for v in share {
+                out.extend_from_slice(&v.to_le_bytes());
+            }
+        }
+        out.extend_from_slice(&version_id.to_be_bytes());
+        out
+    }
+
+    #[test]
+    fn test_from_bytes_v2_roundtrip() {
+        let mut rng = rand::thread_rng();
+        let left_code: Vec<u16> = (0..IRIS_CODE_LENGTH).map(|_| rng.gen()).collect();
+        let left_mask: Vec<u16> = (0..MASK_CODE_LENGTH).map(|_| rng.gen()).collect();
+        let right_code: Vec<u16> = (0..IRIS_CODE_LENGTH).map(|_| rng.gen()).collect();
+        let right_mask: Vec<u16> = (0..MASK_CODE_LENGTH).map(|_| rng.gen()).collect();
+
+        let bytes = v2_record_bytes(42, 7, &left_code, &left_mask, &right_code, &right_mask);
+        assert_eq!(bytes.len(), SINGLE_ELEMENT_SIZE);
+
+        let iris = S3StoredIris::from_bytes(&bytes, SnapshotFormat::V2PlainU16).unwrap();
+        assert_eq!(iris.serial_id(), 42);
+        assert_eq!(iris.version_id(), 7);
+        match iris.shares() {
+            S3IrisShares::PlainU16 {
+                left_code: lc,
+                left_mask: lm,
+                right_code: rc,
+                right_mask: rm,
+            } => {
+                assert_eq!(lc, &left_code);
+                assert_eq!(lm, &left_mask);
+                assert_eq!(rc, &right_code);
+                assert_eq!(rm, &right_mask);
+            }
+            _ => panic!("expected PlainU16 shares"),
+        }
+    }
+
+    /// The same logical shares written in both formats must decode to the same
+    /// u16 values (v1 planes hold `byte ^ 0x80` of each u16 half).
+    #[test]
+    fn test_v1_v2_encode_same_logical_shares() {
+        let mut rng = rand::thread_rng();
+        let shares: [Vec<u16>; 4] = [
+            (0..IRIS_CODE_LENGTH).map(|_| rng.gen()).collect(),
+            (0..MASK_CODE_LENGTH).map(|_| rng.gen()).collect(),
+            (0..IRIS_CODE_LENGTH).map(|_| rng.gen()).collect(),
+            (0..MASK_CODE_LENGTH).map(|_| rng.gen()).collect(),
+        ];
+
+        // v1: per share, the odd plane then the even plane, each `^ 0x80`.
+        let mut v1 = Vec::with_capacity(SINGLE_ELEMENT_SIZE);
+        v1.extend_from_slice(&5u32.to_be_bytes());
+        for share in &shares {
+            v1.extend(share.iter().map(|v| (*v as u8) ^ 0x80));
+            v1.extend(share.iter().map(|v| ((*v >> 8) as u8) ^ 0x80));
+        }
+        v1.extend_from_slice(&3u16.to_be_bytes());
+        assert_eq!(v1.len(), SINGLE_ELEMENT_SIZE);
+
+        let v2 = v2_record_bytes(5, 3, &shares[0], &shares[1], &shares[2], &shares[3]);
+
+        let iris_v1 = S3StoredIris::from_bytes(&v1, SnapshotFormat::V1LegacyLimbs).unwrap();
+        let iris_v2 = S3StoredIris::from_bytes(&v2, SnapshotFormat::V2PlainU16).unwrap();
+
+        let decode_plane = |odd: &[u8], even: &[u8]| -> Vec<u16> {
+            odd.iter()
+                .zip(even)
+                .map(|(o, e)| u16::from_le_bytes([o ^ 0x80, e ^ 0x80]))
+                .collect()
+        };
+        let (
+            S3IrisShares::LegacyLimbs {
+                left_code_odd,
+                left_code_even,
+                left_mask_odd,
+                left_mask_even,
+                right_code_odd,
+                right_code_even,
+                right_mask_odd,
+                right_mask_even,
+            },
+            S3IrisShares::PlainU16 {
+                left_code,
+                left_mask,
+                right_code,
+                right_mask,
+            },
+        ) = (iris_v1.shares(), iris_v2.shares())
+        else {
+            panic!("unexpected share variants");
+        };
+        assert_eq!(&decode_plane(left_code_odd, left_code_even), left_code);
+        assert_eq!(&decode_plane(left_mask_odd, left_mask_even), left_mask);
+        assert_eq!(&decode_plane(right_code_odd, right_code_even), right_code);
+        assert_eq!(&decode_plane(right_mask_odd, right_mask_even), right_mask);
+        assert_eq!(left_code, &shares[0]);
     }
 
     #[tokio::test]
@@ -605,6 +806,7 @@ mod tests {
             timestamp: 0,
             last_serial_id: MOCK_ENTRIES as i64,
             chunk_size: MOCK_CHUNK_SIZE as i64,
+            format: SnapshotFormat::V1LegacyLimbs,
         };
         let (tx, mut rx) = mpsc::channel::<S3StoredIris>(1024);
         let store_arc = Arc::new(store);
@@ -631,6 +833,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_fetch_and_parse_chunks_v2() {
+        const MOCK_ENTRIES: usize = 27;
+        const MOCK_CHUNK_SIZE: usize = 10;
+        let mut store = MockStore::new();
+        let n_chunks = MOCK_ENTRIES.div_ceil(MOCK_CHUNK_SIZE);
+        for i in 0..n_chunks {
+            let start_serial_id = i * MOCK_CHUNK_SIZE + 1;
+            let end_serial_id = min((i + 1) * MOCK_CHUNK_SIZE, MOCK_ENTRIES);
+            store.add_test_data(
+                &format!("out/{start_serial_id}.bin"),
+                (start_serial_id..=end_serial_id).map(dummy_entry).collect(),
+            );
+        }
+
+        let mut last_snapshot_details = snapshot(MOCK_ENTRIES, MOCK_CHUNK_SIZE);
+        last_snapshot_details.format = SnapshotFormat::V2PlainU16;
+        let (tx, mut rx) = mpsc::channel::<S3StoredIris>(1024);
+        let _res = fetch_and_parse_chunks(
+            Arc::new(store),
+            1,
+            "out".to_string(),
+            last_snapshot_details,
+            None,
+            tx,
+            1,
+            0,
+            Arc::new(ShutdownHandler::new(1)),
+        )
+        .await;
+        let mut ids: HashSet<usize> = HashSet::from_iter(1..=MOCK_ENTRIES);
+        while let Some(iris) = rx.recv().await {
+            assert!(
+                matches!(iris.shares(), S3IrisShares::PlainU16 { .. }),
+                "v2 snapshots must parse into plain u16 shares"
+            );
+            ids.remove(&iris.serial_id());
+        }
+        assert!(ids.is_empty());
+    }
+
+    #[tokio::test]
     async fn test_fetch_and_parse_chunks_respects_max_serial_id_to_load() {
         const SNAPSHOT_ENTRIES: usize = 36;
         const MAX_SERIAL_ID_TO_LOAD: usize = 25;
@@ -651,6 +894,7 @@ mod tests {
             timestamp: 0,
             last_serial_id: SNAPSHOT_ENTRIES as i64,
             chunk_size: MOCK_CHUNK_SIZE as i64,
+            format: SnapshotFormat::V1LegacyLimbs,
         };
         let (tx, mut rx) = mpsc::channel::<S3StoredIris>(1024);
         let store_arc = Arc::new(store);
@@ -707,6 +951,7 @@ mod tests {
             timestamp: 0,
             last_serial_id: MOCK_ENTRIES as i64,
             chunk_size: MOCK_CHUNK_SIZE as i64,
+            format: SnapshotFormat::V1LegacyLimbs,
         };
 
         let (tx, mut rx) = mpsc::channel::<S3StoredIris>(1024);


### PR DESCRIPTION
## What

1. **Replace the offset-limb u16 GEMM with the [`u16-gemm`](https://github.com/philsippl/u16-gemm) crate.** Its balanced signed-limb encoding is exact on cuBLAS's i8 tensor-core path, so all zero-point corrections disappear: the `query_sums` GEMV launches, the full-DB CPU sums pass at startup, per-record sums buffers/copies on insert and prefetch paths, `DeviceCompactSums`, and the correction terms in the reduce kernel (now a plain i32→u16 truncation). The three GEMM calls themselves are unchanged. Net **−468 lines** in `iris-mpc-gpu`. See the crate's README for the underlying math.
2. **Version the S3 snapshot format.** The importer now reads both format 1 (legacy `^0x80` limb planes, unchanged) and format 2 (plain little-endian u16 shares — the database representation). The stored planes were a fossil of the old GPU kernel; every consumer decodes them anyway.
3. **Teach the db-exporter to write format 2** behind a `--format-version` flag (default 1, so merging this changes nothing until the flag is flipped). For v2 the export is a verbatim copy of the Postgres column.

Format details: the snapshot marker `{unixTime}_{batchSize}_{lastSerialId}` stays 3-part for format 1; a 4th part (`…_2`) selects the version. v1 and v2 records are byte-identical in size, so the marker is the only signal; unknown versions are skipped, making an old importer fail loudly on newer-only snapshots instead of silently loading garbage. Loader dispatch: v1 → existing `load_single_record_from_s3` path (GPU remaps to balanced limbs at load); v2 → straight into `load_single_record_from_db(u16)`, so CPU/Hawk needs no changes and stops paying the plane decode.

## Testing

- **GPU (3× L40S)**: full `iris-mpc-gpu` suite with `gpu_dependent`, including the 3-party **e2e** (30 batches) and the share_db matmul tests (exact equality vs a plain wrapping-u16 reference). Two pre-existing issues were isolated and reproduced on unmodified `main`: the lib unit tests assume the DB size divides the device count (run pinned to 1 GPU), and a flaky pass-then-SIGSEGV at process exit (identical rates on both branches).
- **u16-gemm crate**: exhaustive encode round-trip over all 2^16 values; GPU tests including inputs that force i32 accumulator wrap; H100 bench: ~90–97% of the measured cuBLAS int8 ceiling.
- **Store**: 11/11 `s3_importer` tests — marker parsing/selection, v2 round-trip, v1/v2 equivalence, end-to-end v2 fetch.
- **Exporter (Go)**: build/vet/gofmt clean; tests cover the v2 layout, record-size parity, unknown-format rejection, marker naming.
- clippy and fmt clean on all touched crates.

## Rollout

1. Merge and deploy MPC nodes (dual-format loader; exporter still emits format 1 — no behavior change).
2. Flip the exporter to `--format-version 2` (deploy order matters in this direction only).
3. Once the last v1 snapshot ages out: delete `S3IrisShares::LegacyLimbs`, the GPU load-time remap, `map_back_to_u16`, and `storeAsEvenOddPairs`; rerand can then land speaking u16 natively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
