### PR TITLE
chore: Stop HNSW for graph update

### DIFF
--- a/deploy/prod/common-values-ampc-hnsw.yaml
+++ b/deploy/prod/common-values-ampc-hnsw.yaml
@@ -1,7 +1,7 @@
 image: "ghcr.io/worldcoin/iris-mpc-cpu:v0.32.6@sha256:8d65ce838edd0ec9ffaa956835174fa85aafbb5eaff2c75e578a95eb4bf4f46c"
 
 environment: prod
-replicaCount: 1
+replicaCount: 0
 
 # Common environment variables shared across all hnsw nodes.
 # Defined as a map (keyed by variable name) so Helm deep-merges these with the


### PR DESCRIPTION
The HNSW needs to be stopped for maintenance, the system will catch up calculations once restarted.
