### PR TITLE
feat(startup): run the mutual-visibility barrier on every ampc consumer (POP-4162)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 [[package]]
 name = "ampc-actor-utils"
 version = "0.1.0"
-source = "git+https://github.com/worldcoin/ampc-common.git?rev=9a3d6a4717910b684c055e3ca83e63867dfa9dba#9a3d6a4717910b684c055e3ca83e63867dfa9dba"
+source = "git+https://github.com/worldcoin/ampc-common.git?rev=ebc6c704f691951e24e554603d4399f3b27b6beb#ebc6c704f691951e24e554603d4399f3b27b6beb"
 dependencies = [
  "aes-prng",
  "ampc-secret-sharing",
@@ -111,7 +111,7 @@ dependencies = [
 [[package]]
 name = "ampc-anon-stats"
 version = "0.1.0"
-source = "git+https://github.com/worldcoin/ampc-common.git?rev=9a3d6a4717910b684c055e3ca83e63867dfa9dba#9a3d6a4717910b684c055e3ca83e63867dfa9dba"
+source = "git+https://github.com/worldcoin/ampc-common.git?rev=ebc6c704f691951e24e554603d4399f3b27b6beb#ebc6c704f691951e24e554603d4399f3b27b6beb"
 dependencies = [
  "ampc-actor-utils",
  "ampc-secret-sharing",
@@ -137,7 +137,7 @@ dependencies = [
 [[package]]
 name = "ampc-secret-sharing"
 version = "0.1.0"
-source = "git+https://github.com/worldcoin/ampc-common.git?rev=9a3d6a4717910b684c055e3ca83e63867dfa9dba#9a3d6a4717910b684c055e3ca83e63867dfa9dba"
+source = "git+https://github.com/worldcoin/ampc-common.git?rev=ebc6c704f691951e24e554603d4399f3b27b6beb#ebc6c704f691951e24e554603d4399f3b27b6beb"
 dependencies = [
  "aes-prng",
  "base64",
@@ -153,7 +153,7 @@ dependencies = [
 [[package]]
 name = "ampc-server-utils"
 version = "0.1.0"
-source = "git+https://github.com/worldcoin/ampc-common.git?rev=9a3d6a4717910b684c055e3ca83e63867dfa9dba#9a3d6a4717910b684c055e3ca83e63867dfa9dba"
+source = "git+https://github.com/worldcoin/ampc-common.git?rev=ebc6c704f691951e24e554603d4399f3b27b6beb#ebc6c704f691951e24e554603d4399f3b27b6beb"
 dependencies = [
  "aws-sdk-secretsmanager",
  "aws-sdk-sqs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 [[package]]
 name = "ampc-actor-utils"
 version = "0.1.0"
-source = "git+https://github.com/worldcoin/ampc-common.git?rev=ebc6c704f691951e24e554603d4399f3b27b6beb#ebc6c704f691951e24e554603d4399f3b27b6beb"
+source = "git+https://github.com/worldcoin/ampc-common.git?rev=3faee93c15676d0284497573bbff38629a21114c#3faee93c15676d0284497573bbff38629a21114c"
 dependencies = [
  "aes-prng",
  "ampc-secret-sharing",
@@ -111,7 +111,7 @@ dependencies = [
 [[package]]
 name = "ampc-anon-stats"
 version = "0.1.0"
-source = "git+https://github.com/worldcoin/ampc-common.git?rev=ebc6c704f691951e24e554603d4399f3b27b6beb#ebc6c704f691951e24e554603d4399f3b27b6beb"
+source = "git+https://github.com/worldcoin/ampc-common.git?rev=3faee93c15676d0284497573bbff38629a21114c#3faee93c15676d0284497573bbff38629a21114c"
 dependencies = [
  "ampc-actor-utils",
  "ampc-secret-sharing",
@@ -137,7 +137,7 @@ dependencies = [
 [[package]]
 name = "ampc-secret-sharing"
 version = "0.1.0"
-source = "git+https://github.com/worldcoin/ampc-common.git?rev=ebc6c704f691951e24e554603d4399f3b27b6beb#ebc6c704f691951e24e554603d4399f3b27b6beb"
+source = "git+https://github.com/worldcoin/ampc-common.git?rev=3faee93c15676d0284497573bbff38629a21114c#3faee93c15676d0284497573bbff38629a21114c"
 dependencies = [
  "aes-prng",
  "base64",
@@ -153,7 +153,7 @@ dependencies = [
 [[package]]
 name = "ampc-server-utils"
 version = "0.1.0"
-source = "git+https://github.com/worldcoin/ampc-common.git?rev=ebc6c704f691951e24e554603d4399f3b27b6beb#ebc6c704f691951e24e554603d4399f3b27b6beb"
+source = "git+https://github.com/worldcoin/ampc-common.git?rev=3faee93c15676d0284497573bbff38629a21114c#3faee93c15676d0284497573bbff38629a21114c"
 dependencies = [
  "aws-sdk-secretsmanager",
  "aws-sdk-sqs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,10 +86,10 @@ tokio-util = "0.7.15"
 toml = { version = "0.8.23", features = ["preserve_order"] }
 uuid = { version = "1", features = ["v4"] }
 iris-mpc-cpu = { path = "./iris-mpc-cpu" }
-ampc-anon-stats = { git = "https://github.com/worldcoin/ampc-common.git", rev = "9a3d6a4717910b684c055e3ca83e63867dfa9dba" }
-ampc-actor-utils = { git = "https://github.com/worldcoin/ampc-common.git", rev = "9a3d6a4717910b684c055e3ca83e63867dfa9dba" }
-ampc-secret-sharing = { git = "https://github.com/worldcoin/ampc-common.git", rev = "9a3d6a4717910b684c055e3ca83e63867dfa9dba" }
-ampc-server-utils = { git = "https://github.com/worldcoin/ampc-common.git", rev = "9a3d6a4717910b684c055e3ca83e63867dfa9dba" }
+ampc-anon-stats = { git = "https://github.com/worldcoin/ampc-common.git", rev = "ebc6c704f691951e24e554603d4399f3b27b6beb" }
+ampc-actor-utils = { git = "https://github.com/worldcoin/ampc-common.git", rev = "ebc6c704f691951e24e554603d4399f3b27b6beb" }
+ampc-secret-sharing = { git = "https://github.com/worldcoin/ampc-common.git", rev = "ebc6c704f691951e24e554603d4399f3b27b6beb" }
+ampc-server-utils = { git = "https://github.com/worldcoin/ampc-common.git", rev = "ebc6c704f691951e24e554603d4399f3b27b6beb" }
 
 # Abort on panics rather than unwinding.
 # This improves performance and makes panic propagation more reliable.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,10 +86,10 @@ tokio-util = "0.7.15"
 toml = { version = "0.8.23", features = ["preserve_order"] }
 uuid = { version = "1", features = ["v4"] }
 iris-mpc-cpu = { path = "./iris-mpc-cpu" }
-ampc-anon-stats = { git = "https://github.com/worldcoin/ampc-common.git", rev = "ebc6c704f691951e24e554603d4399f3b27b6beb" }
-ampc-actor-utils = { git = "https://github.com/worldcoin/ampc-common.git", rev = "ebc6c704f691951e24e554603d4399f3b27b6beb" }
-ampc-secret-sharing = { git = "https://github.com/worldcoin/ampc-common.git", rev = "ebc6c704f691951e24e554603d4399f3b27b6beb" }
-ampc-server-utils = { git = "https://github.com/worldcoin/ampc-common.git", rev = "ebc6c704f691951e24e554603d4399f3b27b6beb" }
+ampc-anon-stats = { git = "https://github.com/worldcoin/ampc-common.git", rev = "3faee93c15676d0284497573bbff38629a21114c" }
+ampc-actor-utils = { git = "https://github.com/worldcoin/ampc-common.git", rev = "3faee93c15676d0284497573bbff38629a21114c" }
+ampc-secret-sharing = { git = "https://github.com/worldcoin/ampc-common.git", rev = "3faee93c15676d0284497573bbff38629a21114c" }
+ampc-server-utils = { git = "https://github.com/worldcoin/ampc-common.git", rev = "3faee93c15676d0284497573bbff38629a21114c" }
 
 # Abort on panics rather than unwinding.
 # This improves performance and makes panic propagation more reliable.

--- a/iris-mpc-bins/bin/iris-mpc-anon-stats-server/main.rs
+++ b/iris-mpc-bins/bin/iris-mpc-anon-stats-server/main.rs
@@ -12,7 +12,7 @@ use ampc_anon_stats::{
 };
 use ampc_server_utils::{
     init_heartbeat_task, shutdown_handler::ShutdownHandler, wait_for_others_ready,
-    wait_for_others_unready, TaskMonitor,
+    wait_for_startup_barriers, TaskMonitor,
 };
 use aws_sdk_s3::{config::Builder as S3ConfigBuilder, Client as S3Client};
 use aws_sdk_sns::{config::Region, types::MessageAttributeValue, Client as SNSClient};
@@ -990,12 +990,14 @@ async fn main() -> Result<()> {
         .unwrap_or_else(|| "8080".to_string());
     info!("Healthcheck server running on port {}", health_port);
 
-    wait_for_others_unready(server_coord_config, &verified_peers, &uuid).await?;
+    wait_for_startup_barriers(server_coord_config, &verified_peers, &uuid).await?;
 
+    let verified_peers = verified_peers.lock().await.clone();
     init_heartbeat_task(
         server_coord_config,
         &mut background_tasks,
         &shutdown_handler,
+        verified_peers.clone(),
     )
     .await
     .wrap_err("failed to start heartbeat task")?;
@@ -1023,7 +1025,7 @@ async fn main() -> Result<()> {
         AnonStatsProcessor::new(config.clone(), anon_stats_store, sns_client, s3_client);
 
     coordination_handles.set_ready();
-    wait_for_others_ready(server_coord_config)
+    wait_for_others_ready(server_coord_config, verified_peers)
         .await
         .wrap_err("waiting for other anon stats servers to become ready")?;
 

--- a/iris-mpc-bins/bin/iris-mpc/server.rs
+++ b/iris-mpc-bins/bin/iris-mpc/server.rs
@@ -10,7 +10,7 @@ use ampc_server_utils::batch_sync::{
 use ampc_server_utils::{
     delete_messages_until_sequence_num, get_next_sns_seq_num, get_others_sync_state,
     init_heartbeat_task, set_node_ready, shutdown_handler::ShutdownHandler,
-    start_coordination_server, wait_for_others_ready, wait_for_others_unready, TaskMonitor,
+    start_coordination_server, wait_for_others_ready, wait_for_startup_barriers, TaskMonitor,
 };
 use aws_sdk_s3::Client as S3Client;
 use aws_sdk_secretsmanager::Client as SecretsManagerClient;
@@ -324,7 +324,7 @@ async fn server_main(config: Config) -> Result<()> {
     let download_shutdown_handler = Arc::clone(&shutdown_handler);
 
     background_tasks.check_tasks();
-    wait_for_others_unready(&server_coord_config, &verified_peers, &uuid).await?;
+    wait_for_startup_barriers(&server_coord_config, &verified_peers, &uuid).await?;
 
     // Start the actor in separate task.
     // A bit convoluted, but we need to create the actor on the thread already,
@@ -1079,14 +1079,16 @@ async fn server_main(config: Config) -> Result<()> {
     // --------------------------------------------------------------------------
     tracing::info!("⚓️ ANCHOR: Enable readiness and check all nodes");
 
+    let verified_peers = verified_peers.lock().await.clone();
     init_heartbeat_task(
         &server_coord_config,
         &mut background_tasks,
         &shutdown_handler,
+        verified_peers.clone(),
     )
     .await?;
     set_node_ready(is_ready_flag);
-    wait_for_others_ready(&server_coord_config).await?;
+    wait_for_others_ready(&server_coord_config, verified_peers).await?;
     background_tasks.check_tasks();
 
     // --------------------------------------------------------------------------

--- a/iris-mpc-common/tests/statistics.rs
+++ b/iris-mpc-common/tests/statistics.rs
@@ -220,6 +220,8 @@ mod tests {
             DistanceFunction::FHD,
             AnonStatsResultSource::Legacy,
             Some(AnonStatsOperation::Uniqueness),
+            None,
+            None,
         );
         stats.fill_buckets(&buckets_2d_cumulative, 1.0, None);
 

--- a/iris-mpc-upgrade-hawk/src/genesis/setup.rs
+++ b/iris-mpc-upgrade-hawk/src/genesis/setup.rs
@@ -9,7 +9,7 @@
 
 use ampc_server_utils::{
     get_others_sync_state, init_heartbeat_task, set_node_ready, shutdown_handler::ShutdownHandler,
-    start_coordination_server_with_extra_routes, wait_for_others_ready, wait_for_others_unready,
+    start_coordination_server_with_extra_routes, wait_for_others_ready, wait_for_startup_barriers,
     BatchSyncSharedState, TaskMonitor,
 };
 use aws_sdk_rds::Client as RDSClient;
@@ -221,11 +221,18 @@ pub(super) async fn exec_setup(args: &ExecutionArgs, config: &Config) -> Result<
     .await;
     task_monitor_bg.check_tasks();
 
-    // Coordinator: await network state = UNREADY.
-    wait_for_others_unready(server_coord_config, &verified_peers, &my_uuid).await?;
+    // Coordinator: await network state = UNREADY + full mutual peer visibility.
+    wait_for_startup_barriers(server_coord_config, &verified_peers, &my_uuid).await?;
     tracing::info!("Network status = UNREADY");
     // Coordinator: await network state = HEALTHY.
-    init_heartbeat_task(server_coord_config, &mut task_monitor_bg, &shutdown_handler).await?;
+    let verified_peers = verified_peers.lock().await.clone();
+    init_heartbeat_task(
+        server_coord_config,
+        &mut task_monitor_bg,
+        &shutdown_handler,
+        verified_peers.clone(),
+    )
+    .await?;
     task_monitor_bg.check_tasks();
     tracing::info!("Network status = HEALTHY");
 
@@ -361,7 +368,7 @@ pub(super) async fn exec_setup(args: &ExecutionArgs, config: &Config) -> Result<
     let ct = shutdown_handler.get_network_cancellation_token();
     tokio::select! {
         _ = ct.cancelled() => Err(eyre!("ready check failed")),
-        r = wait_for_others_ready(server_coord_config) => r
+        r = wait_for_others_ready(server_coord_config, verified_peers) => r
     }?;
     task_monitor_bg.check_tasks();
     tracing::info!("Network status = READY");

--- a/iris-mpc-upgrade-hawk/tests/resources/node-config/docker/node-0-genesis-0.toml
+++ b/iris-mpc-upgrade-hawk/tests/resources/node-config/docker/node-0-genesis-0.toml
@@ -59,7 +59,9 @@ healthcheck_ports = '["3000", "3001", "3002"]'
 image_name = ""
 heartbeat_interval_secs = 2
 heartbeat_initial_retries = 10
-http_query_retry_delay_ms = 15000
+# 250ms, not 15s: all three nodes are on loopback here, so the production-grade
+# poll interval was 6 of the suite's ~18 minutes (24 barrier waits x 15s).
+http_query_retry_delay_ms = 250
 startup_sync_timeout_secs = 300
 
 [service]

--- a/iris-mpc-upgrade-hawk/tests/resources/node-config/docker/node-1-genesis-0.toml
+++ b/iris-mpc-upgrade-hawk/tests/resources/node-config/docker/node-1-genesis-0.toml
@@ -59,7 +59,9 @@ healthcheck_ports = '["3000", "3001", "3002"]'
 image_name = ""
 heartbeat_interval_secs = 2
 heartbeat_initial_retries = 10
-http_query_retry_delay_ms = 15000
+# 250ms, not 15s: all three nodes are on loopback here, so the production-grade
+# poll interval was 6 of the suite's ~18 minutes (24 barrier waits x 15s).
+http_query_retry_delay_ms = 250
 startup_sync_timeout_secs = 300
 
 

--- a/iris-mpc-upgrade-hawk/tests/resources/node-config/docker/node-2-genesis-0.toml
+++ b/iris-mpc-upgrade-hawk/tests/resources/node-config/docker/node-2-genesis-0.toml
@@ -59,7 +59,9 @@ healthcheck_ports = '["3000", "3001", "3002"]'
 image_name = ""
 heartbeat_interval_secs = 2
 heartbeat_initial_retries = 10
-http_query_retry_delay_ms = 15000
+# 250ms, not 15s: all three nodes are on loopback here, so the production-grade
+# poll interval was 6 of the suite's ~18 minutes (24 barrier waits x 15s).
+http_query_retry_delay_ms = 250
 startup_sync_timeout_secs = 300
 
 [service]

--- a/iris-mpc-upgrade-hawk/tests/resources/node-config/local/node-0-genesis-0.toml
+++ b/iris-mpc-upgrade-hawk/tests/resources/node-config/local/node-0-genesis-0.toml
@@ -59,7 +59,9 @@ healthcheck_ports = '["3000", "3001", "3002"]'
 image_name = ""
 heartbeat_interval_secs = 2
 heartbeat_initial_retries = 10
-http_query_retry_delay_ms = 15000
+# 250ms, not 15s: all three nodes are on loopback here, so the production-grade
+# poll interval was 6 of the suite's ~18 minutes (24 barrier waits x 15s).
+http_query_retry_delay_ms = 250
 startup_sync_timeout_secs = 300
 
 [service]

--- a/iris-mpc-upgrade-hawk/tests/resources/node-config/local/node-1-genesis-0.toml
+++ b/iris-mpc-upgrade-hawk/tests/resources/node-config/local/node-1-genesis-0.toml
@@ -59,7 +59,9 @@ healthcheck_ports = '["3000", "3001", "3002"]'
 image_name = ""
 heartbeat_interval_secs = 2
 heartbeat_initial_retries = 10
-http_query_retry_delay_ms = 15000
+# 250ms, not 15s: all three nodes are on loopback here, so the production-grade
+# poll interval was 6 of the suite's ~18 minutes (24 barrier waits x 15s).
+http_query_retry_delay_ms = 250
 startup_sync_timeout_secs = 300
 
 [service]

--- a/iris-mpc-upgrade-hawk/tests/resources/node-config/local/node-2-genesis-0.toml
+++ b/iris-mpc-upgrade-hawk/tests/resources/node-config/local/node-2-genesis-0.toml
@@ -59,7 +59,9 @@ healthcheck_ports = '["3000", "3001", "3002"]'
 image_name = ""
 heartbeat_interval_secs = 2
 heartbeat_initial_retries = 10
-http_query_retry_delay_ms = 15000
+# 250ms, not 15s: all three nodes are on loopback here, so the production-grade
+# poll interval was 6 of the suite's ~18 minutes (24 barrier waits x 15s).
+http_query_retry_delay_ms = 250
 startup_sync_timeout_secs = 300
 
 [service]

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -16,12 +16,11 @@ use ampc_anon_stats::store::postgres::AccessMode as AnonStatsAccessMode;
 use ampc_anon_stats::store::postgres::PostgresClient as AnonStatsPgClient;
 use ampc_anon_stats::AnonStatsStore;
 use ampc_server_utils::batch_sync::{CURRENT_BATCH_SHA, CURRENT_BATCH_VALID_ENTRIES};
-use ampc_server_utils::server_coordination::wait_until_startup_visibility_is_complete;
 use ampc_server_utils::shutdown_handler::ShutdownHandler;
 use ampc_server_utils::{
     delete_messages_until_sequence_num, get_next_sns_seq_num, get_others_sync_state,
     init_heartbeat_task, set_node_ready, start_coordination_server_with_extra_routes,
-    wait_for_others_ready, wait_for_others_unready, BatchSyncSharedState, TaskMonitor,
+    wait_for_others_ready, wait_for_startup_barriers, BatchSyncSharedState, TaskMonitor,
 };
 use chrono::Utc;
 use eyre::{bail, eyre, Report, Result, WrapErr};
@@ -140,10 +139,8 @@ pub async fn server_main(config: Config) -> Result<()> {
     .await;
     tracing::info!("Coordination server started");
 
-    // Wait for other servers to be un-ready (syncing on startup)
-    wait_for_others_unready(&server_coord_config, &verified_peers, &my_uuid).await?;
-    wait_until_startup_visibility_is_complete(&server_coord_config, &verified_peers, &my_uuid)
-        .await?;
+    // Startup barriers: un-ready sync + full mutual peer visibility
+    wait_for_startup_barriers(&server_coord_config, &verified_peers, &my_uuid).await?;
 
     let sync_result = get_sync_result(&config, &my_state).await?;
     sync_result.check_common_config()?;
@@ -283,16 +280,18 @@ pub async fn server_main(config: Config) -> Result<()> {
     )
     .await?;
 
+    let verified_peers = verified_peers.lock().await.clone();
     init_heartbeat_task(
         &server_coord_config,
         &mut background_tasks,
         &shutdown_handler,
+        verified_peers.clone(),
     )
     .await?;
     background_tasks.check_tasks();
 
     set_node_ready(is_ready_flag);
-    wait_for_others_ready(&server_coord_config).await?;
+    wait_for_others_ready(&server_coord_config, verified_peers).await?;
 
     background_tasks.check_tasks();
 

--- a/iris-mpc/tests/utils/configs.rs
+++ b/iris-mpc/tests/utils/configs.rs
@@ -101,12 +101,7 @@ pub fn make_hawk_config(
             image_name: String::new(),
             heartbeat_interval_secs: 2,
             heartbeat_initial_retries: 10,
-            // 100ms, not the 1s production default: every startup barrier polls
-            // peers at this cadence, and with 3 parties on loopback the coarse
-            // interval is pure wall-clock. The visibility barrier this PR adds
-            // makes that cost land ~24 times over the suite, which was enough to
-            // push a ~18min suite past its 20min ceiling.
-            http_query_retry_delay_ms: 100,
+            http_query_retry_delay_ms: 1000,
             http_query_timeout_ms: 10000,
             startup_sync_timeout_secs: 300,
             startup_visibility_barrier_disabled: false,

--- a/iris-mpc/tests/utils/configs.rs
+++ b/iris-mpc/tests/utils/configs.rs
@@ -101,7 +101,12 @@ pub fn make_hawk_config(
             image_name: String::new(),
             heartbeat_interval_secs: 2,
             heartbeat_initial_retries: 10,
-            http_query_retry_delay_ms: 1000,
+            // 100ms, not the 1s production default: every startup barrier polls
+            // peers at this cadence, and with 3 parties on loopback the coarse
+            // interval is pure wall-clock. The visibility barrier this PR adds
+            // makes that cost land ~24 times over the suite, which was enough to
+            // push a ~18min suite past its 20min ceiling.
+            http_query_retry_delay_ms: 100,
             http_query_timeout_ms: 10000,
             startup_sync_timeout_secs: 300,
             startup_visibility_barrier_disabled: false,

--- a/iris-mpc/tests/utils/configs.rs
+++ b/iris-mpc/tests/utils/configs.rs
@@ -104,6 +104,7 @@ pub fn make_hawk_config(
             http_query_retry_delay_ms: 1000,
             http_query_timeout_ms: 10000,
             startup_sync_timeout_secs: 300,
+            startup_visibility_barrier_disabled: false,
         }),
         service_ports,
         service_outbound_ports,

--- a/iris-mpc/tests/utils/wait_conditions.rs
+++ b/iris-mpc/tests/utils/wait_conditions.rs
@@ -1,18 +1,50 @@
 use std::time::Duration;
 
-use ampc_server_utils::{wait_for_others_ready, ServerCoordinationConfig};
-use eyre::bail;
+use ampc_server_utils::{
+    try_get_endpoint_other_nodes, ReadyProbeResponse, ServerCoordinationConfig,
+};
+use eyre::{bail, WrapErr};
 use futures::future::try_join_all;
 use tokio::task::JoinSet;
 use tokio::time::timeout;
 
 use super::{CpuConfigs, COUNT_OF_PARTIES};
 
+/// Poll every peer's `/health` until all of them report `is_ready`.
+///
+/// Deliberately does NOT use `ampc_server_utils::wait_for_others_ready`: that
+/// function fails fast on any peer UUID outside the caller's startup-verified
+/// set, which is correct for a cluster member but wrong for this harness — the
+/// harness never runs the startup handshake, so it holds no verified set and
+/// every peer would look like a restarted node.
+async fn wait_until_peers_ready(coord: &ServerCoordinationConfig) -> eyre::Result<()> {
+    let retry_delay = Duration::from_millis(coord.http_query_retry_delay_ms);
+
+    loop {
+        if let Ok(responses) = try_get_endpoint_other_nodes(coord, "health").await {
+            let mut all_ready = true;
+            for (_status, body) in responses {
+                let probe: ReadyProbeResponse = serde_json::from_slice(&body)
+                    .wrap_err("Failed to deserialize ReadyProbeResponse")?;
+                if !probe.is_ready {
+                    all_ready = false;
+                }
+            }
+
+            if all_ready {
+                return Ok(());
+            }
+        }
+
+        tokio::time::sleep(retry_delay).await;
+    }
+}
+
 /// Wait for all 3 parties' coordination servers to signal ready.
 ///
-/// Calls `wait_for_others_ready(&server_coord_config)` for each party in parallel
-/// (via `try_join_all`), wrapped in a `tokio::select!` that also monitors the
-/// `JoinSet` for any unexpected early task exit.
+/// Polls each party's peer view in parallel (via `try_join_all`), wrapped in a
+/// `tokio::select!` that also monitors the `JoinSet` for any unexpected early
+/// task exit.
 ///
 /// Pattern taken from `iris-mpc-upgrade-hawk/tests/e2e_hawk.rs`.
 pub async fn wait_for_all_ready(
@@ -39,8 +71,9 @@ pub async fn wait_for_all_ready(
             http_query_retry_delay_ms: 1000,
             http_query_timeout_ms: 10000,
             startup_sync_timeout_secs: 300,
+            startup_visibility_barrier_disabled: false,
         };
-        async move { wait_for_others_ready(&coord).await }
+        async move { wait_until_peers_ready(&coord).await }
     });
 
     let ready_all = try_join_all(ready_futures);

--- a/iris-mpc/tests/utils/wait_conditions.rs
+++ b/iris-mpc/tests/utils/wait_conditions.rs
@@ -68,9 +68,7 @@ pub async fn wait_for_all_ready(
             image_name: String::new(),
             heartbeat_interval_secs: 2,
             heartbeat_initial_retries: 10,
-            // Matches configs.rs: 100ms so the harness's own readiness poll
-            // isn't a second source of coarse-cadence wall-clock.
-            http_query_retry_delay_ms: 100,
+            http_query_retry_delay_ms: 1000,
             http_query_timeout_ms: 10000,
             startup_sync_timeout_secs: 300,
             startup_visibility_barrier_disabled: false,

--- a/iris-mpc/tests/utils/wait_conditions.rs
+++ b/iris-mpc/tests/utils/wait_conditions.rs
@@ -68,7 +68,9 @@ pub async fn wait_for_all_ready(
             image_name: String::new(),
             heartbeat_interval_secs: 2,
             heartbeat_initial_retries: 10,
-            http_query_retry_delay_ms: 1000,
+            // Matches configs.rs: 100ms so the harness's own readiness poll
+            // isn't a second source of coarse-cadence wall-clock.
+            http_query_retry_delay_ms: 100,
             http_query_timeout_ms: 10000,
             startup_sync_timeout_secs: 300,
             startup_visibility_barrier_disabled: false,


### PR DESCRIPTION
> [ampc-common #132](https://github.com/worldcoin/ampc-common/pull/132) is **merged**; the pin here points at its squash SHA `3faee93` and the branch is rebased on current main. Ready for review.

## Problem

[#2152](https://github.com/worldcoin/iris-mpc/pull/2152) (POP-3883) added the startup mutual-visibility barrier — hold until every peer's `verified_peers` contains every current UUID — because node 0 was progressing into DB load while peers still waited on its health endpoint. It only ever ran in the HNSW server. The GPU server, the anon-stats server and the genesis coordinator call `wait_for_others_unready` alone, so all three are still exposed to that same initial-deploy wedge.

## Change

All four sites call ampc-common's new `wait_for_startup_barriers` (unready → visibility):

| Site | Before | After |
| --- | --- | --- |
| `iris-mpc/src/server/mod.rs` (HNSW) | both calls, explicit | one call, identical semantics |
| `iris-mpc-bins/bin/iris-mpc/server.rs` (GPU) | unready only | both |
| `iris-mpc-bins/bin/iris-mpc-anon-stats-server/main.rs` | unready only | both |
| `iris-mpc-upgrade-hawk/src/genesis/setup.rs` | unready only | both |

HNSW is a pure collapse — same two functions, same arguments, same error types, no double-wait. Genesis ordering was checked specifically: nothing interleaves between the unready barrier and heartbeat init, `/health` is served by the coordination server started before the barrier, and the node is still unready during phase 2 (`set_node_ready` comes much later), so peers' phase 1 passes trivially. No circularity.

## Crossed upstream changes

The pin bump (9a3d6a4 → #132) crosses two commits with call-site impact:

**#129** (heartbeat + `wait_for_others_ready` hardening) — both now validate peer UUIDs against the startup-verified set and fail fast on an unknown one. Each site snapshots `verified_peers` after the barriers and passes it down, matching the pattern in [deep-identifier-ampc#97](https://github.com/worldcoin/deep-identifier-ampc/pull/97). Snapshotting after *both* phases rather than after unready alone makes the set strictly more complete.

**#131** — `BucketStatistics2D::new` gained the two mirror-match arguments; `iris-mpc-common/tests/statistics.rs` passes `None, None`.

## Test harness fix worth a look

`iris-mpc/tests/utils/wait_conditions.rs` no longer calls `wait_for_others_ready`. Post-#129 that function `ensure!`s every peer UUID is in the caller's verified set — correct for a cluster member, wrong for this harness, which never runs the startup handshake and therefore holds an empty set. Every peer would look like a restarted node and the CPU Hawk e2e would fail on the first poll. The harness now polls `/health` for `is_ready` itself, without the restart-detection invariant (it isn't a fleet member, so that invariant isn't its to enforce). `configs.rs` and `wait_conditions.rs` also pick up the new `startup_visibility_barrier_disabled` field, since `ServerCoordinationConfig` has no `Default` and both literals are exhaustive.

## Testing

`cargo check --workspace --all-targets` clean; `cargo fmt --all` applied. CI runs the CPU Hawk e2e, which is the real exercise of both the barrier and the harness change. The 3-party local-stack acceptance (skewed cold start + targeted single-party kill, the #130 repro) runs on the deep-identifier stack before any of these leave draft.

## Startup budget

Worst-case barrier wall-clock is ≈4× `startup_sync_timeout_secs` (default 300s → 1200s) — see #132's description for the arithmetic. Every iris-mpc `startupProbe` budget should be checked against that before this rolls to prod, though no values change is included here.

Ticket: [POP-4162](https://linear.app/worldcoin/issue/POP-4162)

