### PR TITLE
Refactor matching module

### DIFF
--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -1362,14 +1362,14 @@ impl HawkRequest {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct HawkResult {
     batch: BatchQuery,
-    match_results: matching::BatchStep3,
+    match_results: matching::MatchResults,
     connect_plans: HawkMutation,
 }
 
 impl HawkResult {
     fn new(
         batch: BatchQuery,
-        match_results: matching::BatchStep3,
+        match_results: matching::MatchResults,
         connect_plans: HawkMutation,
     ) -> Self {
         HawkResult {
@@ -1840,14 +1840,14 @@ impl HawkHandle {
 
             // Organize results per orientation. Consult the matching module for details on organizing steps.
             let match_result = {
-                let step1 = matching::BatchStep1::new(&search_results, &luc_ids, request_types);
+                let pending = matching::PendingBatch::new(&search_results, &luc_ids, request_types);
 
-                // Fetch the missing vector IDs for each side and calculate their is_match.
-                let missing_is_match =
-                    is_match_batch(search_queries, step1.missing_vector_ids(), sessions_search)
+                // Compare the other eye for vectors that matched on only one side.
+                let comparison_results =
+                    is_match_batch(search_queries, pending.ids_to_compare(), sessions_search)
                         .await?;
 
-                step1.step2(&missing_is_match, intra_results.await???)
+                pending.resolve(&comparison_results, intra_results.await???)
             };
 
             Ok((search_results, match_result))
@@ -1867,7 +1867,7 @@ impl HawkHandle {
             (
                 search_normal,
                 search_mirror,
-                matches_normal.step3(matches_mirror),
+                matches_normal.decide(matches_mirror),
             )
         };
         let sessions_mutations = &sessions.for_mutations(Orientation::Normal);
@@ -1934,7 +1934,7 @@ impl HawkHandle {
         hawk_actor: &mut HawkActor,
         sessions: &BothEyes<Vec<HawkSession>>,
         search_results: BothEyes<VecRequests<VecRotations<HawkInsertPlan>>>,
-        match_result: &matching::BatchStep3,
+        match_result: &matching::MatchResults,
         identity_updates: IdentityUpdatePlan,
         request: &HawkRequest,
     ) -> Result<HawkMutation> {

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -1901,7 +1901,7 @@ impl HawkHandle {
             hawk_actor,
             sessions_mutations,
             search_normal,
-            &match_result,
+            match_result.decisions(),
             identity_updates,
             &request,
         )
@@ -1934,13 +1934,12 @@ impl HawkHandle {
         hawk_actor: &mut HawkActor,
         sessions: &BothEyes<Vec<HawkSession>>,
         search_results: BothEyes<VecRequests<VecRotations<HawkInsertPlan>>>,
-        match_result: &matching::MatchResults,
+        decisions: &[Decision],
         identity_updates: IdentityUpdatePlan,
         request: &HawkRequest,
     ) -> Result<HawkMutation> {
         use Decision::*;
         let start = Instant::now();
-        let decisions = match_result.decisions();
         let requests_order = &request.batch.requests_order;
 
         // Fetch targeted vector IDs of reauths and identity updates (None for uniqueness insertions).

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -1867,7 +1867,7 @@ impl HawkHandle {
             (
                 search_normal,
                 search_mirror,
-                matches_normal.decide(matches_mirror),
+                matching::ResolvedBatch::decide(matches_normal, matches_mirror),
             )
         };
         let sessions_mutations = &sessions.for_mutations(Orientation::Normal);

--- a/iris-mpc-cpu/src/execution/hawk_main.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main.rs
@@ -117,7 +117,7 @@ use itertools::{izip, Itertools};
 use matching::{
     Decision, Filter, MatchId,
     OnlyOrBoth::{Both, Only},
-    RequestType, UniquenessRequest, DECISION_FILTER,
+    RequestType, DECISION_FILTER,
 };
 use rand::{thread_rng, Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
@@ -1214,28 +1214,30 @@ impl HawkRequest {
             .iter()
             .enumerate()
             .map(|(i, request_type)| match request_type.as_str() {
-                UNIQUENESS_MESSAGE_TYPE => Uniqueness(UniquenessRequest {
+                UNIQUENESS_MESSAGE_TYPE => Uniqueness {
                     skip_persistence: *self.batch.skip_persistence.get(i).unwrap(),
-                }),
-                REAUTH_MESSAGE_TYPE => Reauth(if orient == Orientation::Normal {
-                    let request_id = &self.batch.request_ids[i];
+                },
+                REAUTH_MESSAGE_TYPE => Reauth {
+                    target: if orient == Orientation::Normal {
+                        let request_id = &self.batch.request_ids[i];
 
-                    let or_rule = *self
-                        .batch
-                        .reauth_use_or_rule
-                        .get(request_id)
-                        .unwrap_or(&false);
+                        let or_rule = *self
+                            .batch
+                            .reauth_use_or_rule
+                            .get(request_id)
+                            .unwrap_or(&false);
 
-                    self.batch
-                        .reauth_target_indices
-                        .get(request_id)
-                        .map(|&idx| {
-                            let target_id = registry.from_0_indices(&[idx])[0];
-                            (target_id, or_rule)
-                        })
-                } else {
-                    None
-                }),
+                        self.batch
+                            .reauth_target_indices
+                            .get(request_id)
+                            .map(|&idx| {
+                                let target_id = registry.from_0_indices(&[idx])[0];
+                                (target_id, or_rule)
+                            })
+                    } else {
+                        None
+                    },
+                },
                 RESET_CHECK_MESSAGE_TYPE => IdentityMatchCheck,
                 RECOVERY_CHECK_MESSAGE_TYPE => IdentityMatchCheck,
                 _ => Unsupported,

--- a/iris-mpc-cpu/src/execution/hawk_main/matching.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/matching.rs
@@ -355,35 +355,49 @@ pub const DECISION_FILTER: Filter = Filter {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MatchResults(VecRequests<RequestMatches>);
 
-/// Evaluate whether a uniqueness request matched, given its selected match ids
-/// and the decisions already made for earlier requests in the batch.
+/// The outcome of evaluating a uniqueness request against its selected match ids.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+struct UniquenessOutcome {
+    /// True if anything at all blocks insertion.
+    is_match: bool,
+    /// True if search saturation was the *only* thing blocking insertion.
+    only_supermatch: bool,
+}
+
+/// Evaluate whether a uniqueness request matched, given its selected match ids and the
+/// decisions already made for earlier requests in the batch.
 ///
-/// Returns `(is_match, because_supermatch)` where `because_supermatch` is true
-/// if a `Supermatch` (saturation) id was the reason a match was found. Note this
-/// depends on `Supermatch` being yielded last by `select`, so it is only set
-/// when no ordinary match short-circuited the search first.
-fn uniqueness_is_match(
+/// Attribution to saturation is order-independent: a supermatch is the *only* reason for
+/// a match only when no ordinary id matched, in either orientation.
+fn evaluate_uniqueness(
     ids: impl IntoIterator<Item = MatchId>,
     prior_decisions: &[Decision],
-) -> (bool, bool) {
-    let mut because_supermatch = false;
-    let is_match = ids.into_iter().any(|id| match id {
-        Search(_) | Luc(_) | Reauth(_) => true,
-        Supermatch => {
-            because_supermatch = true;
-            true
-        }
-        IntraBatch(request_i) => {
-            match prior_decisions.get(request_i) {
-                // If the request we matched with will be inserted or updated,
-                // then we are blocked by this intra-batch match.
-                Some(decision) => decision.is_mutation(),
-                // The request we matched with is after us in the batch, so we are not blocked by it.
-                None => false,
+) -> UniquenessOutcome {
+    let mut ordinary_match = false;
+    let mut supermatch = false;
+
+    for id in ids {
+        match id {
+            Search(_) | Luc(_) | Reauth(_) => ordinary_match = true,
+            Supermatch => supermatch = true,
+            IntraBatch(request_i) => {
+                // We are blocked by an intra-batch match only if the request we matched
+                // with will itself be inserted or updated. A request after us in the
+                // batch has no decision yet, so it does not block us.
+                if prior_decisions
+                    .get(request_i)
+                    .is_some_and(Decision::is_mutation)
+                {
+                    ordinary_match = true;
+                }
             }
         }
-    });
-    (is_match, because_supermatch)
+    }
+
+    UniquenessOutcome {
+        is_match: ordinary_match || supermatch,
+        only_supermatch: supermatch && !ordinary_match,
+    }
 }
 
 /// Supermatcher A/B comparison: for requests whose search was extended by the
@@ -400,26 +414,29 @@ fn record_extension_metrics(
         return;
     }
 
-    let (extended_decision, _) = uniqueness_is_match(
+    let extended_decision = evaluate_uniqueness(
         request.select(filter, SearchVariant::Effective),
         prior_decisions,
-    );
+    )
+    .is_match;
 
     let not_supermatch = |id: &MatchId| !matches!(id, Supermatch);
 
-    let (extended_match, _) = uniqueness_is_match(
+    let extended_match = evaluate_uniqueness(
         request
             .select(filter, SearchVariant::Effective)
             .filter(not_supermatch),
         prior_decisions,
-    );
+    )
+    .is_match;
 
-    let (pre_match, _) = uniqueness_is_match(
+    let pre_match = evaluate_uniqueness(
         request
             .select(filter, SearchVariant::Baseline)
             .filter(not_supermatch),
         prior_decisions,
-    );
+    )
+    .is_match;
 
     match (pre_match, extended_decision) {
         (false, true) => {
@@ -476,11 +493,12 @@ impl MatchResults {
 
             let decision = match request.normal.request_type {
                 RequestType::Uniqueness(UniquenessRequest { skip_persistence }) => {
-                    let (is_match, bsm) = uniqueness_is_match(
+                    let outcome = evaluate_uniqueness(
                         request.select(filter, SearchVariant::Effective),
                         &decisions,
                     );
-                    because_supermatch = bsm;
+                    because_supermatch = outcome.only_supermatch;
+                    let is_match = outcome.is_match;
 
                     record_extension_metrics(request, filter, &decisions);
 

--- a/iris-mpc-cpu/src/execution/hawk_main/matching.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/matching.rs
@@ -72,6 +72,54 @@ impl PendingBatch {
     }
 }
 
+/// A value in the form decisions are actually made on, plus the pre-extension
+/// counterfactual retained for supermatcher A/B metrics.
+///
+/// `baseline` is `Some` only when the supermatcher re-searched with a larger `ef` for at
+/// least one rotation of this request. When it is `None`, `effective` *is* the baseline:
+/// no extension happened, so the two would be identical.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct WithBaseline<T> {
+    effective: T,
+    baseline: Option<T>,
+}
+
+/// Which form of the search results to evaluate.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum SearchVariant {
+    /// The results decisions are made on: extended, if the supermatcher ran.
+    Effective,
+    /// What the original search alone would have produced.
+    Baseline,
+}
+
+impl<T> WithBaseline<T> {
+    /// The requested form, falling back to `effective` when no extension happened.
+    fn get(&self, variant: SearchVariant) -> &T {
+        match variant {
+            SearchVariant::Effective => &self.effective,
+            SearchVariant::Baseline => self.baseline.as_ref().unwrap_or(&self.effective),
+        }
+    }
+
+    /// Every stored form: one item when no extension happened, two when it did.
+    fn variants(&self) -> impl Iterator<Item = &T> + '_ {
+        chain!(std::iter::once(&self.effective), &self.baseline)
+    }
+
+    /// True if the supermatcher extended this request's search.
+    fn was_extended(&self) -> bool {
+        self.baseline.is_some()
+    }
+
+    fn map<U>(&self, f: impl Fn(&T) -> U) -> WithBaseline<U> {
+        WithBaseline {
+            effective: f(&self.effective),
+            baseline: self.baseline.as_ref().map(f),
+        }
+    }
+}
+
 /// One request's search matches, split by how many eyes matched, plus per-eye
 /// saturation.
 ///
@@ -87,24 +135,18 @@ struct UnresolvedJoin {
 }
 
 struct PendingRequest {
-    /// Search matches from the (possibly supermatcher-extended) results.
-    join: UnresolvedJoin,
-    /// Search matches from the pre-extension results, present only for requests
-    /// whose search was extended by the supermatcher. `None` means no extension
-    /// happened.
-    pre_join: Option<UnresolvedJoin>,
+    /// Search matches, in the form decisions are made on plus the pre-extension baseline.
+    search: WithBaseline<UnresolvedJoin>,
     luc_ids: Vec<VectorId>,
     request_type: RequestType,
 }
 
 impl UnresolvedJoin {
-    /// Build by merging match results across all rotations
-    /// of both eyes. When `use_pre` is set, the pre-extension matches are used
-    /// for any rotation that was extended by the supermatcher (falling back to
-    /// the normal matches for rotations that were not extended).
+    /// Build by merging match results across all rotations of both eyes, reading the
+    /// requested form of each rotation's results.
     fn from_rotations(
         search_results: BothEyes<&VecRotations<HawkInsertPlan>>,
-        use_pre: bool,
+        variant: SearchVariant,
     ) -> UnresolvedJoin {
         let mut hits_by_id: MapEdges<BothEyes<bool>> = HashMap::new();
 
@@ -112,14 +154,13 @@ impl UnresolvedJoin {
         for (side, rotations) in izip!([LEFT, RIGHT], search_results) {
             // Merge matches from all rotations.
             for rotation in rotations.iter() {
-                let matches = if use_pre {
-                    rotation
+                let matches = match variant {
+                    SearchVariant::Effective => &rotation.classified.matches,
+                    SearchVariant::Baseline => rotation
                         .classified
                         .pre_extension
                         .as_ref()
-                        .unwrap_or(&rotation.classified.matches)
-                } else {
-                    &rotation.classified.matches
+                        .unwrap_or(&rotation.classified.matches),
                 };
                 if matches.saturated {
                     saturated[side] = true;
@@ -154,28 +195,28 @@ impl UnresolvedJoin {
         }
     }
 
-    /// Resolve the one-sided matches into a full join using the MPC-computed
-    /// `comparison_results` for the opposite eye.
-    fn resolve(
-        &self,
-        comparison_results: BothEyes<&MapEdges<bool>>,
-    ) -> VecEdges<(VectorId, BothEyes<bool>)> {
-        let mut full_join: Vec<_> = self
+    /// Resolve the one-eyed matches into a full join, using the MPC comparison results
+    /// for the opposite eye.
+    fn resolve(&self, comparison_results: BothEyes<&MapEdges<bool>>) -> ResolvedJoin {
+        let mut matches: Vec<_> = self
             .matched_both_eyes
             .iter()
             .map(|id| (*id, [true, true]))
             .collect();
         for id in &self.matched_one_eye[LEFT] {
             if let Some(right) = comparison_results[RIGHT].get(id) {
-                full_join.push((*id, [true, *right]));
+                matches.push((*id, [true, *right]));
             }
         }
         for id in &self.matched_one_eye[RIGHT] {
             if let Some(left) = comparison_results[LEFT].get(id) {
-                full_join.push((*id, [*left, true]));
+                matches.push((*id, [*left, true]));
             }
         }
-        full_join
+        ResolvedJoin {
+            matches,
+            saturated: self.saturated,
+        }
     }
 }
 
@@ -185,20 +226,23 @@ impl PendingRequest {
         luc_ids: Vec<VectorId>,
         request_type: RequestType,
     ) -> PendingRequest {
-        let join = UnresolvedJoin::from_rotations(search_results, false);
+        let effective = UnresolvedJoin::from_rotations(search_results, SearchVariant::Effective);
 
-        // Only build the pre-extension join when at least one rotation was
-        // actually extended by the supermatcher; otherwise it equals `join`.
-        let any_pre = search_results.iter().any(|rotations| {
+        // Only build the baseline join when at least one rotation was actually extended
+        // by the supermatcher; otherwise it would equal `effective`.
+        let was_extended = search_results.iter().any(|rotations| {
             rotations
                 .iter()
                 .any(|r| r.classified.pre_extension.is_some())
         });
-        let pre_join = any_pre.then(|| UnresolvedJoin::from_rotations(search_results, true));
+        let baseline = was_extended
+            .then(|| UnresolvedJoin::from_rotations(search_results, SearchVariant::Baseline));
 
         PendingRequest {
-            join,
-            pre_join,
+            search: WithBaseline {
+                effective,
+                baseline,
+            },
             luc_ids,
             request_type,
         }
@@ -211,33 +255,29 @@ impl PendingRequest {
         }
     }
 
+    /// The vectors whose `eye_to_compare` side must be compared via MPC before this
+    /// request's matches can be resolved.
+    ///
+    /// Baseline one-sided matches are included alongside the effective ones, so the
+    /// pre-extension outcome can be resolved from the same MPC results. This is needed
+    /// because a) a one-sided match in the baseline may become a two-sided match after
+    /// extension, and so would not appear in the effective `matched_one_eye`, and
+    /// b) baseline and extended results come from independent searches, so they can
+    /// diverge slightly given the approximate nature of HNSW search.
     fn ids_to_compare(&self, eye_to_compare: usize) -> VecEdges<VectorId> {
         let matched_eye = 1 - eye_to_compare;
-        let matched_one_side = &self.join.matched_one_eye[matched_eye];
+        let one_eyed = self
+            .search
+            .variants()
+            .flat_map(|join| join.matched_one_eye[matched_eye].iter());
 
-        // Include the pre-extension one-sided matches so the pre-extension outcome can be
-        // resolved from the same MPC results. This is needed because a) one-sided matches
-        // pre-extension may become two-sided matches post-extension, and thus would not appear
-        // in post-extension `matched_one_eye`, and b) initial and extended results are derived
-        // from independent searches, so could diverge (slightly) due to the approximate nature
-        // of HNSW search results.
-        let pre_matched_one_side = self
-            .pre_join
-            .iter()
-            .flat_map(|j| j.matched_one_eye[matched_eye].iter());
-
-        // Always add reauth target so is_match is computed even if the search didn't hit it.
+        // Always add the reauth target so is_match is computed even if the search missed it.
         let reauth_id = self.reauth_id().map(|(id, _)| id);
 
-        chain!(
-            matched_one_side,
-            pre_matched_one_side,
-            &self.luc_ids,
-            &reauth_id
-        )
-        .cloned()
-        .unique()
-        .collect_vec()
+        chain!(one_eyed, &self.luc_ids, &reauth_id)
+            .cloned()
+            .unique()
+            .collect_vec()
     }
 
     fn resolve(
@@ -262,18 +302,8 @@ impl PendingRequest {
             (id, or_rule, is_match)
         });
 
-        let join = ResolvedJoin {
-            matches: self.join.resolve(comparison_results),
-            saturated: self.join.saturated,
-        };
-        let pre_join = self.pre_join.as_ref().map(|pre| ResolvedJoin {
-            matches: pre.resolve(comparison_results),
-            saturated: pre.saturated,
-        });
-
         ResolvedRequest {
-            join,
-            pre_join,
+            search: self.search.map(|join| join.resolve(comparison_results)),
             luc_results,
             reauth_result,
             intra_matches,
@@ -366,27 +396,28 @@ fn record_extension_metrics(
     filter: Filter,
     prior_decisions: &[Decision],
 ) {
-    if !request.has_pre_extension() {
+    if !request.was_extended() {
         return;
     }
 
-    // Final extended search matching determination, including possible rejection due to
-    // saturation of extended search results
-    let (extended_decision, _) = uniqueness_is_match(request.select(filter), prior_decisions);
-
-    let not_supermatch = |id: &MatchId| !matches!(id, Supermatch);
-
-    // Extended matching determination, excluding rejection due to saturation of extended search
-    // results -- did we find a real match in the extended results?
-    let (extended_match, _) = uniqueness_is_match(
-        request.select(filter).filter(not_supermatch),
+    let (extended_decision, _) = uniqueness_is_match(
+        request.select(filter, SearchVariant::Effective),
         prior_decisions,
     );
 
-    // Matching determination pre-extension -- this exludes rejection due to saturated search
-    // results, since the results have not been expanded.
+    let not_supermatch = |id: &MatchId| !matches!(id, Supermatch);
+
+    let (extended_match, _) = uniqueness_is_match(
+        request
+            .select(filter, SearchVariant::Effective)
+            .filter(not_supermatch),
+        prior_decisions,
+    );
+
     let (pre_match, _) = uniqueness_is_match(
-        request.select_pre(filter).filter(not_supermatch),
+        request
+            .select(filter, SearchVariant::Baseline)
+            .filter(not_supermatch),
         prior_decisions,
     );
 
@@ -445,7 +476,10 @@ impl MatchResults {
 
             let decision = match request.normal.request_type {
                 RequestType::Uniqueness(UniquenessRequest { skip_persistence }) => {
-                    let (is_match, bsm) = uniqueness_is_match(request.select(filter), &decisions);
+                    let (is_match, bsm) = uniqueness_is_match(
+                        request.select(filter, SearchVariant::Effective),
+                        &decisions,
+                    );
                     because_supermatch = bsm;
 
                     record_extension_metrics(request, filter, &decisions);
@@ -486,7 +520,11 @@ impl MatchResults {
     pub fn select(&self, filter: Filter) -> VecRequests<Vec<MatchId>> {
         self.0
             .iter()
-            .map(|step| step.select(filter).collect_vec())
+            .map(|request| {
+                request
+                    .select(filter, SearchVariant::Effective)
+                    .collect_vec()
+            })
             .collect_vec()
     }
 }
@@ -503,12 +541,8 @@ struct ResolvedJoin {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct ResolvedRequest {
-    /// Search matches from the (possibly supermatcher-extended) results.
-    join: ResolvedJoin,
-    /// Search matches from the pre-extension results, present only when this
-    /// request's search was extended by the supermatcher. `None` means no
-    /// extension happened, in which case the pre-extension outcome equals `join`.
-    pre_join: Option<ResolvedJoin>,
+    /// Resolved search matches, in the form decisions are made on plus the baseline.
+    search: WithBaseline<ResolvedJoin>,
     luc_results: VecEdges<(VectorId, BothEyes<bool>)>,
     reauth_result: Option<(VectorId, UseOrRule, BothEyes<bool>)>,
     intra_matches: Vec<IntraMatch>,
@@ -517,25 +551,12 @@ struct ResolvedRequest {
 
 impl ResolvedRequest {
     /// The IDs of the vectors that matched this request.
-    fn select(&self, filter: Filter) -> impl Iterator<Item = MatchId> + '_ {
-        self.select_with(filter, &self.join)
-    }
+    ///
+    /// The luc, reauth and intra-batch contributions are unaffected by supermatcher
+    /// extension, so only the search join varies with `variant`.
+    fn select(&self, filter: Filter, variant: SearchVariant) -> impl Iterator<Item = MatchId> + '_ {
+        let join = self.search.get(variant);
 
-    /// Like `select`, but using the pre-extension search matches. When this
-    /// request's search was not extended by the supermatcher, this is identical
-    /// to `select`.
-    fn select_pre(&self, filter: Filter) -> impl Iterator<Item = MatchId> + '_ {
-        self.select_with(filter, self.pre_join.as_ref().unwrap_or(&self.join))
-    }
-
-    /// The IDs of the vectors that matched this request, evaluated against a
-    /// specific resolved `join` (the luc/reauth/intra contributions are
-    /// unaffected by supermatcher extension and always use `self`).
-    fn select_with<'a>(
-        &'a self,
-        filter: Filter,
-        join: &'a ResolvedJoin,
-    ) -> impl Iterator<Item = MatchId> + 'a {
         let search = join
             .matches
             .iter()
@@ -604,29 +625,21 @@ struct RequestMatches {
 }
 
 impl RequestMatches {
-    /// The IDs of the vectors that matched at least partially.
-    fn select(&self, filter: Filter) -> impl Iterator<Item = MatchId> + '_ {
+    /// The IDs of the vectors that matched at least partially, in both orientations.
+    fn select(&self, filter: Filter, variant: SearchVariant) -> impl Iterator<Item = MatchId> + '_ {
         chain!(
-            matches!(filter.orient, Only(Normal) | Both).then_some(self.normal.select(filter)),
-            matches!(filter.orient, Only(Mirror) | Both).then_some(self.mirror.select(filter)),
+            matches!(filter.orient, Only(Normal) | Both)
+                .then_some(self.normal.select(filter, variant)),
+            matches!(filter.orient, Only(Mirror) | Both)
+                .then_some(self.mirror.select(filter, variant)),
         )
         .flatten()
     }
 
-    /// Like `select`, but using the pre-extension search matches on both
-    /// orientations. Identical to `select` for requests that were not extended.
-    fn select_pre(&self, filter: Filter) -> impl Iterator<Item = MatchId> + '_ {
-        chain!(
-            matches!(filter.orient, Only(Normal) | Both).then_some(self.normal.select_pre(filter)),
-            matches!(filter.orient, Only(Mirror) | Both).then_some(self.mirror.select_pre(filter)),
-        )
-        .flatten()
-    }
-
-    /// True if this request's search was extended by the supermatcher on either
-    /// orientation, so a pre-extension comparison is meaningful.
-    fn has_pre_extension(&self) -> bool {
-        self.normal.pre_join.is_some() || self.mirror.pre_join.is_some()
+    /// True if the supermatcher extended this request's search in either orientation,
+    /// so a baseline comparison is meaningful.
+    fn was_extended(&self) -> bool {
+        self.normal.search.was_extended() || self.mirror.search.was_extended()
     }
 }
 

--- a/iris-mpc-cpu/src/execution/hawk_main/matching.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/matching.rs
@@ -6,17 +6,18 @@
 //! every id seen on one eye only, we compare the other eye explicitly via MPC, and only
 //! then apply the final matching logic.
 //!
-//! The pipeline runs in three stages:
+//! The pipeline runs in two stages:
 //!
 //! 1. [`PendingBatch::new`] organizes the nearest-neighbour results for one orientation.
 //!    Then:
 //!    1. [`PendingBatch::ids_to_compare`] gives the vectors found on one eye only.
 //!    2. The caller computes their `is_match` on the other eye with MPC.
-//!    3. [`PendingBatch::resolve`] takes those results back.
+//!    3. [`PendingBatch::resolve`] takes those results back, producing a
+//!       [`ResolvedBatch`].
 //! 2. [`ResolvedBatch::decide`] combines the normal and mirror orientations and makes the
 //!    final decision for every request. It is also the only place per-batch supermatcher
-//!    metrics are emitted.
-//! 3. [`MatchResults`] exposes the decisions and the matched ids for reporting.
+//!    metrics are emitted. The resulting [`MatchResults`] exposes those decisions and the
+//!    matched ids for reporting.
 //!
 //! Terms used throughout:
 //!
@@ -211,9 +212,11 @@ enum SearchVariant {
 }
 
 // ===========================================================================
-// Stage 1: join the two eyes' search results
+// Stage 1: join the two eyes' search results, then resolve one-eyed matches via MPC
 // ===========================================================================
 
+/// One orientation's per-request search results, not yet resolved against the other
+/// eye. Consumed by [`PendingBatch::resolve`].
 pub struct PendingBatch(VecRequests<PendingRequest>);
 
 impl PendingBatch {
@@ -264,6 +267,8 @@ impl PendingBatch {
     }
 }
 
+/// One request's search results for one orientation, not yet resolved against the
+/// other eye.
 struct PendingRequest {
     /// Search matches, in the form decisions are made on plus the pre-extension baseline.
     search: WithBaseline<UnresolvedJoin>,
@@ -457,13 +462,16 @@ impl UnresolvedJoin {
 }
 
 // ===========================================================================
-// Stage 2: resolve one-eyed matches with the MPC comparison results
+// Resolved types: request and batch state produced by Stage 1
 // ===========================================================================
 
-/// Results for a batch of requests.
+/// All requests for one orientation, with the other-eye comparisons applied. Consumed
+/// by [`Self::decide`].
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ResolvedBatch(VecRequests<ResolvedRequest>);
 
+/// One resolved request: search, LUC, reauth, and intra-batch matches for one
+/// orientation, after MPC resolution.
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct ResolvedRequest {
     /// Resolved search matches, in the form decisions are made on plus the baseline.
@@ -521,7 +529,7 @@ struct ResolvedJoin {
 }
 
 // ===========================================================================
-// Stage 3: combine orientations and decide
+// Stage 2: combine orientations, decide, and expose results
 // ===========================================================================
 
 /// Combines the results from mirrored checks.
@@ -730,19 +738,20 @@ fn extension_outcome(
     prior_decisions: &[Decision],
 ) -> ExtensionOutcome {
     let not_supermatch = |id: &MatchId| !matches!(id, Supermatch);
-    let evaluate = |variant, exclude_supermatch: bool| {
-        let ids = request.select(filter, variant);
-        if exclude_supermatch {
-            evaluate_uniqueness(ids.filter(not_supermatch), prior_decisions).is_match
-        } else {
-            evaluate_uniqueness(ids, prior_decisions).is_match
-        }
+    let is_match =
+        |variant| evaluate_uniqueness(request.select(filter, variant), prior_decisions).is_match;
+    let is_real_match = |variant| {
+        evaluate_uniqueness(
+            request.select(filter, variant).filter(not_supermatch),
+            prior_decisions,
+        )
+        .is_match
     };
 
     ExtensionOutcome {
-        extended_decision: evaluate(SearchVariant::Effective, false),
-        extended_match: evaluate(SearchVariant::Effective, true),
-        baseline_match: evaluate(SearchVariant::Baseline, true),
+        extended_decision: is_match(SearchVariant::Effective),
+        extended_match: is_real_match(SearchVariant::Effective),
+        baseline_match: is_real_match(SearchVariant::Baseline),
     }
 }
 

--- a/iris-mpc-cpu/src/execution/hawk_main/matching.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/matching.rs
@@ -31,9 +31,8 @@
 
 use super::{
     intra_batch::IntraMatch, BothEyes, HawkInsertPlan, MapEdges, Orientation, StoreId, UseOrRule,
-    VecEdges, VecRequests, VectorId, LEFT, RIGHT,
+    VecEdges, VecRequests, VecRotations, VectorId, LEFT, RIGHT,
 };
-use crate::execution::hawk_main::VecRotations;
 use itertools::{chain, izip, Itertools};
 use std::collections::HashMap;
 
@@ -145,22 +144,19 @@ impl Decision {
     }
 }
 
-// TODO: This could move to `BatchQuery` and maybe use the original types in `smpc_request.rs`.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum RequestType {
     /// A request to check if a vector is unique.
-    Uniqueness(UniquenessRequest),
+    Uniqueness { skip_persistence: bool },
     /// A request to check if a vector is unique without inserting it.
     IdentityMatchCheck,
     /// A request to check if a vector matches a target and replace it.
-    Reauth(Option<(VectorId, UseOrRule)>),
+    Reauth {
+        /// Target vector id and whether to use an OR-rule for comparison
+        target: Option<(VectorId, UseOrRule)>,
+    },
     /// Other features.
     Unsupported,
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct UniquenessRequest {
-    pub skip_persistence: bool,
 }
 
 /// A value in the form decisions are actually made on, plus the pre-extension
@@ -306,7 +302,7 @@ impl PendingRequest {
 
     fn reauth_id(&self) -> Option<(VectorId, UseOrRule)> {
         match self.request_type {
-            RequestType::Reauth(r) => r,
+            RequestType::Reauth { target } => target,
             _ => None,
         }
     }
@@ -594,7 +590,7 @@ impl ResolvedBatch {
             let mut only_supermatch = false;
 
             let decision = match request.normal.request_type {
-                RequestType::Uniqueness(UniquenessRequest { skip_persistence }) => {
+                RequestType::Uniqueness { skip_persistence } => {
                     let outcome = evaluate_uniqueness(
                         request.select(filter, SearchVariant::Effective),
                         &decisions,
@@ -616,7 +612,7 @@ impl ResolvedBatch {
                 // Identity Match Check request. Nothing to do.
                 RequestType::IdentityMatchCheck => NoMutation,
                 // Reauth request.
-                RequestType::Reauth(_) => match request.normal.reauth_result {
+                RequestType::Reauth { .. } => match request.normal.reauth_result {
                     Some((id, or_rule, matches)) if filter.reauth_rule(or_rule, matches) => {
                         ReauthUpdate(id)
                     }

--- a/iris-mpc-cpu/src/execution/hawk_main/matching.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/matching.rs
@@ -569,9 +569,12 @@ impl ResolvedBatch {
     /// This is the one place decisions are computed and the one place the per-request
     /// supermatcher metrics are emitted; callers read the stored vector afterwards via
     /// `MatchResults::decisions()`.
-    pub fn decide(self, mirror: Self) -> MatchResults {
-        assert_eq!(self.0.len(), mirror.0.len());
-        let requests = izip!(self.0, mirror.0)
+    ///
+    /// Note that `normal` and `mirror` inputs play non-equivalent roles in the decision
+    /// procedure, so it is important to provide the inputs in the correct order.
+    pub fn decide(normal: Self, mirror: Self) -> MatchResults {
+        assert_eq!(normal.0.len(), mirror.0.len());
+        let requests = izip!(normal.0, mirror.0)
             .map(|(normal, mirror)| RequestMatches { normal, mirror })
             .collect_vec();
 

--- a/iris-mpc-cpu/src/execution/hawk_main/matching.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/matching.rs
@@ -400,45 +400,44 @@ fn evaluate_uniqueness(
     }
 }
 
-/// Supermatcher A/B comparison: for requests whose search was extended by the
-/// supermatcher, compare the extended search-match outcome against what the
-/// pre-extension search alone would have produced. The `Supermatch` (saturation)
-/// signal is excluded so we isolate whether the extended search surfaced a
-/// *real* neighbor match that the original search missed.
-fn record_extension_metrics(
+/// Supermatcher A/B comparison: the three match determinations an extended search is
+/// judged by. Only meaningful for requests where `RequestMatches::was_extended()`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+struct ExtensionOutcome {
+    /// Final call on the extended results, including rejection due to saturation.
+    extended_decision: bool,
+    /// The extended results ignoring saturation: did the extended search surface a
+    /// *real* neighbour match that the original search missed?
+    extended_match: bool,
+    /// What the original search alone would have concluded. Saturation is excluded here
+    /// too, since those results were never expanded.
+    baseline_match: bool,
+}
+
+fn extension_outcome(
     request: &RequestMatches,
     filter: Filter,
     prior_decisions: &[Decision],
-) {
-    if !request.was_extended() {
-        return;
-    }
-
-    let extended_decision = evaluate_uniqueness(
-        request.select(filter, SearchVariant::Effective),
-        prior_decisions,
-    )
-    .is_match;
-
+) -> ExtensionOutcome {
     let not_supermatch = |id: &MatchId| !matches!(id, Supermatch);
+    let evaluate = |variant, exclude_supermatch: bool| {
+        let ids = request.select(filter, variant);
+        if exclude_supermatch {
+            evaluate_uniqueness(ids.filter(not_supermatch), prior_decisions).is_match
+        } else {
+            evaluate_uniqueness(ids, prior_decisions).is_match
+        }
+    };
 
-    let extended_match = evaluate_uniqueness(
-        request
-            .select(filter, SearchVariant::Effective)
-            .filter(not_supermatch),
-        prior_decisions,
-    )
-    .is_match;
+    ExtensionOutcome {
+        extended_decision: evaluate(SearchVariant::Effective, false),
+        extended_match: evaluate(SearchVariant::Effective, true),
+        baseline_match: evaluate(SearchVariant::Baseline, true),
+    }
+}
 
-    let pre_match = evaluate_uniqueness(
-        request
-            .select(filter, SearchVariant::Baseline)
-            .filter(not_supermatch),
-        prior_decisions,
-    )
-    .is_match;
-
-    match (pre_match, extended_decision) {
+fn record_extension_metrics(outcome: &ExtensionOutcome) {
+    match (outcome.baseline_match, outcome.extended_decision) {
         (false, true) => {
             metrics::counter!("supermatcher_extended_search_changed_decision_to_reject")
                 .increment(1);
@@ -450,7 +449,7 @@ fn record_extension_metrics(
         _ => {}
     }
 
-    match (pre_match, extended_match) {
+    match (outcome.baseline_match, outcome.extended_match) {
         (false, true) => {
             metrics::counter!("supermatcher_extended_search_found_new_match").increment(1);
         }
@@ -460,7 +459,7 @@ fn record_extension_metrics(
         _ => {}
     }
 
-    // Unconditionally count when a request had some pre-extension in one of its searches.
+    // Unconditionally count when a request had an extended search.
     metrics::counter!("supermatcher_extended_search_requests").increment(1);
 }
 
@@ -500,7 +499,9 @@ impl MatchResults {
                     because_supermatch = outcome.only_supermatch;
                     let is_match = outcome.is_match;
 
-                    record_extension_metrics(request, filter, &decisions);
+                    if request.was_extended() {
+                        record_extension_metrics(&extension_outcome(request, filter, &decisions));
+                    }
 
                     if is_match {
                         NoMutation

--- a/iris-mpc-cpu/src/execution/hawk_main/matching.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/matching.rs
@@ -1,3 +1,33 @@
+//! Turning search results into match decisions.
+//!
+//! The two eyes are searched by separate HNSW indices, so each returns its own set of
+//! matching ids. We cannot AND/OR them directly: an id returned for one eye may not have
+//! been considered at all by the other, which does not mean it would not match. So for
+//! every id seen on one eye only, we compare the other eye explicitly via MPC, and only
+//! then apply the final matching logic.
+//!
+//! The pipeline runs in three stages:
+//!
+//! 1. [`PendingBatch::new`] organizes the nearest-neighbour results for one orientation.
+//!    Then:
+//!    1. [`PendingBatch::ids_to_compare`] gives the vectors found on one eye only.
+//!    2. The caller computes their `is_match` on the other eye with MPC.
+//!    3. [`PendingBatch::resolve`] takes those results back.
+//! 2. [`ResolvedBatch::decide`] combines the normal and mirror orientations and makes the
+//!    final decision for every request. It is also the only place per-batch supermatcher
+//!    metrics are emitted.
+//! 3. [`MatchResults`] exposes the decisions and the matched ids for reporting.
+//!
+//! Terms used throughout:
+//!
+//! - **join**: the per-request merge of both eyes' hits, keyed by vector id and recording
+//!   which eye(s) matched. "Unresolved" before the MPC comparisons, "resolved" after.
+//! - **saturation / supermatch**: a search whose results were (nearly) all matches, so
+//!   more matches likely exist beyond `ef`. Treated as a match for uniqueness purposes.
+//! - **effective vs. baseline**: when saturation triggers the supermatcher, the search is
+//!   re-run with a larger `ef` and those extended results become the *effective* ones.
+//!   The original results are kept as the *baseline*, used only for A/B metrics.
+
 use super::{
     intra_batch::IntraMatch, BothEyes, HawkInsertPlan, MapEdges, Orientation, StoreId, UseOrRule,
     VecEdges, VecRequests, VectorId, LEFT, RIGHT,
@@ -6,22 +36,184 @@ use crate::execution::hawk_main::VecRotations;
 use itertools::{chain, izip, Itertools};
 use std::collections::HashMap;
 
-/// Since the two separate HSNW for left and right return separate vectors of matching ids, we
-/// cannot do the trivial AND/OR matching procedure from v2, since the other side might not have
-/// considered that id at all. This however does not mean it would not match, so for all ids that
-/// are given back for one side we do a manual comparison in the other side to get a full
-/// left-right match pair. Only then do we continue to the final matching logic.
+use Decision::*;
+use MatchId::*;
+use OnlyOrBoth::{Both, Only};
+use Orientation::{Mirror, Normal};
+use StoreId::{Left, Right};
+
+// ===========================================================================
+// Vocabulary: filters, match ids, decisions, request types, search variants
+// ===========================================================================
+
+/// Search *AND* policy: only match if both eyes match (like `mergeDbResults`).
 ///
-/// The matching algorithm follows these steps:
+/// LUC *OR* policy: "Local" irises match if either side matches.
 ///
-/// 1. Organize the results of the nearest neighbor search with
-///    `PendingBatch::new`. Then:
+/// Intra-batch *AND* policy: match against requests before this request in the same batch.
 ///
-///    1.a. Get the vectors found on only one side with `ids_to_compare()`.
-///    1.b. Fetch the other side and calculate their `is_match` with MPC.
-///    1.c. Give this back to `resolve(comparison_results)`.
+/// Partial matches: set `eyes: Only(Left)` or `eyes: Only(Right)`.
 ///
-/// 2. `ResolvedBatch::is_matches`: Combine it all into the final match decisions.
+/// Mirror matches: set `orient: Only(Mirror)`.
+#[derive(Copy, Clone)]
+pub struct Filter {
+    pub eyes: OnlyOrBoth<StoreId>,
+    pub orient: OnlyOrBoth<Orientation>,
+    pub intra_batch: bool,
+}
+
+#[derive(Copy, Clone)]
+pub enum OnlyOrBoth<T> {
+    Only(T),
+    Both,
+}
+
+impl Filter {
+    fn search_rule(&self, left: bool, right: bool) -> bool {
+        match self.eyes {
+            Only(Left) => left,
+            Only(Right) => right,
+            Both => left && right,
+        }
+    }
+
+    fn luc_rule(&self, left: bool, right: bool) -> bool {
+        match self.eyes {
+            Only(Left) => left,
+            Only(Right) => right,
+            Both => left || right,
+        }
+    }
+
+    /// Decide if this is a successful reauth based on left and right matches.
+    /// Use the OR or AND rule as specified in the reauth request.
+    fn reauth_rule(&self, or_rule: UseOrRule, [left, right]: BothEyes<bool>) -> bool {
+        match self.eyes {
+            Only(Left) => left,
+            Only(Right) => right,
+            Both if or_rule => left || right,
+            Both => left && right,
+        }
+    }
+
+    fn intra_rule(&self, left: bool, right: bool) -> bool {
+        self.intra_batch && self.search_rule(left, right)
+    }
+
+    /// Supermatch uses OR policy: saturated on either eye is a supermatch.
+    fn supermatch_rule(&self, [left, right]: BothEyes<bool>) -> bool {
+        match self.eyes {
+            Only(Left) => left,
+            Only(Right) => right,
+            Both => left || right,
+        }
+    }
+}
+
+/// Wide filter: any match in any orientation, including intra-batch peers.
+pub const DECISION_FILTER: Filter = Filter {
+    eyes: OnlyOrBoth::Both,
+    orient: OnlyOrBoth::Both,
+    intra_batch: true,
+};
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum MatchId {
+    Search(VectorId),
+    Luc(VectorId),
+    Reauth(VectorId),
+    IntraBatch(usize),
+    /// Search results were saturated (supermatcher).
+    Supermatch,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Decision {
+    UniqueInsert,
+    UniqueInsertSkipped,
+    ReauthUpdate(VectorId),
+    NoMutation,
+}
+
+impl Decision {
+    pub fn is_mutation(&self) -> bool {
+        match self {
+            UniqueInsert | ReauthUpdate(_) => true,
+            UniqueInsertSkipped | NoMutation => false,
+        }
+    }
+}
+
+// TODO: This could move to `BatchQuery` and maybe use the original types in `smpc_request.rs`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum RequestType {
+    /// A request to check if a vector is unique.
+    Uniqueness(UniquenessRequest),
+    /// A request to check if a vector is unique without inserting it.
+    IdentityMatchCheck,
+    /// A request to check if a vector matches a target and replace it.
+    Reauth(Option<(VectorId, UseOrRule)>),
+    /// Other features.
+    Unsupported,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct UniquenessRequest {
+    pub skip_persistence: bool,
+}
+
+/// A value in the form decisions are actually made on, plus the pre-extension
+/// counterfactual retained for supermatcher A/B metrics.
+///
+/// `baseline` is `Some` only when the supermatcher re-searched with a larger `ef` for at
+/// least one rotation of this request. When it is `None`, `effective` *is* the baseline:
+/// no extension happened, so the two would be identical.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct WithBaseline<T> {
+    effective: T,
+    baseline: Option<T>,
+}
+
+impl<T> WithBaseline<T> {
+    /// The requested form, falling back to `effective` when no extension happened.
+    fn get(&self, variant: SearchVariant) -> &T {
+        match variant {
+            SearchVariant::Effective => &self.effective,
+            SearchVariant::Baseline => self.baseline.as_ref().unwrap_or(&self.effective),
+        }
+    }
+
+    /// Every stored form: one item when no extension happened, two when it did.
+    fn variants(&self) -> impl Iterator<Item = &T> + '_ {
+        chain!(std::iter::once(&self.effective), &self.baseline)
+    }
+
+    /// True if the supermatcher extended this request's search.
+    fn was_extended(&self) -> bool {
+        self.baseline.is_some()
+    }
+
+    fn map<U>(&self, f: impl Fn(&T) -> U) -> WithBaseline<U> {
+        WithBaseline {
+            effective: f(&self.effective),
+            baseline: self.baseline.as_ref().map(f),
+        }
+    }
+}
+
+/// Which form of the search results to evaluate.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum SearchVariant {
+    /// The results decisions are made on: extended, if the supermatcher ran.
+    Effective,
+    /// What the original search alone would have produced.
+    Baseline,
+}
+
+// ===========================================================================
+// Stage 1: join the two eyes' search results
+// ===========================================================================
+
 pub struct PendingBatch(VecRequests<PendingRequest>);
 
 impl PendingBatch {
@@ -72,152 +264,11 @@ impl PendingBatch {
     }
 }
 
-/// A value in the form decisions are actually made on, plus the pre-extension
-/// counterfactual retained for supermatcher A/B metrics.
-///
-/// `baseline` is `Some` only when the supermatcher re-searched with a larger `ef` for at
-/// least one rotation of this request. When it is `None`, `effective` *is* the baseline:
-/// no extension happened, so the two would be identical.
-#[derive(Clone, Debug, PartialEq, Eq)]
-struct WithBaseline<T> {
-    effective: T,
-    baseline: Option<T>,
-}
-
-/// Which form of the search results to evaluate.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-enum SearchVariant {
-    /// The results decisions are made on: extended, if the supermatcher ran.
-    Effective,
-    /// What the original search alone would have produced.
-    Baseline,
-}
-
-impl<T> WithBaseline<T> {
-    /// The requested form, falling back to `effective` when no extension happened.
-    fn get(&self, variant: SearchVariant) -> &T {
-        match variant {
-            SearchVariant::Effective => &self.effective,
-            SearchVariant::Baseline => self.baseline.as_ref().unwrap_or(&self.effective),
-        }
-    }
-
-    /// Every stored form: one item when no extension happened, two when it did.
-    fn variants(&self) -> impl Iterator<Item = &T> + '_ {
-        chain!(std::iter::once(&self.effective), &self.baseline)
-    }
-
-    /// True if the supermatcher extended this request's search.
-    fn was_extended(&self) -> bool {
-        self.baseline.is_some()
-    }
-
-    fn map<U>(&self, f: impl Fn(&T) -> U) -> WithBaseline<U> {
-        WithBaseline {
-            effective: f(&self.effective),
-            baseline: self.baseline.as_ref().map(f),
-        }
-    }
-}
-
-/// One request's search matches, split by how many eyes matched, plus per-eye
-/// saturation.
-///
-/// `matched_both_eyes` holds vectors that matched on both eyes directly in the search
-/// results. `matched_one_eye[side]` holds vectors that matched only on `side`;
-/// the other eye is resolved later via `resolve` using the MPC `comparison_results`.
-#[derive(Clone, Debug)]
-struct UnresolvedJoin {
-    matched_both_eyes: VecEdges<VectorId>,
-    matched_one_eye: BothEyes<VecEdges<VectorId>>,
-    /// True per eye if any rotation's match results were saturated (supermatcher).
-    saturated: BothEyes<bool>,
-}
-
 struct PendingRequest {
     /// Search matches, in the form decisions are made on plus the pre-extension baseline.
     search: WithBaseline<UnresolvedJoin>,
     luc_ids: Vec<VectorId>,
     request_type: RequestType,
-}
-
-impl UnresolvedJoin {
-    /// Build by merging match results across all rotations of both eyes, reading the
-    /// requested form of each rotation's results.
-    fn from_rotations(
-        search_results: BothEyes<&VecRotations<HawkInsertPlan>>,
-        variant: SearchVariant,
-    ) -> UnresolvedJoin {
-        let mut hits_by_id: MapEdges<BothEyes<bool>> = HashMap::new();
-
-        let mut saturated = [false, false];
-        for (side, rotations) in izip!([LEFT, RIGHT], search_results) {
-            // Merge matches from all rotations.
-            for rotation in rotations.iter() {
-                let matches = match variant {
-                    SearchVariant::Effective => &rotation.classified.matches,
-                    SearchVariant::Baseline => rotation
-                        .classified
-                        .pre_extension
-                        .as_ref()
-                        .unwrap_or(&rotation.classified.matches),
-                };
-                if matches.saturated {
-                    saturated[side] = true;
-                }
-                for (vector_id, _) in matches.results.iter() {
-                    hits_by_id.entry(*vector_id).or_default()[side] = true;
-                }
-            }
-        }
-
-        let partial_hits_sorted: Vec<_> = hits_by_id
-            .into_iter()
-            .filter(|(_, [is_match_l, is_match_r])| *is_match_l || *is_match_r)
-            .sorted()
-            .collect();
-
-        let mut matched_both_eyes = Vec::new();
-        let mut matched_one_eye: BothEyes<VecEdges<VectorId>> = [Vec::new(), Vec::new()];
-        for (vector_id, is_match_lr) in partial_hits_sorted {
-            match is_match_lr {
-                [true, true] => matched_both_eyes.push(vector_id),
-                [true, false] => matched_one_eye[LEFT].push(vector_id),
-                [false, true] => matched_one_eye[RIGHT].push(vector_id),
-                [false, false] => {}
-            }
-        }
-
-        UnresolvedJoin {
-            matched_both_eyes,
-            matched_one_eye,
-            saturated,
-        }
-    }
-
-    /// Resolve the one-eyed matches into a full join, using the MPC comparison results
-    /// for the opposite eye.
-    fn resolve(&self, comparison_results: BothEyes<&MapEdges<bool>>) -> ResolvedJoin {
-        let mut matches: Vec<_> = self
-            .matched_both_eyes
-            .iter()
-            .map(|id| (*id, [true, true]))
-            .collect();
-        for id in &self.matched_one_eye[LEFT] {
-            if let Some(right) = comparison_results[RIGHT].get(id) {
-                matches.push((*id, [true, *right]));
-            }
-        }
-        for id in &self.matched_one_eye[RIGHT] {
-            if let Some(left) = comparison_results[LEFT].get(id) {
-                matches.push((*id, [*left, true]));
-            }
-        }
-        ResolvedJoin {
-            matches,
-            saturated: self.saturated,
-        }
-    }
 }
 
 impl PendingRequest {
@@ -312,9 +363,192 @@ impl PendingRequest {
     }
 }
 
+/// One request's search matches, split by how many eyes matched, plus per-eye
+/// saturation.
+///
+/// `matched_both_eyes` holds vectors that matched on both eyes directly in the search
+/// results. `matched_one_eye[side]` holds vectors that matched only on `side`;
+/// the other eye is resolved later via `resolve` using the MPC `comparison_results`.
+#[derive(Clone, Debug)]
+struct UnresolvedJoin {
+    matched_both_eyes: VecEdges<VectorId>,
+    matched_one_eye: BothEyes<VecEdges<VectorId>>,
+    /// True per eye if any rotation's match results were saturated (supermatcher).
+    saturated: BothEyes<bool>,
+}
+
+impl UnresolvedJoin {
+    /// Build by merging match results across all rotations of both eyes, reading the
+    /// requested form of each rotation's results.
+    fn from_rotations(
+        search_results: BothEyes<&VecRotations<HawkInsertPlan>>,
+        variant: SearchVariant,
+    ) -> UnresolvedJoin {
+        let mut hits_by_id: MapEdges<BothEyes<bool>> = HashMap::new();
+
+        let mut saturated = [false, false];
+        for (side, rotations) in izip!([LEFT, RIGHT], search_results) {
+            // Merge matches from all rotations.
+            for rotation in rotations.iter() {
+                let matches = match variant {
+                    SearchVariant::Effective => &rotation.classified.matches,
+                    SearchVariant::Baseline => rotation
+                        .classified
+                        .pre_extension
+                        .as_ref()
+                        .unwrap_or(&rotation.classified.matches),
+                };
+                if matches.saturated {
+                    saturated[side] = true;
+                }
+                for (vector_id, _) in matches.results.iter() {
+                    hits_by_id.entry(*vector_id).or_default()[side] = true;
+                }
+            }
+        }
+
+        let partial_hits_sorted: Vec<_> = hits_by_id
+            .into_iter()
+            .filter(|(_, [is_match_l, is_match_r])| *is_match_l || *is_match_r)
+            .sorted()
+            .collect();
+
+        let mut matched_both_eyes = Vec::new();
+        let mut matched_one_eye: BothEyes<VecEdges<VectorId>> = [Vec::new(), Vec::new()];
+        for (vector_id, is_match_lr) in partial_hits_sorted {
+            match is_match_lr {
+                [true, true] => matched_both_eyes.push(vector_id),
+                [true, false] => matched_one_eye[LEFT].push(vector_id),
+                [false, true] => matched_one_eye[RIGHT].push(vector_id),
+                [false, false] => {}
+            }
+        }
+
+        UnresolvedJoin {
+            matched_both_eyes,
+            matched_one_eye,
+            saturated,
+        }
+    }
+
+    /// Resolve the one-eyed matches into a full join, using the MPC comparison results
+    /// for the opposite eye.
+    fn resolve(&self, comparison_results: BothEyes<&MapEdges<bool>>) -> ResolvedJoin {
+        let mut matches: Vec<_> = self
+            .matched_both_eyes
+            .iter()
+            .map(|id| (*id, [true, true]))
+            .collect();
+        for id in &self.matched_one_eye[LEFT] {
+            if let Some(right) = comparison_results[RIGHT].get(id) {
+                matches.push((*id, [true, *right]));
+            }
+        }
+        for id in &self.matched_one_eye[RIGHT] {
+            if let Some(left) = comparison_results[LEFT].get(id) {
+                matches.push((*id, [*left, true]));
+            }
+        }
+        ResolvedJoin {
+            matches,
+            saturated: self.saturated,
+        }
+    }
+}
+
+// ===========================================================================
+// Stage 2: resolve one-eyed matches with the MPC comparison results
+// ===========================================================================
+
 /// Results for a batch of requests.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ResolvedBatch(VecRequests<ResolvedRequest>);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ResolvedRequest {
+    /// Resolved search matches, in the form decisions are made on plus the baseline.
+    search: WithBaseline<ResolvedJoin>,
+    luc_results: VecEdges<(VectorId, BothEyes<bool>)>,
+    reauth_result: Option<(VectorId, UseOrRule, BothEyes<bool>)>,
+    intra_matches: Vec<IntraMatch>,
+    request_type: RequestType,
+}
+
+impl ResolvedRequest {
+    /// The IDs of the vectors that matched this request.
+    ///
+    /// The luc, reauth and intra-batch contributions are unaffected by supermatcher
+    /// extension, so only the search join varies with `variant`.
+    fn select(&self, filter: Filter, variant: SearchVariant) -> impl Iterator<Item = MatchId> + '_ {
+        let join = self.search.get(variant);
+
+        let search = join
+            .matches
+            .iter()
+            .filter(move |(_, [l, r])| filter.search_rule(*l, *r))
+            .map(|(id, _)| Search(*id));
+
+        let luc = self
+            .luc_results
+            .iter()
+            .filter(move |(_, [l, r])| filter.luc_rule(*l, *r))
+            .map(|(id, _)| Luc(*id));
+
+        let reauth = self
+            .reauth_result
+            .filter(move |(_, or_rule, matches)| filter.reauth_rule(*or_rule, *matches))
+            .map(|(id, _, _)| Reauth(id));
+
+        let intra = self
+            .intra_matches
+            .iter()
+            .filter(move |m| filter.intra_rule(m.is_match[LEFT], m.is_match[RIGHT]))
+            .map(|m| IntraBatch(m.other_request_i));
+
+        let supermatch = filter.supermatch_rule(join.saturated).then_some(Supermatch);
+
+        chain!(search, luc, reauth, intra, supermatch)
+    }
+}
+
+/// A search join after the missing-eye MPC comparisons have been resolved, bundled with
+/// its per-eye saturation (supermatcher) flags.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ResolvedJoin {
+    matches: VecEdges<(VectorId, BothEyes<bool>)>,
+    /// True per eye if any rotation's match results were saturated (supermatcher).
+    saturated: BothEyes<bool>,
+}
+
+// ===========================================================================
+// Stage 3: combine orientations and decide
+// ===========================================================================
+
+/// Combines the results from mirrored checks.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct RequestMatches {
+    normal: ResolvedRequest,
+    mirror: ResolvedRequest,
+}
+
+impl RequestMatches {
+    /// The IDs of the vectors that matched at least partially, in both orientations.
+    fn select(&self, filter: Filter, variant: SearchVariant) -> impl Iterator<Item = MatchId> + '_ {
+        chain!(
+            matches!(filter.orient, Only(Normal) | Both)
+                .then_some(self.normal.select(filter, variant)),
+            matches!(filter.orient, Only(Mirror) | Both)
+                .then_some(self.mirror.select(filter, variant)),
+        )
+        .flatten()
+    }
+
+    /// True if the supermatcher extended this request's search in either orientation,
+    /// so a baseline comparison is meaningful.
+    fn was_extended(&self) -> bool {
+        self.normal.search.was_extended() || self.mirror.search.was_extended()
+    }
+}
 
 impl ResolvedBatch {
     /// Combine both orientations and make the final decision for every request.
@@ -396,37 +630,31 @@ impl ResolvedBatch {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum Decision {
-    UniqueInsert,
-    UniqueInsertSkipped,
-    ReauthUpdate(VectorId),
-    NoMutation,
-}
-use Decision::*;
-
-impl Decision {
-    pub fn is_mutation(&self) -> bool {
-        match self {
-            UniqueInsert | ReauthUpdate(_) => true,
-            UniqueInsertSkipped | NoMutation => false,
-        }
-    }
-}
-
-/// Wide filter: any match in any orientation, including intra-batch peers.
-pub const DECISION_FILTER: Filter = Filter {
-    eyes: OnlyOrBoth::Both,
-    orient: OnlyOrBoth::Both,
-    intra_batch: true,
-};
-
 /// The final match results for a batch: what each request matched, and what to do
 /// about it.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MatchResults {
     requests: VecRequests<RequestMatches>,
     decisions: VecRequests<Decision>,
+}
+
+impl MatchResults {
+    /// The final decision of what to do with each request, decided by `decide`.
+    pub fn decisions(&self) -> &[Decision] {
+        &self.decisions
+    }
+
+    /// The IDs of the vectors that matched at least partially.
+    pub fn select(&self, filter: Filter) -> VecRequests<Vec<MatchId>> {
+        self.requests
+            .iter()
+            .map(|request| {
+                request
+                    .select(filter, SearchVariant::Effective)
+                    .collect_vec()
+            })
+            .collect_vec()
+    }
 }
 
 /// The outcome of evaluating a uniqueness request against its selected match ids.
@@ -443,6 +671,10 @@ struct UniquenessOutcome {
 ///
 /// Attribution to saturation is order-independent: a supermatch is the *only* reason for
 /// a match only when no ordinary id matched, in either orientation.
+///
+/// Iterating the full set of ids is deliberate: a short-circuiting `any()` would
+/// mis-attribute `only_supermatch`, because `RequestMatches::select` yields all of the
+/// normal orientation's ids — including its `Supermatch` — before any of the mirror's.
 fn evaluate_uniqueness(
     ids: impl IntoIterator<Item = MatchId>,
     prior_decisions: &[Decision],
@@ -474,14 +706,18 @@ fn evaluate_uniqueness(
     }
 }
 
+// ===========================================================================
+// Supermatcher A/B metrics
+// ===========================================================================
+
 /// Supermatcher A/B comparison: the three match determinations an extended search is
 /// judged by. Only meaningful for requests where `RequestMatches::was_extended()`.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 struct ExtensionOutcome {
     /// Final call on the extended results, including rejection due to saturation.
     extended_decision: bool,
-    /// The extended results ignoring saturation: did the extended search surface a
-    /// *real* neighbour match that the original search missed?
+    /// The effective search results, ignoring saturation: whether they contain a real
+    /// (non-supermatch) neighbour match.
     extended_match: bool,
     /// What the original search alone would have concluded. Saturation is excluded here
     /// too, since those results were never expanded.
@@ -510,6 +746,7 @@ fn extension_outcome(
     }
 }
 
+/// Emits the A/B counters for one extended request.
 fn record_extension_metrics(outcome: &ExtensionOutcome) {
     match (outcome.baseline_match, outcome.extended_decision) {
         (false, true) => {
@@ -535,208 +772,6 @@ fn record_extension_metrics(outcome: &ExtensionOutcome) {
 
     // Unconditionally count when a request had an extended search.
     metrics::counter!("supermatcher_extended_search_requests").increment(1);
-}
-
-impl MatchResults {
-    /// The final decision of what to do with each request, decided by `decide`.
-    pub fn decisions(&self) -> &[Decision] {
-        &self.decisions
-    }
-
-    /// The IDs of the vectors that matched at least partially.
-    pub fn select(&self, filter: Filter) -> VecRequests<Vec<MatchId>> {
-        self.requests
-            .iter()
-            .map(|request| {
-                request
-                    .select(filter, SearchVariant::Effective)
-                    .collect_vec()
-            })
-            .collect_vec()
-    }
-}
-
-/// Results for one request.
-#[derive(Clone, Debug, PartialEq, Eq)]
-/// A search join after the missing-side MPC comparisons have been resolved,
-/// bundled with its per-eye saturation (supermatcher) flags.
-struct ResolvedJoin {
-    matches: VecEdges<(VectorId, BothEyes<bool>)>,
-    /// True per eye if any rotation's match results were saturated (supermatcher).
-    saturated: BothEyes<bool>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-struct ResolvedRequest {
-    /// Resolved search matches, in the form decisions are made on plus the baseline.
-    search: WithBaseline<ResolvedJoin>,
-    luc_results: VecEdges<(VectorId, BothEyes<bool>)>,
-    reauth_result: Option<(VectorId, UseOrRule, BothEyes<bool>)>,
-    intra_matches: Vec<IntraMatch>,
-    request_type: RequestType,
-}
-
-impl ResolvedRequest {
-    /// The IDs of the vectors that matched this request.
-    ///
-    /// The luc, reauth and intra-batch contributions are unaffected by supermatcher
-    /// extension, so only the search join varies with `variant`.
-    fn select(&self, filter: Filter, variant: SearchVariant) -> impl Iterator<Item = MatchId> + '_ {
-        let join = self.search.get(variant);
-
-        let search = join
-            .matches
-            .iter()
-            .filter(move |(_, [l, r])| filter.search_rule(*l, *r))
-            .map(|(id, _)| MatchId::Search(*id));
-
-        let luc = self
-            .luc_results
-            .iter()
-            .filter(move |(_, [l, r])| filter.luc_rule(*l, *r))
-            .map(|(id, _)| MatchId::Luc(*id));
-
-        let reauth = self
-            .reauth_result
-            .filter(move |(_, or_rule, matches)| filter.reauth_rule(*or_rule, *matches))
-            .map(|(id, _, _)| MatchId::Reauth(id));
-
-        let intra = self
-            .intra_matches
-            .iter()
-            .filter(move |m| filter.intra_rule(m.is_match[LEFT], m.is_match[RIGHT]))
-            .map(|m| MatchId::IntraBatch(m.other_request_i));
-
-        let supermatch = filter
-            .supermatch_rule(join.saturated)
-            .then_some(MatchId::Supermatch);
-
-        chain!(search, luc, reauth, intra, supermatch)
-    }
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub enum MatchId {
-    Search(VectorId),
-    Luc(VectorId),
-    Reauth(VectorId),
-    IntraBatch(usize),
-    /// Search results were saturated (supermatcher).
-    Supermatch,
-}
-use MatchId::*;
-
-// TODO: This could move to `BatchQuery` and maybe use the original types in `smpc_request.rs`.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum RequestType {
-    /// A request to check if a vector is unique.
-    Uniqueness(UniquenessRequest),
-    /// A request to check if a vector is unique without inserting it.
-    IdentityMatchCheck,
-    /// A request to check if a vector matches a target and replace it.
-    Reauth(Option<(VectorId, UseOrRule)>),
-    /// Other features.
-    Unsupported,
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct UniquenessRequest {
-    pub skip_persistence: bool,
-}
-
-/// Combines the results from mirrored checks.
-#[derive(Clone, Debug, PartialEq, Eq)]
-struct RequestMatches {
-    normal: ResolvedRequest,
-    mirror: ResolvedRequest,
-}
-
-impl RequestMatches {
-    /// The IDs of the vectors that matched at least partially, in both orientations.
-    fn select(&self, filter: Filter, variant: SearchVariant) -> impl Iterator<Item = MatchId> + '_ {
-        chain!(
-            matches!(filter.orient, Only(Normal) | Both)
-                .then_some(self.normal.select(filter, variant)),
-            matches!(filter.orient, Only(Mirror) | Both)
-                .then_some(self.mirror.select(filter, variant)),
-        )
-        .flatten()
-    }
-
-    /// True if the supermatcher extended this request's search in either orientation,
-    /// so a baseline comparison is meaningful.
-    fn was_extended(&self) -> bool {
-        self.normal.search.was_extended() || self.mirror.search.was_extended()
-    }
-}
-
-/// Search *AND* policy: only match if both eyes match (like `mergeDbResults`).
-///
-/// LUC *OR* policy: "Local" irises match if either side matches.
-///
-/// Intra-batch *AND* policy: match against requests before this request in the same batch.
-///
-/// Partial matches: set `eyes: Only(Left)` or `eyes: Only(Right)`.
-///
-/// Mirror matches: set `orient: Only(Mirror)`.
-#[derive(Copy, Clone)]
-pub struct Filter {
-    pub eyes: OnlyOrBoth<StoreId>,
-    pub orient: OnlyOrBoth<Orientation>,
-    pub intra_batch: bool,
-}
-
-#[derive(Copy, Clone)]
-pub enum OnlyOrBoth<T> {
-    Only(T),
-    Both,
-}
-
-use OnlyOrBoth::{Both, Only};
-use Orientation::{Mirror, Normal};
-use StoreId::{Left, Right};
-
-impl Filter {
-    fn search_rule(&self, left: bool, right: bool) -> bool {
-        match self.eyes {
-            Only(Left) => left,
-            Only(Right) => right,
-            Both => left && right,
-        }
-    }
-
-    fn luc_rule(&self, left: bool, right: bool) -> bool {
-        match self.eyes {
-            Only(Left) => left,
-            Only(Right) => right,
-            Both => left || right,
-        }
-    }
-
-    /// Decide if this is a successful reauth based on left and right matches.
-    /// Use the OR or AND rule as specified in the reauth request.
-    fn reauth_rule(&self, or_rule: UseOrRule, [left, right]: BothEyes<bool>) -> bool {
-        tracing::info!("left: {left}, right: {right}, or_rule: {or_rule}");
-        match self.eyes {
-            Only(Left) => left,
-            Only(Right) => right,
-            Both if or_rule => left || right,
-            Both => left && right,
-        }
-    }
-
-    fn intra_rule(&self, left: bool, right: bool) -> bool {
-        self.intra_batch && self.search_rule(left, right)
-    }
-
-    /// Supermatch uses OR policy: saturated on either eye is a supermatch.
-    fn supermatch_rule(&self, [left, right]: BothEyes<bool>) -> bool {
-        match self.eyes {
-            Only(Left) => left,
-            Only(Right) => right,
-            Both => left || right,
-        }
-    }
 }
 
 #[cfg(test)]

--- a/iris-mpc-cpu/src/execution/hawk_main/matching.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/matching.rs
@@ -15,16 +15,16 @@ use std::collections::HashMap;
 /// The matching algorithm follows these steps:
 ///
 /// 1. Organize the results of the nearest neighbor search with
-///    `BatchStep1::new`. Then:
+///    `PendingBatch::new`. Then:
 ///
-///    1.a. Get the vectors found on only one side with `missing_vector_ids()`.
+///    1.a. Get the vectors found on only one side with `ids_to_compare()`.
 ///    1.b. Fetch the other side and calculate their `is_match` with MPC.
-///    1.c. Give this back to `step2(missing_is_match)`.
+///    1.c. Give this back to `resolve(comparison_results)`.
 ///
-/// 2. `BatchStep2::is_matches`: Combine it all into the final match decisions.
-pub struct BatchStep1(VecRequests<Step1>);
+/// 2. `ResolvedBatch::is_matches`: Combine it all into the final match decisions.
+pub struct PendingBatch(VecRequests<PendingRequest>);
 
-impl BatchStep1 {
+impl PendingBatch {
     pub fn new(
         plans: &BothEyes<VecRequests<VecRotations<HawkInsertPlan>>>,
         luc_ids: &VecRequests<Vec<VectorId>>,
@@ -33,37 +33,39 @@ impl BatchStep1 {
         // Join the results of both eyes into results per eye pair.
         Self(
             izip!(&plans[LEFT], &plans[RIGHT], luc_ids, request_types)
-                .map(|(left, right, luc, rt)| Step1::new([left, right], luc.clone(), rt))
+                .map(|(left, right, luc, rt)| PendingRequest::new([left, right], luc.clone(), rt))
                 .collect_vec(),
         )
     }
 
-    pub fn missing_vector_ids(&self) -> BothEyes<VecRequests<VecEdges<VectorId>>> {
-        [LEFT, RIGHT].map(|side| {
+    /// The vectors that need an MPC comparison on each eye before matches can be resolved.
+    /// Indexed `[eye_to_compare][request]`.
+    pub fn ids_to_compare(&self) -> BothEyes<VecRequests<VecEdges<VectorId>>> {
+        [LEFT, RIGHT].map(|eye| {
             self.0
                 .iter()
-                .map(|step| step.missing_vector_ids(side))
+                .map(|request| request.ids_to_compare(eye))
                 .collect_vec()
         })
     }
 
-    pub fn step2(
+    pub fn resolve(
         self,
-        missing_is_match: &BothEyes<VecRequests<MapEdges<bool>>>,
+        comparison_results: &BothEyes<VecRequests<MapEdges<bool>>>,
         intra_matches: VecRequests<Vec<IntraMatch>>,
-    ) -> BatchStep2 {
-        assert_eq!(self.0.len(), missing_is_match[LEFT].len());
-        assert_eq!(self.0.len(), missing_is_match[RIGHT].len());
+    ) -> ResolvedBatch {
+        assert_eq!(self.0.len(), comparison_results[LEFT].len());
+        assert_eq!(self.0.len(), comparison_results[RIGHT].len());
         assert_eq!(self.0.len(), intra_matches.len());
-        BatchStep2(
+        ResolvedBatch(
             izip!(
                 self.0,
-                &missing_is_match[LEFT],
-                &missing_is_match[RIGHT],
+                &comparison_results[LEFT],
+                &comparison_results[RIGHT],
                 intra_matches,
             )
-            .map(|(step, missing_left, missing_right, intra_matches)| {
-                step.step2([missing_left, missing_right], intra_matches)
+            .map(|(request, left, right, intra_matches)| {
+                request.resolve([left, right], intra_matches)
             })
             .collect_vec(),
         )
@@ -73,29 +75,29 @@ impl BatchStep1 {
 /// One request's search matches, split by how many eyes matched, plus per-eye
 /// saturation.
 ///
-/// `matched_both` holds vectors that matched on both eyes directly in the search
-/// results. `matched_one_side[side]` holds vectors that matched only on `side`;
-/// the other eye is resolved later via `resolve` using the MPC `missing_is_match`.
+/// `matched_both_eyes` holds vectors that matched on both eyes directly in the search
+/// results. `matched_one_eye[side]` holds vectors that matched only on `side`;
+/// the other eye is resolved later via `resolve` using the MPC `comparison_results`.
 #[derive(Clone, Debug)]
-struct SearchJoin {
-    matched_both: VecEdges<VectorId>,
-    matched_one_side: BothEyes<VecEdges<VectorId>>,
+struct UnresolvedJoin {
+    matched_both_eyes: VecEdges<VectorId>,
+    matched_one_eye: BothEyes<VecEdges<VectorId>>,
     /// True per eye if any rotation's match results were saturated (supermatcher).
     saturated: BothEyes<bool>,
 }
 
-struct Step1 {
+struct PendingRequest {
     /// Search matches from the (possibly supermatcher-extended) results.
-    join: SearchJoin,
+    join: UnresolvedJoin,
     /// Search matches from the pre-extension results, present only for requests
     /// whose search was extended by the supermatcher. `None` means no extension
     /// happened.
-    pre_join: Option<SearchJoin>,
+    pre_join: Option<UnresolvedJoin>,
     luc_ids: Vec<VectorId>,
     request_type: RequestType,
 }
 
-impl SearchJoin {
+impl UnresolvedJoin {
     /// Build by merging match results across all rotations
     /// of both eyes. When `use_pre` is set, the pre-extension matches are used
     /// for any rotation that was extended by the supermatcher (falling back to
@@ -103,8 +105,8 @@ impl SearchJoin {
     fn from_rotations(
         search_results: BothEyes<&VecRotations<HawkInsertPlan>>,
         use_pre: bool,
-    ) -> SearchJoin {
-        let mut full_join: MapEdges<BothEyes<bool>> = HashMap::new();
+    ) -> UnresolvedJoin {
+        let mut hits_by_id: MapEdges<BothEyes<bool>> = HashMap::new();
 
         let mut saturated = [false, false];
         for (side, rotations) in izip!([LEFT, RIGHT], search_results) {
@@ -123,53 +125,53 @@ impl SearchJoin {
                     saturated[side] = true;
                 }
                 for (vector_id, _) in matches.results.iter() {
-                    full_join.entry(*vector_id).or_default()[side] = true;
+                    hits_by_id.entry(*vector_id).or_default()[side] = true;
                 }
             }
         }
 
-        let full_join_partial_matches_ordered: Vec<_> = full_join
+        let partial_hits_sorted: Vec<_> = hits_by_id
             .into_iter()
             .filter(|(_, [is_match_l, is_match_r])| *is_match_l || *is_match_r)
             .sorted()
             .collect();
 
-        let mut matched_both = Vec::new();
-        let mut matched_one_side: BothEyes<VecEdges<VectorId>> = [Vec::new(), Vec::new()];
-        for (vector_id, is_match_lr) in full_join_partial_matches_ordered {
+        let mut matched_both_eyes = Vec::new();
+        let mut matched_one_eye: BothEyes<VecEdges<VectorId>> = [Vec::new(), Vec::new()];
+        for (vector_id, is_match_lr) in partial_hits_sorted {
             match is_match_lr {
-                [true, true] => matched_both.push(vector_id),
-                [true, false] => matched_one_side[LEFT].push(vector_id),
-                [false, true] => matched_one_side[RIGHT].push(vector_id),
+                [true, true] => matched_both_eyes.push(vector_id),
+                [true, false] => matched_one_eye[LEFT].push(vector_id),
+                [false, true] => matched_one_eye[RIGHT].push(vector_id),
                 [false, false] => {}
             }
         }
 
-        SearchJoin {
-            matched_both,
-            matched_one_side,
+        UnresolvedJoin {
+            matched_both_eyes,
+            matched_one_eye,
             saturated,
         }
     }
 
     /// Resolve the one-sided matches into a full join using the MPC-computed
-    /// `missing_is_match` results for the opposite eye.
+    /// `comparison_results` for the opposite eye.
     fn resolve(
         &self,
-        missing_is_match: BothEyes<&MapEdges<bool>>,
+        comparison_results: BothEyes<&MapEdges<bool>>,
     ) -> VecEdges<(VectorId, BothEyes<bool>)> {
         let mut full_join: Vec<_> = self
-            .matched_both
+            .matched_both_eyes
             .iter()
             .map(|id| (*id, [true, true]))
             .collect();
-        for id in &self.matched_one_side[LEFT] {
-            if let Some(right) = missing_is_match[RIGHT].get(id) {
+        for id in &self.matched_one_eye[LEFT] {
+            if let Some(right) = comparison_results[RIGHT].get(id) {
                 full_join.push((*id, [true, *right]));
             }
         }
-        for id in &self.matched_one_side[RIGHT] {
-            if let Some(left) = missing_is_match[LEFT].get(id) {
+        for id in &self.matched_one_eye[RIGHT] {
+            if let Some(left) = comparison_results[LEFT].get(id) {
                 full_join.push((*id, [*left, true]));
             }
         }
@@ -177,13 +179,13 @@ impl SearchJoin {
     }
 }
 
-impl Step1 {
+impl PendingRequest {
     fn new(
         search_results: BothEyes<&VecRotations<HawkInsertPlan>>,
         luc_ids: Vec<VectorId>,
         request_type: RequestType,
-    ) -> Step1 {
-        let join = SearchJoin::from_rotations(search_results, false);
+    ) -> PendingRequest {
+        let join = UnresolvedJoin::from_rotations(search_results, false);
 
         // Only build the pre-extension join when at least one rotation was
         // actually extended by the supermatcher; otherwise it equals `join`.
@@ -192,9 +194,9 @@ impl Step1 {
                 .iter()
                 .any(|r| r.classified.pre_extension.is_some())
         });
-        let pre_join = any_pre.then(|| SearchJoin::from_rotations(search_results, true));
+        let pre_join = any_pre.then(|| UnresolvedJoin::from_rotations(search_results, true));
 
-        Step1 {
+        PendingRequest {
             join,
             pre_join,
             luc_ids,
@@ -209,20 +211,20 @@ impl Step1 {
         }
     }
 
-    fn missing_vector_ids(&self, side: usize) -> VecEdges<VectorId> {
-        let other_side = 1 - side;
-        let matched_one_side = &self.join.matched_one_side[other_side];
+    fn ids_to_compare(&self, eye_to_compare: usize) -> VecEdges<VectorId> {
+        let matched_eye = 1 - eye_to_compare;
+        let matched_one_side = &self.join.matched_one_eye[matched_eye];
 
         // Include the pre-extension one-sided matches so the pre-extension outcome can be
         // resolved from the same MPC results. This is needed because a) one-sided matches
         // pre-extension may become two-sided matches post-extension, and thus would not appear
-        // in post-extension `match_one_side`, and b) initial and extended results are derived
+        // in post-extension `matched_one_eye`, and b) initial and extended results are derived
         // from independent searches, so could diverge (slightly) due to the approximate nature
         // of HNSW search results.
         let pre_matched_one_side = self
             .pre_join
             .iter()
-            .flat_map(|j| j.matched_one_side[other_side].iter());
+            .flat_map(|j| j.matched_one_eye[matched_eye].iter());
 
         // Always add reauth target so is_match is computed even if the search didn't hit it.
         let reauth_id = self.reauth_id().map(|(id, _)| id);
@@ -238,38 +240,38 @@ impl Step1 {
         .collect_vec()
     }
 
-    fn step2(
+    fn resolve(
         self,
-        missing_is_match: BothEyes<&MapEdges<bool>>,
+        comparison_results: BothEyes<&MapEdges<bool>>,
         intra_matches: Vec<IntraMatch>,
-    ) -> Step2 {
+    ) -> ResolvedRequest {
         let luc_results = self
             .luc_ids
             .iter()
             .map(|id| {
                 let is_match =
-                    [LEFT, RIGHT].map(|side| *missing_is_match[side].get(id).unwrap_or(&false));
+                    [LEFT, RIGHT].map(|side| *comparison_results[side].get(id).unwrap_or(&false));
                 (*id, is_match)
             })
             .collect_vec();
 
         let reauth_result = self.reauth_id().map(|(id, or_rule)| {
             let is_match =
-                [LEFT, RIGHT].map(|side| *missing_is_match[side].get(&id).unwrap_or(&false));
+                [LEFT, RIGHT].map(|side| *comparison_results[side].get(&id).unwrap_or(&false));
             tracing::info!("Reauth ID: {id}, or_rule: {or_rule}, is_match: {is_match:?}");
             (id, or_rule, is_match)
         });
 
         let join = ResolvedJoin {
-            full_join: self.join.resolve(missing_is_match),
+            matches: self.join.resolve(comparison_results),
             saturated: self.join.saturated,
         };
         let pre_join = self.pre_join.as_ref().map(|pre| ResolvedJoin {
-            full_join: pre.resolve(missing_is_match),
+            matches: pre.resolve(comparison_results),
             saturated: pre.saturated,
         });
 
-        Step2 {
+        ResolvedRequest {
             join,
             pre_join,
             luc_results,
@@ -282,14 +284,14 @@ impl Step1 {
 
 /// Results for a batch of requests.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct BatchStep2(VecRequests<Step2>);
+pub struct ResolvedBatch(VecRequests<ResolvedRequest>);
 
-impl BatchStep2 {
-    pub fn step3(self, mirror: Self) -> BatchStep3 {
+impl ResolvedBatch {
+    pub fn decide(self, mirror: Self) -> MatchResults {
         assert_eq!(self.0.len(), mirror.0.len());
-        BatchStep3(
+        MatchResults(
             izip!(self.0, mirror.0)
-                .map(|(normal, mirror)| Step3 { normal, mirror })
+                .map(|(normal, mirror)| RequestMatches { normal, mirror })
                 .collect_vec(),
         )
     }
@@ -321,7 +323,7 @@ pub const DECISION_FILTER: Filter = Filter {
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct BatchStep3(VecRequests<Step3>);
+pub struct MatchResults(VecRequests<RequestMatches>);
 
 /// Evaluate whether a uniqueness request matched, given its selected match ids
 /// and the decisions already made for earlier requests in the batch.
@@ -359,7 +361,11 @@ fn uniqueness_is_match(
 /// pre-extension search alone would have produced. The `Supermatch` (saturation)
 /// signal is excluded so we isolate whether the extended search surfaced a
 /// *real* neighbor match that the original search missed.
-fn record_extension_metrics(request: &Step3, filter: Filter, prior_decisions: &[Decision]) {
+fn record_extension_metrics(
+    request: &RequestMatches,
+    filter: Filter,
+    prior_decisions: &[Decision],
+) {
     if !request.has_pre_extension() {
         return;
     }
@@ -410,7 +416,7 @@ fn record_extension_metrics(request: &Step3, filter: Filter, prior_decisions: &[
     metrics::counter!("supermatcher_extended_search_requests").increment(1);
 }
 
-impl BatchStep3 {
+impl MatchResults {
     /// The final decision of what to do with a request.
     ///
     /// Emulate the behavior of inserting entries one by one. Intra-batch matches
@@ -490,13 +496,13 @@ impl BatchStep3 {
 /// A search join after the missing-side MPC comparisons have been resolved,
 /// bundled with its per-eye saturation (supermatcher) flags.
 struct ResolvedJoin {
-    full_join: VecEdges<(VectorId, BothEyes<bool>)>,
+    matches: VecEdges<(VectorId, BothEyes<bool>)>,
     /// True per eye if any rotation's match results were saturated (supermatcher).
     saturated: BothEyes<bool>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-struct Step2 {
+struct ResolvedRequest {
     /// Search matches from the (possibly supermatcher-extended) results.
     join: ResolvedJoin,
     /// Search matches from the pre-extension results, present only when this
@@ -509,7 +515,7 @@ struct Step2 {
     request_type: RequestType,
 }
 
-impl Step2 {
+impl ResolvedRequest {
     /// The IDs of the vectors that matched this request.
     fn select(&self, filter: Filter) -> impl Iterator<Item = MatchId> + '_ {
         self.select_with(filter, &self.join)
@@ -531,7 +537,7 @@ impl Step2 {
         join: &'a ResolvedJoin,
     ) -> impl Iterator<Item = MatchId> + 'a {
         let search = join
-            .full_join
+            .matches
             .iter()
             .filter(move |(_, [l, r])| filter.search_rule(*l, *r))
             .map(|(id, _)| MatchId::Search(*id));
@@ -592,12 +598,12 @@ pub struct UniquenessRequest {
 
 /// Combines the results from mirrored checks.
 #[derive(Clone, Debug, PartialEq, Eq)]
-struct Step3 {
-    normal: Step2,
-    mirror: Step2,
+struct RequestMatches {
+    normal: ResolvedRequest,
+    mirror: ResolvedRequest,
 }
 
-impl Step3 {
+impl RequestMatches {
     /// The IDs of the vectors that matched at least partially.
     fn select(&self, filter: Filter) -> impl Iterator<Item = MatchId> + '_ {
         chain!(

--- a/iris-mpc-cpu/src/execution/hawk_main/matching.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/matching.rs
@@ -317,13 +317,82 @@ impl PendingRequest {
 pub struct ResolvedBatch(VecRequests<ResolvedRequest>);
 
 impl ResolvedBatch {
+    /// Combine both orientations and make the final decision for every request.
+    ///
+    /// Emulates inserting entries one by one: intra-batch matches only count if the
+    /// request they matched is itself being inserted or updated. Applies supermatcher
+    /// rejection — if any rotation's match results were saturated on either eye, and
+    /// nothing else matched, the decision is `NoMutation`.
+    ///
+    /// This is the one place decisions are computed and the one place the per-request
+    /// supermatcher metrics are emitted; callers read the stored vector afterwards via
+    /// `MatchResults::decisions()`.
     pub fn decide(self, mirror: Self) -> MatchResults {
         assert_eq!(self.0.len(), mirror.0.len());
-        MatchResults(
-            izip!(self.0, mirror.0)
-                .map(|(normal, mirror)| RequestMatches { normal, mirror })
-                .collect_vec(),
-        )
+        let requests = izip!(self.0, mirror.0)
+            .map(|(normal, mirror)| RequestMatches { normal, mirror })
+            .collect_vec();
+
+        tracing::info!(
+            "Calculating decisions for batch of {} requests",
+            requests.len()
+        );
+        let filter = DECISION_FILTER;
+        let mut decisions = Vec::<Decision>::with_capacity(requests.len());
+
+        for request in &requests {
+            tracing::info!(
+                "Processing request type normal: {:?} mirror {:?}",
+                request.normal.request_type,
+                request.mirror.request_type,
+            );
+            let mut only_supermatch = false;
+
+            let decision = match request.normal.request_type {
+                RequestType::Uniqueness(UniquenessRequest { skip_persistence }) => {
+                    let outcome = evaluate_uniqueness(
+                        request.select(filter, SearchVariant::Effective),
+                        &decisions,
+                    );
+                    only_supermatch = outcome.only_supermatch;
+
+                    if request.was_extended() {
+                        record_extension_metrics(&extension_outcome(request, filter, &decisions));
+                    }
+
+                    if outcome.is_match {
+                        NoMutation
+                    } else if skip_persistence {
+                        UniqueInsertSkipped
+                    } else {
+                        UniqueInsert
+                    }
+                }
+                // Identity Match Check request. Nothing to do.
+                RequestType::IdentityMatchCheck => NoMutation,
+                // Reauth request.
+                RequestType::Reauth(_) => match request.normal.reauth_result {
+                    Some((id, or_rule, matches)) if filter.reauth_rule(or_rule, matches) => {
+                        ReauthUpdate(id)
+                    }
+                    _ => NoMutation,
+                },
+                // Unsupported request. Nothing to do.
+                RequestType::Unsupported => NoMutation,
+            };
+
+            if only_supermatch {
+                tracing::info!("Supermatcher rejection");
+                metrics::counter!("supermatcher_rejections").increment(1);
+            }
+            tracing::info!("Pushing decision: {decision:?}");
+            decisions.push(decision);
+        }
+
+        MatchResults {
+            requests,
+            decisions,
+        }
     }
 }
 
@@ -352,8 +421,13 @@ pub const DECISION_FILTER: Filter = Filter {
     intra_batch: true,
 };
 
+/// The final match results for a batch: what each request matched, and what to do
+/// about it.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct MatchResults(VecRequests<RequestMatches>);
+pub struct MatchResults {
+    requests: VecRequests<RequestMatches>,
+    decisions: VecRequests<Decision>,
+}
 
 /// The outcome of evaluating a uniqueness request against its selected match ids.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -464,80 +538,14 @@ fn record_extension_metrics(outcome: &ExtensionOutcome) {
 }
 
 impl MatchResults {
-    /// The final decision of what to do with a request.
-    ///
-    /// Emulate the behavior of inserting entries one by one. Intra-batch matches
-    /// only count if they are being inserted themselves.
-    ///
-    /// Applies supermatcher rejection: if any rotation's match results were
-    /// saturated on either eye, the decision is forced to `NoMutation`.
-    pub fn decisions(&self) -> VecRequests<Decision> {
-        tracing::info!(
-            "Calculating decisions for batch of {} requests",
-            self.0.len()
-        );
-        use Decision::*;
-
-        let filter = DECISION_FILTER;
-
-        let mut decisions = Vec::<Decision>::with_capacity(self.0.len());
-
-        for request in &self.0 {
-            tracing::info!(
-                "Processing request type normal: {:?} mirror {:?}",
-                request.normal.request_type,
-                request.mirror.request_type,
-            );
-            let mut because_supermatch = false;
-
-            let decision = match request.normal.request_type {
-                RequestType::Uniqueness(UniquenessRequest { skip_persistence }) => {
-                    let outcome = evaluate_uniqueness(
-                        request.select(filter, SearchVariant::Effective),
-                        &decisions,
-                    );
-                    because_supermatch = outcome.only_supermatch;
-                    let is_match = outcome.is_match;
-
-                    if request.was_extended() {
-                        record_extension_metrics(&extension_outcome(request, filter, &decisions));
-                    }
-
-                    if is_match {
-                        NoMutation
-                    } else if skip_persistence {
-                        UniqueInsertSkipped
-                    } else {
-                        UniqueInsert
-                    }
-                }
-                // Identity Match Check request. Nothing to do.
-                RequestType::IdentityMatchCheck => NoMutation,
-                // Reauth request.
-                RequestType::Reauth(_) => match request.normal.reauth_result {
-                    Some((id, or_rule, matches)) if filter.reauth_rule(or_rule, matches) => {
-                        ReauthUpdate(id)
-                    }
-                    _ => NoMutation,
-                },
-                // Unsupported request. Nothing to do.
-                RequestType::Unsupported => NoMutation,
-            };
-
-            if because_supermatch {
-                tracing::info!("Supermatcher rejection");
-                metrics::counter!("supermatcher_rejections").increment(1);
-            }
-            tracing::info!("Pushing decision: {decision:?}");
-            decisions.push(decision);
-        }
-
-        decisions
+    /// The final decision of what to do with each request, decided by `decide`.
+    pub fn decisions(&self) -> &[Decision] {
+        &self.decisions
     }
 
     /// The IDs of the vectors that matched at least partially.
     pub fn select(&self, filter: Filter) -> VecRequests<Vec<MatchId>> {
-        self.0
+        self.requests
             .iter()
             .map(|request| {
                 request

--- a/iris-mpc-cpu/src/execution/hawk_main/matching.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/matching.rs
@@ -42,175 +42,6 @@ use OnlyOrBoth::{Both, Only};
 use Orientation::{Mirror, Normal};
 use StoreId::{Left, Right};
 
-// ===========================================================================
-// Vocabulary: filters, match ids, decisions, request types, search variants
-// ===========================================================================
-
-/// Search *AND* policy: only match if both eyes match (like `mergeDbResults`).
-///
-/// LUC *OR* policy: "Local" irises match if either side matches.
-///
-/// Intra-batch *AND* policy: match against requests before this request in the same batch.
-///
-/// Partial matches: set `eyes: Only(Left)` or `eyes: Only(Right)`.
-///
-/// Mirror matches: set `orient: Only(Mirror)`.
-#[derive(Copy, Clone)]
-pub struct Filter {
-    pub eyes: OnlyOrBoth<StoreId>,
-    pub orient: OnlyOrBoth<Orientation>,
-    pub intra_batch: bool,
-}
-
-#[derive(Copy, Clone)]
-pub enum OnlyOrBoth<T> {
-    Only(T),
-    Both,
-}
-
-impl Filter {
-    fn search_rule(&self, left: bool, right: bool) -> bool {
-        match self.eyes {
-            Only(Left) => left,
-            Only(Right) => right,
-            Both => left && right,
-        }
-    }
-
-    fn luc_rule(&self, left: bool, right: bool) -> bool {
-        match self.eyes {
-            Only(Left) => left,
-            Only(Right) => right,
-            Both => left || right,
-        }
-    }
-
-    /// Decide if this is a successful reauth based on left and right matches.
-    /// Use the OR or AND rule as specified in the reauth request.
-    fn reauth_rule(&self, or_rule: UseOrRule, [left, right]: BothEyes<bool>) -> bool {
-        match self.eyes {
-            Only(Left) => left,
-            Only(Right) => right,
-            Both if or_rule => left || right,
-            Both => left && right,
-        }
-    }
-
-    fn intra_rule(&self, left: bool, right: bool) -> bool {
-        self.intra_batch && self.search_rule(left, right)
-    }
-
-    /// Supermatch uses OR policy: saturated on either eye is a supermatch.
-    fn supermatch_rule(&self, [left, right]: BothEyes<bool>) -> bool {
-        match self.eyes {
-            Only(Left) => left,
-            Only(Right) => right,
-            Both => left || right,
-        }
-    }
-}
-
-/// Wide filter: any match in any orientation, including intra-batch peers.
-pub const DECISION_FILTER: Filter = Filter {
-    eyes: OnlyOrBoth::Both,
-    orient: OnlyOrBoth::Both,
-    intra_batch: true,
-};
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub enum MatchId {
-    Search(VectorId),
-    Luc(VectorId),
-    Reauth(VectorId),
-    IntraBatch(usize),
-    /// Search results were saturated (supermatcher).
-    Supermatch,
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum Decision {
-    UniqueInsert,
-    UniqueInsertSkipped,
-    ReauthUpdate(VectorId),
-    NoMutation,
-}
-
-impl Decision {
-    pub fn is_mutation(&self) -> bool {
-        match self {
-            UniqueInsert | ReauthUpdate(_) => true,
-            UniqueInsertSkipped | NoMutation => false,
-        }
-    }
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum RequestType {
-    /// A request to check if a vector is unique.
-    Uniqueness { skip_persistence: bool },
-    /// A request to check if a vector is unique without inserting it.
-    IdentityMatchCheck,
-    /// A request to check if a vector matches a target and replace it.
-    Reauth {
-        /// Target vector id and whether to use an OR-rule for comparison
-        target: Option<(VectorId, UseOrRule)>,
-    },
-    /// Other features.
-    Unsupported,
-}
-
-/// A value in the form decisions are actually made on, plus the pre-extension
-/// counterfactual retained for supermatcher A/B metrics.
-///
-/// `baseline` is `Some` only when the supermatcher re-searched with a larger `ef` for at
-/// least one rotation of this request. When it is `None`, `effective` *is* the baseline:
-/// no extension happened, so the two would be identical.
-#[derive(Clone, Debug, PartialEq, Eq)]
-struct WithBaseline<T> {
-    effective: T,
-    baseline: Option<T>,
-}
-
-impl<T> WithBaseline<T> {
-    /// The requested form, falling back to `effective` when no extension happened.
-    fn get(&self, variant: SearchVariant) -> &T {
-        match variant {
-            SearchVariant::Effective => &self.effective,
-            SearchVariant::Baseline => self.baseline.as_ref().unwrap_or(&self.effective),
-        }
-    }
-
-    /// Every stored form: one item when no extension happened, two when it did.
-    fn variants(&self) -> impl Iterator<Item = &T> + '_ {
-        chain!(std::iter::once(&self.effective), &self.baseline)
-    }
-
-    /// True if the supermatcher extended this request's search.
-    fn was_extended(&self) -> bool {
-        self.baseline.is_some()
-    }
-
-    fn map<U>(&self, f: impl Fn(&T) -> U) -> WithBaseline<U> {
-        WithBaseline {
-            effective: f(&self.effective),
-            baseline: self.baseline.as_ref().map(f),
-        }
-    }
-}
-
-/// Which form of the search results to evaluate.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-enum SearchVariant {
-    /// The results decisions are made on: extended, if the supermatcher ran.
-    Effective,
-    /// What the original search alone would have produced.
-    Baseline,
-}
-
-// ===========================================================================
-// Stage 1: join the two eyes' search results, then resolve one-eyed matches via MPC
-// ===========================================================================
-
 /// One orientation's per-request search results, not yet resolved against the other
 /// eye. Consumed by [`PendingBatch::resolve`].
 pub struct PendingBatch(VecRequests<PendingRequest>);
@@ -263,6 +94,68 @@ impl PendingBatch {
     }
 }
 
+/// One request's search matches, split by how many eyes matched, plus per-eye
+/// saturation.
+///
+/// `matched_both_eyes` holds vectors that matched on both eyes directly in the search
+/// results. `matched_one_eye[side]` holds vectors that matched only on `side`;
+/// the other eye is resolved later via `resolve` using the MPC `comparison_results`.
+#[derive(Clone, Debug)]
+struct UnresolvedJoin {
+    matched_both_eyes: VecEdges<VectorId>,
+    matched_one_eye: BothEyes<VecEdges<VectorId>>,
+    /// True per eye if any rotation's match results were saturated (supermatcher).
+    saturated: BothEyes<bool>,
+}
+
+/// A value in the form decisions are actually made on, plus the pre-extension
+/// counterfactual retained for supermatcher A/B metrics.
+///
+/// `baseline` is `Some` only when the supermatcher re-searched with a larger `ef` for at
+/// least one rotation of this request. When it is `None`, `effective` *is* the baseline:
+/// no extension happened, so the two would be identical.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct WithBaseline<T> {
+    effective: T,
+    baseline: Option<T>,
+}
+
+impl<T> WithBaseline<T> {
+    /// The requested form, falling back to `effective` when no extension happened.
+    fn get(&self, variant: SearchVariant) -> &T {
+        match variant {
+            SearchVariant::Effective => &self.effective,
+            SearchVariant::Baseline => self.baseline.as_ref().unwrap_or(&self.effective),
+        }
+    }
+
+    /// Every stored form: one item when no extension happened, two when it did.
+    fn variants(&self) -> impl Iterator<Item = &T> + '_ {
+        chain!(std::iter::once(&self.effective), &self.baseline)
+    }
+
+    /// True if the supermatcher extended this request's search.
+    fn was_extended(&self) -> bool {
+        self.baseline.is_some()
+    }
+
+    fn map<U>(&self, f: impl Fn(&T) -> U) -> WithBaseline<U> {
+        WithBaseline {
+            effective: f(&self.effective),
+            baseline: self.baseline.as_ref().map(f),
+        }
+    }
+}
+
+/// Which form of the search results to evaluate.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum SearchVariant {
+    /// The results decisions are made on: extended, if the supermatcher ran.
+    Effective,
+    /// What the original search alone would have produced.
+    Baseline,
+}
+
 /// One request's search results for one orientation, not yet resolved against the
 /// other eye.
 struct PendingRequest {
@@ -270,6 +163,85 @@ struct PendingRequest {
     search: WithBaseline<UnresolvedJoin>,
     luc_ids: Vec<VectorId>,
     request_type: RequestType,
+}
+
+impl UnresolvedJoin {
+    /// Build by merging match results across all rotations of both eyes, reading the
+    /// requested form of each rotation's results.
+    fn from_rotations(
+        search_results: BothEyes<&VecRotations<HawkInsertPlan>>,
+        variant: SearchVariant,
+    ) -> UnresolvedJoin {
+        let mut hits_by_id: MapEdges<BothEyes<bool>> = HashMap::new();
+
+        let mut saturated = [false, false];
+        for (side, rotations) in izip!([LEFT, RIGHT], search_results) {
+            // Merge matches from all rotations.
+            for rotation in rotations.iter() {
+                let matches = match variant {
+                    SearchVariant::Effective => &rotation.classified.matches,
+                    SearchVariant::Baseline => rotation
+                        .classified
+                        .pre_extension
+                        .as_ref()
+                        .unwrap_or(&rotation.classified.matches),
+                };
+                if matches.saturated {
+                    saturated[side] = true;
+                }
+                for (vector_id, _) in matches.results.iter() {
+                    hits_by_id.entry(*vector_id).or_default()[side] = true;
+                }
+            }
+        }
+
+        let partial_hits_sorted: Vec<_> = hits_by_id
+            .into_iter()
+            .filter(|(_, [is_match_l, is_match_r])| *is_match_l || *is_match_r)
+            .sorted()
+            .collect();
+
+        let mut matched_both_eyes = Vec::new();
+        let mut matched_one_eye: BothEyes<VecEdges<VectorId>> = [Vec::new(), Vec::new()];
+        for (vector_id, is_match_lr) in partial_hits_sorted {
+            match is_match_lr {
+                [true, true] => matched_both_eyes.push(vector_id),
+                [true, false] => matched_one_eye[LEFT].push(vector_id),
+                [false, true] => matched_one_eye[RIGHT].push(vector_id),
+                [false, false] => {}
+            }
+        }
+
+        UnresolvedJoin {
+            matched_both_eyes,
+            matched_one_eye,
+            saturated,
+        }
+    }
+
+    /// Resolve the one-eyed matches into a full join, using the MPC comparison results
+    /// for the opposite eye.
+    fn resolve(&self, comparison_results: BothEyes<&MapEdges<bool>>) -> ResolvedJoin {
+        let mut matches: Vec<_> = self
+            .matched_both_eyes
+            .iter()
+            .map(|id| (*id, [true, true]))
+            .collect();
+        for id in &self.matched_one_eye[LEFT] {
+            if let Some(right) = comparison_results[RIGHT].get(id) {
+                matches.push((*id, [true, *right]));
+            }
+        }
+        for id in &self.matched_one_eye[RIGHT] {
+            if let Some(left) = comparison_results[LEFT].get(id) {
+                matches.push((*id, [*left, true]));
+            }
+        }
+        ResolvedJoin {
+            matches,
+            saturated: self.saturated,
+        }
+    }
 }
 
 impl PendingRequest {
@@ -364,195 +336,156 @@ impl PendingRequest {
     }
 }
 
-/// One request's search matches, split by how many eyes matched, plus per-eye
-/// saturation.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Decision {
+    UniqueInsert,
+    UniqueInsertSkipped,
+    ReauthUpdate(VectorId),
+    NoMutation,
+}
+
+impl Decision {
+    pub fn is_mutation(&self) -> bool {
+        match self {
+            UniqueInsert | ReauthUpdate(_) => true,
+            UniqueInsertSkipped | NoMutation => false,
+        }
+    }
+}
+
+/// Wide filter: any match in any orientation, including intra-batch peers.
+pub const DECISION_FILTER: Filter = Filter {
+    eyes: OnlyOrBoth::Both,
+    orient: OnlyOrBoth::Both,
+    intra_batch: true,
+};
+
+/// The final match results for a batch: what each request matched, and what to do
+/// about it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MatchResults {
+    requests: VecRequests<RequestMatches>,
+    decisions: VecRequests<Decision>,
+}
+
+/// The outcome of evaluating a uniqueness request against its selected match ids.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+struct UniquenessOutcome {
+    /// True if anything at all blocks insertion.
+    is_match: bool,
+    /// True if search saturation was the *only* thing blocking insertion.
+    only_supermatch: bool,
+}
+
+/// Evaluate whether a uniqueness request matched, given its selected match ids and the
+/// decisions already made for earlier requests in the batch.
 ///
-/// `matched_both_eyes` holds vectors that matched on both eyes directly in the search
-/// results. `matched_one_eye[side]` holds vectors that matched only on `side`;
-/// the other eye is resolved later via `resolve` using the MPC `comparison_results`.
-#[derive(Clone, Debug)]
-struct UnresolvedJoin {
-    matched_both_eyes: VecEdges<VectorId>,
-    matched_one_eye: BothEyes<VecEdges<VectorId>>,
-    /// True per eye if any rotation's match results were saturated (supermatcher).
-    saturated: BothEyes<bool>,
-}
+/// Attribution to saturation is order-independent: a supermatch is the *only* reason for
+/// a match only when no ordinary id matched, in either orientation.
+///
+/// Iterating the full set of ids is deliberate: a short-circuiting `any()` would
+/// mis-attribute `only_supermatch`, because `RequestMatches::select` yields all of the
+/// normal orientation's ids — including its `Supermatch` — before any of the mirror's.
+fn evaluate_uniqueness(
+    ids: impl IntoIterator<Item = MatchId>,
+    prior_decisions: &[Decision],
+) -> UniquenessOutcome {
+    let mut ordinary_match = false;
+    let mut supermatch = false;
 
-impl UnresolvedJoin {
-    /// Build by merging match results across all rotations of both eyes, reading the
-    /// requested form of each rotation's results.
-    fn from_rotations(
-        search_results: BothEyes<&VecRotations<HawkInsertPlan>>,
-        variant: SearchVariant,
-    ) -> UnresolvedJoin {
-        let mut hits_by_id: MapEdges<BothEyes<bool>> = HashMap::new();
-
-        let mut saturated = [false, false];
-        for (side, rotations) in izip!([LEFT, RIGHT], search_results) {
-            // Merge matches from all rotations.
-            for rotation in rotations.iter() {
-                let matches = match variant {
-                    SearchVariant::Effective => &rotation.classified.matches,
-                    SearchVariant::Baseline => rotation
-                        .classified
-                        .pre_extension
-                        .as_ref()
-                        .unwrap_or(&rotation.classified.matches),
-                };
-                if matches.saturated {
-                    saturated[side] = true;
-                }
-                for (vector_id, _) in matches.results.iter() {
-                    hits_by_id.entry(*vector_id).or_default()[side] = true;
+    for id in ids {
+        match id {
+            Search(_) | Luc(_) | Reauth(_) => ordinary_match = true,
+            Supermatch => supermatch = true,
+            IntraBatch(request_i) => {
+                // We are blocked by an intra-batch match only if the request we matched
+                // with will itself be inserted or updated. A request after us in the
+                // batch has no decision yet, so it does not block us.
+                if prior_decisions
+                    .get(request_i)
+                    .is_some_and(Decision::is_mutation)
+                {
+                    ordinary_match = true;
                 }
             }
         }
-
-        let partial_hits_sorted: Vec<_> = hits_by_id
-            .into_iter()
-            .filter(|(_, [is_match_l, is_match_r])| *is_match_l || *is_match_r)
-            .sorted()
-            .collect();
-
-        let mut matched_both_eyes = Vec::new();
-        let mut matched_one_eye: BothEyes<VecEdges<VectorId>> = [Vec::new(), Vec::new()];
-        for (vector_id, is_match_lr) in partial_hits_sorted {
-            match is_match_lr {
-                [true, true] => matched_both_eyes.push(vector_id),
-                [true, false] => matched_one_eye[LEFT].push(vector_id),
-                [false, true] => matched_one_eye[RIGHT].push(vector_id),
-                [false, false] => {}
-            }
-        }
-
-        UnresolvedJoin {
-            matched_both_eyes,
-            matched_one_eye,
-            saturated,
-        }
     }
 
-    /// Resolve the one-eyed matches into a full join, using the MPC comparison results
-    /// for the opposite eye.
-    fn resolve(&self, comparison_results: BothEyes<&MapEdges<bool>>) -> ResolvedJoin {
-        let mut matches: Vec<_> = self
-            .matched_both_eyes
-            .iter()
-            .map(|id| (*id, [true, true]))
-            .collect();
-        for id in &self.matched_one_eye[LEFT] {
-            if let Some(right) = comparison_results[RIGHT].get(id) {
-                matches.push((*id, [true, *right]));
-            }
-        }
-        for id in &self.matched_one_eye[RIGHT] {
-            if let Some(left) = comparison_results[LEFT].get(id) {
-                matches.push((*id, [*left, true]));
-            }
-        }
-        ResolvedJoin {
-            matches,
-            saturated: self.saturated,
-        }
+    UniquenessOutcome {
+        is_match: ordinary_match || supermatch,
+        only_supermatch: supermatch && !ordinary_match,
     }
 }
 
-// ===========================================================================
-// Resolved types: request and batch state produced by Stage 1
-// ===========================================================================
+/// Supermatcher A/B comparison: the three match determinations an extended search is
+/// judged by. Only meaningful for requests where `RequestMatches::was_extended()`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+struct ExtensionOutcome {
+    /// Final call on the extended results, including rejection due to saturation.
+    extended_decision: bool,
+    /// The effective search results, ignoring saturation: whether they contain a real
+    /// (non-supermatch) neighbour match.
+    extended_match: bool,
+    /// What the original search alone would have concluded. Saturation is excluded here
+    /// too, since those results were never expanded.
+    baseline_match: bool,
+}
+
+fn extension_outcome(
+    request: &RequestMatches,
+    filter: Filter,
+    prior_decisions: &[Decision],
+) -> ExtensionOutcome {
+    let not_supermatch = |id: &MatchId| !matches!(id, Supermatch);
+    let is_match =
+        |variant| evaluate_uniqueness(request.select(filter, variant), prior_decisions).is_match;
+    let is_real_match = |variant| {
+        evaluate_uniqueness(
+            request.select(filter, variant).filter(not_supermatch),
+            prior_decisions,
+        )
+        .is_match
+    };
+
+    ExtensionOutcome {
+        extended_decision: is_match(SearchVariant::Effective),
+        extended_match: is_real_match(SearchVariant::Effective),
+        baseline_match: is_real_match(SearchVariant::Baseline),
+    }
+}
+
+/// Emits the A/B counters for one extended request.
+fn record_extension_metrics(outcome: &ExtensionOutcome) {
+    match (outcome.baseline_match, outcome.extended_decision) {
+        (false, true) => {
+            metrics::counter!("supermatcher_extended_search_changed_decision_to_reject")
+                .increment(1);
+        }
+        (true, false) => {
+            metrics::counter!("supermatcher_extended_search_changed_decision_to_accept")
+                .increment(1);
+        }
+        _ => {}
+    }
+
+    match (outcome.baseline_match, outcome.extended_match) {
+        (false, true) => {
+            metrics::counter!("supermatcher_extended_search_found_new_match").increment(1);
+        }
+        (true, false) => {
+            metrics::counter!("supermatcher_extended_search_lost_match").increment(1);
+        }
+        _ => {}
+    }
+
+    // Unconditionally count when a request had an extended search.
+    metrics::counter!("supermatcher_extended_search_requests").increment(1);
+}
 
 /// All requests for one orientation, with the other-eye comparisons applied. Consumed
 /// by [`Self::decide`].
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ResolvedBatch(VecRequests<ResolvedRequest>);
-
-/// One resolved request: search, LUC, reauth, and intra-batch matches for one
-/// orientation, after MPC resolution.
-#[derive(Clone, Debug, PartialEq, Eq)]
-struct ResolvedRequest {
-    /// Resolved search matches, in the form decisions are made on plus the baseline.
-    search: WithBaseline<ResolvedJoin>,
-    luc_results: VecEdges<(VectorId, BothEyes<bool>)>,
-    reauth_result: Option<(VectorId, UseOrRule, BothEyes<bool>)>,
-    intra_matches: Vec<IntraMatch>,
-    request_type: RequestType,
-}
-
-impl ResolvedRequest {
-    /// The IDs of the vectors that matched this request.
-    ///
-    /// The luc, reauth and intra-batch contributions are unaffected by supermatcher
-    /// extension, so only the search join varies with `variant`.
-    fn select(&self, filter: Filter, variant: SearchVariant) -> impl Iterator<Item = MatchId> + '_ {
-        let join = self.search.get(variant);
-
-        let search = join
-            .matches
-            .iter()
-            .filter(move |(_, [l, r])| filter.search_rule(*l, *r))
-            .map(|(id, _)| Search(*id));
-
-        let luc = self
-            .luc_results
-            .iter()
-            .filter(move |(_, [l, r])| filter.luc_rule(*l, *r))
-            .map(|(id, _)| Luc(*id));
-
-        let reauth = self
-            .reauth_result
-            .filter(move |(_, or_rule, matches)| filter.reauth_rule(*or_rule, *matches))
-            .map(|(id, _, _)| Reauth(id));
-
-        let intra = self
-            .intra_matches
-            .iter()
-            .filter(move |m| filter.intra_rule(m.is_match[LEFT], m.is_match[RIGHT]))
-            .map(|m| IntraBatch(m.other_request_i));
-
-        let supermatch = filter.supermatch_rule(join.saturated).then_some(Supermatch);
-
-        chain!(search, luc, reauth, intra, supermatch)
-    }
-}
-
-/// A search join after the missing-eye MPC comparisons have been resolved, bundled with
-/// its per-eye saturation (supermatcher) flags.
-#[derive(Clone, Debug, PartialEq, Eq)]
-struct ResolvedJoin {
-    matches: VecEdges<(VectorId, BothEyes<bool>)>,
-    /// True per eye if any rotation's match results were saturated (supermatcher).
-    saturated: BothEyes<bool>,
-}
-
-// ===========================================================================
-// Stage 2: combine orientations, decide, and expose results
-// ===========================================================================
-
-/// Combines the results from mirrored checks.
-#[derive(Clone, Debug, PartialEq, Eq)]
-struct RequestMatches {
-    normal: ResolvedRequest,
-    mirror: ResolvedRequest,
-}
-
-impl RequestMatches {
-    /// The IDs of the vectors that matched at least partially, in both orientations.
-    fn select(&self, filter: Filter, variant: SearchVariant) -> impl Iterator<Item = MatchId> + '_ {
-        chain!(
-            matches!(filter.orient, Only(Normal) | Both)
-                .then_some(self.normal.select(filter, variant)),
-            matches!(filter.orient, Only(Mirror) | Both)
-                .then_some(self.mirror.select(filter, variant)),
-        )
-        .flatten()
-    }
-
-    /// True if the supermatcher extended this request's search in either orientation,
-    /// so a baseline comparison is meaningful.
-    fn was_extended(&self) -> bool {
-        self.normal.search.was_extended() || self.mirror.search.was_extended()
-    }
-}
 
 impl ResolvedBatch {
     /// Combine both orientations and make the final decision for every request.
@@ -637,14 +570,6 @@ impl ResolvedBatch {
     }
 }
 
-/// The final match results for a batch: what each request matched, and what to do
-/// about it.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct MatchResults {
-    requests: VecRequests<RequestMatches>,
-    decisions: VecRequests<Decision>,
-}
-
 impl MatchResults {
     /// The final decision of what to do with each request, decided by `decide`.
     pub fn decisions(&self) -> &[Decision] {
@@ -664,122 +589,177 @@ impl MatchResults {
     }
 }
 
-/// The outcome of evaluating a uniqueness request against its selected match ids.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-struct UniquenessOutcome {
-    /// True if anything at all blocks insertion.
-    is_match: bool,
-    /// True if search saturation was the *only* thing blocking insertion.
-    only_supermatch: bool,
+/// A search join after the missing-eye MPC comparisons have been resolved, bundled with
+/// its per-eye saturation (supermatcher) flags.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ResolvedJoin {
+    matches: VecEdges<(VectorId, BothEyes<bool>)>,
+    /// True per eye if any rotation's match results were saturated (supermatcher).
+    saturated: BothEyes<bool>,
 }
 
-/// Evaluate whether a uniqueness request matched, given its selected match ids and the
-/// decisions already made for earlier requests in the batch.
-///
-/// Attribution to saturation is order-independent: a supermatch is the *only* reason for
-/// a match only when no ordinary id matched, in either orientation.
-///
-/// Iterating the full set of ids is deliberate: a short-circuiting `any()` would
-/// mis-attribute `only_supermatch`, because `RequestMatches::select` yields all of the
-/// normal orientation's ids — including its `Supermatch` — before any of the mirror's.
-fn evaluate_uniqueness(
-    ids: impl IntoIterator<Item = MatchId>,
-    prior_decisions: &[Decision],
-) -> UniquenessOutcome {
-    let mut ordinary_match = false;
-    let mut supermatch = false;
+/// One resolved request: search, LUC, reauth, and intra-batch matches for one
+/// orientation, after MPC resolution.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ResolvedRequest {
+    /// Resolved search matches, in the form decisions are made on plus the baseline.
+    search: WithBaseline<ResolvedJoin>,
+    luc_results: VecEdges<(VectorId, BothEyes<bool>)>,
+    reauth_result: Option<(VectorId, UseOrRule, BothEyes<bool>)>,
+    intra_matches: Vec<IntraMatch>,
+    request_type: RequestType,
+}
 
-    for id in ids {
-        match id {
-            Search(_) | Luc(_) | Reauth(_) => ordinary_match = true,
-            Supermatch => supermatch = true,
-            IntraBatch(request_i) => {
-                // We are blocked by an intra-batch match only if the request we matched
-                // with will itself be inserted or updated. A request after us in the
-                // batch has no decision yet, so it does not block us.
-                if prior_decisions
-                    .get(request_i)
-                    .is_some_and(Decision::is_mutation)
-                {
-                    ordinary_match = true;
-                }
-            }
-        }
+impl ResolvedRequest {
+    /// The IDs of the vectors that matched this request.
+    ///
+    /// The luc, reauth and intra-batch contributions are unaffected by supermatcher
+    /// extension, so only the search join varies with `variant`.
+    fn select(&self, filter: Filter, variant: SearchVariant) -> impl Iterator<Item = MatchId> + '_ {
+        let join = self.search.get(variant);
+
+        let search = join
+            .matches
+            .iter()
+            .filter(move |(_, [l, r])| filter.search_rule(*l, *r))
+            .map(|(id, _)| Search(*id));
+
+        let luc = self
+            .luc_results
+            .iter()
+            .filter(move |(_, [l, r])| filter.luc_rule(*l, *r))
+            .map(|(id, _)| Luc(*id));
+
+        let reauth = self
+            .reauth_result
+            .filter(move |(_, or_rule, matches)| filter.reauth_rule(*or_rule, *matches))
+            .map(|(id, _, _)| Reauth(id));
+
+        let intra = self
+            .intra_matches
+            .iter()
+            .filter(move |m| filter.intra_rule(m.is_match[LEFT], m.is_match[RIGHT]))
+            .map(|m| IntraBatch(m.other_request_i));
+
+        let supermatch = filter.supermatch_rule(join.saturated).then_some(Supermatch);
+
+        chain!(search, luc, reauth, intra, supermatch)
     }
-
-    UniquenessOutcome {
-        is_match: ordinary_match || supermatch,
-        only_supermatch: supermatch && !ordinary_match,
-    }
 }
 
-// ===========================================================================
-// Supermatcher A/B metrics
-// ===========================================================================
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum MatchId {
+    Search(VectorId),
+    Luc(VectorId),
+    Reauth(VectorId),
+    IntraBatch(usize),
+    /// Search results were saturated (supermatcher).
+    Supermatch,
+}
 
-/// Supermatcher A/B comparison: the three match determinations an extended search is
-/// judged by. Only meaningful for requests where `RequestMatches::was_extended()`.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-struct ExtensionOutcome {
-    /// Final call on the extended results, including rejection due to saturation.
-    extended_decision: bool,
-    /// The effective search results, ignoring saturation: whether they contain a real
-    /// (non-supermatch) neighbour match.
-    extended_match: bool,
-    /// What the original search alone would have concluded. Saturation is excluded here
-    /// too, since those results were never expanded.
-    baseline_match: bool,
+pub enum RequestType {
+    /// A request to check if a vector is unique.
+    Uniqueness { skip_persistence: bool },
+    /// A request to check if a vector is unique without inserting it.
+    IdentityMatchCheck,
+    /// A request to check if a vector matches a target and replace it.
+    Reauth {
+        /// Target vector id and whether to use an OR-rule for comparison
+        target: Option<(VectorId, UseOrRule)>,
+    },
+    /// Other features.
+    Unsupported,
 }
 
-fn extension_outcome(
-    request: &RequestMatches,
-    filter: Filter,
-    prior_decisions: &[Decision],
-) -> ExtensionOutcome {
-    let not_supermatch = |id: &MatchId| !matches!(id, Supermatch);
-    let is_match =
-        |variant| evaluate_uniqueness(request.select(filter, variant), prior_decisions).is_match;
-    let is_real_match = |variant| {
-        evaluate_uniqueness(
-            request.select(filter, variant).filter(not_supermatch),
-            prior_decisions,
+/// Combines the results from mirrored checks.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct RequestMatches {
+    normal: ResolvedRequest,
+    mirror: ResolvedRequest,
+}
+
+impl RequestMatches {
+    /// The IDs of the vectors that matched at least partially, in both orientations.
+    fn select(&self, filter: Filter, variant: SearchVariant) -> impl Iterator<Item = MatchId> + '_ {
+        chain!(
+            matches!(filter.orient, Only(Normal) | Both)
+                .then_some(self.normal.select(filter, variant)),
+            matches!(filter.orient, Only(Mirror) | Both)
+                .then_some(self.mirror.select(filter, variant)),
         )
-        .is_match
-    };
+        .flatten()
+    }
 
-    ExtensionOutcome {
-        extended_decision: is_match(SearchVariant::Effective),
-        extended_match: is_real_match(SearchVariant::Effective),
-        baseline_match: is_real_match(SearchVariant::Baseline),
+    /// True if the supermatcher extended this request's search in either orientation,
+    /// so a baseline comparison is meaningful.
+    fn was_extended(&self) -> bool {
+        self.normal.search.was_extended() || self.mirror.search.was_extended()
     }
 }
 
-/// Emits the A/B counters for one extended request.
-fn record_extension_metrics(outcome: &ExtensionOutcome) {
-    match (outcome.baseline_match, outcome.extended_decision) {
-        (false, true) => {
-            metrics::counter!("supermatcher_extended_search_changed_decision_to_reject")
-                .increment(1);
+/// Search *AND* policy: only match if both eyes match (like `mergeDbResults`).
+///
+/// LUC *OR* policy: "Local" irises match if either side matches.
+///
+/// Intra-batch *AND* policy: match against requests before this request in the same batch.
+///
+/// Partial matches: set `eyes: Only(Left)` or `eyes: Only(Right)`.
+///
+/// Mirror matches: set `orient: Only(Mirror)`.
+#[derive(Copy, Clone)]
+pub struct Filter {
+    pub eyes: OnlyOrBoth<StoreId>,
+    pub orient: OnlyOrBoth<Orientation>,
+    pub intra_batch: bool,
+}
+
+#[derive(Copy, Clone)]
+pub enum OnlyOrBoth<T> {
+    Only(T),
+    Both,
+}
+
+impl Filter {
+    fn search_rule(&self, left: bool, right: bool) -> bool {
+        match self.eyes {
+            Only(Left) => left,
+            Only(Right) => right,
+            Both => left && right,
         }
-        (true, false) => {
-            metrics::counter!("supermatcher_extended_search_changed_decision_to_accept")
-                .increment(1);
-        }
-        _ => {}
     }
 
-    match (outcome.baseline_match, outcome.extended_match) {
-        (false, true) => {
-            metrics::counter!("supermatcher_extended_search_found_new_match").increment(1);
+    fn luc_rule(&self, left: bool, right: bool) -> bool {
+        match self.eyes {
+            Only(Left) => left,
+            Only(Right) => right,
+            Both => left || right,
         }
-        (true, false) => {
-            metrics::counter!("supermatcher_extended_search_lost_match").increment(1);
-        }
-        _ => {}
     }
 
-    // Unconditionally count when a request had an extended search.
-    metrics::counter!("supermatcher_extended_search_requests").increment(1);
+    /// Decide if this is a successful reauth based on left and right matches.
+    /// Use the OR or AND rule as specified in the reauth request.
+    fn reauth_rule(&self, or_rule: UseOrRule, [left, right]: BothEyes<bool>) -> bool {
+        match self.eyes {
+            Only(Left) => left,
+            Only(Right) => right,
+            Both if or_rule => left || right,
+            Both => left && right,
+        }
+    }
+
+    fn intra_rule(&self, left: bool, right: bool) -> bool {
+        self.intra_batch && self.search_rule(left, right)
+    }
+
+    /// Supermatch uses OR policy: saturated on either eye is a supermatch.
+    fn supermatch_rule(&self, [left, right]: BothEyes<bool>) -> bool {
+        match self.eyes {
+            Only(Left) => left,
+            Only(Right) => right,
+            Both => left || right,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/iris-mpc-cpu/src/execution/hawk_main/matching/tests.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/matching/tests.rs
@@ -188,18 +188,63 @@ fn test_evaluate_uniqueness() {
     );
 }
 
+/// One scenario for [`run_test_matching`]: a few knobs describing what the searches and
+/// the MPC comparisons found, plus what the pipeline is expected to conclude.
+///
+/// The fields fall into three groups: what the HNSW searches returned (`search_match`,
+/// `saturated`, `pre_extension`), what the follow-up MPC comparisons answered
+/// (`other_side_match`, `reauth_match`), and what kind of request this is
+/// (`request_type`). `expected_decision` and `expected_matches` are the assertions, and
+/// are read only by [`test_matching`]'s loop — tests that assert directly leave them at
+/// their [`Default`] values.
+///
+/// Everything not named in a literal comes from [`TestCase::default`]: a uniqueness
+/// request that persists, whose searches found no full match and were not saturated, and
+/// whose comparisons all came back negative.
 #[derive(Clone, Debug)]
 struct TestCase {
+    /// Whether both eyes' searches found `BOTH_MATCH`, the fixture's only two-eyed hit.
+    /// This is the one way to get a match that needs no MPC comparison to confirm, since
+    /// the AND rule over both eyes is already satisfied by the search results alone.
     search_match: bool,
+
+    /// The answer the simulated MPC comparison gives for every id compared against the
+    /// **left** eye — that is, for ids the right eye's search hit but the left eye never
+    /// inspected. The right eye's comparisons are always negative, so this is the only
+    /// knob for turning a one-eyed search hit into a confirmed two-eyed match.
     other_side_match: bool,
+
+    /// The answer the simulated MPC comparison gives for the `REAUTH` target on both
+    /// eyes, overriding `other_side_match` for that id. Only meaningful for
+    /// [`RequestType::Reauth`] cases, where it decides whether the reauth succeeds.
     reauth_match: bool,
+
     /// Saturated flags per eye: [left, right]. Simulates super-matcher.
+    ///
+    /// A saturated search returned nearly as many matches as `ef`, so more probably
+    /// exist beyond what was retrieved. That alone counts as a match
+    /// ([`MatchId::Supermatch`]) and blocks insertion, even with no concrete match id.
     saturated: BothEyes<bool>,
+
     /// Simulates a supermatcher extended search: what the original search alone found.
     /// `None` means no extension happened.
+    ///
+    /// When set, the fixture's search results become the *extended* ones and this becomes
+    /// the baseline they are compared against, which is what drives the A/B metrics in
+    /// [`extension_outcome`]. Setting it also grows the set of ids sent for MPC
+    /// comparison, since baseline one-eyed hits need their other eye resolved too.
     pre_extension: Option<BaselineSearch>,
+
+    /// The [`Decision`] the pipeline should reach for this request.
     expected_decision: Decision,
+
+    /// The match ids the request should report under [`HawkResult::MATCH_IDS_FILTER`],
+    /// compared as a set.
     expected_matches: Vec<MatchId>,
+
+    /// Which kind of request this is, selecting the branch [`ResolvedBatch::decide`] takes:
+    /// uniqueness (with or without persistence), identity match check, reauth, or
+    /// unsupported.
     request_type: RequestType,
 }
 
@@ -544,6 +589,41 @@ fn baseline_match_ids(batch: &MatchResults, filter: Filter) -> Vec<MatchId> {
         .collect_vec()
 }
 
+/// Drive one [`TestCase`] through the whole matching pipeline and return the result.
+///
+/// This fabricates a plausible pair of eye searches, then plays the part of the two
+/// asynchronous helpers the real pipeline depends on — the MPC other-eye comparisons
+/// (`is_match_batch`) and the intra-batch comparisons (`intra_batch_is_match`) — so the
+/// matching logic can be tested without any MPC session or network:
+///
+/// 1. Build a [`HawkInsertPlan`] per eye from the fixture ids below, replicated across
+///    every rotation, and hand both to [`PendingBatch::new`].
+/// 2. Ask for [`PendingBatch::ids_to_compare`] and **assert the exact set** for each eye.
+///    This assertion runs for every case, so each one re-checks which vectors the
+///    pipeline decides need an other-eye comparison.
+/// 3. Answer those comparisons from the test case: every left-eye comparison returns
+///    `other_side_match`, every right-eye one returns `false`, and `REAUTH` returns
+///    `reauth_match` on both eyes.
+/// 4. Report no intra-batch matches, then resolve via [`PendingBatch::resolve`].
+/// 5. Combine orientations with [`ResolvedBatch::decide`], using a clone of the resolved
+///    batch as the mirror.
+///
+/// The searches are the same every time apart from the test case's knobs. Each fixture id
+/// exercises one path: `BOTH_MATCH` is the only id both eyes match (when `search_match`);
+/// `LEFT_MATCH` and `RIGHT_MATCH` are hit by one eye and need the other compared;
+/// `BOTH_FOUND` was seen by both eyes but matched only on the left; `LUC_REQUESTED` is
+/// compared on both eyes because the request asked for it, and `LUC_REQUESTED_DUP` is an
+/// alias of `LEFT_MATCH` that proves duplicates are collapsed; `REAUTH` is compared even
+/// though no search hit it; and `BASELINE_ONLY` appears solely in the pre-extension
+/// baseline, so it is reached only through [`TestCase::pre_extension`].
+///
+/// Two limits are worth highlighting:
+///
+/// - **One request per batch.** Intra-batch matching is therefore never exercised — a
+///   request has no peers to be blocked by.
+/// - **The mirror orientation is a clone of the normal one.** No case here can produce a
+///   disagreement between orientations, so anything that depends on their asymmetry is
+///   invisible.
 fn run_test_matching(tc: &TestCase) -> MatchResults {
     let req_i = 0;
     let distance = || DistanceShare::new(Share::default(), Share::default());
@@ -557,7 +637,11 @@ fn run_test_matching(tc: &TestCase) -> MatchResults {
         match_right.push(BOTH_MATCH);
     }
 
-    let saturated = tc.saturated;
+    // Build one eye's search result: the same `HawkInsertPlan` for every rotation, holding
+    // the ids this eye matched plus the ids it merely inspected (which reach only the HNSW
+    // links, not the `classified` matches the matching logic reads). `side_saturated` is
+    // this eye's saturation flag; a `Some` baseline simulates a supermatcher extension,
+    // making `match_ids` the extended results and the baseline the pre-extension ones.
     let search_result = |match_ids: Vec<VectorId>,
                          non_match_ids: Vec<VectorId>,
                          side_saturated: bool,
@@ -598,6 +682,7 @@ fn run_test_matching(tc: &TestCase) -> MatchResults {
         ])
     };
 
+    let saturated = tc.saturated;
     let baseline_for = |side: usize| {
         tc.pre_extension
             .as_ref()
@@ -620,6 +705,7 @@ fn run_test_matching(tc: &TestCase) -> MatchResults {
     ];
     let luc_ids = vec![vec![LUC_REQUESTED, LUC_REQUESTED_DUP]];
     let request_types = vec![tc.request_type];
+
     let pending = PendingBatch::new(&search_results, &luc_ids, request_types);
 
     let ids_to_compare = pending.ids_to_compare();

--- a/iris-mpc-cpu/src/execution/hawk_main/matching/tests.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/matching/tests.rs
@@ -485,7 +485,10 @@ fn test_extension_outcome_lost_match() {
     );
 }
 
-/// Without an extension the two views agree, so nothing is reported as changed.
+/// Without an extension *and* without saturation, all three determinations agree: this
+/// fixture has `saturated: [false, false]`, so `extended_decision` (which includes
+/// saturation) coincides with `extended_match`/`baseline_match` (which exclude it). A
+/// fixture with saturation would not pin this equality.
 #[test]
 fn test_extension_outcome_without_extension() {
     let case = TestCase {
@@ -619,7 +622,7 @@ fn run_test_matching(tc: &TestCase) -> MatchResults {
     let request_types = vec![tc.request_type];
     let pending = PendingBatch::new(&search_results, &luc_ids, request_types);
 
-    let missing_ids = pending.ids_to_compare();
+    let ids_to_compare = pending.ids_to_compare();
 
     // We will inspect the other side of partial search results.
     let mut expect_left = vec![RIGHT_MATCH, LUC_REQUESTED, LUC_REQUESTED_DUP];
@@ -653,36 +656,37 @@ fn run_test_matching(tc: &TestCase) -> MatchResults {
     let expect_right = expect_right.into_iter().unique().collect_vec();
 
     assert_equal_sets(
-        &missing_ids[LEFT][req_i],
+        &ids_to_compare[LEFT][req_i],
         &expect_left,
-        "Left side missing IDs",
+        "Left side ids to compare",
     );
     assert_equal_sets(
-        &missing_ids[RIGHT][req_i],
+        &ids_to_compare[RIGHT][req_i],
         &expect_right,
-        "Right side missing IDs",
+        "Right side ids to compare",
     );
 
-    // Simulate `calculate_missing_is_match(..)`.
+    // Simulate the caller's `is_match_batch(..)` (in `hawk_main/is_match_batch.rs`),
+    // which computes these comparisons and passes them into `PendingBatch::resolve`.
     // Make it match or not depending on `with_other_side_match`.
-    let mut missing_is_match = [vec![HashMap::new()], vec![HashMap::new()]];
-    for id in &missing_ids[LEFT][req_i] {
-        missing_is_match[LEFT][req_i].insert(*id, tc.other_side_match);
+    let mut comparison_results = [vec![HashMap::new()], vec![HashMap::new()]];
+    for id in &ids_to_compare[LEFT][req_i] {
+        comparison_results[LEFT][req_i].insert(*id, tc.other_side_match);
     }
-    for id in &missing_ids[RIGHT][req_i] {
-        missing_is_match[RIGHT][req_i].insert(*id, false);
+    for id in &ids_to_compare[RIGHT][req_i] {
+        comparison_results[RIGHT][req_i].insert(*id, false);
     }
 
     // Make the reauth request match.
     if matches!(tc.request_type, RequestType::Reauth(_)) {
-        *missing_is_match[LEFT][req_i].get_mut(&REAUTH).unwrap() = tc.reauth_match;
-        *missing_is_match[RIGHT][req_i].get_mut(&REAUTH).unwrap() = tc.reauth_match;
+        *comparison_results[LEFT][req_i].get_mut(&REAUTH).unwrap() = tc.reauth_match;
+        *comparison_results[RIGHT][req_i].get_mut(&REAUTH).unwrap() = tc.reauth_match;
     }
 
     // Simulate `intra_batch_is_match(..)`
     let intra_matches = vec![vec![]];
 
-    let resolved = pending.resolve(&missing_is_match, intra_matches);
+    let resolved = pending.resolve(&comparison_results, intra_matches);
 
     // Do the same with mirrored matching. Amazingly, we got exactly the same result in this test.
     let resolved_mirror = resolved.clone();

--- a/iris-mpc-cpu/src/execution/hawk_main/matching/tests.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/matching/tests.rs
@@ -424,6 +424,82 @@ fn test_baseline_equals_extended_without_extension() {
     assert_equal_sets(&baseline, &extended[0], "baseline equals extended");
 }
 
+/// The extended search found a full match the original search had missed.
+#[test]
+fn test_extension_outcome_found_new_match() {
+    let case = TestCase {
+        search_match: true,
+        saturated: [false, false],
+        pre_extension: Some(BaselineSearch {
+            matched: [
+                vec![LEFT_MATCH, BOTH_FOUND, BASELINE_ONLY],
+                vec![RIGHT_MATCH],
+            ],
+            saturated: [true, false],
+        }),
+        // `expected_decision` / `expected_matches` are omitted: this test asserts on
+        // `extension_outcome` directly and never goes through `test_matching`'s loop.
+        ..TestCase::default()
+    };
+    let results = run_test_matching(&case);
+    let request = request_0(&results);
+
+    assert!(request.was_extended());
+    assert_eq!(
+        extension_outcome(request, DECISION_FILTER, &[]),
+        ExtensionOutcome {
+            extended_decision: true,
+            extended_match: true,
+            // Saturation is excluded, so the original search alone found nothing.
+            baseline_match: false,
+        },
+    );
+}
+
+/// The extended search lost a full match the original search had found.
+#[test]
+fn test_extension_outcome_lost_match() {
+    let case = TestCase {
+        search_match: false,
+        saturated: [false, false],
+        pre_extension: Some(BaselineSearch {
+            matched: [
+                vec![LEFT_MATCH, BOTH_FOUND, BOTH_MATCH],
+                vec![RIGHT_MATCH, BOTH_MATCH],
+            ],
+            saturated: [false, false],
+        }),
+        ..TestCase::default()
+    };
+    let results = run_test_matching(&case);
+    let request = request_0(&results);
+
+    assert!(request.was_extended());
+    assert_eq!(
+        extension_outcome(request, DECISION_FILTER, &[]),
+        ExtensionOutcome {
+            extended_decision: false,
+            extended_match: false,
+            baseline_match: true,
+        },
+    );
+}
+
+/// Without an extension the two views agree, so nothing is reported as changed.
+#[test]
+fn test_extension_outcome_without_extension() {
+    let case = TestCase {
+        search_match: true,
+        ..TestCase::default()
+    };
+    let results = run_test_matching(&case);
+    let request = request_0(&results);
+
+    assert!(!request.was_extended());
+    let outcome = extension_outcome(request, DECISION_FILTER, &[]);
+    assert_eq!(outcome.baseline_match, outcome.extended_match);
+}
+
 // ### Hypothetical search results
 /// Left matches; right was inspected but does not match.
 const BOTH_FOUND: VectorId = VectorId::from_serial_id(1);

--- a/iris-mpc-cpu/src/execution/hawk_main/matching/tests.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/matching/tests.rs
@@ -498,6 +498,7 @@ fn test_extension_outcome_without_extension() {
     assert!(!request.was_extended());
     let outcome = extension_outcome(request, DECISION_FILTER, &[]);
     assert_eq!(outcome.baseline_match, outcome.extended_match);
+    assert_eq!(outcome.baseline_match, outcome.extended_decision);
 }
 
 // ### Hypothetical search results

--- a/iris-mpc-cpu/src/execution/hawk_main/matching/tests.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/matching/tests.rs
@@ -122,6 +122,72 @@ fn test_supermatch_rule() {
     }
 }
 
+#[test]
+fn test_evaluate_uniqueness() {
+    let v = VectorId::from_serial_id(1);
+
+    // Nothing matched.
+    assert_eq!(
+        evaluate_uniqueness([], &[]),
+        UniquenessOutcome {
+            is_match: false,
+            only_supermatch: false,
+        },
+    );
+    // Saturation alone is the only reason this is a match.
+    assert_eq!(
+        evaluate_uniqueness([Supermatch], &[]),
+        UniquenessOutcome {
+            is_match: true,
+            only_supermatch: true,
+        },
+    );
+    // An ordinary match takes priority, whichever order the ids arrive in. The
+    // supermatch-first case is real: `RequestMatches::select` yields every id of the
+    // normal orientation, including its supermatch, before any mirror id.
+    for ids in [vec![Search(v), Supermatch], vec![Supermatch, Search(v)]] {
+        assert_eq!(
+            evaluate_uniqueness(ids.clone(), &[]),
+            UniquenessOutcome {
+                is_match: true,
+                only_supermatch: false,
+            },
+            "for ids {ids:?}",
+        );
+    }
+    // An intra-batch peer blocks us only if it is itself being inserted or updated.
+    assert_eq!(
+        evaluate_uniqueness([IntraBatch(0)], &[UniqueInsert]),
+        UniquenessOutcome {
+            is_match: true,
+            only_supermatch: false,
+        },
+    );
+    assert_eq!(
+        evaluate_uniqueness([IntraBatch(0)], &[NoMutation]),
+        UniquenessOutcome {
+            is_match: false,
+            only_supermatch: false,
+        },
+    );
+    // A peer later in the batch has no decision yet, so it does not block us.
+    assert_eq!(
+        evaluate_uniqueness([IntraBatch(5)], &[]),
+        UniquenessOutcome {
+            is_match: false,
+            only_supermatch: false,
+        },
+    );
+    // A non-blocking peer does not displace the supermatch attribution.
+    assert_eq!(
+        evaluate_uniqueness([Supermatch, IntraBatch(0)], &[NoMutation]),
+        UniquenessOutcome {
+            is_match: true,
+            only_supermatch: true,
+        },
+    );
+}
+
 #[derive(Clone, Debug)]
 struct TestCase {
     search_match: bool,

--- a/iris-mpc-cpu/src/execution/hawk_main/matching/tests.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/matching/tests.rs
@@ -302,15 +302,15 @@ fn test_matching() {
     ];
 
     for case in &cases {
-        let batch_step_3 = run_test_matching(case);
-        let decisions = batch_step_3.decisions();
+        let results = run_test_matching(case);
+        let decisions = results.decisions();
         assert_eq!(
             decisions,
             vec![case.expected_decision],
             "Failed for case: {case:?}",
         );
 
-        let match_ids = batch_step_3.select(HawkResult::MATCH_IDS_FILTER);
+        let match_ids = results.select(HawkResult::MATCH_IDS_FILTER);
         let [match_ids] = match_ids.try_into().unwrap();
         assert_equal_sets(&match_ids, &case.expected_matches, case);
     }
@@ -387,16 +387,16 @@ struct BaselineSearch {
 }
 
 /// The single request in a one-request test batch.
-fn request_0(batch: &BatchStep3) -> &Step3 {
+fn request_0(batch: &MatchResults) -> &RequestMatches {
     &batch.0[0]
 }
 
 /// The match ids the pre-extension (baseline) search alone would have produced.
-fn baseline_match_ids(batch: &BatchStep3, filter: Filter) -> Vec<MatchId> {
+fn baseline_match_ids(batch: &MatchResults, filter: Filter) -> Vec<MatchId> {
     request_0(batch).select_pre(filter).collect_vec()
 }
 
-fn run_test_matching(tc: &TestCase) -> BatchStep3 {
+fn run_test_matching(tc: &TestCase) -> MatchResults {
     let req_i = 0;
     let distance = || DistanceShare::new(Share::default(), Share::default());
 
@@ -472,9 +472,9 @@ fn run_test_matching(tc: &TestCase) -> BatchStep3 {
     ];
     let luc_ids = vec![vec![LUC_REQUESTED, LUC_REQUESTED_DUP]];
     let request_types = vec![tc.request_type];
-    let batch1 = BatchStep1::new(&search_results, &luc_ids, request_types);
+    let pending = PendingBatch::new(&search_results, &luc_ids, request_types);
 
-    let missing_ids = batch1.missing_vector_ids();
+    let missing_ids = pending.ids_to_compare();
 
     // We will inspect the other side of partial search results.
     let mut expect_left = vec![RIGHT_MATCH, LUC_REQUESTED, LUC_REQUESTED_DUP];
@@ -537,13 +537,13 @@ fn run_test_matching(tc: &TestCase) -> BatchStep3 {
     // Simulate `intra_batch_is_match(..)`
     let intra_matches = vec![vec![]];
 
-    let batch2 = batch1.step2(&missing_is_match, intra_matches);
+    let resolved = pending.resolve(&missing_is_match, intra_matches);
 
     // Do the same with mirrored matching. Amazingly, we got exactly the same result in this test.
-    let batch2_mirror = batch2.clone();
+    let resolved_mirror = resolved.clone();
 
     // Return the final decision for the request.
-    batch2.step3(batch2_mirror)
+    resolved.decide(resolved_mirror)
 }
 
 /// Assert that two sets are equal, ignoring order, and without duplicates.

--- a/iris-mpc-cpu/src/execution/hawk_main/matching/tests.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/matching/tests.rs
@@ -331,8 +331,8 @@ fn test_baseline_selection_differs_from_extended() {
             ],
             saturated: [true, false],
         }),
-        expected_decision: Decision::NoMutation,
-        expected_matches: vec![MatchId::Search(BOTH_MATCH)],
+        // `expected_decision`/`expected_matches` are omitted: this test asserts
+        // directly below rather than through `test_matching`'s table loop.
         ..TestCase::default()
     };
     let batch = run_test_matching(&case);
@@ -349,8 +349,6 @@ fn test_baseline_selection_differs_from_extended() {
 fn test_baseline_equals_extended_without_extension() {
     let case = TestCase {
         search_match: true,
-        expected_decision: Decision::NoMutation,
-        expected_matches: vec![MatchId::Search(BOTH_MATCH)],
         ..TestCase::default()
     };
     let batch = run_test_matching(&case);

--- a/iris-mpc-cpu/src/execution/hawk_main/matching/tests.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/matching/tests.rs
@@ -778,7 +778,7 @@ fn run_test_matching(tc: &TestCase) -> MatchResults {
     let resolved_mirror = resolved.clone();
 
     // Return the final decision for the request.
-    resolved.decide(resolved_mirror)
+    ResolvedBatch::decide(resolved, resolved_mirror)
 }
 
 /// Assert that two sets are equal, ignoring order, and without duplicates.

--- a/iris-mpc-cpu/src/execution/hawk_main/matching/tests.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/matching/tests.rs
@@ -393,7 +393,9 @@ fn request_0(batch: &MatchResults) -> &RequestMatches {
 
 /// The match ids the pre-extension (baseline) search alone would have produced.
 fn baseline_match_ids(batch: &MatchResults, filter: Filter) -> Vec<MatchId> {
-    request_0(batch).select_pre(filter).collect_vec()
+    request_0(batch)
+        .select(filter, SearchVariant::Baseline)
+        .collect_vec()
 }
 
 fn run_test_matching(tc: &TestCase) -> MatchResults {

--- a/iris-mpc-cpu/src/execution/hawk_main/matching/tests.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/matching/tests.rs
@@ -372,7 +372,7 @@ fn test_matching() {
         let decisions = results.decisions();
         assert_eq!(
             decisions,
-            vec![case.expected_decision],
+            [case.expected_decision].as_slice(),
             "Failed for case: {case:?}",
         );
 
@@ -530,7 +530,7 @@ struct BaselineSearch {
 
 /// The single request in a one-request test batch.
 fn request_0(batch: &MatchResults) -> &RequestMatches {
-    &batch.0[0]
+    &batch.requests[0]
 }
 
 /// The match ids the pre-extension (baseline) search alone would have produced.

--- a/iris-mpc-cpu/src/execution/hawk_main/matching/tests.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/matching/tests.rs
@@ -129,6 +129,9 @@ struct TestCase {
     reauth_match: bool,
     /// Saturated flags per eye: [left, right]. Simulates super-matcher.
     saturated: BothEyes<bool>,
+    /// Simulates a supermatcher extended search: what the original search alone found.
+    /// `None` means no extension happened.
+    pre_extension: Option<BaselineSearch>,
     expected_decision: Decision,
     expected_matches: Vec<MatchId>,
     request_type: RequestType,
@@ -141,6 +144,7 @@ impl Default for TestCase {
             other_side_match: false,
             reauth_match: false,
             saturated: [false, false],
+            pre_extension: None,
             expected_decision: NoMutation,
             expected_matches: vec![],
             request_type: RequestType::Uniqueness(UniquenessRequest {
@@ -263,6 +267,38 @@ fn test_matching() {
             expected_matches: vec![],
             ..TestCase::default()
         },
+        // ### Super-matcher extended search
+        // The extended search found BOTH_MATCH, which the original search missed;
+        // extending also resolved the left eye's saturation.
+        TestCase {
+            search_match: true,
+            saturated: [false, false],
+            pre_extension: Some(BaselineSearch {
+                matched: [
+                    vec![LEFT_MATCH, BOTH_FOUND, BASELINE_ONLY],
+                    vec![RIGHT_MATCH],
+                ],
+                saturated: [true, false],
+            }),
+            expected_decision: Decision::NoMutation,
+            expected_matches: vec![MatchId::Search(BOTH_MATCH)],
+            ..TestCase::default()
+        },
+        // The extended search *lost* a match the original search had found.
+        TestCase {
+            search_match: false,
+            saturated: [false, false],
+            pre_extension: Some(BaselineSearch {
+                matched: [
+                    vec![LEFT_MATCH, BOTH_FOUND, BOTH_MATCH],
+                    vec![RIGHT_MATCH, BOTH_MATCH],
+                ],
+                saturated: [false, false],
+            }),
+            expected_decision: Decision::UniqueInsert,
+            expected_matches: vec![],
+            ..TestCase::default()
+        },
     ];
 
     for case in &cases {
@@ -280,6 +316,50 @@ fn test_matching() {
     }
 }
 
+/// The pre-extension (baseline) view of a request is selected independently of the
+/// extended view: here the original search found no full match, only saturation,
+/// while the extended search found one.
+#[test]
+fn test_baseline_selection_differs_from_extended() {
+    let case = TestCase {
+        search_match: true,
+        saturated: [false, false],
+        pre_extension: Some(BaselineSearch {
+            matched: [
+                vec![LEFT_MATCH, BOTH_FOUND, BASELINE_ONLY],
+                vec![RIGHT_MATCH],
+            ],
+            saturated: [true, false],
+        }),
+        expected_decision: Decision::NoMutation,
+        expected_matches: vec![MatchId::Search(BOTH_MATCH)],
+        ..TestCase::default()
+    };
+    let batch = run_test_matching(&case);
+
+    let extended = batch.select(HawkResult::MATCH_IDS_FILTER);
+    assert_equal_sets(&extended[0], &[MatchId::Search(BOTH_MATCH)], "extended");
+
+    let baseline = baseline_match_ids(&batch, HawkResult::MATCH_IDS_FILTER);
+    assert_equal_sets(&baseline, &[MatchId::Supermatch], "baseline");
+}
+
+/// A request with no extended search has no separate baseline: the two views agree.
+#[test]
+fn test_baseline_equals_extended_without_extension() {
+    let case = TestCase {
+        search_match: true,
+        expected_decision: Decision::NoMutation,
+        expected_matches: vec![MatchId::Search(BOTH_MATCH)],
+        ..TestCase::default()
+    };
+    let batch = run_test_matching(&case);
+
+    let extended = batch.select(HawkResult::MATCH_IDS_FILTER);
+    let baseline = baseline_match_ids(&batch, HawkResult::MATCH_IDS_FILTER);
+    assert_equal_sets(&baseline, &extended[0], "baseline equals extended");
+}
+
 // ### Hypothetical search results
 /// Left matches; right was inspected but does not match.
 const BOTH_FOUND: VectorId = VectorId::from_serial_id(1);
@@ -295,6 +375,28 @@ const LUC_REQUESTED: VectorId = VectorId::from_serial_id(5);
 const LUC_REQUESTED_DUP: VectorId = LEFT_MATCH;
 /// The request wants us to reauthenticate this ID.
 const REAUTH: VectorId = VectorId::from_serial_id(6);
+/// Only the pre-extension (baseline) search found this, on the left eye.
+const BASELINE_ONLY: VectorId = VectorId::from_serial_id(7);
+
+/// A simulated pre-extension (baseline) search result: what each eye's search found
+/// *before* the supermatcher re-searched with a larger `ef`.
+#[derive(Clone, Debug)]
+struct BaselineSearch {
+    /// Matching vector ids per eye: `[left, right]`.
+    matched: BothEyes<Vec<VectorId>>,
+    /// Saturation flag per eye: `[left, right]`.
+    saturated: BothEyes<bool>,
+}
+
+/// The single request in a one-request test batch.
+fn request_0(batch: &BatchStep3) -> &Step3 {
+    &batch.0[0]
+}
+
+/// The match ids the pre-extension (baseline) search alone would have produced.
+fn baseline_match_ids(batch: &BatchStep3, filter: Filter) -> Vec<MatchId> {
+    request_0(batch).select_pre(filter).collect_vec()
+}
 
 fn run_test_matching(tc: &TestCase) -> BatchStep3 {
     let req_i = 0;
@@ -310,42 +412,64 @@ fn run_test_matching(tc: &TestCase) -> BatchStep3 {
     }
 
     let saturated = tc.saturated;
-    let search_result =
-        |match_ids: Vec<VectorId>, non_match_ids: Vec<VectorId>, side_saturated: bool| {
-            let links_unstructured = vec![chain!(match_ids.clone(), non_match_ids).collect_vec()];
+    let search_result = |match_ids: Vec<VectorId>,
+                         non_match_ids: Vec<VectorId>,
+                         side_saturated: bool,
+                         baseline: Option<(Vec<VectorId>, bool)>| {
+        let links_unstructured = vec![chain!(match_ids.clone(), non_match_ids).collect_vec()];
 
-            let matches: Vec<_> = match_ids.iter().cloned().map(|v| (v, distance())).collect();
-            let insert_plan = HawkInsertPlan {
-                classified: ClassifiedMatches {
-                    anon_stats_matches: SaturableMatches {
-                        results: matches.clone(),
-                        saturated: side_saturated,
-                    },
-                    matches: SaturableMatches {
-                        results: matches,
-                        saturated: side_saturated,
-                    },
-                    pre_extension: None,
+        let as_results =
+            |ids: &[VectorId]| -> Vec<_> { ids.iter().cloned().map(|v| (v, distance())).collect() };
+
+        let matches: Vec<_> = as_results(&match_ids);
+        let pre_extension = baseline.map(|(ids, saturated)| SaturableMatches {
+            results: as_results(&ids),
+            saturated,
+        });
+
+        let insert_plan = HawkInsertPlan {
+            classified: ClassifiedMatches {
+                anon_stats_matches: SaturableMatches {
+                    results: matches.clone(),
+                    saturated: side_saturated,
                 },
-                plan: InsertPlanV {
-                    query: Aby3Query::new(QueryId::new()),
-                    links: links_unstructured,
-                    update_ep: UpdateEntryPoint::False,
-                    as_of: 0,
+                matches: SaturableMatches {
+                    results: matches,
+                    saturated: side_saturated,
                 },
-            };
-            VecRotations::from(vec![
-                insert_plan;
-                HAWK_BASE_ROTATIONS_MASK.count_ones() as usize
-            ])
+                pre_extension,
+            },
+            plan: InsertPlanV {
+                query: Aby3Query::new(QueryId::new()),
+                links: links_unstructured,
+                update_ep: UpdateEntryPoint::False,
+                as_of: 0,
+            },
         };
+        VecRotations::from(vec![
+            insert_plan;
+            HAWK_BASE_ROTATIONS_MASK.count_ones() as usize
+        ])
+    };
+
+    let baseline_for = |side: usize| {
+        tc.pre_extension
+            .as_ref()
+            .map(|b| (b.matched[side].clone(), b.saturated[side]))
+    };
 
     let search_results = [
-        vec![search_result(match_left, non_match_left, saturated[LEFT])],
+        vec![search_result(
+            match_left,
+            non_match_left,
+            saturated[LEFT],
+            baseline_for(LEFT),
+        )],
         vec![search_result(
             match_right,
             non_match_right,
             saturated[RIGHT],
+            baseline_for(RIGHT),
         )],
     ];
     let luc_ids = vec![vec![LUC_REQUESTED, LUC_REQUESTED_DUP]];
@@ -366,6 +490,24 @@ fn run_test_matching(tc: &TestCase) -> BatchStep3 {
         expect_left.push(REAUTH);
         expect_right.push(REAUTH);
     }
+
+    // Baseline one-sided matches also need an other-eye comparison, so that the
+    // pre-extension outcome can be resolved from the same MPC results.
+    if let Some(baseline) = &tc.pre_extension {
+        for id in &baseline.matched[LEFT] {
+            if !baseline.matched[RIGHT].contains(id) {
+                expect_right.push(*id);
+            }
+        }
+        for id in &baseline.matched[RIGHT] {
+            if !baseline.matched[LEFT].contains(id) {
+                expect_left.push(*id);
+            }
+        }
+    }
+    // `assert_equal_sets` rejects duplicates, and a baseline hit may already be expected.
+    let expect_left = expect_left.into_iter().unique().collect_vec();
+    let expect_right = expect_right.into_iter().unique().collect_vec();
 
     assert_equal_sets(
         &missing_ids[LEFT][req_i],

--- a/iris-mpc-cpu/src/execution/hawk_main/matching/tests.rs
+++ b/iris-mpc-cpu/src/execution/hawk_main/matching/tests.rs
@@ -258,9 +258,9 @@ impl Default for TestCase {
             pre_extension: None,
             expected_decision: NoMutation,
             expected_matches: vec![],
-            request_type: RequestType::Uniqueness(UniquenessRequest {
+            request_type: RequestType::Uniqueness {
                 skip_persistence: false,
-            }),
+            },
         }
     }
 }
@@ -279,9 +279,9 @@ fn test_matching() {
         TestCase {
             search_match: false,
             other_side_match: false,
-            request_type: RequestType::Uniqueness(UniquenessRequest {
+            request_type: RequestType::Uniqueness {
                 skip_persistence: true,
-            }),
+            },
             expected_decision: Decision::UniqueInsertSkipped,
             expected_matches: vec![],
             ..TestCase::default()
@@ -318,14 +318,18 @@ fn test_matching() {
         },
         // ### Reauth requests
         TestCase {
-            request_type: RequestType::Reauth(Some((REAUTH, false as UseOrRule))),
+            request_type: RequestType::Reauth {
+                target: Some((REAUTH, false as UseOrRule)),
+            },
             reauth_match: true,
             expected_decision: Decision::ReauthUpdate(REAUTH),
             expected_matches: vec![MatchId::Reauth(REAUTH)],
             ..TestCase::default()
         },
         TestCase {
-            request_type: RequestType::Reauth(Some((REAUTH, false as UseOrRule))),
+            request_type: RequestType::Reauth {
+                target: Some((REAUTH, false as UseOrRule)),
+            },
             reauth_match: false,
             expected_decision: Decision::NoMutation,
             expected_matches: vec![],
@@ -363,9 +367,9 @@ fn test_matching() {
         },
         // Saturated with skip_persistence → still NoMutation (supermatch overrides)
         TestCase {
-            request_type: RequestType::Uniqueness(UniquenessRequest {
+            request_type: RequestType::Uniqueness {
                 skip_persistence: true,
-            }),
+            },
             saturated: [true, false],
             expected_decision: Decision::NoMutation,
             expected_matches: vec![MatchId::Supermatch],
@@ -718,7 +722,7 @@ fn run_test_matching(tc: &TestCase) -> MatchResults {
     // it was already inspected and optimize it away, but we do not.
 
     // For a reauth request, we will inspect the reauth target vector.
-    if matches!(tc.request_type, RequestType::Reauth(_)) {
+    if matches!(tc.request_type, RequestType::Reauth { .. }) {
         expect_left.push(REAUTH);
         expect_right.push(REAUTH);
     }
@@ -764,7 +768,7 @@ fn run_test_matching(tc: &TestCase) -> MatchResults {
     }
 
     // Make the reauth request match.
-    if matches!(tc.request_type, RequestType::Reauth(_)) {
+    if matches!(tc.request_type, RequestType::Reauth { .. }) {
         *comparison_results[LEFT][req_i].get_mut(&REAUTH).unwrap() = tc.reauth_match;
         *comparison_results[RIGHT][req_i].get_mut(&REAUTH).unwrap() = tc.reauth_match;
     }


### PR DESCRIPTION
Refactors `iris-mpc-cpu/src/execution/hawk_main/matching.rs` for legibility, and fixes a metrics bug found along the way.

## Why

The module's organization made it hard to follow: types named for their position in a sequence (`Step1`/`Step2`/`Step3`/`BatchStepN`), declarations interleaved arbitrarily, six `use X::*` statements scattered mid-file, and a module doc still describing a method (`BatchStep2::is_matches`) that no longer existed.

Two concrete defects sat underneath that:

1. **`decisions()` double-emitted its metrics.** It recomputed the decision vector *and* emitted six per-batch counters on every call — and `hawk_main.rs` called it twice per batch, from `handle_mutations` and from `job_result`.
2. **The supermatcher pre-extension counterfactual was woven through the pipeline** as a parallel branch in six places, for what is purely an A/B observability measurement.

## What changed

**Names.** The three pipeline stages are named for what they hold: `PendingBatch`/`PendingRequest` (one-eyed search hits awaiting the other-eye MPC comparison) → `ResolvedBatch`/`ResolvedRequest` → `RequestMatches`/`MatchResults`, with `UnresolvedJoin`/`ResolvedJoin` for the per-request joins. Methods read as actions: `ids_to_compare()`, `resolve()`, `decide()`.

**Decisions are a pipeline stage.** `ResolvedBatch::decide(mirror)` consumes both orientation batches, computes the decision vector once, emits the metrics once, and stores the result. `decisions()` is now a `&[Decision]` accessor, and `handle_mutations` takes `&[Decision]` rather than the whole result — so it cannot recompute even if someone wanted it to. Double emission is now structurally prevented rather than prevented by convention.

**Pre-extension is one concept.** `WithBaseline<T>` holds `effective` plus an optional `baseline`; `SearchVariant` selects between them. The paired `join`/`pre_join` fields and `select`/`select_pre` methods are gone, `ids_to_compare` iterates variants uniformly instead of special-casing, and `SearchVariant` never reaches the public API — only the metrics code passes `Baseline`.

**The A/B judgement is testable.** `record_extension_metrics` split into a pure `extension_outcome() -> ExtensionOutcome` plus a thin emitter.

**One extra defect fixed.** `because_supermatch` was order-dependent *across* orientations, not just within one: `RequestMatches::select` yields all of the normal orientation's ids — including its `Supermatch` — before any of the mirror's, so the short-circuiting `any()` reached normal's saturation before mirror's real search match. A request rejected by a genuine mirror match was therefore counted as a supermatcher rejection. Now `evaluate_uniqueness` returns a named `UniquenessOutcome` and computes `only_supermatch` as `supermatch_present && !any_ordinary_match`, independent of yield order.

**Layout.** Vocabulary first, then the pipeline in execution order, then the supermatcher A/B metrics as an appendix, with banner comments and a rewritten module doc including a glossary (join, saturation/supermatch, effective vs. baseline).

## Observable changes

Everything else is behavior-preserving. The `Decision` vector and `ids_to_compare`'s MPC input are bit-identical to before, including ordering.

1. The six `supermatcher_*` counters emitted from `matching.rs` emit once per batch instead of twice — **values halve**. The two counters in `search.rs` are untouched.
2. `supermatcher_rejections` drops **further** from the order-independence fix above. The new definition is a strict subset of the old, so it can only go down.
3. The four decision-loop `info!` lines also halve. One copy previously came from `job_result`, which runs on the submitter's task under the `submit_batch_query` span rather than the actor's — so any log-derived alert on `"Supermatcher rejection"` both halves and narrows.
4. `Filter::reauth_rule`'s per-call `info!` is removed. It fired ~8x per batch per reauth request from a pure predicate; the same id/`or_rule`/`is_match` information is still logged once per reauth request in `PendingRequest::resolve`.
5. Corollary of (1): metrics now emit right after both orientations resolve, before mutation handling. If `update_anon_stats` or `search_to_identity_update` fails, the counters now increment where previously they would not have.

## Testing

The pre-extension path had no coverage before this branch (`tests.rs` set `pre_extension: None` in every case). It now has characterization tests written before the refactor touched it.

- Unit tests: 6 -> 12. New coverage for baseline vs. extended selection, `ids_to_compare` picking up baseline-only one-eyed matches, all three `extension_outcome` combinations, and the order-independent supermatch attribution.
- `cargo test --release -p iris-mpc-cpu -- --test-threads=1` -> 381 passed, 0 failed.
- `cargo test --release -p iris-mpc-cpu --test e2e -- --ignored` -> 2 passed. Worth running on changes to this module: the unit tests build one-request batches and set `mirror = normal.clone()`, so they cannot reach the intra-batch accumulator or any orientation asymmetry. `e2e_uniqueness_test` covers exactly those.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.

## Reviewing this

The commits are ordered so each is independently reviewable, and the two behavior-changing ones are isolated:

| Commit | |
|---|---|
| `3a0436f1d`, `4c2e76888` | tests only — the safety net, passing against unmodified code |
| `5d2e815bd` | pure rename |
| `342316d68` | `WithBaseline` container |
| `f5440e6bd` | **behavior change** — supermatch attribution |
| `b892a65d2` | metrics split |
| `30a7d2a5f` | **behavior change** — decisions computed once |
| `28c0ae000`, `c3e01bcd3` | relocation and docs |

## Known trade-off

`decide` computes decisions and emits counters together, so there is no path to compute a `MatchResults` without incrementing production counters. That coupling is deliberate — it is what makes double emission hard to reintroduce — but it would need revisiting for a replay or dry-run tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
