### PR TITLE
deploy(prod): bump hnsw graph-persistence job to v0.32.6 (fix VersionMissing crash)

### DIFF
--- a/deploy/prod/common-values-ampc-hnsw-graph-persistence-job.yaml
+++ b/deploy/prod/common-values-ampc-hnsw-graph-persistence-job.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc-cpu:v0.32.5@sha256:9d61c8672ad6bed5e1591dcf9ff57584b4d5dd265bad2961cbd55ce04d7b1ac8"
+image: "ghcr.io/worldcoin/iris-mpc-cpu:v0.32.6@sha256:8d65ce838edd0ec9ffaa956835174fa85aafbb5eaff2c75e578a95eb4bf4f46c"
 
 environment: prod
 schedule: "0 11 * * *"


### PR DESCRIPTION
## What

One-line pin bump: prod `ampc-hnsw-graph-persistence-job` image `iris-mpc-cpu:v0.32.5` → `v0.32.6@sha256:8d65ce83…` — the exact tag@digest the prod HNSW fleet has run since #2267.

## Why

The v0.32.6 fleet rollout applied migration `20260616000002_add_ingested_requests` to the HNSW Aurora DBs. This job's v0.32.5 binary embeds the older migration set, and sqlx refuses to boot against a database with applied migrations it doesn't know (`VersionMissing`) — so the job has been crashing since last week's deploy.

Same coupling class we handled for the fleet itself at the coordinated release; this job was the one component missed in #2267's 12-pin sweep.

## Verification

- Digest is registry-authoritative (buildx imagetools, same provenance as the #2267 pins).
- Rollback: repin v0.32.5 only after DB migrations are reverted — practically roll-forward-only, same as the fleet.