### PR TITLE
[verify] e2e per-party DB fix + ampc-common 9a3d6a4 bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 [[package]]
 name = "ampc-actor-utils"
 version = "0.1.0"
-source = "git+https://github.com/worldcoin/ampc-common.git?rev=bcc6addbaab6297db7699a8c739d9056b0bdcbe#bcc6addbaab6297db7699a8c739d9056b0bdcbed"
+source = "git+https://github.com/worldcoin/ampc-common.git?rev=9a3d6a4717910b684c055e3ca83e63867dfa9dba#9a3d6a4717910b684c055e3ca83e63867dfa9dba"
 dependencies = [
  "aes-prng",
  "ampc-secret-sharing",
@@ -111,7 +111,7 @@ dependencies = [
 [[package]]
 name = "ampc-anon-stats"
 version = "0.1.0"
-source = "git+https://github.com/worldcoin/ampc-common.git?rev=bcc6addbaab6297db7699a8c739d9056b0bdcbe#bcc6addbaab6297db7699a8c739d9056b0bdcbed"
+source = "git+https://github.com/worldcoin/ampc-common.git?rev=9a3d6a4717910b684c055e3ca83e63867dfa9dba#9a3d6a4717910b684c055e3ca83e63867dfa9dba"
 dependencies = [
  "ampc-actor-utils",
  "ampc-secret-sharing",
@@ -137,7 +137,7 @@ dependencies = [
 [[package]]
 name = "ampc-secret-sharing"
 version = "0.1.0"
-source = "git+https://github.com/worldcoin/ampc-common.git?rev=bcc6addbaab6297db7699a8c739d9056b0bdcbe#bcc6addbaab6297db7699a8c739d9056b0bdcbed"
+source = "git+https://github.com/worldcoin/ampc-common.git?rev=9a3d6a4717910b684c055e3ca83e63867dfa9dba#9a3d6a4717910b684c055e3ca83e63867dfa9dba"
 dependencies = [
  "aes-prng",
  "base64",
@@ -153,7 +153,7 @@ dependencies = [
 [[package]]
 name = "ampc-server-utils"
 version = "0.1.0"
-source = "git+https://github.com/worldcoin/ampc-common.git?rev=bcc6addbaab6297db7699a8c739d9056b0bdcbe#bcc6addbaab6297db7699a8c739d9056b0bdcbed"
+source = "git+https://github.com/worldcoin/ampc-common.git?rev=9a3d6a4717910b684c055e3ca83e63867dfa9dba#9a3d6a4717910b684c055e3ca83e63867dfa9dba"
 dependencies = [
  "aws-sdk-secretsmanager",
  "aws-sdk-sqs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,10 +86,10 @@ tokio-util = "0.7.15"
 toml = { version = "0.8.23", features = ["preserve_order"] }
 uuid = { version = "1", features = ["v4"] }
 iris-mpc-cpu = { path = "./iris-mpc-cpu" }
-ampc-anon-stats = { git = "https://github.com/worldcoin/ampc-common.git", rev = "bcc6addbaab6297db7699a8c739d9056b0bdcbe" }
-ampc-actor-utils = { git = "https://github.com/worldcoin/ampc-common.git", rev = "bcc6addbaab6297db7699a8c739d9056b0bdcbe" }
-ampc-secret-sharing = { git = "https://github.com/worldcoin/ampc-common.git", rev = "bcc6addbaab6297db7699a8c739d9056b0bdcbe" }
-ampc-server-utils = { git = "https://github.com/worldcoin/ampc-common.git", rev = "bcc6addbaab6297db7699a8c739d9056b0bdcbe" }
+ampc-anon-stats = { git = "https://github.com/worldcoin/ampc-common.git", rev = "9a3d6a4717910b684c055e3ca83e63867dfa9dba" }
+ampc-actor-utils = { git = "https://github.com/worldcoin/ampc-common.git", rev = "9a3d6a4717910b684c055e3ca83e63867dfa9dba" }
+ampc-secret-sharing = { git = "https://github.com/worldcoin/ampc-common.git", rev = "9a3d6a4717910b684c055e3ca83e63867dfa9dba" }
+ampc-server-utils = { git = "https://github.com/worldcoin/ampc-common.git", rev = "9a3d6a4717910b684c055e3ca83e63867dfa9dba" }
 
 # Abort on panics rather than unwinding.
 # This improves performance and makes panic propagation more reliable.

--- a/iris-mpc/tests/utils/configs.rs
+++ b/iris-mpc/tests/utils/configs.rs
@@ -154,10 +154,20 @@ pub fn make_hawk_config(
 
 fn make_config(party_id: usize, db_host: &str) -> CpuNodeConfig {
     CpuNodeConfig {
-        // All three parties share the same Postgres instance; schemas provide
-        // isolation.  The `postgres` database always exists in the hawk-db
-        // compose (`docker-compose.hawk-db.yaml`).
-        db_url: format!("postgres://postgres:postgres@{db_host}:5432/postgres"),
+        // Each party gets its OWN database (created up-front by
+        // `CpuTestContext::ensure_party_databases`), mirroring prod where the
+        // three parties run on three separate Aurora clusters.
+        //
+        // They must NOT share one database: `sqlx::migrate!().run()` holds a
+        // per-database advisory lock across the whole run, and any migration
+        // using `CREATE INDEX CONCURRENTLY` (e.g. the anon-stats
+        // `..._created_at_index`) waits for every other open snapshot in that
+        // database. With a shared DB, party 0 holds the lock and its CONCURRENTLY
+        // build waits on parties 1/2, which are blocked on the same lock — a
+        // circular wait Postgres resolves as `deadlock detected`, killing hawk
+        // startup. Separate databases give each party its own advisory lock and
+        // catalog, so concurrent migration is deadlock-free (and matches prod).
+        db_url: format!("postgres://postgres:postgres@{db_host}:5432/cpu_party_db_{party_id}"),
         // Must match prepare_stores() formula: schema_name + suffix + "_" + env + "_" + party_id
         // = "cpu_party" + "" + "_dev_" + N  →  "cpu_party_dev_N"
         db_schema: format!("cpu_party_dev_{party_id}"),

--- a/iris-mpc/tests/utils/runner.rs
+++ b/iris-mpc/tests/utils/runner.rs
@@ -151,8 +151,12 @@ impl CpuTestContext {
                 .force_path_style(true)
                 .build(),
         );
+        let configs = Self::load_configs(&env);
+        Self::ensure_party_databases(&configs)
+            .await
+            .expect("failed to create per-party test databases");
         Self {
-            configs: Self::load_configs(&env),
+            configs,
             s3_client,
             env,
             kind,
@@ -164,6 +168,46 @@ impl CpuTestContext {
     fn load_configs(env: &TestEnvironment) -> CpuConfigs {
         crate::utils::configs::hardcoded_configs(env)
     }
+
+    /// Create each party's database if it does not yet exist.
+    ///
+    /// The parties run on separate databases (see `configs::make_config`) so
+    /// their concurrent startup migrations don't deadlock on a shared advisory
+    /// lock. Postgres has no `CREATE DATABASE IF NOT EXISTS`, so we connect to
+    /// the always-present `postgres` maintenance database, check `pg_database`,
+    /// and create any missing party DB. Done once here, sequentially, before any
+    /// party or hawk server connects — so there is no create-time race.
+    async fn ensure_party_databases(configs: &CpuConfigs) -> eyre::Result<()> {
+        use sqlx::{Connection, Executor, PgConnection};
+
+        for cfg in configs.iter() {
+            let (maintenance_url, db_name) = maintenance_url_and_db(&cfg.db_url)?;
+            let mut conn = PgConnection::connect(&maintenance_url).await?;
+            let exists: Option<i32> =
+                sqlx::query_scalar("SELECT 1 FROM pg_database WHERE datname = $1")
+                    .bind(&db_name)
+                    .fetch_optional(&mut conn)
+                    .await?;
+            if exists.is_none() {
+                // db_name is `cpu_party_db_{0,1,2}` (see make_config) — no user
+                // input — but quote the identifier defensively regardless.
+                conn.execute(format!("CREATE DATABASE \"{db_name}\"").as_str())
+                    .await?;
+                tracing::info!("created per-party test database {db_name}");
+            }
+            conn.close().await?;
+        }
+        Ok(())
+    }
+}
+
+/// Split a party `db_url` into (`maintenance_url` pointing at the `postgres`
+/// database on the same server, the party's `db_name`).
+fn maintenance_url_and_db(db_url: &str) -> eyre::Result<(String, String)> {
+    let (prefix, db_name) = db_url
+        .rsplit_once('/')
+        .ok_or_else(|| eyre::eyre!("db_url has no '/': {db_url}"))?;
+    Ok((format!("{prefix}/postgres"), db_name.to_string()))
 }
 
 /// Execution environment — controls addresses and S3 endpoint.


### PR DESCRIPTION
Verification branch: the CPU Hawk e2e harness fix (per-party database, resolves the shared-DB migration deadlock) ON TOP of the ampc-common 9a3d6a4 bump (#2305). If this goes green, it proves the harness fix unblocks the bump. Intended split after verification: land the harness fix as its own PR off main (unblocks any ampc-common bump), then rebase #2305. DO NOT MERGE as-is.