### PR TITLE
chore: Modify KAIST team config

### DIFF
--- a/.github/workflows/prod-deploy-approvals.yml
+++ b/.github/workflows/prod-deploy-approvals.yml
@@ -34,8 +34,7 @@ jobs:
               'stneng',        // UC Berkeley
               'jweberphipps',  // UC Berkeley
               'happyhappy-jun',// KAIST
-              'ismty0805',     // KAIST
-              'myungkyuKoo',   // KAIST
+              'jungwook235',   // KAIST
               'reneraab',      // FAU
               'SyrineSlim',    // FAU
               'sebhlr'         // FAU


### PR DESCRIPTION
This pull request makes an update to the list of KAIST approvers in the production deployment workflow. Two users were offboarded and another was onboarded to ensure the correct team members have deployment approval permissions.