### PR TITLE
ci(anon-stats): rebuild image on root Cargo.toml/Cargo.lock changes

### DIFF
--- a/.github/workflows/build-and-push-anon-stats-server.yaml
+++ b/.github/workflows/build-and-push-anon-stats-server.yaml
@@ -10,6 +10,12 @@ on:
       - iris-mpc-anon-stats-server/**
       - iris-mpc-bins/bin/iris-mpc-anon-stats-server/**
       - iris-mpc-common/**
+      # Root manifest changes (e.g. an ampc-common rev bump) change what this
+      # binary compiles but live outside the crate paths above — without these
+      # the image silently isn't rebuilt on a dependency bump (missed on the
+      # 2026-07-28 ampc-common #130 bump).
+      - Cargo.toml
+      - Cargo.lock
       - .github/workflows/build-and-push-anon-stats-server.yaml
 
   release:


### PR DESCRIPTION
The `build-and-push-anon-stats-server` path filter covers the crate dirs (`iris-mpc-anon-stats-server/**`, `iris-mpc-common/**`, …) but **not the root `Cargo.toml`/`Cargo.lock`**. An ampc-common rev bump changes what the binary compiles yet lives only in the root manifest, so CI silently skips rebuilding the image.

This bit the 2026-07-28 ampc-common `9a3d6a4`/#130 bump (#2305): the GPU (`iris-mpc`) and `iris-mpc-cpu` images rebuilt on the merge, but anon-stats-server did not — leaving no new image to deploy. Adding `Cargo.toml` + `Cargo.lock` to `paths:` fixes it for this and every future dependency bump.

(For the current bump I've already `workflow_dispatch`-ed a build on main @ 316476f to unblock the stage deploy; this PR is the durable fix.)