### PR TITLE
chore(prod): bump HNSW to v0.32.8 for the startup barrier

### DIFF
--- a/deploy/prod/common-values-ampc-hnsw-anon-stats-server.yaml
+++ b/deploy/prod/common-values-ampc-hnsw-anon-stats-server.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/anon-stats-server:v0.32.6@sha256:bb88af42ca4a1c4af2803adb65f9ca09da6028011dad55d607b3c8affd6b0f6a"
+image: "ghcr.io/worldcoin/anon-stats-server:v0.32.8@sha256:fb42e8448cfdd2cee01db069a17ed4181318f3290457024f5662cc30562a20f7"
 
 environment: prod
 replicaCount: 1

--- a/deploy/prod/common-values-ampc-hnsw.yaml
+++ b/deploy/prod/common-values-ampc-hnsw.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc-cpu:v0.32.7@sha256:65b142c510e3772e23f727120c6eff40e26c966a31980b8999a87a7d536e4392"
+image: "ghcr.io/worldcoin/iris-mpc-cpu:v0.32.8@sha256:c655837eb5feec85c84259bf9ff409ce9988fd3f55a9a0abf81133ca9553cad6"
 
 environment: prod
 replicaCount: 1


### PR DESCRIPTION
v0.32.7 predates #2318, so prod HNSW has been running without the mutual-visibility startup barrier. Parties 0 and 2 have been crash-looping with a clean exit 1 roughly hourly since v0.32.7 went out on 07-31 14:05Z; v0.32.8 contains the barrier.

No ampc-common bump needed, main already pins 3faee93 (#132).

Extra:
- anon-stats-server v0.32.6 -> v0.32.8, the other ampc consumer #2318 touched in this fleet
