### PR TITLE
deploy(stage): iris-mpc core + anon-stats → 6429fa5c (ampc-common #130)

### DIFF
--- a/deploy/stage/common-values-ampc-hnsw-anon-stats-server.yaml
+++ b/deploy/stage/common-values-ampc-hnsw-anon-stats-server.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/anon-stats-server:v0.32.6@sha256:bb88af42ca4a1c4af2803adb65f9ca09da6028011dad55d607b3c8affd6b0f6a"
+image: "ghcr.io/worldcoin/anon-stats-server:6429fa5c3cd96ca5e1839da651588d6807c0c6ff"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/common-values-ampc-hnsw.yaml
+++ b/deploy/stage/common-values-ampc-hnsw.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc-cpu:v0.32.6@sha256:8d65ce838edd0ec9ffaa956835174fa85aafbb5eaff2c75e578a95eb4bf4f46c"
+image: "ghcr.io/worldcoin/iris-mpc-cpu:6429fa5c3cd96ca5e1839da651588d6807c0c6ff"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/common-values-anon-stats-server.yaml
+++ b/deploy/stage/common-values-anon-stats-server.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/anon-stats-server:v0.32.6@sha256:bb88af42ca4a1c4af2803adb65f9ca09da6028011dad55d607b3c8affd6b0f6a"
+image: "ghcr.io/worldcoin/anon-stats-server:6429fa5c3cd96ca5e1839da651588d6807c0c6ff"
 
 environment: stage
 replicaCount: 1

--- a/deploy/stage/common-values-iris-mpc.yaml
+++ b/deploy/stage/common-values-iris-mpc.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc:2d968f087722df97081bca86330734e7aabb7820"
+image: "ghcr.io/worldcoin/iris-mpc:6429fa5c3cd96ca5e1839da651588d6807c0c6ff"
 
 environment: stage
 replicaCount: 1


### PR DESCRIPTION
Deploys ampc-common **9a3d6a4** (startup-wedge fix #130) to the iris-mpc **stage** fleets — core + anon-stats, all pinned to `6429fa5c` (built green from main: bump #2305 + anon-stats path-filter fix #2311; tags confirmed pushed).

| file | binary | fleet | from → to |
|---|---|---|---|
| `common-values-iris-mpc.yaml` | iris-mpc | GPU/smpcv2 | `2d968f08` → `6429fa5c` |
| `common-values-ampc-hnsw.yaml` | iris-mpc-cpu | HNSW | `v0.32.6` → `6429fa5c` |
| `common-values-anon-stats-server.yaml` | anon-stats-server | smpcv2 | `v0.32.6` → `6429fa5c` |
| `common-values-ampc-hnsw-anon-stats-server.yaml` | anon-stats-server | HNSW | `v0.32.6` → `6429fa5c` |

Not touched: retention-reaper, db-exporter, reshare (separate tools, unaffected by the bump).

**Mixed-version note:** #130's self-heal is fully effective once all 3 parties of a fleet run the new build — restart fleets together if handshake churn shows during the rolling transition. Prod pins are a separate later step after stage soak.