### PR TITLE
feat(retention): enable prod modifications retention for real (POP-4134, DRY_RUN=false)

### DIFF
--- a/deploy/prod/common-values-ampc-hnsw-modifications-retention.yaml
+++ b/deploy/prod/common-values-ampc-hnsw-modifications-retention.yaml
@@ -14,7 +14,7 @@ suspend: false
 
 env:
   RETENTION__ENABLED: "true"
-  RETENTION__DRY_RUN: "true"
+  RETENTION__DRY_RUN: "false"
 
 replicaCount: 1
 

--- a/deploy/prod/common-values-ampc-hnsw-modifications-retention.yaml
+++ b/deploy/prod/common-values-ampc-hnsw-modifications-retention.yaml
@@ -5,11 +5,10 @@
 # instance in a follow-up (same binary, values + cluster-apps entry only).
 image: "ghcr.io/worldcoin/retention-reaper:v0.32.6@sha256:366cc7dcd9e9132bbfe2b5719332ff8d1f301ed5b487cbfc458fbc97cca92ace"
 
-# ENABLED IN DRY-RUN (POP-4134 prod enablement): un-suspended + ENABLED + DRY_RUN=true —
-# runs daily and PREVIEWS the guarded DELETE (read-only COUNT, no rows removed). Expect
-# would-delete 0 until ~30d after the prod created_at migration (backfill) + the
-# newest-10k floor. Flip DRY_RUN to "false" per the POP-4134 ladder once previews + the
-# POP-4136 monitors look right.
+# LIVE DELETION (POP-4134): ENABLED + DRY_RUN=false — the daily run executes the guarded
+# DELETE on rows past the retention window, bounded by the newest-10k floor. Deleted rows
+# are unrecoverable. Kill switch: RETENTION__DRY_RUN back to "true" reverts to read-only
+# previews; suspend: true stops runs entirely.
 suspend: false
 
 env:

--- a/deploy/prod/common-values-iris-mpc-modifications-retention.yaml
+++ b/deploy/prod/common-values-iris-mpc-modifications-retention.yaml
@@ -17,7 +17,7 @@ suspend: false
 
 env:
   RETENTION__ENABLED: "true"
-  RETENTION__DRY_RUN: "true"
+  RETENTION__DRY_RUN: "false"
 
 replicaCount: 1
 

--- a/deploy/prod/common-values-iris-mpc-modifications-retention.yaml
+++ b/deploy/prod/common-values-iris-mpc-modifications-retention.yaml
@@ -8,11 +8,10 @@
 # this pool with a 13-day clean record.
 image: "ghcr.io/worldcoin/retention-reaper:v0.32.6@sha256:366cc7dcd9e9132bbfe2b5719332ff8d1f301ed5b487cbfc458fbc97cca92ace"
 
-# ENABLED IN DRY-RUN (POP-4134 prod enablement): un-suspended + ENABLED + DRY_RUN=true —
-# runs daily and PREVIEWS the guarded DELETE (read-only COUNT, no rows removed). Expect
-# would-delete 0 until ~30d after the prod created_at migration (backfill) + the
-# newest-10k floor. Flip DRY_RUN to "false" per the POP-4134 ladder once previews + the
-# POP-4136 monitors look right.
+# LIVE DELETION (POP-4134): ENABLED + DRY_RUN=false — the daily run executes the guarded
+# DELETE on rows past the retention window, bounded by the newest-10k floor. Deleted rows
+# are unrecoverable. Kill switch: RETENTION__DRY_RUN back to "true" reverts to read-only
+# previews; suspend: true stops runs entirely.
 suspend: false
 
 env:


### PR DESCRIPTION
Split from #2328 per review discussion (Ertugrul). Flips both prod modifications reapers (smpcv2 + ampc-hnsw) to real deletion.

**Stage trim+bounce test: PASSED (2026-08-03, both fleets).** One-off Jobs cloned from the reaper CronJobs with the window narrowed to 14d and the newest-rows floor lowered to 500 (kept above the 328-row startup-sync lookback):

- Real deletes: **20,164 rows ×3 parties (HNSW)**, **20,159 ×3 (GPU)** — identical per fleet, cross-party consistent.
- Coordinated fleet restarts after the trim: all 6 pods 1/1, zero crash loops.
- Boot over the trimmed table exercised the full path on every party: `Grouped modifications: 328` → `Modifications to update: [], to delete: []` (no cross-party divergence) → `Replaying last 328 modification results to SNS`.

Remaining consideration (non-blocking, separate PR if wanted): genesis modification replay is watermark-forward with no limit, so a graph checkpoint dormant >30d would silently skip trimmed rows — a loud-failure guard (`MIN(id) > last_indexed_modification_id` → abort) would convert that to a clean error.

Inert until ~08-15 even once merged (prod created_at backfill 07-16 + 30d window + newest-10k floor).
