### PR TITLE
chore: bump ampc-common to 9a3d6a4 — startup-wedge fix (#130) for GPU/HNSW/anon-stats binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 [[package]]
 name = "ampc-actor-utils"
 version = "0.1.0"
-source = "git+https://github.com/worldcoin/ampc-common.git?rev=bcc6addbaab6297db7699a8c739d9056b0bdcbe#bcc6addbaab6297db7699a8c739d9056b0bdcbed"
+source = "git+https://github.com/worldcoin/ampc-common.git?rev=9a3d6a4717910b684c055e3ca83e63867dfa9dba#9a3d6a4717910b684c055e3ca83e63867dfa9dba"
 dependencies = [
  "aes-prng",
  "ampc-secret-sharing",
@@ -111,7 +111,7 @@ dependencies = [
 [[package]]
 name = "ampc-anon-stats"
 version = "0.1.0"
-source = "git+https://github.com/worldcoin/ampc-common.git?rev=bcc6addbaab6297db7699a8c739d9056b0bdcbe#bcc6addbaab6297db7699a8c739d9056b0bdcbed"
+source = "git+https://github.com/worldcoin/ampc-common.git?rev=9a3d6a4717910b684c055e3ca83e63867dfa9dba#9a3d6a4717910b684c055e3ca83e63867dfa9dba"
 dependencies = [
  "ampc-actor-utils",
  "ampc-secret-sharing",
@@ -137,7 +137,7 @@ dependencies = [
 [[package]]
 name = "ampc-secret-sharing"
 version = "0.1.0"
-source = "git+https://github.com/worldcoin/ampc-common.git?rev=bcc6addbaab6297db7699a8c739d9056b0bdcbe#bcc6addbaab6297db7699a8c739d9056b0bdcbed"
+source = "git+https://github.com/worldcoin/ampc-common.git?rev=9a3d6a4717910b684c055e3ca83e63867dfa9dba#9a3d6a4717910b684c055e3ca83e63867dfa9dba"
 dependencies = [
  "aes-prng",
  "base64",
@@ -153,7 +153,7 @@ dependencies = [
 [[package]]
 name = "ampc-server-utils"
 version = "0.1.0"
-source = "git+https://github.com/worldcoin/ampc-common.git?rev=bcc6addbaab6297db7699a8c739d9056b0bdcbe#bcc6addbaab6297db7699a8c739d9056b0bdcbed"
+source = "git+https://github.com/worldcoin/ampc-common.git?rev=9a3d6a4717910b684c055e3ca83e63867dfa9dba#9a3d6a4717910b684c055e3ca83e63867dfa9dba"
 dependencies = [
  "aws-sdk-secretsmanager",
  "aws-sdk-sqs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,10 +86,10 @@ tokio-util = "0.7.15"
 toml = { version = "0.8.23", features = ["preserve_order"] }
 uuid = { version = "1", features = ["v4"] }
 iris-mpc-cpu = { path = "./iris-mpc-cpu" }
-ampc-anon-stats = { git = "https://github.com/worldcoin/ampc-common.git", rev = "bcc6addbaab6297db7699a8c739d9056b0bdcbe" }
-ampc-actor-utils = { git = "https://github.com/worldcoin/ampc-common.git", rev = "bcc6addbaab6297db7699a8c739d9056b0bdcbe" }
-ampc-secret-sharing = { git = "https://github.com/worldcoin/ampc-common.git", rev = "bcc6addbaab6297db7699a8c739d9056b0bdcbe" }
-ampc-server-utils = { git = "https://github.com/worldcoin/ampc-common.git", rev = "bcc6addbaab6297db7699a8c739d9056b0bdcbe" }
+ampc-anon-stats = { git = "https://github.com/worldcoin/ampc-common.git", rev = "9a3d6a4717910b684c055e3ca83e63867dfa9dba" }
+ampc-actor-utils = { git = "https://github.com/worldcoin/ampc-common.git", rev = "9a3d6a4717910b684c055e3ca83e63867dfa9dba" }
+ampc-secret-sharing = { git = "https://github.com/worldcoin/ampc-common.git", rev = "9a3d6a4717910b684c055e3ca83e63867dfa9dba" }
+ampc-server-utils = { git = "https://github.com/worldcoin/ampc-common.git", rev = "9a3d6a4717910b684c055e3ca83e63867dfa9dba" }
 
 # Abort on panics rather than unwinding.
 # This improves performance and makes panic propagation more reliable.


### PR DESCRIPTION
Delivers [ampc-common #130](https://github.com/worldcoin/ampc-common/pull/130) to every coordination consumer in this repo (GPU server, HNSW server, anon-stats-server, genesis): **in-process retry of the startup unready barrier + graceful shutdown on peer UUID change** instead of the swallowed heartbeat panic. This is the fix for the skewed-restart wedge class (HNSW stage 2026-07-09, prod DI anon-stats 2026-07-27 — locally reproduced and verified self-healing <1 min with both halves).

Crossed ampc-common commits (bcc6addb → 9a3d6a4):
- `9a3d6a4` #130 — the startup fix (this PR's payload)
- `c47f0b5` #127 — face anon-stats op support (additive)
- `d42a62d` #128 — created_at + concurrent-index migration on `anon_stats_2d_di` — **instant here** (this side's table is empty); applies at anon-stats-server boot
(#122 handshake hardening was already on board.)

**Stage rollout:** after CI builds, stage image pins (values) need their bump to the new build — follow-up PR once images exist. Mixed-version note: full self-heal benefit arrives once all 3 parties of a fleet run the new build; restart fleets together if churn appears during transition.

cargo check workspace clean. Related: POP-4162 (visibility-barrier adoption for the non-HNSW binaries).