### PR TITLE
ci: resolve the runner account explicitly in the genesis image build

### DIFF
--- a/.github/workflows/build-and-push-upgrade-hawk.yaml
+++ b/.github/workflows/build-and-push-upgrade-hawk.yaml
@@ -33,10 +33,12 @@ jobs:
       - name: Install Docker
         run: |
           curl -fsSL https://get.docker.com | sh
-          sudo usermod -aG docker $USER
+          # $USER is unset on the ARC runners; resolve the account explicitly.
+          RUNNER_USER=$(id -un)
+          sudo usermod -aG docker "$RUNNER_USER"
           sudo apt-get update
           sudo apt-get install acl
-          sudo setfacl --modify user:$USER:rw /var/run/docker.sock
+          sudo setfacl --modify "user:$RUNNER_USER:rw" /var/run/docker.sock
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
       - name: Log in to the Container registry


### PR DESCRIPTION
The Install Docker step in `build-and-push-upgrade-hawk.yaml` runs `usermod`/`setfacl` against `$USER`, which is unset on the ARC runners, so the step exits with a usage error. The workflow has failed on every main push since the runner migration. Resolve the account explicitly with `id -un` instead.