### PR TITLE
[DO NOT MERGE] ci bisect: ampc-common d42a62d (#128 only)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,10 +86,10 @@ tokio-util = "0.7.15"
 toml = { version = "0.8.23", features = ["preserve_order"] }
 uuid = { version = "1", features = ["v4"] }
 iris-mpc-cpu = { path = "./iris-mpc-cpu" }
-ampc-anon-stats = { git = "https://github.com/worldcoin/ampc-common.git", rev = "bcc6addbaab6297db7699a8c739d9056b0bdcbe" }
-ampc-actor-utils = { git = "https://github.com/worldcoin/ampc-common.git", rev = "bcc6addbaab6297db7699a8c739d9056b0bdcbe" }
-ampc-secret-sharing = { git = "https://github.com/worldcoin/ampc-common.git", rev = "bcc6addbaab6297db7699a8c739d9056b0bdcbe" }
-ampc-server-utils = { git = "https://github.com/worldcoin/ampc-common.git", rev = "bcc6addbaab6297db7699a8c739d9056b0bdcbe" }
+ampc-anon-stats = { git = "https://github.com/worldcoin/ampc-common.git", rev = "d42a62d" }
+ampc-actor-utils = { git = "https://github.com/worldcoin/ampc-common.git", rev = "d42a62d" }
+ampc-secret-sharing = { git = "https://github.com/worldcoin/ampc-common.git", rev = "d42a62d" }
+ampc-server-utils = { git = "https://github.com/worldcoin/ampc-common.git", rev = "d42a62d" }
 
 # Abort on panics rather than unwinding.
 # This improves performance and makes panic propagation more reliable.

--- a/iris-mpc/tests/e2e_hawk_init.rs
+++ b/iris-mpc/tests/e2e_hawk_init.rs
@@ -163,3 +163,5 @@ fn test_wal_109() -> eyre::Result<()> {
 fn test_wal_110() -> eyre::Result<()> {
     run_test!(110, 1, Wal110::new())
 }
+
+// ci-bisect d42a62d (DO NOT MERGE)


### PR DESCRIPTION
Third bisect point. base green, c47f0b5(#128+#127) red, 9a3d6a4(+#130) red. This pins d42a62d = #128 (anon_stats_2d_di created_at migration) ALONE. #128 only adds SQL files under ampc-common anon_stats_migrations/ — inert to iris-mpc (hawk runs sqlx::migrate!("./../migrations")), so if this is RED the cause is timing/rebuild-exposed not #128 content; if GREEN the culprit is #127. DO NOT MERGE.