### PR TITLE
Address cargo-deny-action error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2231,11 +2231,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]


### PR DESCRIPTION
Address 
```
error[unsound]: `event-listener` allows `!Send` tags to cross thread boundaries via `StackSlot`
    ┌─ /github/workspace/Cargo.lock:183:1
    │
183 │ event-listener 5.4.1 registry+https://github.com/rust-lang/crates.io-index
    │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unsound advisory detected
    │
    ├ ID: RUSTSEC-2026-0221
    ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0221
 
```