### PR TITLE
deploy(stage): GPU MPCV2 modifications retention reaper — dry-run (POP-4134)

### DIFF
--- a/deploy/stage/common-values-iris-mpc-modifications-retention.yaml
+++ b/deploy/stage/common-values-iris-mpc-modifications-retention.yaml
@@ -1,0 +1,43 @@
+# POP-3931 / POP-4134 — `modifications` retention CronJob (stage, smpcv2 clusters — the
+# GPU MPCV2 DB's copy). Stage counterpart of the prod GPU reaper (added in #2267); the
+# missing rung — the HNSW-system reaper was validated on stage but this one jumped
+# straight into the prod release. This lands it on stage in DRY-RUN so its schema
+# (SMPC_stage_N), namespace (iris-mpc-db-exporter), and DB reachability are exercised
+# before prod enablement.
+#
+# Runs in the iris-mpc-db-exporter namespace — the existing CronJob precedent for reaching
+# the GPU iris Aurora from generic nodes (its `application` secret holds
+# DATABASE_AURORA_URL; no pod SG or dedicated pool needed, mirroring iris-mpc-db-exporter).
+image: "ghcr.io/worldcoin/retention-reaper:v0.32.6@sha256:366cc7dcd9e9132bbfe2b5719332ff8d1f301ed5b487cbfc458fbc97cca92ace"
+
+# STAGE ENABLE, DRY-RUN: previews the exact delete predicate (read-only COUNT) daily.
+# Expected 0 for the first 30 days (created_at backfilled at migration boot) + the
+# newest-10k floor on the low-volume table. Flip DRY_RUN to "false" after clean previews
+# (mirrors the HNSW-side reaper's stage path).
+env:
+  RETENTION__ENABLED: "true"
+  RETENTION__DRY_RUN: "true"
+
+replicaCount: 1
+
+environment: stage
+
+# Daily, 04:30 UTC — ladder: anon-stats 03:30, hnsw modifications 04:00, this 04:30.
+schedule: "30 4 * * *"
+backoffLimit: 0
+
+concurrencyPolicy: Forbid
+
+imagePullSecrets:
+  - name: github-secret
+
+resources:
+  limits:
+    cpu: "500m"
+    memory: 256Mi
+  requests:
+    cpu: "100m"
+    memory: 128Mi
+
+nodeSelector:
+  kubernetes.io/arch: amd64

--- a/deploy/stage/smpcv2-0-stage/values-iris-mpc-modifications-retention.yaml
+++ b/deploy/stage/smpcv2-0-stage/values-iris-mpc-modifications-retention.yaml
@@ -1,0 +1,31 @@
+# POP-3931 / POP-4134 — modifications retention (retention-reaper), smpcv2 party 0 (stage).
+# Per-node. Reaps the GPU MPCV2 DB's modifications copy in the live GPU stage schema. The
+# hnsw-side twin reaps that system's own copy; the two databases are disjoint.
+#
+# Guard anatomy (ANDed onto the binary's own created_at < now() - 30 days conjunct):
+#   - status/persisted: only terminal, fully-persisted rows (never in-flight)
+#   - id < MIN(id of newest 10000 rows): always retain the newest 10k regardless — keeps
+#     the cross-party startup-sync window intact AND guarantees the MAX(id)+1 assignment
+#     trigger can never see an emptied table (id reuse).
+env:
+  RUST_LOG: "info"
+  RETENTION__DB_SCHEMA: "SMPC_stage_0"
+  RETENTION__PARTY: "0"
+  RETENTION__SERVICE__SERVICE_NAME: "retention-reaper-modifications-smpcv2-0"
+  RETENTION__SERVICE__METRICS__PORT: "8125"
+  RETENTION__SERVICE__METRICS__QUEUE_SIZE: "5000"
+  RETENTION__SERVICE__METRICS__BUFFER_SIZE: "256"
+  RETENTION__SERVICE__METRICS__PREFIX: "retention-reaper-modifications-smpcv2-0"
+  RETENTION__DB_URL:
+    valueFrom:
+      secretKeyRef:
+        name: application
+        key: DATABASE_AURORA_URL
+  RETENTION__SERVICE__METRICS__HOST:
+    valueFrom:
+      fieldRef:
+        fieldPath: status.hostIP
+  RETENTION_JOBS: >-
+    [{"table":"modifications","ts_column":"created_at","retention":"30 days",
+    "batch_size":2000,"batch_pause_ms":250,
+    "guard":"status = 'COMPLETED' AND persisted AND id < (SELECT COALESCE(MIN(id), 0) FROM (SELECT id FROM modifications ORDER BY id DESC LIMIT 10000) newest)"}]

--- a/deploy/stage/smpcv2-1-stage/values-iris-mpc-modifications-retention.yaml
+++ b/deploy/stage/smpcv2-1-stage/values-iris-mpc-modifications-retention.yaml
@@ -1,0 +1,31 @@
+# POP-3931 / POP-4134 — modifications retention (retention-reaper), smpcv2 party 1 (stage).
+# Per-node. Reaps the GPU MPCV2 DB's modifications copy in the live GPU stage schema. The
+# hnsw-side twin reaps that system's own copy; the two databases are disjoint.
+#
+# Guard anatomy (ANDed onto the binary's own created_at < now() - 30 days conjunct):
+#   - status/persisted: only terminal, fully-persisted rows (never in-flight)
+#   - id < MIN(id of newest 10000 rows): always retain the newest 10k regardless — keeps
+#     the cross-party startup-sync window intact AND guarantees the MAX(id)+1 assignment
+#     trigger can never see an emptied table (id reuse).
+env:
+  RUST_LOG: "info"
+  RETENTION__DB_SCHEMA: "SMPC_stage_1"
+  RETENTION__PARTY: "1"
+  RETENTION__SERVICE__SERVICE_NAME: "retention-reaper-modifications-smpcv2-1"
+  RETENTION__SERVICE__METRICS__PORT: "8125"
+  RETENTION__SERVICE__METRICS__QUEUE_SIZE: "5000"
+  RETENTION__SERVICE__METRICS__BUFFER_SIZE: "256"
+  RETENTION__SERVICE__METRICS__PREFIX: "retention-reaper-modifications-smpcv2-1"
+  RETENTION__DB_URL:
+    valueFrom:
+      secretKeyRef:
+        name: application
+        key: DATABASE_AURORA_URL
+  RETENTION__SERVICE__METRICS__HOST:
+    valueFrom:
+      fieldRef:
+        fieldPath: status.hostIP
+  RETENTION_JOBS: >-
+    [{"table":"modifications","ts_column":"created_at","retention":"30 days",
+    "batch_size":2000,"batch_pause_ms":250,
+    "guard":"status = 'COMPLETED' AND persisted AND id < (SELECT COALESCE(MIN(id), 0) FROM (SELECT id FROM modifications ORDER BY id DESC LIMIT 10000) newest)"}]

--- a/deploy/stage/smpcv2-2-stage/values-iris-mpc-modifications-retention.yaml
+++ b/deploy/stage/smpcv2-2-stage/values-iris-mpc-modifications-retention.yaml
@@ -1,0 +1,31 @@
+# POP-3931 / POP-4134 — modifications retention (retention-reaper), smpcv2 party 2 (stage).
+# Per-node. Reaps the GPU MPCV2 DB's modifications copy in the live GPU stage schema. The
+# hnsw-side twin reaps that system's own copy; the two databases are disjoint.
+#
+# Guard anatomy (ANDed onto the binary's own created_at < now() - 30 days conjunct):
+#   - status/persisted: only terminal, fully-persisted rows (never in-flight)
+#   - id < MIN(id of newest 10000 rows): always retain the newest 10k regardless — keeps
+#     the cross-party startup-sync window intact AND guarantees the MAX(id)+1 assignment
+#     trigger can never see an emptied table (id reuse).
+env:
+  RUST_LOG: "info"
+  RETENTION__DB_SCHEMA: "SMPC_stage_2"
+  RETENTION__PARTY: "2"
+  RETENTION__SERVICE__SERVICE_NAME: "retention-reaper-modifications-smpcv2-2"
+  RETENTION__SERVICE__METRICS__PORT: "8125"
+  RETENTION__SERVICE__METRICS__QUEUE_SIZE: "5000"
+  RETENTION__SERVICE__METRICS__BUFFER_SIZE: "256"
+  RETENTION__SERVICE__METRICS__PREFIX: "retention-reaper-modifications-smpcv2-2"
+  RETENTION__DB_URL:
+    valueFrom:
+      secretKeyRef:
+        name: application
+        key: DATABASE_AURORA_URL
+  RETENTION__SERVICE__METRICS__HOST:
+    valueFrom:
+      fieldRef:
+        fieldPath: status.hostIP
+  RETENTION_JOBS: >-
+    [{"table":"modifications","ts_column":"created_at","retention":"30 days",
+    "batch_size":2000,"batch_pause_ms":250,
+    "guard":"status = 'COMPLETED' AND persisted AND id < (SELECT COALESCE(MIN(id), 0) FROM (SELECT id FROM modifications ORDER BY id DESC LIMIT 10000) newest)"}]


### PR DESCRIPTION
Closes the **stage-validation gap** for the `modifications` retention reaper.

## The gap
The modifications reaper was validated on stage only for the **HNSW** system (ampc-hnsw). The **GPU/MPCV2** copy's reaper was added straight into the prod release (#2267) after the 07-07 rescope and **never ran on stage** — so it's queued for prod (via #2267 + cluster-apps #312) with no dry-run preview, no schema/namespace/reachability validation. This PR lands its stage counterpart.

## What
- `deploy/stage/common-values-iris-mpc-modifications-retention.yaml` + `smpcv2-{0,1,2}-stage/values-iris-mpc-modifications-retention.yaml`.
- Reaps the **GPU iris Aurora** (`DATABASE_AURORA_URL`), stage schema `SMPC_stage_N`, in the **iris-mpc-db-exporter** namespace (the existing CronJob precedent for reaching that DB from generic nodes — no pod SG needed).
- **Dry-run** (`ENABLED=true, DRY_RUN=true`, no `suspend`), same guard as the HNSW twin (30d age + `status='COMPLETED' AND persisted` + newest-10k floor), schedule 04:30Z (ladder: anon-stats 03:30, hnsw-modifications 04:00, this 04:30).
- Image matches the stage HNSW reaper (`v0.32.6`).

## Sequencing
Merge this first, then the companion cluster-apps PR that registers `iris-mpc-modifications-retention` on the 3 smpcv2 stage bootstraps (bootstrap valueFiles must exist on iris-mpc main first). Then it previews daily like the HNSW one did; flip `DRY_RUN=false` after clean previews. Expect `would delete 0` for a while (created_at backfill + newest-10k floor).

Part of [POP-4134](https://linear.app/worldcoin/issue/POP-4134). anon-stats + HNSW-modifications stage reapers already deployed; this is the last stage rung.