### PR TITLE
deploy(stage): modifications reapers (HNSW + GPU) dry-run → false (POP-4134)

### DIFF
--- a/deploy/stage/common-values-ampc-hnsw-modifications-retention.yaml
+++ b/deploy/stage/common-values-ampc-hnsw-modifications-retention.yaml
@@ -11,16 +11,15 @@
 #
 image: "ghcr.io/worldcoin/retention-reaper:v0.32.6@sha256:366cc7dcd9e9132bbfe2b5719332ff8d1f301ed5b487cbfc458fbc97cca92ace"
 
-# STAGE ENABLE, DRY-RUN: the hawk image bump in this same PR applies the created_at
-# migration to the HNSW DB at boot; the reaper then previews the exact delete predicate
-# (read-only COUNT) daily. Expected counts: 0 for the first 30 days (backfill stamps all
-# rows at migration time) — the dry run proves the query is valid against the migrated
-# schema (created_at present, guard incl. the newest-10k subselect executes). Flip
-# DRY_RUN to "false" after the first clean previews; nothing becomes deletable before
-# the 30d clock matures anyway.
+# STAGE LIVE: dry-run cleared after clean daily previews (2026-07-09 → 2026-07-20 all
+# "would delete 0"). The reaper now performs the real guarded DELETE. This is a no-op
+# today by design — created_at was backfilled at the migration boot (~2026-07-09), so the
+# 30d age floor makes nothing deletable before ~2026-08-08, and the newest-10k floor holds
+# on the low-volume stage table. Flipping now makes it real ahead of the clock (no second
+# PR needed at maturity) and keeps stage exercising the true delete path.
 env:
   RETENTION__ENABLED: "true"
-  RETENTION__DRY_RUN: "true"
+  RETENTION__DRY_RUN: "false"
 
 replicaCount: 1
 

--- a/deploy/stage/common-values-iris-mpc-modifications-retention.yaml
+++ b/deploy/stage/common-values-iris-mpc-modifications-retention.yaml
@@ -10,13 +10,14 @@
 # DATABASE_AURORA_URL; no pod SG or dedicated pool needed, mirroring iris-mpc-db-exporter).
 image: "ghcr.io/worldcoin/retention-reaper:v0.32.6@sha256:366cc7dcd9e9132bbfe2b5719332ff8d1f301ed5b487cbfc458fbc97cca92ace"
 
-# STAGE ENABLE, DRY-RUN: previews the exact delete predicate (read-only COUNT) daily.
-# Expected 0 for the first 30 days (created_at backfilled at migration boot) + the
-# newest-10k floor on the low-volume table. Flip DRY_RUN to "false" after clean previews
-# (mirrors the HNSW-side reaper's stage path).
+# STAGE LIVE: dry-run cleared — the reaper now performs the real guarded DELETE against
+# the GPU MPCV2 DB. No-op today by design (created_at backfilled at migration boot + the
+# newest-10k floor on the low-volume table → deletes 0 until ~2026-08-08); flipping now
+# exercises the real path on stage, both systems, ahead of the clock. Preview validated
+# live 2026-07-20 (connected SMPC_stage_0, would delete 0). Mirrors the HNSW-side reaper.
 env:
   RETENTION__ENABLED: "true"
-  RETENTION__DRY_RUN: "true"
+  RETENTION__DRY_RUN: "false"
 
 replicaCount: 1
 


### PR DESCRIPTION
Flips **both stage `modifications` retention reapers** from dry-run to real deletion — HNSW (ampc-hnsw) and GPU/MPCV2 (iris-mpc). Values-only, off main. Part of [POP-4134](https://linear.app/worldcoin/issue/POP-4134).

## Why now / why it's safe
Both reapers have previewed `would delete 0` (HNSW: ~11 days of clean scheduled runs 07-09→07-20; GPU: validated live 2026-07-20 — connected `SMPC_stage_0`, would delete 0). Turning off dry-run is a **no-op today by design** on both:
- `created_at` backfilled at migration boot → 30d age floor makes nothing deletable before **~2026-08-08**;
- the newest-10k floor holds on the low-volume stage tables regardless.

Flipping now exercises the real guarded-DELETE path in stage on **both systems**, so no second PR is needed when the clock matures.

## Scope
- `RETENTION__DRY_RUN` `true`→`false` in the two stage common-values (`ampc-hnsw` + `iris-mpc` modifications). `ENABLED` stays `true`; no `suspend`.
- anon-stats reapers untouched (already live since 07-09). Prod unaffected (ships `suspend:true`; enabled separately per the POP-4134 ladder).

## Verify after merge
Next scheduled runs (04:00Z HNSW, 04:30Z GPU) log `retention job ok` (real path, not `(dry run)`) with `rows_deleted=0` until ~08-08.
