### PR TITLE
[DO NOT MERGE] ci control: CPU Hawk E2E on #2305's base

### DIFF
--- a/iris-mpc/tests/e2e_hawk_init.rs
+++ b/iris-mpc/tests/e2e_hawk_init.rs
@@ -163,3 +163,5 @@ fn test_wal_109() -> eyre::Result<()> {
 fn test_wal_110() -> eyre::Result<()> {
     run_test!(110, 1, Wal110::new())
 }
+
+// ci-control: no-op comment to satisfy the changed-files gate (DO NOT MERGE)


### PR DESCRIPTION
Empty-commit control for the deterministic wal-test migration deadlock seen on #2305 (both attempts): runs the identical e2e on base 06673c8bd WITHOUT the ampc-common bump. Green here → the bump is implicated and #2305 stays blocked pending root-cause; red here → main is already broken and #2305 is exonerated. Will be closed after the run either way.