### PR TITLE
test(e2e): give each hawk party its own database (fix shared-DB migration deadlock)

### DIFF
--- a/iris-mpc/tests/utils/configs.rs
+++ b/iris-mpc/tests/utils/configs.rs
@@ -154,10 +154,20 @@ pub fn make_hawk_config(
 
 fn make_config(party_id: usize, db_host: &str) -> CpuNodeConfig {
     CpuNodeConfig {
-        // All three parties share the same Postgres instance; schemas provide
-        // isolation.  The `postgres` database always exists in the hawk-db
-        // compose (`docker-compose.hawk-db.yaml`).
-        db_url: format!("postgres://postgres:postgres@{db_host}:5432/postgres"),
+        // Each party gets its OWN database (created up-front by
+        // `CpuTestContext::ensure_party_databases`), mirroring prod where the
+        // three parties run on three separate Aurora clusters.
+        //
+        // They must NOT share one database: `sqlx::migrate!().run()` holds a
+        // per-database advisory lock across the whole run, and any migration
+        // using `CREATE INDEX CONCURRENTLY` (e.g. the anon-stats
+        // `..._created_at_index`) waits for every other open snapshot in that
+        // database. With a shared DB, party 0 holds the lock and its CONCURRENTLY
+        // build waits on parties 1/2, which are blocked on the same lock — a
+        // circular wait Postgres resolves as `deadlock detected`, killing hawk
+        // startup. Separate databases give each party its own advisory lock and
+        // catalog, so concurrent migration is deadlock-free (and matches prod).
+        db_url: format!("postgres://postgres:postgres@{db_host}:5432/cpu_party_db_{party_id}"),
         // Must match prepare_stores() formula: schema_name + suffix + "_" + env + "_" + party_id
         // = "cpu_party" + "" + "_dev_" + N  →  "cpu_party_dev_N"
         db_schema: format!("cpu_party_dev_{party_id}"),

--- a/iris-mpc/tests/utils/runner.rs
+++ b/iris-mpc/tests/utils/runner.rs
@@ -151,8 +151,12 @@ impl CpuTestContext {
                 .force_path_style(true)
                 .build(),
         );
+        let configs = Self::load_configs(&env);
+        Self::ensure_party_databases(&configs)
+            .await
+            .expect("failed to create per-party test databases");
         Self {
-            configs: Self::load_configs(&env),
+            configs,
             s3_client,
             env,
             kind,
@@ -164,6 +168,46 @@ impl CpuTestContext {
     fn load_configs(env: &TestEnvironment) -> CpuConfigs {
         crate::utils::configs::hardcoded_configs(env)
     }
+
+    /// Create each party's database if it does not yet exist.
+    ///
+    /// The parties run on separate databases (see `configs::make_config`) so
+    /// their concurrent startup migrations don't deadlock on a shared advisory
+    /// lock. Postgres has no `CREATE DATABASE IF NOT EXISTS`, so we connect to
+    /// the always-present `postgres` maintenance database, check `pg_database`,
+    /// and create any missing party DB. Done once here, sequentially, before any
+    /// party or hawk server connects — so there is no create-time race.
+    async fn ensure_party_databases(configs: &CpuConfigs) -> eyre::Result<()> {
+        use sqlx::{Connection, Executor, PgConnection};
+
+        for cfg in configs.iter() {
+            let (maintenance_url, db_name) = maintenance_url_and_db(&cfg.db_url)?;
+            let mut conn = PgConnection::connect(&maintenance_url).await?;
+            let exists: Option<i32> =
+                sqlx::query_scalar("SELECT 1 FROM pg_database WHERE datname = $1")
+                    .bind(&db_name)
+                    .fetch_optional(&mut conn)
+                    .await?;
+            if exists.is_none() {
+                // db_name is `cpu_party_db_{0,1,2}` (see make_config) — no user
+                // input — but quote the identifier defensively regardless.
+                conn.execute(format!("CREATE DATABASE \"{db_name}\"").as_str())
+                    .await?;
+                tracing::info!("created per-party test database {db_name}");
+            }
+            conn.close().await?;
+        }
+        Ok(())
+    }
+}
+
+/// Split a party `db_url` into (`maintenance_url` pointing at the `postgres`
+/// database on the same server, the party's `db_name`).
+fn maintenance_url_and_db(db_url: &str) -> eyre::Result<(String, String)> {
+    let (prefix, db_name) = db_url
+        .rsplit_once('/')
+        .ok_or_else(|| eyre::eyre!("db_url has no '/': {db_url}"))?;
+    Ok((format!("{prefix}/postgres"), db_name.to_string()))
 }
 
 /// Execution environment — controls addresses and S3 endpoint.


### PR DESCRIPTION
## Problem

The CPU Hawk e2e runs all three parties against **one** Postgres instance, separated only by schema (`configs.rs`). `sqlx::migrate!().run()` holds a **per-database** advisory lock across the whole migration run, and any migration using `CREATE INDEX CONCURRENTLY` waits for every other open snapshot in that database. On a shared DB: party 0 holds the advisory lock and its CONCURRENTLY build waits on parties 1/2, which are blocked on the same lock → circular wait → `deadlock detected`, which kills hawk startup (`wal_105/109/110`: *"hawk_main task exited unexpectedly before ready: while executing migrations: deadlock detected"*).

Reproduced the exact cycle locally:
```
Process 100 waits for ExclusiveLock on advisory lock [5,0,42,1]; blocked by process 98.
Process 98 waits for ShareLock on virtual transaction 5/2; blocked by process 100.
```

**Latent since the harness was written** — dormant while no new anon-stats migration exists, and triggered by *any* ampc-common bump that adds one (surfaced by POP-4104 #128's `_created_at_index` and POP-4111 #127's face-op index). It is **CI-only**: prod runs the three parties on three separate Aurora clusters, so each has its own advisory lock and catalog and never hits this.

## Fix

Give each party its **own database** (`cpu_party_db_{0,1,2}`), created up-front in `CpuTestContext` before any party or hawk server connects (Postgres has no `CREATE DATABASE IF NOT EXISTS`, so we check `pg_database` on the maintenance DB and create if missing, once, sequentially — no create race). This matches prod topology and eliminates the shared advisory lock. No migration files are touched (so no live-cluster checksum risk); `db_schema` is unchanged.

## Verification

Reproduced per-party databases locally → 3/3 concurrent CONCURRENTLY builds succeed, 0 deadlocks. And end-to-end: this fix on top of the ampc-common `9a3d6a4` bump (the exact combination that failed 4× — #2305) runs the CPU Hawk e2e **green, 5/5 wal tests** (verification branch #2309, run 30349896607). Base without this fix is green only because no new migration is present; add any and it deadlocks.

Unblocks #2305 (and any future ampc-common bump).