### PR TITLE
deploy(stage): pin GPU modifications reaper to the anon-stats-server pool (POP-4134)

### DIFF
--- a/deploy/stage/common-values-iris-mpc-modifications-retention.yaml
+++ b/deploy/stage/common-values-iris-mpc-modifications-retention.yaml
@@ -5,9 +5,9 @@
 # (SMPC_stage_N), namespace (iris-mpc-db-exporter), and DB reachability are exercised
 # before prod enablement.
 #
-# Runs in the iris-mpc-db-exporter namespace — the existing CronJob precedent for reaching
-# the GPU iris Aurora from generic nodes (its `application` secret holds
-# DATABASE_AURORA_URL; no pod SG or dedicated pool needed, mirroring iris-mpc-db-exporter).
+# Runs in the iris-mpc-db-exporter namespace for its `application` secret
+# (DATABASE_AURORA_URL). NOTE the original "generic nodes reach the Aurora, mirroring
+# iris-mpc-db-exporter" assumption held on prod but NOT on stage — see nodeSelector below.
 image: "ghcr.io/worldcoin/retention-reaper:v0.32.6@sha256:366cc7dcd9e9132bbfe2b5719332ff8d1f301ed5b487cbfc458fbc97cca92ace"
 
 # STAGE LIVE: dry-run cleared — the reaper now performs the real guarded DELETE against
@@ -40,5 +40,22 @@ resources:
     cpu: "100m"
     memory: 128Mi
 
+# Schedule onto the dedicated anon-stats-server node pool. On smpcv2 stage, Aurora
+# reachability is granted per node pool (not per-pod SG): every scheduled run
+# 2026-07-21 → 2026-07-27 landed on a generic node and died on the eager first
+# connection ("pool timed out while waiting for an open connection", sqlx 30s), while
+# the anon-stats reaper — same Aurora, same daily cadence — succeeds from this pool
+# (its values document this exact failure mode). The db-exporter only "works from
+# generic nodes" because its 25Gi request happens to land it on big-pool nodes.
+# Mirrors deploy/stage/common-values-anon-stats-retention.yaml.
 nodeSelector:
   kubernetes.io/arch: amd64
+  workload: anon-stats-server
+
+# The dedicated pool is tainted; mirror the anon-stats-server toleration so the reaper
+# schedules there.
+tolerations:
+  - key: dedicated
+    operator: Equal
+    value: anonStatsServer
+    effect: NoSchedule


### PR DESCRIPTION
## Problem

The stage GPU `modifications` retention reaper (`iris-mpc-modifications-retention`, ns `iris-mpc-db-exporter`, smpcv2 stage clusters) has **failed every scheduled 04:30Z run since 2026-07-21** on all 3 parties:

```
Connecting to V2 database with, schema: SMPC_stage_N     (at :06)
pool timed out while waiting for an open connection      (at :36)
Error: failed to connect to postgres
```

## Root cause

- `PostgresClient::new` connects **eagerly** (sqlx default 30s acquire timeout — matches the :06→:36 timing exactly): zero TCP connections could be established → network blackhole, not load (RDS `database_connections` ≤ 5.5 across the failure window).
- On smpcv2 **stage**, Aurora reachability is granted **per node pool**, not per-pod SG. The reaper only pinned `arch: amd64`, so its pods land on generic nodes with no DB path. The 2026-07-20 forced preview and a lone party-2 success on 07-25 were node lottery.
- The stage **anon-stats** reaper values document this exact failure mode ("Without this the reaper lands on a generic node and times out connecting to Postgres") and pin the `anon-stats-server` pool — from which they connect to the **same Aurora** daily. The "db-exporter runs from generic nodes" precedent holds on prod but not stage (the exporter's 25Gi request lands it on big-pool nodes).

## Fix

Mirror the anon-stats reaper's placement: `nodeSelector workload: anon-stats-server` + the `dedicated=anonStatsServer` toleration. Stage values only; the prod GPU reaper runs fine from generic nodes and is untouched.

## Verification plan

After merge + app sync: force one job (`kubectl create job --from=cronjob/iris-mpc-modifications-retention ...`) on one party → expect `retention-reaper starting` → `completed` (deletes 0 until ~2026-08-08 by design); then confirm the next scheduled 04:30Z run completes on all 3 parties.

Linear: POP-4134 / POP-3931
