### PR TITLE
allow peer restarts before all are ready

### DIFF
--- a/.github/workflows/temp-branch-build-and-push-hawk-arm64.yaml
+++ b/.github/workflows/temp-branch-build-and-push-hawk-arm64.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "dev"
+      - "sw/harden_state_machine"
 
     paths-ignore:
       - "deploy/**"

--- a/.github/workflows/temp-branch-build-and-push-hawk-arm64.yaml
+++ b/.github/workflows/temp-branch-build-and-push-hawk-arm64.yaml
@@ -30,12 +30,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
-      - name: Install Docker
-        run: |
-          curl -fsSL https://get.docker.com | sh
-          sudo usermod -aG docker $USER
-          sudo apt-get install acl
-          sudo setfacl --modify user:$USER:rw /var/run/docker.sock
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
       - name: Log in to the Container registry

--- a/.github/workflows/temp-branch-build-and-push-hawk-arm64.yaml
+++ b/.github/workflows/temp-branch-build-and-push-hawk-arm64.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "dev"
-      - "sw/harden_state_machine"
 
     paths-ignore:
       - "deploy/**"
@@ -30,6 +29,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+      - name: Install Docker
+        run: |
+          curl -fsSL https://get.docker.com | sh
+          sudo usermod -aG docker $USER
+          sudo apt-get install acl
+          sudo setfacl --modify user:$USER:rw /var/run/docker.sock
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
       - name: Log in to the Container registry

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1584,6 +1584,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1986,6 +1995,29 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -3129,6 +3161,7 @@ dependencies = [
  "bytemuck",
  "chrono",
  "clap",
+ "derive_more",
  "eyre",
  "futures",
  "hex",
@@ -3143,6 +3176,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_with",
  "serial_test",
  "sodiumoxide",
  "sqlx",
@@ -4612,7 +4646,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -4645,7 +4679,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -6710,6 +6744,12 @@ name = "unicode-properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ chrono = "0.4.42"
 base64 = "0.22.1"
 bytemuck = { version = "1.17", features = ["derive"] }
 data-encoding = "2.6.0"
+derive_more = { version = "2.1.1", features = ["debug", "display", "from_str"] }
 dotenvy = "0.15"
 eyre = "0.6"
 futures = "0.3.30"
@@ -64,7 +65,7 @@ memmap2 = "0.9.5"
 serde = { version = "1.0", features = ["derive"] }
 serde-big-array = "0.5.1"
 serde_json = "1"
-serde_with = { version = "3", features = ["std"] }
+serde_with = { version = "3", features = ["std", "hex"] }
 bincode = "1.3.3"
 sqlx = { version = "0.8", features = ["runtime-tokio-native-tls", "postgres", "chrono"] }
 sodiumoxide = "0.2.7"

--- a/iris-mpc-common/src/config/mod.rs
+++ b/iris-mpc-common/src/config/mod.rs
@@ -341,6 +341,20 @@ pub struct Config {
     /// run can produce (hours for a full migration).
     #[serde(default = "default_genesis_sync_timeout_secs")]
     pub genesis_sync_timeout_secs: u64,
+
+    /// Test hook: park the startup sequence indefinitely on *entering* this
+    /// phase, named as in `Phase::as_str` (`"propose"`, `"commit"`, ...).
+    ///
+    /// Exists because the phases it names are milliseconds wide on an empty
+    /// fleet — far too narrow for an e2e test to land a kill in by polling
+    /// `/startup-state`. Holding the party makes the kill point exact instead of
+    /// probable. Unset in production; leaving it set wedges the node.
+    ///
+    /// Deliberately absent from [`CommonConfig`]: it must not reach the
+    /// cross-party config hash, or holding one party would change the startup
+    /// epoch and break the very agreement the tests exercise.
+    #[serde(default)]
+    pub startup_hold_at_phase: Option<String>,
 }
 
 fn default_full_scan_side() -> Eye {
@@ -883,6 +897,7 @@ impl From<Config> for CommonConfig {
             graph_checkpoint_bucket_name: _,
             graph_checkpoint_bucket_region: _,
             genesis_sync_timeout_secs: _, // genesis-only operational knob, not part of the common hash
+            startup_hold_at_phase: _,     // test hook, must not enter the common hash
         } = value;
 
         assert!(

--- a/iris-mpc-common/src/config/mod.rs
+++ b/iris-mpc-common/src/config/mod.rs
@@ -343,15 +343,15 @@ pub struct Config {
     pub genesis_sync_timeout_secs: u64,
 
     /// Test hook: park the startup sequence indefinitely on *entering* this phase,
-    /// named as in `Phase::as_str` (`"propose"`, `"commit"`, ...).
+    /// named as in `Phase::to_string()` (`"propose"`, `"commit"`, ...).
     ///
     /// Exists because those phases are milliseconds wide on an empty fleet, far too
     /// narrow for an e2e test to land a kill in by polling `/startup-state`. Unset
     /// in production; leaving it set wedges the node.
     ///
     /// Deliberately absent from [`CommonConfig`]: it must not reach the cross-party
-    /// config hash, or holding one party would change the startup epoch and break
-    /// the very agreement the tests exercise.
+    /// config hash, or holding one party would change the startup fleet digest and
+    /// break the very agreement the tests exercise.
     #[serde(default)]
     pub startup_hold_at_phase: Option<String>,
 }

--- a/iris-mpc-common/src/config/mod.rs
+++ b/iris-mpc-common/src/config/mod.rs
@@ -350,8 +350,8 @@ pub struct Config {
     /// in production; leaving it set wedges the node.
     ///
     /// Deliberately absent from [`CommonConfig`]: it must not reach the cross-party
-    /// config hash, or holding one party would change the startup fleet digest and
-    /// break the very agreement the tests exercise.
+    /// config hash, or holding one party would change the startup fleet sync-state
+    /// digest and break the very agreement the tests exercise.
     #[serde(default)]
     pub startup_hold_at_phase: Option<String>,
 }

--- a/iris-mpc-common/src/config/mod.rs
+++ b/iris-mpc-common/src/config/mod.rs
@@ -342,17 +342,16 @@ pub struct Config {
     #[serde(default = "default_genesis_sync_timeout_secs")]
     pub genesis_sync_timeout_secs: u64,
 
-    /// Test hook: park the startup sequence indefinitely on *entering* this
-    /// phase, named as in `Phase::as_str` (`"propose"`, `"commit"`, ...).
+    /// Test hook: park the startup sequence indefinitely on *entering* this phase,
+    /// named as in `Phase::as_str` (`"propose"`, `"commit"`, ...).
     ///
-    /// Exists because the phases it names are milliseconds wide on an empty
-    /// fleet — far too narrow for an e2e test to land a kill in by polling
-    /// `/startup-state`. Holding the party makes the kill point exact instead of
-    /// probable. Unset in production; leaving it set wedges the node.
+    /// Exists because those phases are milliseconds wide on an empty fleet, far too
+    /// narrow for an e2e test to land a kill in by polling `/startup-state`. Unset
+    /// in production; leaving it set wedges the node.
     ///
-    /// Deliberately absent from [`CommonConfig`]: it must not reach the
-    /// cross-party config hash, or holding one party would change the startup
-    /// epoch and break the very agreement the tests exercise.
+    /// Deliberately absent from [`CommonConfig`]: it must not reach the cross-party
+    /// config hash, or holding one party would change the startup epoch and break
+    /// the very agreement the tests exercise.
     #[serde(default)]
     pub startup_hold_at_phase: Option<String>,
 }

--- a/iris-mpc-common/src/config/mod.rs
+++ b/iris-mpc-common/src/config/mod.rs
@@ -344,14 +344,6 @@ pub struct Config {
 
     /// Test hook: park the startup sequence indefinitely on *entering* this phase,
     /// named as in `Phase::to_string()` (`"propose"`, `"commit"`, ...).
-    ///
-    /// Exists because those phases are milliseconds wide on an empty fleet, far too
-    /// narrow for an e2e test to land a kill in by polling `/startup-state`. Unset
-    /// in production; leaving it set wedges the node.
-    ///
-    /// Deliberately absent from [`CommonConfig`]: it must not reach the cross-party
-    /// config hash, or holding one party would change the startup fleet sync-state
-    /// digest and break the very agreement the tests exercise.
     #[serde(default)]
     pub startup_hold_at_phase: Option<String>,
 }

--- a/iris-mpc-cpu/src/graph_checkpoint/s3_client/streaming_download.rs
+++ b/iris-mpc-cpu/src/graph_checkpoint/s3_client/streaming_download.rs
@@ -24,7 +24,7 @@
 //! (`Range: bytes=START-END`), up to [`DEFAULT_DOWNLOAD_PARALLELISM`] in
 //! flight at once and emitted in ascending offset order. Each range is
 //! fetched independently and retried up to [`RANGE_MAX_RETRIES`] times with
-//! [`RANGE_RETRY_DELAY`] between attempts before it bubbles up as a fatal
+//! `RANGE_RETRY_DELAY` between attempts before it bubbles up as a fatal
 //! error. Transient network errors thus cost at most one range re-fetch,
 //! not a full restart of the download.
 //!

--- a/iris-mpc/Cargo.toml
+++ b/iris-mpc/Cargo.toml
@@ -20,6 +20,7 @@ tracing.workspace = true
 serde_json.workspace = true
 eyre.workspace = true
 clap.workspace = true
+derive_more.workspace = true
 bytemuck.workspace = true
 rand.workspace = true
 reqwest.workspace = true
@@ -31,6 +32,7 @@ iris-mpc-store = { path = "../iris-mpc-store" }
 itertools.workspace = true
 metrics.workspace = true
 serde = { version = "1.0.214", features = ["derive"] }
+serde_with.workspace = true
 iris-mpc-cpu.workspace = true
 chrono.workspace = true
 sqlx.workspace = true

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -238,11 +238,28 @@ pub async fn server_main(config: Config) -> Result<()> {
         //
         // SAFETY DEPENDENCY: peers serve their SyncState from a snapshot taken
         // at THEIR boot, so an exchanged frontier can under-report persists
-        // made after that peer booted. This is sound today only because the
-        // startup unready-gate + heartbeat teardown force full-fleet restarts
-        // (every frontier is rebuilt after its party's last commit). If
-        // coordination is ever relaxed to allow solo restarts, this exchange
-        // must move to a live DB read in the sync endpoint.
+        // made after that peer booted. Under-reporting releases rows the peers
+        // moved past, and this party re-forms them — a permanent batch
+        // divergence.
+        //
+        // What makes this sound is NOT that restarts are always fleet-wide —
+        // `spawn_startup_watch` deliberately lets a peer rejoin a startup in
+        // progress, so that is no longer true. It is sound because a party only
+        // persists rows in the main loop, i.e. after it is ready, and the
+        // startup unready-gate (`wait_for_others_unready`) refuses to let this
+        // startup proceed alongside a peer that is already serving: such a peer
+        // is `is_ready` and has not verified our UUID, so we never get here.
+        // Every snapshot we read therefore belongs to a party that has not
+        // persisted anything since taking it.
+        //
+        // A rejoining peer does not weaken this: rejoin requires its facts —
+        // including its own frontier — to be unchanged, and it re-reads the same
+        // peer snapshots, so it computes the same frontier it would have on a
+        // cold fleet boot.
+        //
+        // If the unready gate is ever relaxed to let a startup proceed while a
+        // peer is serving, this exchange must move to a live DB read in the sync
+        // endpoint.
         let fleet_frontier = sync_result.max_persisted_sequence_number();
         if let Some(frontier) = &fleet_frontier {
             let marked = iris_store
@@ -335,10 +352,17 @@ pub async fn server_main(config: Config) -> Result<()> {
 
     // A verdict reached during the load can only be acted on here: the load
     // does not poll the (cooperative) shutdown handler, so this is the first
-    // point where a peer that changed its data mid-load stops us. Take the peer
-    // set only after the check — from here on `verified_peers` is frozen and the
-    // heartbeat owns supervision.
+    // point where a peer that changed its data mid-load stops us.
     startup_watch.check()?;
+
+    // Re-run the commit barrier before freezing the peer set. The watch records
+    // a rejoined peer's new UUID only on its next poll, so a peer that came back
+    // late in the load could still be missing from `verified_peers` at this
+    // instant — and everything downstream (the heartbeat's first-contact check,
+    // `wait_for_others_ready`) reads the frozen snapshot and kills the node on an
+    // unknown UUID. Blocking here until every peer currently reports our epoch
+    // makes the rejoin deterministic instead of a race against the poll cadence.
+    wait_for_epoch_commit(&server_coord_config, &verified_peers, plan.epoch()).await?;
 
     let verified_peers = verified_peers.lock().await.clone();
     init_heartbeat_task(

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -1,7 +1,7 @@
 pub mod startup_phase;
 
 use crate::server::startup_phase::{
-    observe_peer_epochs, AgreedPlan, PartyFacts, Phase, StartupStateHandle,
+    spawn_startup_watch, wait_for_epoch_commit, AgreedPlan, PartyFacts, Phase, StartupStateHandle,
 };
 use crate::services::aws::clients::AwsClients;
 use crate::services::processors::batch::{receive_batch_stream, spawn_db_backed_ingest_task};
@@ -71,10 +71,6 @@ pub const SQS_POLLING_INTERVAL: Duration = Duration::from_secs(1);
 pub const MAX_CONCURRENT_REQUESTS: usize = 32;
 const PEER_ROUND_TIMEOUT: Duration = Duration::from_secs(10);
 const CHECKPOINT_WINDOW: usize = 10;
-/// Wall-clock budget for the observation-only peer epoch comparison. Kept short:
-/// nothing depends on the outcome yet, so it must not add materially to startup.
-const EPOCH_OBSERVATION_BUDGET: Duration = Duration::from_secs(30);
-const EPOCH_OBSERVATION_RETRY_DELAY: Duration = Duration::from_millis(500);
 
 /// Main logic for initialization and execution of AMPC iris uniqueness server
 /// nodes.
@@ -168,7 +164,7 @@ pub async fn server_main(config: Config) -> Result<()> {
 
     // Derive this startup's epoch from the exchanged states. Every party
     // computes it from the same three fact sets, so agreement needs no extra
-    // round trip
+    // round trip and no leader.
     let plan = AgreedPlan::from_states(&sync_result.all_states)?;
     tracing::info!(
         "Derived startup epoch {} over {} parties (my facts {})",
@@ -178,13 +174,22 @@ pub async fn server_main(config: Config) -> Result<()> {
     );
     startup_state.set_epoch(plan.epoch()).await;
     startup_state.enter(Phase::Commit).await;
-    observe_peer_epochs(
-        &server_coord_config,
+
+    // Commit barrier. Nothing below may mutate local storage until every party
+    // has published this same epoch: converging under a plan a peer never
+    // agreed to is the divergence this prevents.
+    wait_for_epoch_commit(&server_coord_config, &verified_peers, plan.epoch()).await?;
+
+    // From here until we are ready, the epoch is what identifies a peer — not
+    // its UUID — so a peer that restarts and re-derives this epoch rejoins
+    // without forcing us to reload. Armed before converge because the DB load
+    // below is long and nothing else watches peers during it.
+    let startup_watch = spawn_startup_watch(
+        server_coord_config.clone(),
+        Arc::clone(&verified_peers),
+        Arc::clone(&shutdown_handler),
         plan.epoch(),
-        EPOCH_OBSERVATION_BUDGET,
-        EPOCH_OBSERVATION_RETRY_DELAY,
-    )
-    .await;
+    );
 
     startup_state.enter(Phase::Converge).await;
 
@@ -290,6 +295,9 @@ pub async fn server_main(config: Config) -> Result<()> {
 
     startup_state.enter(Phase::Load).await;
 
+    // Don't start the load if converge already voided the epoch.
+    startup_watch.check()?;
+
     let mut hawk_actor = init_hawk_actor(
         &config,
         &aws_clients.checkpoint_s3_client,
@@ -325,6 +333,13 @@ pub async fn server_main(config: Config) -> Result<()> {
     )
     .await?;
 
+    // A verdict reached during the load can only be acted on here: the load
+    // does not poll the (cooperative) shutdown handler, so this is the first
+    // point where a peer that changed its data mid-load stops us. Take the peer
+    // set only after the check — from here on `verified_peers` is frozen and the
+    // heartbeat owns supervision.
+    startup_watch.check()?;
+
     let verified_peers = verified_peers.lock().await.clone();
     init_heartbeat_task(
         &server_coord_config,
@@ -338,6 +353,7 @@ pub async fn server_main(config: Config) -> Result<()> {
     set_node_ready(is_ready_flag);
     wait_for_others_ready(&server_coord_config, verified_peers).await?;
     startup_state.enter(Phase::Serving).await;
+    startup_watch.stop();
 
     background_tasks.check_tasks();
 

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -1,8 +1,8 @@
 pub mod startup_phase;
 
 use crate::server::startup_phase::{
-    derive_epoch, facts_digest, spawn_startup_watch, wait_for_epoch_commit, Phase,
-    StartupStateHandle,
+    hash_fleet_sync_states, hash_sync_state, spawn_startup_watch, wait_for_fleet_digest_commit,
+    Phase, StartupStateHandle,
 };
 use crate::services::aws::clients::AwsClients;
 use crate::services::processors::batch::{receive_batch_stream, spawn_db_backed_ingest_task};
@@ -141,7 +141,7 @@ pub async fn server_main(config: Config) -> Result<()> {
     // to be handed to it.
     let startup_state = StartupStateHandle::new(
         server_coord_config.party_id,
-        facts_digest(&my_state),
+        hash_sync_state(&my_state),
         config
             .startup_hold_at_phase
             .as_deref()
@@ -168,32 +168,32 @@ pub async fn server_main(config: Config) -> Result<()> {
     let sync_result = get_sync_result(&config, &my_state).await?;
     sync_result.check_common_config()?;
 
-    // Derive this startup's epoch from the exchanged states. Every party computes
-    // it from the same fact sets, so agreement needs no extra round trip and no
-    // leader.
-    let epoch = derive_epoch(&sync_result.all_states)?;
+    // Digest the exchanged states into the value that keys this startup. Every
+    // party computes it from the same states, so agreement needs no extra round
+    // trip and no leader.
+    let fleet_digest = hash_fleet_sync_states(&sync_result.all_states)?;
     tracing::info!(
-        "Derived startup epoch {} over {} parties",
-        epoch,
+        "Derived startup fleet digest {} over {} parties",
+        fleet_digest,
         sync_result.all_states.len()
     );
-    startup_state.set_epoch(epoch).await;
+    startup_state.set_fleet_digest(fleet_digest).await;
     startup_state.enter(Phase::Commit).await;
 
     // Commit barrier. Nothing below may mutate local storage until every party has
-    // published this same epoch: converging under a plan a peer never agreed to is
-    // the divergence this prevents.
-    wait_for_epoch_commit(&server_coord_config, &verified_peers, epoch).await?;
+    // published this same fleet digest: converging over states a peer never agreed
+    // to is the divergence this prevents.
+    wait_for_fleet_digest_commit(&server_coord_config, &verified_peers, fleet_digest).await?;
 
-    // From here until we are ready, the epoch is what identifies a peer — not its
-    // UUID — so a peer that restarts and re-derives this epoch rejoins without
+    // From here until we are ready, the fleet digest is what identifies a peer — not
+    // its UUID — so a peer that restarts and recomputes this digest rejoins without
     // forcing us to reload. Armed before converge because the DB load below is long
     // and nothing else watches peers during it.
     let startup_watch = spawn_startup_watch(
         server_coord_config.clone(),
         Arc::clone(&verified_peers),
         Arc::clone(&shutdown_handler),
-        epoch,
+        fleet_digest,
     );
 
     startup_state.enter(Phase::Converge).await;
@@ -252,7 +252,7 @@ pub async fn server_main(config: Config) -> Result<()> {
         // (`wait_for_others_unready`) refuses to proceed alongside a peer that is
         // already serving. Every snapshot we read therefore belongs to a party that
         // has not persisted anything since taking it. A rejoining peer re-reads the
-        // same snapshots and requires its own facts to be unchanged, so it computes
+        // same snapshots and requires its own SyncState to be unchanged, so it computes
         // the frontier it would have on a cold fleet boot.
         //
         // If that gate is ever relaxed, this exchange must move to a live DB read
@@ -309,7 +309,7 @@ pub async fn server_main(config: Config) -> Result<()> {
 
     startup_state.enter(Phase::Load).await;
 
-    // Don't start the load if converge already voided the epoch.
+    // Don't start the load if converge already voided this startup.
     startup_watch.check()?;
 
     let mut hawk_actor = init_hawk_actor(
@@ -356,7 +356,7 @@ pub async fn server_main(config: Config) -> Result<()> {
     // in the load could still be missing from `verified_peers` — and everything
     // downstream (the heartbeat's first-contact check, `wait_for_others_ready`)
     // reads the frozen snapshot and kills the node on an unknown UUID.
-    wait_for_epoch_commit(&server_coord_config, &verified_peers, epoch).await?;
+    wait_for_fleet_digest_commit(&server_coord_config, &verified_peers, fleet_digest).await?;
 
     let verified_peers = verified_peers.lock().await.clone();
     init_heartbeat_task(

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -1,3 +1,8 @@
+pub mod startup_phase;
+
+use crate::server::startup_phase::{
+    observe_peer_epochs, AgreedPlan, PartyFacts, Phase, StartupStateHandle,
+};
 use crate::services::aws::clients::AwsClients;
 use crate::services::processors::batch::{receive_batch_stream, spawn_db_backed_ingest_task};
 use crate::services::processors::job::{process_job_result, BatchTimings};
@@ -66,6 +71,10 @@ pub const SQS_POLLING_INTERVAL: Duration = Duration::from_secs(1);
 pub const MAX_CONCURRENT_REQUESTS: usize = 32;
 const PEER_ROUND_TIMEOUT: Duration = Duration::from_secs(10);
 const CHECKPOINT_WINDOW: usize = 10;
+/// Wall-clock budget for the observation-only peer epoch comparison. Kept short:
+/// nothing depends on the outcome yet, so it must not add materially to startup.
+const EPOCH_OBSERVATION_BUDGET: Duration = Duration::from_secs(30);
+const EPOCH_OBSERVATION_RETRY_DELAY: Duration = Duration::from_millis(500);
 
 /// Main logic for initialization and execution of AMPC iris uniqueness server
 /// nodes.
@@ -128,22 +137,56 @@ pub async fn server_main(config: Config) -> Result<()> {
         server_coord_config.healthcheck_ports
     );
 
+    // Live startup-state document, published alongside the coordination
+    // server's own routes. Unlike `/startup-sync` — which serves a `my_state`
+    // clone captured at construction — this is read from a shared handle, so
+    // peers see the phase we are actually in. Created before the server starts
+    // because its router has to be handed to it.
+    let startup_state = StartupStateHandle::new(
+        server_coord_config.party_id,
+        PartyFacts::from_sync_state(&my_state).digest(),
+    );
+
     let (is_ready_flag, verified_peers, my_uuid) = start_coordination_server_with_extra_routes(
         &server_coord_config,
         &mut background_tasks,
         &shutdown_handler,
         &my_state,
         Some(batch_sync_shared_state.clone()),
-        None,
+        Some(startup_state.router()),
     )
     .await;
+    startup_state.set_uuid(my_uuid.clone()).await;
     tracing::info!("Coordination server started");
 
     // Startup barriers: un-ready sync + full mutual peer visibility
     wait_for_startup_barriers(&server_coord_config, &verified_peers, &my_uuid).await?;
+    startup_state.enter(Phase::Propose).await;
 
     let sync_result = get_sync_result(&config, &my_state).await?;
     sync_result.check_common_config()?;
+
+    // Derive this startup's epoch from the exchanged states. Every party
+    // computes it from the same three fact sets, so agreement needs no extra
+    // round trip
+    let plan = AgreedPlan::from_states(&sync_result.all_states)?;
+    tracing::info!(
+        "Derived startup epoch {} over {} parties (my facts {})",
+        plan.epoch(),
+        plan.party_count(),
+        startup_state.snapshot().await.facts.short()
+    );
+    startup_state.set_epoch(plan.epoch()).await;
+    startup_state.enter(Phase::Commit).await;
+    observe_peer_epochs(
+        &server_coord_config,
+        plan.epoch(),
+        EPOCH_OBSERVATION_BUDGET,
+        EPOCH_OBSERVATION_RETRY_DELAY,
+    )
+    .await;
+
+    startup_state.enter(Phase::Converge).await;
 
     // Handle modifications sync
     if config.enable_modifications_sync {
@@ -245,6 +288,8 @@ pub async fn server_main(config: Config) -> Result<()> {
         return Ok(());
     }
 
+    startup_state.enter(Phase::Load).await;
+
     let mut hawk_actor = init_hawk_actor(
         &config,
         &aws_clients.checkpoint_s3_client,
@@ -292,6 +337,7 @@ pub async fn server_main(config: Config) -> Result<()> {
 
     set_node_ready(is_ready_flag);
     wait_for_others_ready(&server_coord_config, verified_peers).await?;
+    startup_state.enter(Phase::Serving).await;
 
     background_tasks.check_tasks();
 

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -1,7 +1,8 @@
 pub mod startup_phase;
 
 use crate::server::startup_phase::{
-    spawn_startup_watch, wait_for_epoch_commit, AgreedPlan, PartyFacts, Phase, StartupStateHandle,
+    derive_epoch, facts_digest, spawn_startup_watch, wait_for_epoch_commit, Phase,
+    StartupStateHandle,
 };
 use crate::services::aws::clients::AwsClients;
 use crate::services::processors::batch::{receive_batch_stream, spawn_db_backed_ingest_task};
@@ -133,16 +134,14 @@ pub async fn server_main(config: Config) -> Result<()> {
         server_coord_config.healthcheck_ports
     );
 
-    // Live startup-state document, published alongside the coordination
-    // server's own routes. Unlike `/startup-sync` — which serves a `my_state`
-    // clone captured at construction — this is read from a shared handle, so
-    // peers see the phase we are actually in. Created before the server starts
-    // because its router has to be handed to it.
+    // Live startup-state document, published alongside the coordination server's
+    // own routes. Unlike `/startup-sync` — which serves a `my_state` clone captured
+    // at construction — this is read from a shared handle, so peers see the phase
+    // we are actually in. Created before the server starts because its router has
+    // to be handed to it.
     let startup_state = StartupStateHandle::new(
         server_coord_config.party_id,
-        PartyFacts::from_sync_state(&my_state).digest(),
-    )
-    .with_hold_at(
+        facts_digest(&my_state),
         config
             .startup_hold_at_phase
             .as_deref()
@@ -169,33 +168,32 @@ pub async fn server_main(config: Config) -> Result<()> {
     let sync_result = get_sync_result(&config, &my_state).await?;
     sync_result.check_common_config()?;
 
-    // Derive this startup's epoch from the exchanged states. Every party
-    // computes it from the same three fact sets, so agreement needs no extra
-    // round trip and no leader.
-    let plan = AgreedPlan::from_states(&sync_result.all_states)?;
+    // Derive this startup's epoch from the exchanged states. Every party computes
+    // it from the same fact sets, so agreement needs no extra round trip and no
+    // leader.
+    let epoch = derive_epoch(&sync_result.all_states)?;
     tracing::info!(
-        "Derived startup epoch {} over {} parties (my facts {})",
-        plan.epoch(),
-        plan.party_count(),
-        startup_state.snapshot().await.facts.short()
+        "Derived startup epoch {} over {} parties",
+        epoch,
+        sync_result.all_states.len()
     );
-    startup_state.set_epoch(plan.epoch()).await;
+    startup_state.set_epoch(epoch).await;
     startup_state.enter(Phase::Commit).await;
 
-    // Commit barrier. Nothing below may mutate local storage until every party
-    // has published this same epoch: converging under a plan a peer never
-    // agreed to is the divergence this prevents.
-    wait_for_epoch_commit(&server_coord_config, &verified_peers, plan.epoch()).await?;
+    // Commit barrier. Nothing below may mutate local storage until every party has
+    // published this same epoch: converging under a plan a peer never agreed to is
+    // the divergence this prevents.
+    wait_for_epoch_commit(&server_coord_config, &verified_peers, epoch).await?;
 
-    // From here until we are ready, the epoch is what identifies a peer — not
-    // its UUID — so a peer that restarts and re-derives this epoch rejoins
-    // without forcing us to reload. Armed before converge because the DB load
-    // below is long and nothing else watches peers during it.
+    // From here until we are ready, the epoch is what identifies a peer — not its
+    // UUID — so a peer that restarts and re-derives this epoch rejoins without
+    // forcing us to reload. Armed before converge because the DB load below is long
+    // and nothing else watches peers during it.
     let startup_watch = spawn_startup_watch(
         server_coord_config.clone(),
         Arc::clone(&verified_peers),
         Arc::clone(&shutdown_handler),
-        plan.epoch(),
+        epoch,
     );
 
     startup_state.enter(Phase::Converge).await;
@@ -244,29 +242,21 @@ pub async fn server_main(config: Config) -> Result<()> {
         // apart.
         //
         // SAFETY DEPENDENCY: peers serve their SyncState from a snapshot taken
-        // at THEIR boot, so an exchanged frontier can under-report persists
-        // made after that peer booted. Under-reporting releases rows the peers
-        // moved past, and this party re-forms them — a permanent batch
-        // divergence.
+        // at THEIR boot, so an exchanged frontier can under-report persists made
+        // after that peer booted, releasing rows the peers moved past for this
+        // party to re-form — a permanent batch divergence.
         //
-        // What makes this sound is NOT that restarts are always fleet-wide —
-        // `spawn_startup_watch` deliberately lets a peer rejoin a startup in
-        // progress, so that is no longer true. It is sound because a party only
-        // persists rows in the main loop, i.e. after it is ready, and the
-        // startup unready-gate (`wait_for_others_unready`) refuses to let this
-        // startup proceed alongside a peer that is already serving: such a peer
-        // is `is_ready` and has not verified our UUID, so we never get here.
-        // Every snapshot we read therefore belongs to a party that has not
-        // persisted anything since taking it.
+        // This is sound not because restarts are fleet-wide (`spawn_startup_watch`
+        // deliberately lets a peer rejoin a startup in progress) but because a
+        // party only persists rows once it is serving, and the startup unready-gate
+        // (`wait_for_others_unready`) refuses to proceed alongside a peer that is
+        // already serving. Every snapshot we read therefore belongs to a party that
+        // has not persisted anything since taking it. A rejoining peer re-reads the
+        // same snapshots and requires its own facts to be unchanged, so it computes
+        // the frontier it would have on a cold fleet boot.
         //
-        // A rejoining peer does not weaken this: rejoin requires its facts —
-        // including its own frontier — to be unchanged, and it re-reads the same
-        // peer snapshots, so it computes the same frontier it would have on a
-        // cold fleet boot.
-        //
-        // If the unready gate is ever relaxed to let a startup proceed while a
-        // peer is serving, this exchange must move to a live DB read in the sync
-        // endpoint.
+        // If that gate is ever relaxed, this exchange must move to a live DB read
+        // in the sync endpoint.
         let fleet_frontier = sync_result.max_persisted_sequence_number();
         if let Some(frontier) = &fleet_frontier {
             let marked = iris_store
@@ -357,19 +347,16 @@ pub async fn server_main(config: Config) -> Result<()> {
     )
     .await?;
 
-    // A verdict reached during the load can only be acted on here: the load
-    // does not poll the (cooperative) shutdown handler, so this is the first
-    // point where a peer that changed its data mid-load stops us.
+    // A verdict reached during the load can only be acted on here: the load does
+    // not poll the (cooperative) shutdown handler.
     startup_watch.check()?;
 
-    // Re-run the commit barrier before freezing the peer set. The watch records
-    // a rejoined peer's new UUID only on its next poll, so a peer that came back
-    // late in the load could still be missing from `verified_peers` at this
-    // instant — and everything downstream (the heartbeat's first-contact check,
-    // `wait_for_others_ready`) reads the frozen snapshot and kills the node on an
-    // unknown UUID. Blocking here until every peer currently reports our epoch
-    // makes the rejoin deterministic instead of a race against the poll cadence.
-    wait_for_epoch_commit(&server_coord_config, &verified_peers, plan.epoch()).await?;
+    // Re-run the commit barrier before freezing the peer set. The watch records a
+    // rejoined peer's new UUID only on its next poll, so a peer that came back late
+    // in the load could still be missing from `verified_peers` — and everything
+    // downstream (the heartbeat's first-contact check, `wait_for_others_ready`)
+    // reads the frozen snapshot and kills the node on an unknown UUID.
+    wait_for_epoch_commit(&server_coord_config, &verified_peers, epoch).await?;
 
     let verified_peers = verified_peers.lock().await.clone();
     init_heartbeat_task(

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -1144,7 +1144,14 @@ async fn run_main_server_loop(
                     .unwrap_or_else(|| Utc::now().format("run-%Y%m%dT%H%M%SZ").to_string());
                 let hash_prefix = hex::encode(&batch_hash[0..4]);
 
-                match guard.report().build() {
+                // Bound to a local before the `match`, not inlined into the
+                // scrutinee. `guard.report()` yields a `ReportBuilder`, which is
+                // `!Send` (it holds a `Box<dyn Fn(&mut Frames)>`), and temporaries in
+                // a match scrutinee stay alive for the whole `match` — including the
+                // `upload_file_to_s3` awaits in the arms below. That would make all
+                // of `server_main` `!Send` and unspawnable. The `;` here drops it.
+                let built = guard.report().build();
+                match built {
                     Ok(report) => {
                         if !config.pprof_profile_only {
                             let mut svg = Vec::new();

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -1,7 +1,7 @@
 pub mod startup_phase;
 
 use crate::server::startup_phase::{
-    hash_fleet_sync_states, hash_sync_state, spawn_startup_watch,
+    hash_fleet_sync_states, hash_sync_state, spawn_desync_watch,
     wait_for_fleet_sync_state_digest_commit, Phase, StartupStateHandle,
 };
 use crate::services::aws::clients::AwsClients;
@@ -134,11 +134,6 @@ pub async fn server_main(config: Config) -> Result<()> {
         server_coord_config.healthcheck_ports
     );
 
-    // Live startup-state document, published alongside the coordination server's
-    // own routes. Unlike `/startup-sync` — which serves a `my_state` clone captured
-    // at construction — this is read from a shared handle, so peers see the phase
-    // we are actually in. Created before the server starts because its router has
-    // to be handed to it.
     let startup_state = StartupStateHandle::new(
         server_coord_config.party_id,
         hash_sync_state(&my_state),
@@ -168,9 +163,6 @@ pub async fn server_main(config: Config) -> Result<()> {
     let sync_result = get_sync_result(&config, &my_state).await?;
     sync_result.check_common_config()?;
 
-    // Digest the exchanged states into the value that keys this startup. Every
-    // party computes it from the same states, so agreement needs no extra round
-    // trip and no leader.
     let fleet_sync_state_digest = hash_fleet_sync_states(&sync_result.all_states)?;
     tracing::info!(
         "Derived startup fleet sync-state digest {} over {} parties",
@@ -182,9 +174,6 @@ pub async fn server_main(config: Config) -> Result<()> {
         .await;
     startup_state.enter(Phase::Commit).await;
 
-    // Commit barrier. Nothing below may mutate local storage until every party has
-    // published this same fleet sync-state digest: converging over states a peer
-    // never agreed to is the divergence this prevents.
     wait_for_fleet_sync_state_digest_commit(
         &server_coord_config,
         &verified_peers,
@@ -192,11 +181,7 @@ pub async fn server_main(config: Config) -> Result<()> {
     )
     .await?;
 
-    // From here until we are ready, the fleet sync-state digest is what identifies a
-    // peer — not its UUID — so a peer that restarts and recomputes it rejoins without
-    // forcing us to reload. Armed before converge because the DB load below is long
-    // and nothing else watches peers during it.
-    let startup_watch = spawn_startup_watch(
+    let desync_watch = spawn_desync_watch(
         server_coord_config.clone(),
         Arc::clone(&verified_peers),
         Arc::clone(&shutdown_handler),
@@ -253,7 +238,7 @@ pub async fn server_main(config: Config) -> Result<()> {
         // after that peer booted, releasing rows the peers moved past for this
         // party to re-form — a permanent batch divergence.
         //
-        // This is sound not because restarts are fleet-wide (`spawn_startup_watch`
+        // This is sound not because restarts are fleet-wide (`spawn_desync_watch`
         // deliberately lets a peer rejoin a startup in progress) but because a
         // party only persists rows once it is serving, and the startup unready-gate
         // (`wait_for_others_unready`) refuses to proceed alongside a peer that is
@@ -315,9 +300,7 @@ pub async fn server_main(config: Config) -> Result<()> {
     }
 
     startup_state.enter(Phase::Load).await;
-
-    // Don't start the load if converge already voided this startup.
-    startup_watch.check()?;
+    desync_watch.check()?;
 
     let mut hawk_actor = init_hawk_actor(
         &config,
@@ -354,9 +337,7 @@ pub async fn server_main(config: Config) -> Result<()> {
     )
     .await?;
 
-    // A verdict reached during the load can only be acted on here: the load does
-    // not poll the (cooperative) shutdown handler.
-    startup_watch.check()?;
+    desync_watch.check()?;
 
     // Re-run the commit barrier before freezing the peer set. The watch records a
     // rejoined peer's new UUID only on its next poll, so a peer that came back late
@@ -383,7 +364,7 @@ pub async fn server_main(config: Config) -> Result<()> {
     set_node_ready(is_ready_flag);
     wait_for_others_ready(&server_coord_config, verified_peers).await?;
     startup_state.enter(Phase::Serving).await;
-    startup_watch.stop();
+    desync_watch.stop();
 
     background_tasks.check_tasks();
 

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -1,8 +1,8 @@
 pub mod startup_phase;
 
 use crate::server::startup_phase::{
-    hash_fleet_sync_states, hash_sync_state, spawn_startup_watch, wait_for_fleet_digest_commit,
-    Phase, StartupStateHandle,
+    hash_fleet_sync_states, hash_sync_state, spawn_startup_watch,
+    wait_for_fleet_sync_state_digest_commit, Phase, StartupStateHandle,
 };
 use crate::services::aws::clients::AwsClients;
 use crate::services::processors::batch::{receive_batch_stream, spawn_db_backed_ingest_task};
@@ -171,29 +171,36 @@ pub async fn server_main(config: Config) -> Result<()> {
     // Digest the exchanged states into the value that keys this startup. Every
     // party computes it from the same states, so agreement needs no extra round
     // trip and no leader.
-    let fleet_digest = hash_fleet_sync_states(&sync_result.all_states)?;
+    let fleet_sync_state_digest = hash_fleet_sync_states(&sync_result.all_states)?;
     tracing::info!(
-        "Derived startup fleet digest {} over {} parties",
-        fleet_digest,
+        "Derived startup fleet sync-state digest {} over {} parties",
+        fleet_sync_state_digest,
         sync_result.all_states.len()
     );
-    startup_state.set_fleet_digest(fleet_digest).await;
+    startup_state
+        .set_fleet_sync_state_digest(fleet_sync_state_digest)
+        .await;
     startup_state.enter(Phase::Commit).await;
 
     // Commit barrier. Nothing below may mutate local storage until every party has
-    // published this same fleet digest: converging over states a peer never agreed
-    // to is the divergence this prevents.
-    wait_for_fleet_digest_commit(&server_coord_config, &verified_peers, fleet_digest).await?;
+    // published this same fleet sync-state digest: converging over states a peer
+    // never agreed to is the divergence this prevents.
+    wait_for_fleet_sync_state_digest_commit(
+        &server_coord_config,
+        &verified_peers,
+        fleet_sync_state_digest,
+    )
+    .await?;
 
-    // From here until we are ready, the fleet digest is what identifies a peer — not
-    // its UUID — so a peer that restarts and recomputes this digest rejoins without
+    // From here until we are ready, the fleet sync-state digest is what identifies a
+    // peer — not its UUID — so a peer that restarts and recomputes it rejoins without
     // forcing us to reload. Armed before converge because the DB load below is long
     // and nothing else watches peers during it.
     let startup_watch = spawn_startup_watch(
         server_coord_config.clone(),
         Arc::clone(&verified_peers),
         Arc::clone(&shutdown_handler),
-        fleet_digest,
+        fleet_sync_state_digest,
     );
 
     startup_state.enter(Phase::Converge).await;
@@ -356,7 +363,12 @@ pub async fn server_main(config: Config) -> Result<()> {
     // in the load could still be missing from `verified_peers` — and everything
     // downstream (the heartbeat's first-contact check, `wait_for_others_ready`)
     // reads the frozen snapshot and kills the node on an unknown UUID.
-    wait_for_fleet_digest_commit(&server_coord_config, &verified_peers, fleet_digest).await?;
+    wait_for_fleet_sync_state_digest_commit(
+        &server_coord_config,
+        &verified_peers,
+        fleet_sync_state_digest,
+    )
+    .await?;
 
     let verified_peers = verified_peers.lock().await.clone();
     init_heartbeat_task(

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -141,6 +141,13 @@ pub async fn server_main(config: Config) -> Result<()> {
     let startup_state = StartupStateHandle::new(
         server_coord_config.party_id,
         PartyFacts::from_sync_state(&my_state).digest(),
+    )
+    .with_hold_at(
+        config
+            .startup_hold_at_phase
+            .as_deref()
+            .map(str::parse::<Phase>)
+            .transpose()?,
     );
 
     let (is_ready_flag, verified_peers, my_uuid) = start_coordination_server_with_extra_routes(

--- a/iris-mpc/src/server/startup_phase.rs
+++ b/iris-mpc/src/server/startup_phase.rs
@@ -1,4 +1,4 @@
-//! Startup phase tracking and the data-derived *epoch* that keys it.
+//! Startup phase tracking and the data-derived [`SyncStateDigest`] that keys it.
 //!
 //! # Why this exists
 //!
@@ -10,56 +10,59 @@
 //! the multi-minute DB load whenever one peer bounces, even with the data
 //! unchanged.
 //!
-//! So startup coordination is keyed on the *data* instead. An [`Epoch`] is a
-//! digest of the whole starting configuration: every party's DB length,
-//! ingest/queue frontier, modifications tail and common config. It is a
+//! So startup coordination is keyed on the *data* instead. A fleet-wide
+//! [`SyncStateDigest`] covers the whole starting configuration: every party's DB
+//! length, ingest/queue frontier, modifications tail and common config. It is a
 //! deterministic function of the exchanged [`SyncState`]s, so all parties derive
 //! it with no extra round trip and no leader. A peer that restarts and recomputes
-//! the same epoch is provably resuming the same startup and may rejoin; one that
-//! comes back with different facts derives a different epoch, which is exactly
-//! the signal that the initial sync is void and the whole fleet must restart.
+//! the same fleet digest is provably resuming the same startup and may rejoin; one
+//! that comes back with a different [`SyncState`] computes a different fleet
+//! digest, which is exactly the signal that the initial sync is void and the whole
+//! fleet must restart.
 //!
 //! [`SyncState`] carries no party id and peers are polled in an arbitrary order,
-//! so the epoch digests the *sorted multiset* of per-party fact digests rather
-//! than a party-indexed vector. Duplicates are preserved, so a party's facts
-//! changing from "same as peers" to "different" still moves the epoch.
+//! so the fleet digest covers the *sorted multiset* of per-party digests rather
+//! than a party-indexed vector. Duplicates are preserved, so one party's
+//! [`SyncState`] changing from "same as peers" to "different" still changes the
+//! fleet digest.
 //!
 //! # The surviving peers are the durable record
 //!
-//! There is deliberately no persisted epoch table. The authority on which startup
+//! There is deliberately no persisted digest table. The authority on which startup
 //! is in progress is the set of peers still running it, published on
 //! [`STARTUP_STATE_ROUTE`] from their live [`StartupStateHandle`]s. A restarting
-//! party rebuilds its [`SyncState`] from its DB and re-derives the epoch from its
-//! peers' boot snapshots; it reproduces the in-flight epoch **exactly when its own
-//! facts are unchanged**, so the rejoin condition checks itself — no durable
-//! state, no migration, no staleness guard. If every party restarts at once there
-//! is no epoch to rejoin and all three derive a fresh one, which is the correct
-//! outcome rather than a degradation.
+//! party rebuilds its [`SyncState`] from its DB and re-derives the fleet digest
+//! from its peers' boot snapshots; it reproduces the in-flight fleet digest
+//! **exactly when its own [`SyncState`] is unchanged**, so the rejoin condition
+//! checks itself — no durable state, no migration, no staleness guard. If every
+//! party restarts at once there is no in-flight fleet digest to rejoin and all
+//! three derive a fresh one, which is the correct outcome rather than a
+//! degradation.
 //!
 //! # What rejoin covers
 //!
-//! Rejoin works whenever the restarting party's facts are unchanged, which covers
-//! the whole [`Phase::Load`] window — the long one, and the reason any of this
-//! exists — provided [`Phase::Converge`] had no work to do, the normal case for a
-//! healthy fleet.
+//! Rejoin works whenever the restarting party's [`SyncState`] is unchanged, which
+//! covers the whole [`Phase::Load`] window — the long one, and the reason any of
+//! this exists — provided [`Phase::Converge`] had no work to do, the normal case
+//! for a healthy fleet.
 //!
 //! It does not cover a restart after a converge that actually mutated local
-//! state: such a party recomputes different facts and the fleet restarts, exactly
+//! state: such a party computes a different digest and the fleet restarts, exactly
 //! as it does today unconditionally. So the crash-recovery boot, the one where
 //! converge has real work, is also the one that cannot rejoin. Same for
 //! `next_sns_sequence_num` with `db_backed_ingest` disabled, where it is a live
 //! SQS queue head that the converge-phase trim moves.
 //!
-//! Replaying converge on a rejoin is safe because the facts projection was chosen
-//! to *see* every converge-phase mutation, so "facts unchanged" already implies
-//! "converge had no effect": `sync_modifications` shows up in `db_len` and the
-//! modifications digest, `sync_graph_mutations` in that digest via
+//! Replaying converge on a rejoin is safe because [`hash_sync_state`] projects
+//! [`SyncState`] so as to *see* every converge-phase mutation, so "same digest"
+//! already implies "converge had no effect": `sync_modifications` shows up in
+//! `db_len` and the modifications digest, `sync_graph_mutations` in that digest via
 //! `graph_mutation_bytes`, the ingest frontier skip-ahead in
 //! `max_persisted_sequence_number`, the queue trim in `next_sns_sequence_num`. The
 //! one exception, releasing unpersisted ingest claims, touches only rows above the
 //! frontier and is idempotent by construction. Anything added to converge later
-//! must be fact-visible or idempotent, or a party could rejoin having silently
-//! applied it twice.
+//! must be visible to [`hash_sync_state`] or idempotent, or a party could rejoin
+//! having silently applied it twice.
 //!
 //! [`wait_for_others_ready`]: ampc_server_utils::wait_for_others_ready
 
@@ -91,16 +94,16 @@ pub const STARTUP_STATE_ENDPOINT: &str = "startup-state";
 /// Domain separators. Every digest in this module is tagged so that a byte
 /// string which is valid input to one level of the construction cannot be
 /// reinterpreted at another level.
-const FACTS_DOMAIN: &[u8] = b"iris-mpc/startup-facts/v1";
+const SYNC_STATE_DOMAIN: &[u8] = b"iris-mpc/startup-sync-state/v1";
 const MODIFICATIONS_DOMAIN: &[u8] = b"iris-mpc/startup-modifications/v1";
-const EPOCH_DOMAIN: &[u8] = b"iris-mpc/startup-epoch/v1";
+const FLEET_DOMAIN: &[u8] = b"iris-mpc/startup-fleet-sync-state/v1";
 
 /// Where a node is in its startup sequence.
 ///
 /// Published to peers so they can tell "still loading" from "dead" — a
 /// distinction the coordination server cannot express today, since `/health`
 /// answers 200 unconditionally and `/ready` only flips after the load completes.
-/// Ordered by progress: a node only ever moves forward within one epoch.
+/// Ordered by progress: a node only ever moves forward within one startup.
 #[derive(
     Debug,
     Clone,
@@ -119,18 +122,18 @@ const EPOCH_DOMAIN: &[u8] = b"iris-mpc/startup-epoch/v1";
 pub enum Phase {
     /// Coordination server up, peers not yet mutually visible.
     Discover,
-    /// Mutual visibility established; exchanging startup facts.
+    /// Mutual visibility established; exchanging [`SyncState`]s.
     Propose,
-    /// Facts exchanged and an epoch derived from them.
+    /// States exchanged and the fleet digest derived from them.
     Commit,
-    /// Applying the agreed plan to local storage (modifications roll-forward,
-    /// graph WAL, ingest frontier skip-ahead, queue trim).
+    /// Applying the synchronized [`SyncState`]s to local storage (modifications
+    /// roll-forward, graph WAL, ingest frontier skip-ahead, queue trim).
     Converge,
     /// The DB load. NOT peer-independent: `init_hawk_actor` runs
     /// `restart_from_checkpoint`, a cross-party consensus round with a 10s
     /// `PEER_ROUND_TIMEOUT`, concurrently with the iris load. A peer that vanishes
-    /// here fails its peers inside the load, before the epoch layer gets to decide
-    /// anything — so rejoin does not yet cover this window.
+    /// here fails its peers inside the load, before the fleet digest comparison
+    /// gets to decide anything — so rejoin does not yet cover this window.
     Load,
     /// Ready, heartbeat armed, main loop running.
     Serving,
@@ -148,8 +151,12 @@ impl Phase {
     ];
 }
 
-/// A 32-byte SHA-256 digest, carried as a lowercase hex string in JSON so the
-/// document stays greppable in logs and readable with `curl`.
+/// A 32-byte SHA-256 digest over one or more [`SyncState`]s: over a single
+/// party's, from [`hash_sync_state`], or over the whole fleet's, from
+/// [`hash_fleet_sync_states`].
+///
+/// Carried as a lowercase hex string in JSON so the document stays greppable in
+/// logs and readable with `curl`.
 #[derive(
     Clone,
     Copy,
@@ -166,11 +173,11 @@ impl Phase {
 #[serde_as]
 #[display("{}", hex::encode(_0))] // _0 accesses the inner [u8; 32]
 #[debug("{self}")] // Delegates Debug directly to Display
-pub struct Digest(#[serde_as(as = "Hex")] [u8; 32]);
+pub struct SyncStateDigest(#[serde_as(as = "Hex")] [u8; 32]);
 
-impl Digest {
-    fn of(bytes: &[u8]) -> Self {
-        Digest(sha256_bytes(bytes))
+impl SyncStateDigest {
+    fn from_bytes(bytes: &[u8]) -> Self {
+        SyncStateDigest(sha256_bytes(bytes))
     }
 
     /// Short form for log lines, where the full 64 hex chars are noise.
@@ -179,32 +186,7 @@ impl Digest {
     }
 }
 
-/// The epoch id: a digest over the sorted multiset of all parties' fact
-/// digests. Distinct from [`Digest`] only in the type system, to keep a facts
-/// digest from being passed where an epoch is expected.
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    Serialize,
-    Deserialize,
-    derive_more::Display,
-)]
-#[display("{}", _0)]
-pub struct Epoch(Digest);
-
-impl Epoch {
-    pub fn short(&self) -> String {
-        self.0.short()
-    }
-}
-
-/// Canonical digest of one party's startup facts: everything about its local
+/// Canonical digest of one party's [`SyncState`]: everything about its local
 /// state that the startup sync reads, and that must therefore be identical
 /// across a restart for a rejoin to be safe.
 ///
@@ -215,51 +197,56 @@ impl Epoch {
 ///
 /// Encoded by hand rather than via `serde_json` so the wire format of
 /// [`SyncState`] can evolve (field renames, `serde(default)` additions) without
-/// silently changing every epoch. Every variable-length field is length-prefixed,
-/// so no two distinct fact sets can encode to the same bytes by shifting a
-/// boundary.
-pub fn facts_digest(state: &SyncState) -> Digest {
-    let modifications = digest_modifications(&state.modifications, &state.graph_mutation_bytes);
-
+/// silently changing every digest. Every variable-length field is
+/// length-prefixed, so no two distinct states can encode to the same bytes by
+/// shifting a boundary.
+pub fn hash_sync_state(state: &SyncState) -> SyncStateDigest {
     let mut buf = Vec::with_capacity(128);
-    buf.extend_from_slice(FACTS_DOMAIN);
+    buf.extend_from_slice(SYNC_STATE_DOMAIN);
     buf.extend_from_slice(&state.db_len.to_be_bytes());
     push_opt_u128(&mut buf, state.next_sns_sequence_num);
     push_opt_str(&mut buf, state.max_persisted_sequence_number.as_deref());
-    buf.extend_from_slice(&digest_common_config(&state.common_config).0);
-    buf.extend_from_slice(&modifications.0);
-    Digest::of(&buf)
+    buf.extend_from_slice(&digest_common_config(&state.common_config));
+    buf.extend_from_slice(&digest_modifications(
+        &state.modifications,
+        &state.graph_mutation_bytes,
+    ));
+    SyncStateDigest::from_bytes(&buf)
 }
 
-/// Derive this startup's epoch from all parties' states, including this party's
-/// own.
+/// Digest all parties' states, including this party's own, into the one value
+/// they all key this startup on.
 ///
 /// `states` is expected to be [`SyncResult::all_states`], which is
 /// `[my_state] ++ peers`.
 ///
 /// [`SyncResult::all_states`]: iris_mpc_common::helpers::sync::SyncResult
-pub fn derive_epoch(states: &[SyncState]) -> Result<Epoch> {
+pub fn hash_fleet_sync_states(states: &[SyncState]) -> Result<SyncStateDigest> {
     if states.len() < 2 {
         bail!(
-            "cannot derive a startup epoch from {} state(s): it is only meaningful over the whole \
-             fleet",
+            "cannot digest a fleet of {} state(s): the fleet digest is only meaningful over every \
+             party",
             states.len()
         );
     }
 
-    let mut facts: Vec<Digest> = states.iter().map(facts_digest).collect();
-    // Sort so the epoch is independent of the order peers were polled in.
-    facts.sort_unstable();
+    let mut digests: Vec<SyncStateDigest> = states.iter().map(hash_sync_state).collect();
+    // Sort so the fleet digest is independent of the order peers were polled in.
+    digests.sort_unstable();
 
-    let mut buf = Vec::with_capacity(EPOCH_DOMAIN.len() + 8 + facts.len() * 32);
-    buf.extend_from_slice(EPOCH_DOMAIN);
+    let mut buf = Vec::with_capacity(
+        FLEET_DOMAIN.len()
+            + std::mem::size_of::<u64>()
+            + (digests.len() * std::mem::size_of::<SyncStateDigest>()),
+    );
+    buf.extend_from_slice(FLEET_DOMAIN);
     // Party count is part of the preimage: a two-party and a three-party fleet
     // that happen to share a digest prefix must not collide.
-    buf.extend_from_slice(&(facts.len() as u64).to_be_bytes());
-    for digest in &facts {
+    buf.extend_from_slice(&(digests.len() as u64).to_be_bytes());
+    for digest in &digests {
         buf.extend_from_slice(&digest.0);
     }
-    Ok(Epoch(Digest::of(&buf)))
+    Ok(SyncStateDigest::from_bytes(&buf))
 }
 
 /// The single document a node publishes about its own startup.
@@ -280,11 +267,12 @@ pub struct StartupState {
     pub uuid: Option<String>,
     pub phase: Phase,
     pub phase_started_at: DateTime<Utc>,
-    /// Digest of this party's own facts, known from the moment its
-    /// [`SyncState`] is built — i.e. before any peer has been contacted.
-    pub facts: Digest,
-    /// `None` until the facts exchange completes and the epoch is derived.
-    pub epoch: Option<Epoch>,
+    /// Digest of this party's own [`SyncState`], known from the moment that state
+    /// is built — i.e. before any peer has been contacted.
+    pub sync_state_digest: SyncStateDigest,
+    /// Digest over every party's [`SyncState`], `None` until the state exchange
+    /// completes and it can be derived.
+    pub fleet_digest: Option<SyncStateDigest>,
 }
 
 /// Live, shared handle to this node's [`StartupState`]; the write side of
@@ -308,15 +296,19 @@ impl StartupStateHandle {
     /// every production path: the party parks forever on entering that phase,
     /// *after* publishing it, so peers keep seeing a node legitimately sitting
     /// there — which is precisely the state an e2e test wants to kill.
-    pub fn new(party_id: usize, facts: Digest, hold_at: Option<Phase>) -> Self {
+    pub fn new(
+        party_id: usize,
+        sync_state_digest: SyncStateDigest,
+        hold_at: Option<Phase>,
+    ) -> Self {
         StartupStateHandle {
             state: Arc::new(RwLock::new(StartupState {
                 party_id,
                 uuid: None,
                 phase: Phase::Discover,
                 phase_started_at: Utc::now(),
-                facts,
-                epoch: None,
+                sync_state_digest,
+                fleet_digest: None,
             })),
             hold_at,
         }
@@ -325,8 +317,8 @@ impl StartupStateHandle {
     /// Router to hand to `start_coordination_server_with_extra_routes`.
     ///
     /// Always answers 200: the document is meaningful in every phase, and a
-    /// pre-agreement node is described by `epoch: null` rather than by an error
-    /// status. Peers distinguish the cases by reading the fields.
+    /// pre-agreement node is described by `fleet_digest: null` rather than by an
+    /// error status. Peers distinguish the cases by reading the fields.
     pub fn router(&self) -> Router {
         let state = Arc::clone(&self.state);
         Router::new().route(
@@ -380,9 +372,9 @@ impl StartupStateHandle {
         }
     }
 
-    /// Record the derived epoch. Called once, on entering [`Phase::Commit`].
-    pub async fn set_epoch(&self, epoch: Epoch) {
-        self.state.write().await.epoch = Some(epoch);
+    /// Record the derived fleet digest. Called once, on entering [`Phase::Commit`].
+    pub async fn set_fleet_digest(&self, digest: SyncStateDigest) {
+        self.state.write().await.fleet_digest = Some(digest);
     }
 }
 
@@ -398,8 +390,8 @@ impl StartupStateHandle {
 /// Returns what it managed to read plus a description of each peer it could not,
 /// rather than failing on the first unreachable one. A down peer must not blind us
 /// to the other: the reachable peer's UUID still needs recording (that is what
-/// lets a *restarting* peer past its visibility barrier), and its epoch is still
-/// worth checking for disagreement. Callers that need every peer — the commit
+/// lets a *restarting* peer past its visibility barrier), and its fleet digest is
+/// still worth checking for disagreement. Callers that need every peer — the commit
 /// barrier — check `failures` themselves.
 async fn poll_peer_states(
     config: &ServerCoordinationConfig,
@@ -458,11 +450,12 @@ async fn fetch_peer_state(
 /// Record a peer incarnation as seen, so the coordination server advertises it on
 /// `/health` and the `ampc-server-utils` checks downstream accept it.
 ///
-/// Bookkeeping, not authorization — which lives entirely in the epoch comparison.
-/// `wait_until_startup_visibility_is_complete` needs this from us before a
-/// restarted peer can get far enough to publish an epoch at all, so withholding it
-/// until the epoch matched would deadlock: the peer cannot pass its visibility
-/// barrier until we list its UUID, and cannot publish an epoch until it does.
+/// Bookkeeping, not authorization — which lives entirely in the fleet digest
+/// comparison. `wait_until_startup_visibility_is_complete` needs this from us
+/// before a restarted peer can get far enough to publish a fleet digest at all, so
+/// withholding it until the digests matched would deadlock: the peer cannot pass
+/// its visibility barrier until we list its UUID, and cannot publish a digest
+/// until it does.
 async fn record_peer_uuids(verified_peers: &Arc<Mutex<HashSet<String>>>, peers: &[StartupState]) {
     let mut verified = verified_peers.lock().await;
     for peer in peers {
@@ -479,71 +472,75 @@ async fn record_peer_uuids(verified_peers: &Arc<Mutex<HashSet<String>>>, peers: 
     }
 }
 
-/// What a round of peer observations says about the epoch.
+/// What a round of peer observations says about the fleet digest.
 #[derive(Debug, Clone, PartialEq, Eq)]
-enum EpochVerdict {
-    /// Every peer published this epoch.
+enum AgreementVerdict {
+    /// Every peer published this fleet digest.
     Committed,
-    /// One or more peers have not published an epoch yet: either they have not
-    /// reached [`Phase::Commit`], or they restarted and are on their way back.
+    /// One or more peers have not published a fleet digest yet: either they have
+    /// not reached [`Phase::Commit`], or they restarted and are on their way back.
     Pending(Vec<(usize, Phase)>),
-    /// A peer published a different epoch, so the agreed plan is void.
-    Void(Vec<(usize, Option<Epoch>)>),
+    /// A peer published a different fleet digest, so this startup is void.
+    Void(Vec<(usize, Option<SyncStateDigest>)>),
 }
 
-/// Classify one round of peer documents against our own epoch.
+/// Classify one round of peer documents against our own fleet digest.
 ///
 /// Shared by the commit barrier and the startup watch so the two cannot drift on
-/// what counts as disagreement. Fails closed both ways: [`EpochVerdict::Void`]
-/// beats [`EpochVerdict::Pending`], and an empty peer list is `Pending` rather
+/// what counts as disagreement. Fails closed both ways: [`AgreementVerdict::Void`]
+/// beats [`AgreementVerdict::Pending`], and an empty peer list is `Pending` rather
 /// than a vacuous `Committed`.
-fn classify_peers(my_epoch: Epoch, peers: &[StartupState]) -> EpochVerdict {
+fn classify_peers(my_digest: SyncStateDigest, peers: &[StartupState]) -> AgreementVerdict {
     let void: Vec<_> = peers
         .iter()
-        .filter(|peer| peer.epoch.is_some_and(|epoch| epoch != my_epoch))
-        .map(|peer| (peer.party_id, peer.epoch))
+        .filter(|peer| peer.fleet_digest.is_some_and(|digest| digest != my_digest))
+        .map(|peer| (peer.party_id, peer.fleet_digest))
         .collect();
 
     if !void.is_empty() {
-        return EpochVerdict::Void(void);
+        return AgreementVerdict::Void(void);
     }
 
     if peers.is_empty() {
-        return EpochVerdict::Pending(Vec::new());
+        return AgreementVerdict::Pending(Vec::new());
     }
 
     let pending: Vec<_> = peers
         .iter()
-        .filter(|peer| peer.epoch.is_none())
+        .filter(|peer| peer.fleet_digest.is_none())
         .map(|peer| (peer.party_id, peer.phase))
         .collect();
 
     if pending.is_empty() {
-        EpochVerdict::Committed
+        AgreementVerdict::Committed
     } else {
-        EpochVerdict::Pending(pending)
+        AgreementVerdict::Pending(pending)
     }
 }
 
-/// Commit barrier: hold until every peer has published *this* epoch.
+/// Commit barrier: hold until every peer has published *this* fleet digest.
 ///
-/// Nothing may mutate local storage before this returns. Converging under a plan
-/// a peer never agreed to is the failure mode the barrier exists to prevent.
+/// Nothing may mutate local storage before this returns. Converging over states a
+/// peer never agreed to is the failure mode the barrier exists to prevent.
 ///
 /// A mismatch is *not* "the parties' data diverged" — divergence is normal, and is
-/// what the modifications roll-forward exists to repair. The epoch digests the
-/// whole starting configuration, differences included, so parties that legitimately
-/// disagree about their persisted frontier still derive the same epoch. A mismatch
-/// means the parties saw *different inputs*: some party's facts changed between the
-/// exchange and now, in practice because it restarted with different data. The
-/// agreed plan is void, and the error returned here triggers the full-fleet restart
-/// that makes every party re-derive from current state.
-pub async fn wait_for_epoch_commit(
+/// what the modifications roll-forward exists to repair. The fleet digest covers
+/// the whole starting configuration, differences included, so parties that
+/// legitimately disagree about their persisted frontier still derive the same fleet
+/// digest. A mismatch means the parties saw *different inputs*: some party's
+/// [`SyncState`] changed between the exchange and now, in practice because it
+/// restarted with different data. This startup is void, and the error returned here
+/// triggers the full-fleet restart that makes every party re-derive from current
+/// state.
+pub async fn wait_for_fleet_digest_commit(
     config: &ServerCoordinationConfig,
     verified_peers: &Arc<Mutex<HashSet<String>>>,
-    my_epoch: Epoch,
+    my_digest: SyncStateDigest,
 ) -> Result<()> {
-    tracing::info!("Waiting for peers to commit startup epoch {}", my_epoch);
+    tracing::info!(
+        "Waiting for peers to commit startup fleet digest {}",
+        my_digest
+    );
 
     let budget = Duration::from_secs(config.startup_sync_timeout_secs);
     let retry_delay = Duration::from_millis(config.http_query_retry_delay_ms);
@@ -555,10 +552,10 @@ pub async fn wait_for_epoch_commit(
         attempt += 1;
         let remaining = deadline.saturating_duration_since(Instant::now());
         if remaining.is_zero() {
-            metrics::counter!("startup_epoch_commit_timeout").increment(1);
+            metrics::counter!("startup_fleet_digest_commit_timeout").increment(1);
             bail!(
-                "peers did not commit startup epoch {} within {:?}",
-                my_epoch,
+                "peers did not commit startup fleet digest {} within {:?}",
+                my_digest,
                 budget
             );
         }
@@ -577,27 +574,27 @@ pub async fn wait_for_epoch_commit(
             continue;
         }
 
-        match classify_peers(my_epoch, &peers) {
-            EpochVerdict::Void(disagreeing) => {
-                metrics::counter!("startup_epoch_mismatch").increment(1);
+        match classify_peers(my_digest, &peers) {
+            AgreementVerdict::Void(disagreeing) => {
+                metrics::counter!("startup_fleet_digest_mismatch").increment(1);
                 bail!(
-                    "startup epoch mismatch: mine is {}, peers report {:?}. The agreed plan is \
-                     void; every party must restart and re-derive from current state.",
-                    my_epoch,
+                    "startup fleet digest mismatch: mine is {}, peers report {:?}. This startup \
+                     is void; every party must restart and re-derive from current state.",
+                    my_digest,
                     disagreeing
                 );
             }
-            EpochVerdict::Committed => {
+            AgreementVerdict::Committed => {
                 tracing::info!(
-                    "Startup epoch {} committed by all {} parties",
-                    my_epoch,
+                    "Startup fleet digest {} committed by all {} parties",
+                    my_digest,
                     peers.len() + 1
                 );
-                metrics::counter!("startup_epoch_agreement").increment(1);
+                metrics::counter!("startup_fleet_digest_agreement").increment(1);
                 return Ok(());
             }
-            EpochVerdict::Pending(pending) => {
-                tracing::debug!("Peers have not committed an epoch yet: {:?}", pending);
+            AgreementVerdict::Pending(pending) => {
+                tracing::debug!("Peers have not committed a fleet digest yet: {:?}", pending);
                 let remaining = deadline.saturating_duration_since(Instant::now());
                 tokio::time::sleep(retry_delay.min(remaining)).await;
             }
@@ -622,12 +619,12 @@ fn log_poll_failure(attempt: u32, failures: &[String]) {
 /// phases. Aborts the task when dropped.
 pub struct StartupWatch {
     task: JoinHandle<()>,
-    /// Set once, to the reason the epoch was voided.
+    /// Set once, to the reason this startup was voided.
     verdict: Arc<OnceLock<String>>,
 }
 
 impl StartupWatch {
-    /// Fail if the watch observed a peer on a different epoch.
+    /// Fail if the watch observed a peer on a different fleet digest.
     ///
     /// Call at every point where startup can still be abandoned cheaply. In
     /// particular, call it after the DB load: `trigger_manual_shutdown` is
@@ -664,21 +661,21 @@ impl Drop for StartupWatch {
 /// `wait_for_others_ready` and the heartbeat's first-contact check both kill an
 /// otherwise healthy node.
 ///
-/// The watch replaces that identity test with the epoch test:
+/// The watch replaces that identity test with the fleet digest test:
 ///
-/// - peer republishes this epoch (whatever its UUID) — it is provably resuming
-///   the same startup, so it is recorded as verified and both parties carry on.
-///   A restart is invisible to us, which is the entire point;
-/// - peer publishes a different epoch — its data changed, the plan is void, and
-///   we abandon startup;
-/// - peer publishes no epoch, or is unreachable — it is mid-restart. Tolerated:
-///   it will either republish this epoch or a different one, and the ready
-///   barrier still bounds how long a peer may fail to arrive.
+/// - peer republishes this fleet digest (whatever its UUID) — it is provably
+///   resuming the same startup, so it is recorded as verified and both parties
+///   carry on. A restart is invisible to us, which is the entire point;
+/// - peer publishes a different fleet digest — its data changed, this startup is
+///   void, and we abandon it;
+/// - peer publishes no fleet digest, or is unreachable — it is mid-restart.
+///   Tolerated: it will either republish this digest or a different one, and the
+///   ready barrier still bounds how long a peer may fail to arrive.
 pub fn spawn_startup_watch(
     config: ServerCoordinationConfig,
     verified_peers: Arc<Mutex<HashSet<String>>>,
     shutdown_handler: Arc<ShutdownHandler>,
-    epoch: Epoch,
+    fleet_digest: SyncStateDigest,
 ) -> StartupWatch {
     let verdict = Arc::new(OnceLock::new());
 
@@ -709,21 +706,21 @@ pub fn spawn_startup_watch(
                     // to absorb — so it is rate-limited rather than warned on every
                     // round. The ready barrier and the heartbeat bound the terminal
                     // cases. Unlike the commit barrier we carry on with a partial
-                    // view: a reachable peer on the wrong epoch is still a verdict.
+                    // view: a reachable peer on the wrong digest is still a verdict.
                     failures += 1;
                     log_poll_failure(failures, &poll_failures);
                 }
 
                 record_peer_uuids(&verified_peers, &peers).await;
 
-                if let EpochVerdict::Void(disagreeing) = classify_peers(epoch, &peers) {
+                if let AgreementVerdict::Void(disagreeing) = classify_peers(fleet_digest, &peers) {
                     let reason = format!(
-                        "startup watch found a peer on a different epoch: mine is {epoch}, peers \
-                         report {disagreeing:?}. The agreed plan is void; abandoning startup so \
-                         every party re-derives from current state."
+                        "startup watch found a peer on a different fleet digest: mine is \
+                         {fleet_digest}, peers report {disagreeing:?}. This startup is void; \
+                         abandoning it so every party re-derives from current state."
                     );
                     tracing::error!("{}", reason);
-                    metrics::counter!("startup_epoch_mismatch").increment(1);
+                    metrics::counter!("startup_fleet_digest_mismatch").increment(1);
 
                     let _ = verdict.set(reason);
 
@@ -735,11 +732,11 @@ pub fn spawn_startup_watch(
 
                 for peer in &peers {
                     tracing::debug!(
-                        "Startup watch: party {} in phase {} (epoch {})",
+                        "Startup watch: party {} in phase {} (fleet digest {})",
                         peer.party_id,
                         peer.phase,
-                        peer.epoch
-                            .map(|e| e.short())
+                        peer.fleet_digest
+                            .map(|digest| digest.short())
                             .unwrap_or_else(|| "pending".to_string())
                     );
                 }
@@ -750,17 +747,20 @@ pub fn spawn_startup_watch(
     StartupWatch { task, verdict }
 }
 
-fn digest_common_config(config: &CommonConfig) -> Digest {
+/// SHA-256 of the common config, as bytes to fold into [`hash_sync_state`]'s
+/// preimage.
+fn digest_common_config(config: &CommonConfig) -> Vec<u8> {
     // `CommonConfig` is all scalars, `Vec`s and `Option`s — no maps — so
     // `serde_json` field order is the declaration order and the encoding is
     // deterministic. It is also already compared field-by-field across parties
     // by `SyncResult::check_common_config`, so any difference the digest sees
     // is a difference that check would reject anyway.
     let bytes = serde_json::to_vec(config).expect("CommonConfig serialization to JSON failed");
-    Digest::of(&bytes)
+    sha256_bytes(&bytes).to_vec()
 }
 
-/// Digest the modifications tail together with its graph WAL entries.
+/// SHA-256 of the modifications tail together with its graph WAL entries, as
+/// bytes to fold into [`hash_sync_state`]'s preimage.
 ///
 /// `graph_mutation_bytes` is parallel-by-index to `modifications`, so the two
 /// are zipped before being sorted by modification id — canonicalizing the order
@@ -769,7 +769,7 @@ fn digest_common_config(config: &CommonConfig) -> Digest {
 fn digest_modifications(
     modifications: &[Modification],
     graph_mutation_bytes: &[Option<Vec<u8>>],
-) -> Digest {
+) -> Vec<u8> {
     let mut rows: Vec<(&Modification, Option<&Vec<u8>>)> = modifications
         .iter()
         .enumerate()
@@ -796,7 +796,7 @@ fn digest_modifications(
             None => buf.push(0),
         }
     }
-    Digest::of(&buf)
+    sha256_bytes(&buf).to_vec()
 }
 
 // Canonical encoding helpers. Every variable-length value is length-prefixed
@@ -873,62 +873,62 @@ mod tests {
         ]
     }
 
-    fn epoch_of(states: &[SyncState]) -> Epoch {
-        derive_epoch(states).unwrap()
+    fn fleet_digest_of(states: &[SyncState]) -> SyncStateDigest {
+        hash_fleet_sync_states(states).unwrap()
     }
 
     #[test]
-    fn epoch_is_independent_of_collection_order() {
+    fn fleet_digest_is_independent_of_collection_order() {
         // The whole design rests on this: each party polls its peers in its own
-        // order, yet all must derive the same epoch with no extra round trip.
-        let baseline = epoch_of(&fleet());
+        // order, yet all must derive the same fleet digest with no extra round trip.
+        let baseline = fleet_digest_of(&fleet());
 
         let mut rotated = fleet();
         rotated.rotate_left(1);
-        assert_eq!(baseline, epoch_of(&rotated));
+        assert_eq!(baseline, fleet_digest_of(&rotated));
 
         let mut reversed = fleet();
         reversed.reverse();
-        assert_eq!(baseline, epoch_of(&reversed));
+        assert_eq!(baseline, fleet_digest_of(&reversed));
     }
 
     #[test]
-    fn epoch_changes_when_any_party_fact_changes() {
-        let baseline = epoch_of(&fleet());
+    fn fleet_digest_changes_when_any_party_state_changes() {
+        let baseline = fleet_digest_of(&fleet());
 
         // The motivating case: a peer restarts and comes back with a different
-        // persisted frontier. That must void the epoch.
+        // persisted frontier. That must void this startup.
         let mut changed = fleet();
         changed[2].max_persisted_sequence_number = Some("0000000000000011".to_string());
         assert_ne!(
             baseline,
-            epoch_of(&changed),
-            "a changed persisted frontier must change the epoch"
+            fleet_digest_of(&changed),
+            "a changed persisted frontier must change the fleet digest"
         );
 
         let mut changed = fleet();
         changed[0].db_len += 1;
-        assert_ne!(baseline, epoch_of(&changed));
+        assert_ne!(baseline, fleet_digest_of(&changed));
 
         let mut changed = fleet();
         changed[1].modifications[0].status = "COMPLETED_WITH_ERROR".to_string();
-        assert_ne!(baseline, epoch_of(&changed));
+        assert_ne!(baseline, fleet_digest_of(&changed));
 
         let mut changed = fleet();
         changed[1].modifications[0].persisted = false;
-        assert_ne!(baseline, epoch_of(&changed));
+        assert_ne!(baseline, fleet_digest_of(&changed));
 
         let mut changed = fleet();
         changed[1].next_sns_sequence_num = None;
-        assert_ne!(baseline, epoch_of(&changed));
+        assert_ne!(baseline, fleet_digest_of(&changed));
 
         let mut changed = fleet();
         changed[0].graph_mutation_bytes = vec![Some(vec![0xcd; 16]), None];
-        assert_ne!(baseline, epoch_of(&changed));
+        assert_ne!(baseline, fleet_digest_of(&changed));
     }
 
     #[test]
-    fn duplicate_facts_are_kept_as_a_multiset() {
+    fn duplicate_party_digests_are_kept_as_a_multiset() {
         // Two parties in sync and one behind must not hash the same as three
         // parties in sync: collapsing duplicates would erase the difference.
         let all_agree = vec![
@@ -936,18 +936,18 @@ mod tests {
             state(100, Some("0000000000000010")),
             state(100, Some("0000000000000010")),
         ];
-        assert_ne!(epoch_of(&fleet()), epoch_of(&all_agree));
+        assert_ne!(fleet_digest_of(&fleet()), fleet_digest_of(&all_agree));
     }
 
     #[test]
-    fn party_count_is_part_of_the_epoch() {
+    fn party_count_is_part_of_the_fleet_digest() {
         let states = fleet();
-        assert_ne!(epoch_of(&states), epoch_of(&states[..2]));
+        assert_ne!(fleet_digest_of(&states), fleet_digest_of(&states[..2]));
     }
 
     #[test]
-    fn a_single_state_cannot_derive_an_epoch() {
-        assert!(derive_epoch(&fleet()[..1]).is_err());
+    fn a_single_state_cannot_make_a_fleet_digest() {
+        assert!(hash_fleet_sync_states(&fleet()[..1]).is_err());
     }
 
     #[test]
@@ -962,7 +962,7 @@ mod tests {
         b.modifications[0].request_type = "abc".to_string();
         b.modifications[0].status = "d".to_string();
 
-        assert_ne!(facts_digest(&a), facts_digest(&b));
+        assert_ne!(hash_sync_state(&a), hash_sync_state(&b));
     }
 
     #[test]
@@ -974,7 +974,7 @@ mod tests {
         reversed.modifications.reverse();
         reversed.graph_mutation_bytes.reverse();
 
-        assert_eq!(facts_digest(&forward), facts_digest(&reversed));
+        assert_eq!(hash_sync_state(&forward), hash_sync_state(&reversed));
     }
 
     #[test]
@@ -985,16 +985,19 @@ mod tests {
         let mut mispaired = forward.clone();
         mispaired.modifications.reverse();
 
-        assert_ne!(facts_digest(&forward), facts_digest(&mispaired));
+        assert_ne!(hash_sync_state(&forward), hash_sync_state(&mispaired));
     }
 
     #[test]
-    fn epoch_survives_a_json_round_trip() {
-        // Peers parse the epoch out of each other's documents, so the hex encoding
-        // has to be exact.
-        let epoch = epoch_of(&fleet());
-        let json = serde_json::to_string(&epoch).unwrap();
-        assert_eq!(serde_json::from_str::<Epoch>(&json).unwrap(), epoch);
+    fn a_digest_survives_a_json_round_trip() {
+        // Peers parse the fleet digest out of each other's documents, so the hex
+        // encoding has to be exact.
+        let digest = fleet_digest_of(&fleet());
+        let json = serde_json::to_string(&digest).unwrap();
+        assert_eq!(
+            serde_json::from_str::<SyncStateDigest>(&json).unwrap(),
+            digest
+        );
     }
 
     #[test]
@@ -1011,8 +1014,8 @@ mod tests {
     async fn a_hold_publishes_its_phase_before_parking() {
         // The whole point of the hook: peers must see a party legitimately
         // sitting in the held phase, so `enter` has to publish before it parks.
-        let facts = facts_digest(&state(100, None));
-        let handle = StartupStateHandle::new(1, facts, Some(Phase::Propose));
+        let digest = hash_sync_state(&state(100, None));
+        let handle = StartupStateHandle::new(1, digest, Some(Phase::Propose));
 
         let entering = tokio::spawn({
             let handle = handle.clone();
@@ -1031,147 +1034,150 @@ mod tests {
         entering.abort();
 
         // A phase that is not the held one still advances normally.
-        let handle = StartupStateHandle::new(1, facts, Some(Phase::Load));
+        let handle = StartupStateHandle::new(1, digest, Some(Phase::Load));
         handle.enter(Phase::Propose).await;
         assert_eq!(handle.snapshot().await.phase, Phase::Propose);
     }
 
     #[tokio::test]
-    async fn published_document_tracks_phase_and_epoch() {
-        let facts = facts_digest(&state(100, None));
-        let handle = StartupStateHandle::new(1, facts, None);
+    async fn published_document_tracks_phase_and_fleet_digest() {
+        let digest = hash_sync_state(&state(100, None));
+        let handle = StartupStateHandle::new(1, digest, None);
 
         let initial = handle.snapshot().await;
         assert_eq!(initial.phase, Phase::Discover);
-        assert!(initial.epoch.is_none());
+        assert!(initial.fleet_digest.is_none());
         assert!(initial.uuid.is_none());
-        assert_eq!(initial.facts, facts);
+        assert_eq!(initial.sync_state_digest, digest);
 
         handle.set_uuid("uuid-1".to_string()).await;
 
-        let epoch = epoch_of(&fleet());
+        let fleet_digest = fleet_digest_of(&fleet());
         handle.enter(Phase::Propose).await;
         handle.enter(Phase::Commit).await;
-        handle.set_epoch(epoch).await;
+        handle.set_fleet_digest(fleet_digest).await;
 
         let committed = handle.snapshot().await;
         assert_eq!(committed.phase, Phase::Commit);
-        assert_eq!(committed.epoch, Some(epoch));
+        assert_eq!(committed.fleet_digest, Some(fleet_digest));
 
         // The document must survive the wire: peers parse exactly this.
         let json = serde_json::to_string(&committed).unwrap();
         let parsed: StartupState = serde_json::from_str(&json).unwrap();
-        assert_eq!(parsed.epoch, Some(epoch));
+        assert_eq!(parsed.fleet_digest, Some(fleet_digest));
         assert_eq!(parsed.phase, Phase::Commit);
         assert_eq!(parsed.party_id, 1);
         assert_eq!(parsed.uuid.as_deref(), Some("uuid-1"));
     }
 
-    fn peer(party_id: usize, phase: Phase, epoch: Option<Epoch>) -> StartupState {
+    fn peer(party_id: usize, phase: Phase, fleet_digest: Option<SyncStateDigest>) -> StartupState {
         StartupState {
             party_id,
             uuid: Some(format!("uuid-{party_id}")),
             phase,
             phase_started_at: Utc::now(),
-            facts: facts_digest(&state(100, None)),
-            epoch,
+            sync_state_digest: hash_sync_state(&state(100, None)),
+            fleet_digest,
         }
     }
 
-    fn other_epoch() -> Epoch {
+    fn other_fleet_digest() -> SyncStateDigest {
         let mut changed = fleet();
         changed[0].db_len = 12_345;
-        epoch_of(&changed)
+        fleet_digest_of(&changed)
     }
 
     #[test]
-    fn all_peers_on_my_epoch_is_committed() {
-        let mine = epoch_of(&fleet());
+    fn all_peers_on_my_fleet_digest_is_committed() {
+        let mine = fleet_digest_of(&fleet());
         let peers = [
             peer(1, Phase::Commit, Some(mine)),
             peer(2, Phase::Load, Some(mine)),
         ];
-        assert_eq!(classify_peers(mine, &peers), EpochVerdict::Committed);
+        assert_eq!(classify_peers(mine, &peers), AgreementVerdict::Committed);
     }
 
     #[test]
-    fn a_peer_without_an_epoch_is_pending_not_void() {
+    fn a_peer_without_a_fleet_digest_is_pending_not_void() {
         // Either it has not reached Commit, or it restarted and is on its way
         // back. Neither is a disagreement.
-        let mine = epoch_of(&fleet());
+        let mine = fleet_digest_of(&fleet());
         let peers = [
             peer(1, Phase::Commit, Some(mine)),
             peer(2, Phase::Discover, None),
         ];
         assert_eq!(
             classify_peers(mine, &peers),
-            EpochVerdict::Pending(vec![(2, Phase::Discover)])
+            AgreementVerdict::Pending(vec![(2, Phase::Discover)])
         );
     }
 
     #[test]
-    fn a_peer_on_a_different_epoch_voids_the_plan() {
+    fn a_peer_on_a_different_fleet_digest_voids_the_startup() {
         // The motivating failure: a peer restarted with changed data.
-        let mine = epoch_of(&fleet());
-        let theirs = other_epoch();
+        let mine = fleet_digest_of(&fleet());
+        let theirs = other_fleet_digest();
         let peers = [
             peer(1, Phase::Commit, Some(mine)),
             peer(2, Phase::Commit, Some(theirs)),
         ];
         assert_eq!(
             classify_peers(mine, &peers),
-            EpochVerdict::Void(vec![(2, Some(theirs))])
+            AgreementVerdict::Void(vec![(2, Some(theirs))])
         );
     }
 
     #[test]
     fn void_takes_precedence_over_pending() {
         // Fail closed: one peer still arriving must not mask another peer that
-        // has already proven the plan void.
-        let mine = epoch_of(&fleet());
-        let theirs = other_epoch();
+        // has already proven this startup void.
+        let mine = fleet_digest_of(&fleet());
+        let theirs = other_fleet_digest();
         let peers = [
             peer(1, Phase::Discover, None),
             peer(2, Phase::Commit, Some(theirs)),
         ];
         assert_eq!(
             classify_peers(mine, &peers),
-            EpochVerdict::Void(vec![(2, Some(theirs))])
+            AgreementVerdict::Void(vec![(2, Some(theirs))])
         );
     }
 
     #[test]
     fn no_peers_is_pending_not_vacuously_committed() {
         // A round that saw nobody must never satisfy the commit barrier.
-        let mine = epoch_of(&fleet());
-        assert_eq!(classify_peers(mine, &[]), EpochVerdict::Pending(Vec::new()));
+        let mine = fleet_digest_of(&fleet());
+        assert_eq!(
+            classify_peers(mine, &[]),
+            AgreementVerdict::Pending(Vec::new())
+        );
     }
 
     #[test]
     fn rejoin_condition_is_self_checking() {
         // The core claim of the peer-memory design. A restarting party rebuilds
-        // its own state from its DB and re-derives the epoch from its peers'
+        // its own state from its DB and re-derives the fleet digest from its peers'
         // (unchanged) boot snapshots.
         let original = fleet();
-        let in_flight = epoch_of(&original);
+        let in_flight = fleet_digest_of(&original);
 
-        // Facts unchanged across the restart — converge had no work to do — so
-        // the party reproduces the in-flight epoch and rejoins.
+        // State unchanged across the restart — converge had no work to do — so
+        // the party reproduces the in-flight fleet digest and rejoins.
         let mut rebooted = original.clone();
         rebooted[0] = state(100, Some("0000000000000010"));
         assert_eq!(
             in_flight,
-            epoch_of(&rebooted),
-            "an unchanged party must reproduce the in-flight epoch"
+            fleet_digest_of(&rebooted),
+            "an unchanged party must reproduce the in-flight fleet digest"
         );
 
-        // Facts changed across the restart — converge mutated local state, or the
-        // data really did move — so the epoch differs and the fleet restarts.
+        // State changed across the restart — converge mutated local state, or the
+        // data really did move — so the digest differs and the fleet restarts.
         let mut rebooted = original.clone();
         rebooted[0] = state(101, Some("0000000000000011"));
         assert_ne!(
             in_flight,
-            epoch_of(&rebooted),
+            fleet_digest_of(&rebooted),
             "a changed party must not be able to rejoin"
         );
     }

--- a/iris-mpc/src/server/startup_phase.rs
+++ b/iris-mpc/src/server/startup_phase.rs
@@ -38,32 +38,91 @@
 //! party's facts changing from "same as peers" to "different" still moves the
 //! epoch.
 //!
-//! # Current status: observation only
+//! # The surviving peers are the durable record
 //!
-//! Nothing here fails a startup yet. [`StartupStateHandle`] publishes the live
-//! document on [`STARTUP_STATE_ROUTE`] and [`observe_peer_epochs`] logs whether
-//! the parties agree, so epoch determinism can be confirmed on a real cluster
-//! before any teardown decision depends on it. Enforcement (the commit barrier
-//! and the rejoin acceptance path) comes next, and needs the durable per-party
-//! generation counter that [`StartupState::generation`] is reserved for.
+//! There is deliberately no persisted epoch table. The authority on "which
+//! startup is in progress" is the set of peers still running it, held in their
+//! live [`StartupStateHandle`]s and served on [`STARTUP_STATE_ROUTE`]. A
+//! restarting party does not read a local record and try to prove it still
+//! matches; it simply rebuilds its [`SyncState`] from its DB and re-derives the
+//! epoch from its peers' boot snapshots. It reproduces the in-flight epoch
+//! **exactly when its own facts are unchanged**, so the rejoin condition checks
+//! itself — no durable state, no schema migration, and no generation counter to
+//! guard against stale records, because in-process state cannot go stale.
+//!
+//! If every party restarts at once there is no epoch to rejoin, and all three
+//! derive a fresh one from current data. That is the correct outcome, not a
+//! degradation.
+//!
+//! # What rejoin covers, and what it does not
+//!
+//! Rejoin works whenever the restarting party's facts are unchanged. That covers
+//! the whole [`Phase::Load`] window — the long one, and the reason any of this
+//! exists — provided [`Phase::Converge`] had no work to do, which is the normal
+//! case for a healthy fleet: nothing to roll forward, no rows to skip ahead.
+//!
+//! It does not cover a restart *after* a converge that actually mutated local
+//! state. Such a party recomputes different facts, derives a different epoch, and
+//! the fleet restarts. Two consequences worth knowing:
+//!
+//! - the crash-recovery boot — the one where converge has real work — is also
+//!   the one that cannot rejoin, so it behaves exactly as it does today;
+//! - with `db_backed_ingest` disabled, `next_sns_sequence_num` is a live SQS
+//!   queue head that the converge-phase queue trim moves, so rejoin after
+//!   converge is unavailable on that path for the same reason.
+//!
+//! Both fall back to a full-fleet restart, which is what happens today
+//! unconditionally. Nothing gets worse; the common case gets much better.
+//!
+//! Extending rejoin to a mutated converge means predicting each party's
+//! post-converge facts and pinning them in the plan — real work, and only worth
+//! doing if the crash-during-converge window turns out to matter in practice.
+//!
+//! # Why an unchanged epoch also means converge is safe to replay
+//!
+//! A rejoining party re-runs its own converge, so replay has to be harmless. It
+//! is, and not by luck: the facts projection was chosen to *see* every
+//! converge-phase mutation, so "facts unchanged" already implies "converge had
+//! no effect".
+//!
+//! - `sync_modifications` moves modification statuses and iris rows → visible in
+//!   `db_len` and the modifications digest;
+//! - `sync_graph_mutations` inserts graph WAL rows → visible in the modifications
+//!   digest, which folds in `graph_mutation_bytes`;
+//! - the ingest frontier skip-ahead moves the persisted frontier → visible in
+//!   `max_persisted_sequence_number`;
+//! - the SQS queue trim moves the queue head → visible in
+//!   `next_sns_sequence_num`.
+//!
+//! The one exception is releasing unpersisted ingest claims, which touches only
+//! rows above the frontier and so is invisible to the projection. That step is
+//! idempotent by construction — releasing an already-released claim is a no-op,
+//! and re-formation is deterministic — so replaying it is safe regardless.
+//!
+//! Anything added to converge later must either be fact-visible or idempotent.
+//! A mutation that is neither would let a party rejoin having silently applied it
+//! twice.
 //!
 //! [`wait_for_others_ready`]: ampc_server_utils::wait_for_others_ready
 
+use ampc_server_utils::shutdown_handler::ShutdownHandler;
 use ampc_server_utils::{try_get_endpoint_other_nodes, ServerCoordinationConfig};
 use axum::routing::get;
 use axum::Router;
 use chrono::{DateTime, Utc};
-use eyre::{bail, Result};
+use eyre::{bail, eyre, Result, WrapErr};
 use iris_mpc_common::config::CommonConfig;
 use iris_mpc_common::helpers::sha256::sha256_bytes;
 use iris_mpc_common::helpers::sync::{Modification, SyncState};
 use serde::de::Error as _;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use sodiumoxide::hex;
+use std::collections::HashSet;
 use std::fmt;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, Instant};
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
+use tokio::task::JoinHandle;
 
 /// Axum path serving the live startup-state document.
 pub const STARTUP_STATE_ROUTE: &str = "/startup-state";
@@ -154,14 +213,15 @@ impl Serialize for Digest {
 }
 
 impl<'de> Deserialize<'de> for Digest {
-    fn deserialize<D: Deserializer<'de>>(
-        deserializer: D,
-    ) -> std::result::Result<Self, D::Error> {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
         let s = String::deserialize(deserializer)?;
         let bytes = hex::decode(&s)
             .map_err(|_| D::Error::custom(format!("digest is not valid hex: {s}")))?;
         let bytes: [u8; 32] = bytes.try_into().map_err(|_| {
-            D::Error::custom(format!("digest must be 32 bytes, got {} hex chars", s.len()))
+            D::Error::custom(format!(
+                "digest must be 32 bytes, got {} hex chars",
+                s.len()
+            ))
         })?;
         Ok(Digest(bytes))
     }
@@ -325,10 +385,13 @@ pub struct StartupState {
     /// be handed to it — correlation-only data, so it is not worth inverting
     /// that ordering upstream.
     pub uuid: Option<String>,
-    /// Durable, monotonic per party: bumped whenever a party abandons an epoch,
-    /// so a stale document from a previous attempt cannot be mistaken for the
-    /// current one (the ABA guard). Always 0 until the epoch record is
-    /// persisted, which enforcement will add.
+    /// Reserved, always 0.
+    ///
+    /// Intended as an ABA guard for a durable epoch record; the peer-memory
+    /// design made that record unnecessary (see the module docs), so nothing
+    /// sets it. Retained as a `serde(default)` field so documents stay
+    /// compatible in both directions across a rolling deploy.
+    #[serde(default)]
     pub generation: u64,
     pub phase: Phase,
     pub phase_started_at: DateTime<Utc>,
@@ -445,111 +508,338 @@ impl StartupStateHandle {
     }
 }
 
-/// Poll peers' startup-state documents and report whether they derived the same
-/// epoch.
+/// Fetch and parse every peer's startup-state document.
 ///
-/// Observation only: every outcome — disagreement, unreachable peer, timeout —
-/// is logged and counted, never returned as an error. The point is to confirm
-/// on a live cluster that the canonicalization really is deterministic across
-/// parties before anything is allowed to fail on it.
-pub async fn observe_peer_epochs(
+/// A peer whose document cannot be parsed is an error rather than a skipped
+/// entry: a caller counting agreeing peers must not be able to reach quorum
+/// because a disagreeing peer was quietly dropped.
+async fn poll_peer_states(
     config: &ServerCoordinationConfig,
-    my_epoch: Epoch,
     budget: Duration,
-    retry_delay: Duration,
-) {
+) -> Result<Vec<StartupState>> {
+    // `try_get_endpoint_other_nodes` retries internally against its own
+    // `startup_sync_timeout_secs` budget, which is unrelated to the caller's,
+    // so cap it here rather than inheriting it.
+    let responses = tokio::time::timeout(
+        budget,
+        try_get_endpoint_other_nodes(config, STARTUP_STATE_ENDPOINT),
+    )
+    .await
+    .map_err(|_| eyre!("timed out polling peer startup state after {:?}", budget))??;
+
+    responses
+        .into_iter()
+        .map(|(status, body)| {
+            serde_json::from_slice::<StartupState>(&body).wrap_err_with(|| {
+                format!("failed to deserialize peer startup state (status {status})")
+            })
+        })
+        .collect()
+}
+
+/// Record a peer incarnation as seen, so the coordination server advertises it
+/// on `/health` and the `ampc-server-utils` checks downstream accept it.
+///
+/// This is bookkeeping, not authorization: it says "this incarnation exists and
+/// we have observed it", which is exactly what
+/// `wait_until_startup_visibility_is_complete` needs from us before a restarted
+/// peer can get far enough to publish an epoch at all. Withholding it until the
+/// epoch matched would deadlock — the peer cannot pass its visibility barrier
+/// until we list its UUID, and it cannot publish an epoch until it passes that
+/// barrier. Authorization lives entirely in the epoch comparison below.
+async fn record_peer_uuids(verified_peers: &Arc<Mutex<HashSet<String>>>, peers: &[StartupState]) {
+    let mut verified = verified_peers.lock().await;
+    for peer in peers {
+        if let Some(uuid) = &peer.uuid {
+            if verified.insert(uuid.clone()) {
+                tracing::info!(
+                    "Recorded peer party {} incarnation {} (phase {})",
+                    peer.party_id,
+                    uuid,
+                    peer.phase
+                );
+            }
+        }
+    }
+}
+
+/// What a round of peer observations says about the epoch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum EpochVerdict {
+    /// Every peer published this epoch.
+    Committed,
+    /// One or more peers have not published an epoch yet: either they have not
+    /// reached [`Phase::Commit`], or they restarted and are on their way back.
+    Pending(Vec<(usize, Phase)>),
+    /// A peer published a different epoch, so the agreed plan is void.
+    Void(Vec<(usize, Option<Epoch>)>),
+}
+
+/// Classify one round of peer documents against our own epoch.
+///
+/// Shared by the commit barrier and the startup watch so the two cannot drift
+/// apart on what counts as disagreement. Fails closed in both directions:
+/// [`EpochVerdict::Void`] takes precedence over [`EpochVerdict::Pending`], and an
+/// empty peer list is `Pending` rather than a vacuous `Committed`.
+fn classify_peers(my_epoch: Epoch, peers: &[StartupState]) -> EpochVerdict {
+    let void: Vec<_> = peers
+        .iter()
+        .filter(|peer| peer.epoch.is_some_and(|epoch| epoch != my_epoch))
+        .map(|peer| (peer.party_id, peer.epoch))
+        .collect();
+
+    if !void.is_empty() {
+        return EpochVerdict::Void(void);
+    }
+
+    if peers.is_empty() {
+        return EpochVerdict::Pending(Vec::new());
+    }
+
+    let pending: Vec<_> = peers
+        .iter()
+        .filter(|peer| peer.epoch.is_none())
+        .map(|peer| (peer.party_id, peer.phase))
+        .collect();
+
+    if pending.is_empty() {
+        EpochVerdict::Committed
+    } else {
+        EpochVerdict::Pending(pending)
+    }
+}
+
+/// Commit barrier: hold until every peer has published *this* epoch.
+///
+/// Nothing may mutate local storage before this returns. Converging under a plan
+/// a peer never agreed to is the failure mode the barrier exists to prevent.
+///
+/// # What a mismatch does and does not mean
+///
+/// A mismatch is *not* "the parties' data diverged" — divergence is normal and
+/// is precisely what the modifications roll-forward exists to repair. The epoch
+/// is a digest of the whole starting configuration, differences included, so
+/// three parties that legitimately disagree about their persisted frontier still
+/// derive the same epoch from the same three fact sets.
+///
+/// A mismatch means the parties saw *different inputs*: some party's facts
+/// changed between the exchange and now, which in practice means it restarted
+/// and came back with different data. The agreed plan is then void, and every
+/// party must abandon it and re-derive from current state — the full-fleet
+/// restart this returns an error to trigger.
+pub async fn wait_for_epoch_commit(
+    config: &ServerCoordinationConfig,
+    verified_peers: &Arc<Mutex<HashSet<String>>>,
+    my_epoch: Epoch,
+) -> Result<()> {
+    tracing::info!("Waiting for peers to commit startup epoch {}", my_epoch);
+
+    let budget = Duration::from_secs(config.startup_sync_timeout_secs);
+    let retry_delay = Duration::from_millis(config.http_query_retry_delay_ms);
     let deadline = Instant::now() + budget;
 
     loop {
         let remaining = deadline.saturating_duration_since(Instant::now());
         if remaining.is_zero() {
-            tracing::warn!(
-                "Could not confirm peer startup epochs within {:?}; proceeding (observation only)",
+            metrics::counter!("startup_epoch_commit_timeout").increment(1);
+            bail!(
+                "peers did not commit startup epoch {} within {:?}",
+                my_epoch,
                 budget
             );
-            metrics::counter!("startup_epoch_observation_timeout").increment(1);
-            return;
         }
 
-        // `try_get_endpoint_other_nodes` retries internally against its own
-        // `startup_sync_timeout_secs` budget, which is unrelated to ours, so
-        // cap it here rather than inheriting it.
-        let responses = match tokio::time::timeout(
-            remaining,
-            try_get_endpoint_other_nodes(config, STARTUP_STATE_ENDPOINT),
-        )
-        .await
-        {
-            Ok(Ok(responses)) => responses,
-            Ok(Err(err)) => {
+        let peers = match poll_peer_states(config, remaining).await {
+            Ok(peers) => peers,
+            Err(err) => {
                 tracing::warn!("Failed to poll peer startup state: {:?}", err);
                 tokio::time::sleep(retry_delay.min(remaining)).await;
                 continue;
             }
-            Err(_) => continue, // deadline hit; handled at the top of the loop
         };
 
-        let mut peers = Vec::with_capacity(responses.len());
-        for (status, body) in responses {
-            match serde_json::from_slice::<StartupState>(&body) {
-                Ok(state) => peers.push(state),
-                Err(err) => {
-                    tracing::warn!(
-                        "Failed to deserialize peer startup state (status {}): {:?}",
-                        status,
-                        err
+        record_peer_uuids(verified_peers, &peers).await;
+
+        match classify_peers(my_epoch, &peers) {
+            EpochVerdict::Void(disagreeing) => {
+                metrics::counter!("startup_epoch_mismatch").increment(1);
+                bail!(
+                    "startup epoch mismatch: mine is {}, peers report {:?}. The agreed plan is \
+                     void; every party must restart and re-derive from current state.",
+                    my_epoch,
+                    format_epochs(&disagreeing)
+                );
+            }
+            EpochVerdict::Committed => {
+                tracing::info!(
+                    "Startup epoch {} committed by all {} parties",
+                    my_epoch,
+                    peers.len() + 1
+                );
+                metrics::counter!("startup_epoch_agreement").increment(1);
+                return Ok(());
+            }
+            EpochVerdict::Pending(pending) => {
+                tracing::debug!("Peers have not committed an epoch yet: {:?}", pending);
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                tokio::time::sleep(retry_delay.min(remaining)).await;
+            }
+        }
+    }
+}
+
+fn format_epochs(peers: &[(usize, Option<Epoch>)]) -> Vec<(usize, String)> {
+    peers
+        .iter()
+        .map(|(party_id, epoch)| {
+            (
+                *party_id,
+                epoch
+                    .map(|epoch| epoch.to_string())
+                    .unwrap_or_else(|| "none".to_string()),
+            )
+        })
+        .collect()
+}
+
+/// Guard for the background task that watches peers across the converge and
+/// load phases. Aborts the task when dropped.
+pub struct StartupWatch {
+    task: JoinHandle<()>,
+    /// Set once, to the reason the epoch was voided.
+    verdict: Arc<StdMutex<Option<String>>>,
+}
+
+impl StartupWatch {
+    /// Fail if the watch observed a peer on a different epoch.
+    ///
+    /// Call at every point where startup can still be abandoned cheaply. In
+    /// particular, call it after the DB load: `trigger_manual_shutdown` is
+    /// cooperative, and the load does not poll it, so a verdict reached while
+    /// loading is only acted on once the load returns.
+    pub fn check(&self) -> Result<()> {
+        let verdict = self
+            .verdict
+            .lock()
+            .expect("startup watch verdict mutex poisoned")
+            .clone();
+        match verdict {
+            Some(reason) => bail!("{reason}"),
+            None => Ok(()),
+        }
+    }
+
+    /// Stop watching. Called on reaching [`Phase::Serving`], after which the
+    /// heartbeat owns peer supervision and its UUID-mismatch teardown is the
+    /// correct policy — a peer that restarts once sessions exist cannot rejoin.
+    pub fn stop(self) {
+        self.task.abort();
+    }
+}
+
+impl Drop for StartupWatch {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+/// Watch peers for the duration of converge and load — the window in which
+/// nothing else is looking.
+///
+/// This closes the gap that forces today's full-fleet restarts. The heartbeat is
+/// only armed after the load, so a peer that dies during the load is invisible
+/// until the ready barrier, and a peer that *restarts* during it is rejected
+/// outright: its new UUID is absent from the frozen `verified_peers` set, so
+/// `wait_for_others_ready` and the heartbeat's first-contact check both kill an
+/// otherwise healthy node.
+///
+/// The watch replaces that identity test with the epoch test:
+///
+/// - peer republishes this epoch (whatever its UUID) — it is provably resuming
+///   the same startup, so it is recorded as verified and both parties carry on.
+///   A restart is invisible to us, which is the entire point;
+/// - peer publishes a different epoch — its data changed, the plan is void, and
+///   we abandon startup;
+/// - peer publishes no epoch, or is unreachable — it is mid-restart. Tolerated:
+///   it will either republish this epoch or a different one, and the ready
+///   barrier still bounds how long a peer may fail to arrive.
+///
+/// Note what makes the first case work without any durable record: a restarting
+/// peer rebuilds its [`SyncState`] from its DB and re-derives the epoch from its
+/// peers' boot snapshots, so it reproduces this epoch **exactly when its own
+/// facts are unchanged** — the rejoin condition is self-checking. It therefore
+/// holds for the common case of a converge that had no work to do, and correctly
+/// fails when converge actually mutated local state (see the module docs).
+pub fn spawn_startup_watch(
+    config: ServerCoordinationConfig,
+    verified_peers: Arc<Mutex<HashSet<String>>>,
+    shutdown_handler: Arc<ShutdownHandler>,
+    epoch: Epoch,
+) -> StartupWatch {
+    let verdict = Arc::new(StdMutex::new(None));
+
+    let task = tokio::spawn({
+        let verdict = Arc::clone(&verdict);
+        // Reuse the heartbeat cadence: this is the same job, over the phase of
+        // startup where the heartbeat itself cannot yet run.
+        let poll_interval = Duration::from_secs(config.heartbeat_interval_secs);
+
+        async move {
+            loop {
+                tokio::time::sleep(poll_interval).await;
+
+                if shutdown_handler.is_shutting_down() {
+                    tracing::info!("Startup watch stopping: shutdown already in progress");
+                    return;
+                }
+
+                let peers = match poll_peer_states(&config, poll_interval).await {
+                    Ok(peers) => peers,
+                    Err(err) => {
+                        // Expected while a peer restarts; the ready barrier and
+                        // heartbeat bound the terminal cases.
+                        tracing::warn!("Startup watch could not poll peers: {:?}", err);
+                        continue;
+                    }
+                };
+
+                record_peer_uuids(&verified_peers, &peers).await;
+
+                if let EpochVerdict::Void(disagreeing) = classify_peers(epoch, &peers) {
+                    let disagreeing = format_epochs(&disagreeing);
+                    let reason = format!(
+                        "startup watch found a peer on a different epoch: mine is {epoch}, peers \
+                         report {disagreeing:?}. The agreed plan is void; abandoning startup so \
+                         every party re-derives from current state."
+                    );
+                    tracing::error!("{}", reason);
+                    metrics::counter!("startup_epoch_mismatch").increment(1);
+
+                    *verdict
+                        .lock()
+                        .expect("startup watch verdict mutex poisoned") = Some(reason);
+
+                    if !shutdown_handler.is_shutting_down() {
+                        shutdown_handler.trigger_manual_shutdown();
+                    }
+                    return;
+                }
+
+                for peer in &peers {
+                    tracing::debug!(
+                        "Startup watch: party {} in phase {} (epoch {})",
+                        peer.party_id,
+                        peer.phase,
+                        peer.epoch
+                            .map(|e| e.short())
+                            .unwrap_or_else(|| "pending".to_string())
                     );
                 }
             }
         }
+    });
 
-        // A peer that has not reached Commit yet has no epoch to compare;
-        // that is expected, since the three parties get here independently.
-        let pending: Vec<_> = peers
-            .iter()
-            .filter(|peer| peer.epoch.is_none())
-            .map(|peer| (peer.party_id, peer.phase))
-            .collect();
-
-        if !pending.is_empty() {
-            tracing::debug!("Peers have not derived an epoch yet: {:?}", pending);
-            let remaining = deadline.saturating_duration_since(Instant::now());
-            tokio::time::sleep(retry_delay.min(remaining)).await;
-            continue;
-        }
-
-        let disagreeing: Vec<_> = peers
-            .iter()
-            .filter(|peer| peer.epoch != Some(my_epoch))
-            .map(|peer| {
-                (
-                    peer.party_id,
-                    peer.epoch.map(|e| e.to_string()),
-                    peer.facts.short(),
-                )
-            })
-            .collect();
-
-        if disagreeing.is_empty() {
-            tracing::info!(
-                "Startup epoch {} agreed by all {} parties",
-                my_epoch,
-                peers.len() + 1
-            );
-            metrics::counter!("startup_epoch_agreement").increment(1);
-        } else {
-            // Under enforcement this is the "initial sync is void, restart the
-            // fleet" trigger. For now it is loud but harmless.
-            tracing::error!(
-                "Startup epoch MISMATCH: mine is {}, peers report {:?}. Under enforcement this \
-                 would void the epoch and restart the fleet.",
-                my_epoch,
-                disagreeing
-            );
-            metrics::counter!("startup_epoch_mismatch").increment(1);
-        }
-        return;
-    }
+    StartupWatch { task, verdict }
 }
 
 fn digest_common_config(config: &CommonConfig) -> Digest {
@@ -862,6 +1152,116 @@ mod tests {
         assert_eq!(parsed.party_id, 1);
         assert_eq!(parsed.generation, 0);
         assert_eq!(parsed.uuid.as_deref(), Some("uuid-1"));
+    }
+
+    fn peer(party_id: usize, phase: Phase, epoch: Option<Epoch>) -> StartupState {
+        StartupState {
+            party_id,
+            uuid: Some(format!("uuid-{party_id}")),
+            generation: 0,
+            phase,
+            phase_started_at: Utc::now(),
+            facts: PartyFacts::from_sync_state(&state(100, None)).digest(),
+            epoch,
+        }
+    }
+
+    fn other_epoch() -> Epoch {
+        let mut changed = fleet();
+        changed[0].db_len = 12_345;
+        AgreedPlan::from_states(&changed).unwrap().epoch()
+    }
+
+    #[test]
+    fn all_peers_on_my_epoch_is_committed() {
+        let mine = AgreedPlan::from_states(&fleet()).unwrap().epoch();
+        let peers = [
+            peer(1, Phase::Commit, Some(mine)),
+            peer(2, Phase::Load, Some(mine)),
+        ];
+        assert_eq!(classify_peers(mine, &peers), EpochVerdict::Committed);
+    }
+
+    #[test]
+    fn a_peer_without_an_epoch_is_pending_not_void() {
+        // Either it has not reached Commit, or it restarted and is on its way
+        // back. Neither is a disagreement.
+        let mine = AgreedPlan::from_states(&fleet()).unwrap().epoch();
+        let peers = [
+            peer(1, Phase::Commit, Some(mine)),
+            peer(2, Phase::Discover, None),
+        ];
+        assert_eq!(
+            classify_peers(mine, &peers),
+            EpochVerdict::Pending(vec![(2, Phase::Discover)])
+        );
+    }
+
+    #[test]
+    fn a_peer_on_a_different_epoch_voids_the_plan() {
+        // The motivating failure: a peer restarted with changed data.
+        let mine = AgreedPlan::from_states(&fleet()).unwrap().epoch();
+        let theirs = other_epoch();
+        let peers = [
+            peer(1, Phase::Commit, Some(mine)),
+            peer(2, Phase::Commit, Some(theirs)),
+        ];
+        assert_eq!(
+            classify_peers(mine, &peers),
+            EpochVerdict::Void(vec![(2, Some(theirs))])
+        );
+    }
+
+    #[test]
+    fn void_takes_precedence_over_pending() {
+        // Fail closed: one peer still arriving must not mask another peer that
+        // has already proven the plan void.
+        let mine = AgreedPlan::from_states(&fleet()).unwrap().epoch();
+        let theirs = other_epoch();
+        let peers = [
+            peer(1, Phase::Discover, None),
+            peer(2, Phase::Commit, Some(theirs)),
+        ];
+        assert_eq!(
+            classify_peers(mine, &peers),
+            EpochVerdict::Void(vec![(2, Some(theirs))])
+        );
+    }
+
+    #[test]
+    fn no_peers_is_pending_not_vacuously_committed() {
+        // A round that saw nobody must never satisfy the commit barrier.
+        let mine = AgreedPlan::from_states(&fleet()).unwrap().epoch();
+        assert_eq!(classify_peers(mine, &[]), EpochVerdict::Pending(Vec::new()));
+    }
+
+    #[test]
+    fn rejoin_condition_is_self_checking() {
+        // The core claim of the peer-memory design. A restarting party rebuilds
+        // its own state from its DB and re-derives the epoch from its peers'
+        // (unchanged) boot snapshots.
+        let original = fleet();
+        let in_flight = AgreedPlan::from_states(&original).unwrap().epoch();
+
+        // Facts unchanged across the restart — converge had no work to do — so
+        // the party reproduces the in-flight epoch and rejoins.
+        let mut rebooted = original.clone();
+        rebooted[0] = state(100, Some("0000000000000010"));
+        assert_eq!(
+            in_flight,
+            AgreedPlan::from_states(&rebooted).unwrap().epoch(),
+            "an unchanged party must reproduce the in-flight epoch"
+        );
+
+        // Facts changed across the restart — converge mutated local state, or the
+        // data really did move — so the epoch differs and the fleet restarts.
+        let mut rebooted = original.clone();
+        rebooted[0] = state(101, Some("0000000000000011"));
+        assert_ne!(
+            in_flight,
+            AgreedPlan::from_states(&rebooted).unwrap().epoch(),
+            "a changed party must not be able to rejoin"
+        );
     }
 
     #[test]

--- a/iris-mpc/src/server/startup_phase.rs
+++ b/iris-mpc/src/server/startup_phase.rs
@@ -1,0 +1,875 @@
+//! Startup phase tracking and the data-derived *epoch* that keys it.
+//!
+//! # Why this exists
+//!
+//! Peer coordination during startup is currently keyed on a random per-boot
+//! UUID: the heartbeat's first-contact check and [`wait_for_others_ready`]
+//! reject any peer whose UUID is outside the startup-verified set. That is the
+//! right policy once a node is serving — MPC session state shared with a
+//! restarted peer is unrecoverable — but during startup it is stricter than
+//! necessary. A peer that bounces while the fleet is still loading forces every
+//! party to restart and re-run the multi-minute DB load, even when nothing about
+//! the data changed.
+//!
+//! The fix is to key startup coordination on the *data* rather than on identity.
+//! An [`Epoch`] is a digest of the whole starting configuration: every party's
+//! DB length, ingest/queue frontier, modifications tail and common config. It is
+//! a deterministic function of the exchanged [`SyncState`]s, so all three
+//! parties derive the identical value with no extra round trip and no leader.
+//! Two consequences follow directly:
+//!
+//! - a peer that restarts and recomputes the same epoch is provably resuming the
+//!   same startup, so it may rejoin and its peers need never restart;
+//! - a peer that comes back with a different `max_persisted_sequence_number`
+//!   (or db length, or modifications tail) yields a different epoch, which is
+//!   exactly the signal that the initial sync is void and the whole fleet must
+//!   restart.
+//!
+//! # Attribution-free canonicalization
+//!
+//! [`SyncState`] carries no party id, and the order in which peers' states are
+//! collected is not something a party can attribute to a slot. So the epoch is
+//! built from the *sorted multiset* of per-party fact digests rather than from a
+//! party-indexed vector. Sorting makes the result independent of collection
+//! order on every party, and a party can still check its own participation by
+//! testing its own digest for membership ([`AgreedPlan::contains`]) — which is
+//! all the rejoin decision needs. Duplicate digests (the common case, where all
+//! three parties are perfectly in sync) are preserved by the multiset, so a
+//! party's facts changing from "same as peers" to "different" still moves the
+//! epoch.
+//!
+//! # Current status: observation only
+//!
+//! Nothing here fails a startup yet. [`StartupStateHandle`] publishes the live
+//! document on [`STARTUP_STATE_ROUTE`] and [`observe_peer_epochs`] logs whether
+//! the parties agree, so epoch determinism can be confirmed on a real cluster
+//! before any teardown decision depends on it. Enforcement (the commit barrier
+//! and the rejoin acceptance path) comes next, and needs the durable per-party
+//! generation counter that [`StartupState::generation`] is reserved for.
+//!
+//! [`wait_for_others_ready`]: ampc_server_utils::wait_for_others_ready
+
+use ampc_server_utils::{try_get_endpoint_other_nodes, ServerCoordinationConfig};
+use axum::routing::get;
+use axum::Router;
+use chrono::{DateTime, Utc};
+use eyre::{bail, Result};
+use iris_mpc_common::config::CommonConfig;
+use iris_mpc_common::helpers::sha256::sha256_bytes;
+use iris_mpc_common::helpers::sync::{Modification, SyncState};
+use serde::de::Error as _;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use sodiumoxide::hex;
+use std::fmt;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::RwLock;
+
+/// Axum path serving the live startup-state document.
+pub const STARTUP_STATE_ROUTE: &str = "/startup-state";
+
+/// The same route as an endpoint name, for
+/// [`try_get_endpoint_other_nodes`]-style peer polling.
+pub const STARTUP_STATE_ENDPOINT: &str = "startup-state";
+
+/// Domain separators. Every digest in this module is tagged so that a byte
+/// string which is valid input to one level of the construction cannot be
+/// reinterpreted at another level.
+const FACTS_DOMAIN: &[u8] = b"iris-mpc/startup-facts/v1";
+const MODIFICATIONS_DOMAIN: &[u8] = b"iris-mpc/startup-modifications/v1";
+const EPOCH_DOMAIN: &[u8] = b"iris-mpc/startup-epoch/v1";
+
+/// Where a node is in its startup sequence.
+///
+/// Published to peers so they can tell "still loading" from "dead" — a
+/// distinction the coordination server cannot express today, since `/health`
+/// answers 200 unconditionally and `/ready` only flips after the load
+/// completes. Variants are ordered, and a node only ever moves forward within
+/// one epoch; going backwards requires a new epoch (and, once enforcement
+/// lands, a bumped generation).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Phase {
+    /// Coordination server up, peers not yet mutually visible.
+    Discover,
+    /// Mutual visibility established; exchanging startup facts.
+    Propose,
+    /// Facts exchanged and an epoch derived from them.
+    Commit,
+    /// Applying the agreed plan to local storage (modifications roll-forward,
+    /// graph WAL, ingest frontier skip-ahead, queue trim).
+    Converge,
+    /// Local-only heavy work: the iris/graph DB load.
+    Load,
+    /// Ready, heartbeat armed, main loop running.
+    Serving,
+}
+
+impl Phase {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Phase::Discover => "discover",
+            Phase::Propose => "propose",
+            Phase::Commit => "commit",
+            Phase::Converge => "converge",
+            Phase::Load => "load",
+            Phase::Serving => "serving",
+        }
+    }
+}
+
+impl fmt::Display for Phase {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A 32-byte SHA-256 digest, carried as a lowercase hex string in JSON so the
+/// document stays greppable in logs and readable with `curl`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Digest([u8; 32]);
+
+impl Digest {
+    fn of(bytes: &[u8]) -> Self {
+        Digest(sha256_bytes(bytes))
+    }
+
+    /// Short form for log lines, where the full 64 hex chars are noise.
+    pub fn short(&self) -> String {
+        hex::encode(&self.0[..6])
+    }
+}
+
+impl fmt::Display for Digest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&hex::encode(self.0))
+    }
+}
+
+impl Serialize for Digest {
+    // Spelled out because `eyre::Result` is in scope for the rest of the module.
+    fn serialize<S: Serializer>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error> {
+        serializer.serialize_str(&hex::encode(self.0))
+    }
+}
+
+impl<'de> Deserialize<'de> for Digest {
+    fn deserialize<D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> std::result::Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        let bytes = hex::decode(&s)
+            .map_err(|_| D::Error::custom(format!("digest is not valid hex: {s}")))?;
+        let bytes: [u8; 32] = bytes.try_into().map_err(|_| {
+            D::Error::custom(format!("digest must be 32 bytes, got {} hex chars", s.len()))
+        })?;
+        Ok(Digest(bytes))
+    }
+}
+
+/// The epoch id: a digest over the sorted multiset of all parties' fact
+/// digests. Distinct from [`Digest`] only in the type system, to keep a facts
+/// digest from being passed where an epoch is expected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct Epoch(Digest);
+
+impl Epoch {
+    pub fn short(&self) -> String {
+        self.0.short()
+    }
+}
+
+impl fmt::Display for Epoch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// One party's startup facts: everything about its local state that the startup
+/// sync reads and that must therefore be identical across a restart for a
+/// rejoin to be safe.
+///
+/// This is a projection of [`SyncState`] and deliberately *not* the whole
+/// struct: `graph_mutation_bytes` is folded into `modifications` (it is
+/// parallel-by-index to it and can be megabytes), and nothing is kept that is
+/// not part of the startup decision.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PartyFacts {
+    pub db_len: u64,
+    pub next_sns_sequence_num: Option<u128>,
+    pub max_persisted_sequence_number: Option<String>,
+    pub common_config: Digest,
+    /// Digest over the modifications tail zipped with its graph WAL entries.
+    pub modifications: Digest,
+}
+
+impl PartyFacts {
+    pub fn from_sync_state(state: &SyncState) -> Self {
+        PartyFacts {
+            db_len: state.db_len,
+            next_sns_sequence_num: state.next_sns_sequence_num,
+            max_persisted_sequence_number: state.max_persisted_sequence_number.clone(),
+            common_config: digest_common_config(&state.common_config),
+            modifications: digest_modifications(&state.modifications, &state.graph_mutation_bytes),
+        }
+    }
+
+    /// Canonical digest of these facts.
+    ///
+    /// Encoded by hand rather than via `serde_json` so the wire format of
+    /// [`SyncState`] can evolve (field renames, `serde(default)` additions)
+    /// without silently changing every epoch. Every variable-length field is
+    /// length-prefixed, so no two distinct fact sets can encode to the same
+    /// bytes by shifting a boundary.
+    pub fn digest(&self) -> Digest {
+        let mut buf = Vec::with_capacity(128);
+        buf.extend_from_slice(FACTS_DOMAIN);
+        buf.extend_from_slice(&self.db_len.to_be_bytes());
+        push_opt_u128(&mut buf, self.next_sns_sequence_num);
+        push_opt_str(&mut buf, self.max_persisted_sequence_number.as_deref());
+        buf.extend_from_slice(&self.common_config.0);
+        buf.extend_from_slice(&self.modifications.0);
+        Digest::of(&buf)
+    }
+}
+
+/// The startup plan every party derives independently from the exchanged
+/// [`SyncState`]s, together with the epoch that identifies it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgreedPlan {
+    /// Per-party fact digests, sorted — a multiset, not a party-indexed vector
+    /// (see the module docs on attribution-free canonicalization).
+    facts: Vec<Digest>,
+    epoch: Epoch,
+}
+
+impl AgreedPlan {
+    /// Derive the plan from all parties' states, including this party's own.
+    ///
+    /// `states` is expected to be [`SyncResult::all_states`], which is
+    /// `[my_state] ++ peers`.
+    ///
+    /// [`SyncResult::all_states`]: iris_mpc_common::helpers::sync::SyncResult
+    pub fn from_states(states: &[SyncState]) -> Result<Self> {
+        if states.len() < 2 {
+            bail!(
+                "cannot derive a startup epoch from {} state(s): the plan is only meaningful over \
+                 the whole fleet",
+                states.len()
+            );
+        }
+        let facts = states
+            .iter()
+            .map(|state| PartyFacts::from_sync_state(state).digest())
+            .collect();
+        Ok(Self::from_fact_digests(facts))
+    }
+
+    fn from_fact_digests(mut facts: Vec<Digest>) -> Self {
+        // Sort so the epoch is independent of the order peers were polled in.
+        facts.sort_unstable();
+
+        let mut buf = Vec::with_capacity(EPOCH_DOMAIN.len() + 8 + facts.len() * 32);
+        buf.extend_from_slice(EPOCH_DOMAIN);
+        // Party count is part of the preimage: a two-party and a three-party
+        // fleet that happen to share a digest prefix must not collide.
+        buf.extend_from_slice(&(facts.len() as u64).to_be_bytes());
+        for digest in &facts {
+            buf.extend_from_slice(&digest.0);
+        }
+
+        AgreedPlan {
+            epoch: Epoch(Digest::of(&buf)),
+            facts,
+        }
+    }
+
+    pub fn epoch(&self) -> Epoch {
+        self.epoch
+    }
+
+    pub fn party_count(&self) -> usize {
+        self.facts.len()
+    }
+
+    /// Whether `facts` is one of the fact sets this plan was built from.
+    ///
+    /// The basis of the future rejoin check: a restarting party recomputes its
+    /// facts from its DB and asks the persisted plan whether they still belong
+    /// to it.
+    pub fn contains(&self, facts: &Digest) -> bool {
+        self.facts.contains(facts)
+    }
+
+    pub fn fact_digests(&self) -> &[Digest] {
+        &self.facts
+    }
+}
+
+/// The single document a node publishes about its own startup.
+///
+/// Consolidates what is spread across `/health`, `/ready` and `/startup-sync`
+/// today, and unlike `/startup-sync` — which serves a `my_state` clone captured
+/// when the coordination server was constructed — it is read live from
+/// [`StartupStateHandle`], so it reflects the node's current phase rather than
+/// its state at boot.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StartupState {
+    pub party_id: usize,
+    /// This incarnation's coordination UUID. Kept for correlation with
+    /// `/health` and the heartbeat; it is deliberately *not* what peers key
+    /// their startup decisions on.
+    ///
+    /// `None` for the brief window before the coordination server is
+    /// constructed, since the UUID is minted inside it while this route has to
+    /// be handed to it — correlation-only data, so it is not worth inverting
+    /// that ordering upstream.
+    pub uuid: Option<String>,
+    /// Durable, monotonic per party: bumped whenever a party abandons an epoch,
+    /// so a stale document from a previous attempt cannot be mistaken for the
+    /// current one (the ABA guard). Always 0 until the epoch record is
+    /// persisted, which enforcement will add.
+    pub generation: u64,
+    pub phase: Phase,
+    pub phase_started_at: DateTime<Utc>,
+    /// Digest of this party's own facts, known from the moment its
+    /// [`SyncState`] is built — i.e. before any peer has been contacted.
+    pub facts: Digest,
+    /// `None` until the facts exchange completes and the epoch is derived.
+    pub epoch: Option<Epoch>,
+}
+
+/// Live, shared handle to this node's [`StartupState`]; the write side of
+/// [`STARTUP_STATE_ROUTE`].
+#[derive(Debug, Clone)]
+pub struct StartupStateHandle {
+    state: Arc<RwLock<StartupState>>,
+}
+
+impl StartupStateHandle {
+    /// Create the handle in [`Phase::Discover`].
+    ///
+    /// Must be called before the coordination server starts, since its router
+    /// is passed in as an extra route; the UUID it mints arrives afterwards via
+    /// [`StartupStateHandle::set_uuid`].
+    pub fn new(party_id: usize, facts: Digest) -> Self {
+        StartupStateHandle {
+            state: Arc::new(RwLock::new(StartupState {
+                party_id,
+                uuid: None,
+                generation: 0,
+                phase: Phase::Discover,
+                phase_started_at: Utc::now(),
+                facts,
+                epoch: None,
+            })),
+        }
+    }
+
+    /// Router to hand to `start_coordination_server_with_extra_routes`.
+    ///
+    /// Always answers 200: the document is meaningful in every phase, and a
+    /// pre-agreement node is described by `epoch: null` rather than by an error
+    /// status. Peers distinguish the cases by reading the fields.
+    pub fn router(&self) -> Router {
+        let state = Arc::clone(&self.state);
+        Router::new().route(
+            STARTUP_STATE_ROUTE,
+            get(move || {
+                let state = Arc::clone(&state);
+                async move {
+                    let snapshot = state.read().await.clone();
+                    serde_json::to_string(&snapshot)
+                        .expect("StartupState serialization to JSON failed")
+                }
+            }),
+        )
+    }
+
+    pub async fn snapshot(&self) -> StartupState {
+        self.state.read().await.clone()
+    }
+
+    /// Record the coordination UUID once the coordination server has minted it.
+    pub async fn set_uuid(&self, uuid: String) {
+        self.state.write().await.uuid = Some(uuid);
+    }
+
+    /// Advance to `phase`, logging the transition and the time the previous
+    /// phase took.
+    ///
+    /// A backwards transition is logged as an error rather than rejected: while
+    /// this module is observation-only, a wrong phase label must not be able to
+    /// fail a startup that would otherwise have succeeded.
+    pub async fn enter(&self, phase: Phase) {
+        let now = Utc::now();
+        let mut state = self.state.write().await;
+        let previous = state.phase;
+        let elapsed = now.signed_duration_since(state.phase_started_at);
+
+        if phase < previous {
+            tracing::error!(
+                "Startup phase moved backwards: {} -> {} (epoch {:?})",
+                previous,
+                phase,
+                state.epoch.map(|e| e.short())
+            );
+        }
+
+        state.phase = phase;
+        state.phase_started_at = now;
+        drop(state);
+
+        tracing::info!(
+            "Startup phase {} -> {} (previous phase took {}s)",
+            previous,
+            phase,
+            elapsed.num_seconds()
+        );
+        metrics::counter!("startup_phase_entered", "phase" => phase.as_str()).increment(1);
+    }
+
+    /// Record the derived epoch. Called once, on entering [`Phase::Commit`].
+    pub async fn set_epoch(&self, epoch: Epoch) {
+        let mut state = self.state.write().await;
+        if let Some(previous) = state.epoch {
+            if previous != epoch {
+                tracing::error!(
+                    "Startup epoch changed within one boot: {} -> {}",
+                    previous,
+                    epoch
+                );
+            }
+        }
+        state.epoch = Some(epoch);
+    }
+}
+
+/// Poll peers' startup-state documents and report whether they derived the same
+/// epoch.
+///
+/// Observation only: every outcome — disagreement, unreachable peer, timeout —
+/// is logged and counted, never returned as an error. The point is to confirm
+/// on a live cluster that the canonicalization really is deterministic across
+/// parties before anything is allowed to fail on it.
+pub async fn observe_peer_epochs(
+    config: &ServerCoordinationConfig,
+    my_epoch: Epoch,
+    budget: Duration,
+    retry_delay: Duration,
+) {
+    let deadline = Instant::now() + budget;
+
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            tracing::warn!(
+                "Could not confirm peer startup epochs within {:?}; proceeding (observation only)",
+                budget
+            );
+            metrics::counter!("startup_epoch_observation_timeout").increment(1);
+            return;
+        }
+
+        // `try_get_endpoint_other_nodes` retries internally against its own
+        // `startup_sync_timeout_secs` budget, which is unrelated to ours, so
+        // cap it here rather than inheriting it.
+        let responses = match tokio::time::timeout(
+            remaining,
+            try_get_endpoint_other_nodes(config, STARTUP_STATE_ENDPOINT),
+        )
+        .await
+        {
+            Ok(Ok(responses)) => responses,
+            Ok(Err(err)) => {
+                tracing::warn!("Failed to poll peer startup state: {:?}", err);
+                tokio::time::sleep(retry_delay.min(remaining)).await;
+                continue;
+            }
+            Err(_) => continue, // deadline hit; handled at the top of the loop
+        };
+
+        let mut peers = Vec::with_capacity(responses.len());
+        for (status, body) in responses {
+            match serde_json::from_slice::<StartupState>(&body) {
+                Ok(state) => peers.push(state),
+                Err(err) => {
+                    tracing::warn!(
+                        "Failed to deserialize peer startup state (status {}): {:?}",
+                        status,
+                        err
+                    );
+                }
+            }
+        }
+
+        // A peer that has not reached Commit yet has no epoch to compare;
+        // that is expected, since the three parties get here independently.
+        let pending: Vec<_> = peers
+            .iter()
+            .filter(|peer| peer.epoch.is_none())
+            .map(|peer| (peer.party_id, peer.phase))
+            .collect();
+
+        if !pending.is_empty() {
+            tracing::debug!("Peers have not derived an epoch yet: {:?}", pending);
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            tokio::time::sleep(retry_delay.min(remaining)).await;
+            continue;
+        }
+
+        let disagreeing: Vec<_> = peers
+            .iter()
+            .filter(|peer| peer.epoch != Some(my_epoch))
+            .map(|peer| {
+                (
+                    peer.party_id,
+                    peer.epoch.map(|e| e.to_string()),
+                    peer.facts.short(),
+                )
+            })
+            .collect();
+
+        if disagreeing.is_empty() {
+            tracing::info!(
+                "Startup epoch {} agreed by all {} parties",
+                my_epoch,
+                peers.len() + 1
+            );
+            metrics::counter!("startup_epoch_agreement").increment(1);
+        } else {
+            // Under enforcement this is the "initial sync is void, restart the
+            // fleet" trigger. For now it is loud but harmless.
+            tracing::error!(
+                "Startup epoch MISMATCH: mine is {}, peers report {:?}. Under enforcement this \
+                 would void the epoch and restart the fleet.",
+                my_epoch,
+                disagreeing
+            );
+            metrics::counter!("startup_epoch_mismatch").increment(1);
+        }
+        return;
+    }
+}
+
+fn digest_common_config(config: &CommonConfig) -> Digest {
+    // `CommonConfig` is all scalars, `Vec`s and `Option`s — no maps — so
+    // `serde_json` field order is the declaration order and the encoding is
+    // deterministic. It is also already compared field-by-field across parties
+    // by `SyncResult::check_common_config`, so any difference the digest sees
+    // is a difference that check would reject anyway.
+    let bytes = serde_json::to_vec(config).expect("CommonConfig serialization to JSON failed");
+    Digest::of(&bytes)
+}
+
+/// Digest the modifications tail together with its graph WAL entries.
+///
+/// `graph_mutation_bytes` is parallel-by-index to `modifications`, so the two
+/// are zipped before being sorted by modification id — canonicalizing the order
+/// without breaking the pairing. Mutation blobs are folded in by digest rather
+/// than by value: they are large, and only their identity matters here.
+fn digest_modifications(
+    modifications: &[Modification],
+    graph_mutation_bytes: &[Option<Vec<u8>>],
+) -> Digest {
+    let mut rows: Vec<(&Modification, Option<&Vec<u8>>)> = modifications
+        .iter()
+        .enumerate()
+        .map(|(i, m)| (m, graph_mutation_bytes.get(i).and_then(Option::as_ref)))
+        .collect();
+    rows.sort_unstable_by_key(|(m, _)| m.id);
+
+    let mut buf = Vec::with_capacity(MODIFICATIONS_DOMAIN.len() + 8 + rows.len() * 96);
+    buf.extend_from_slice(MODIFICATIONS_DOMAIN);
+    buf.extend_from_slice(&(rows.len() as u64).to_be_bytes());
+    for (modification, mutation) in rows {
+        buf.extend_from_slice(&modification.id.to_be_bytes());
+        push_opt_i64(&mut buf, modification.serial_id);
+        push_str(&mut buf, &modification.request_type);
+        push_opt_str(&mut buf, modification.s3_url.as_deref());
+        push_str(&mut buf, &modification.status);
+        buf.push(u8::from(modification.persisted));
+        push_opt_str(&mut buf, modification.result_message_body.as_deref());
+        match mutation {
+            Some(bytes) => {
+                buf.push(1);
+                buf.extend_from_slice(&sha256_bytes(bytes));
+            }
+            None => buf.push(0),
+        }
+    }
+    Digest::of(&buf)
+}
+
+// Canonical encoding helpers. Every variable-length value is length-prefixed
+// and every optional value is tagged, so distinct inputs cannot share an
+// encoding by shifting a field boundary.
+
+fn push_str(buf: &mut Vec<u8>, value: &str) {
+    buf.extend_from_slice(&(value.len() as u64).to_be_bytes());
+    buf.extend_from_slice(value.as_bytes());
+}
+
+fn push_opt_str(buf: &mut Vec<u8>, value: Option<&str>) {
+    match value {
+        Some(value) => {
+            buf.push(1);
+            push_str(buf, value);
+        }
+        None => buf.push(0),
+    }
+}
+
+fn push_opt_i64(buf: &mut Vec<u8>, value: Option<i64>) {
+    match value {
+        Some(value) => {
+            buf.push(1);
+            buf.extend_from_slice(&value.to_be_bytes());
+        }
+        None => buf.push(0),
+    }
+}
+
+fn push_opt_u128(buf: &mut Vec<u8>, value: Option<u128>) {
+    match value {
+        Some(value) => {
+            buf.push(1);
+            buf.extend_from_slice(&value.to_be_bytes());
+        }
+        None => buf.push(0),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn modification(id: i64, status: &str) -> Modification {
+        Modification {
+            id,
+            serial_id: Some(id * 10),
+            request_type: "uniqueness".to_string(),
+            s3_url: Some(format!("s3://bucket/{id}")),
+            status: status.to_string(),
+            persisted: true,
+            result_message_body: None,
+        }
+    }
+
+    fn state(db_len: u64, max_persisted: Option<&str>) -> SyncState {
+        SyncState {
+            db_len,
+            modifications: vec![modification(1, "COMPLETED"), modification(2, "IN_PROGRESS")],
+            next_sns_sequence_num: Some(42),
+            common_config: CommonConfig::default(),
+            graph_mutation_bytes: vec![Some(vec![0xab; 16]), None],
+            max_persisted_sequence_number: max_persisted.map(str::to_string),
+        }
+    }
+
+    fn fleet() -> Vec<SyncState> {
+        vec![
+            state(100, Some("0000000000000010")),
+            state(100, Some("0000000000000010")),
+            state(100, Some("0000000000000009")),
+        ]
+    }
+
+    #[test]
+    fn epoch_is_independent_of_collection_order() {
+        // The whole design rests on this: each party polls its peers in its own
+        // order, yet all must derive the same epoch with no extra round trip.
+        let baseline = AgreedPlan::from_states(&fleet()).unwrap();
+
+        let mut rotated = fleet();
+        rotated.rotate_left(1);
+        assert_eq!(
+            baseline.epoch(),
+            AgreedPlan::from_states(&rotated).unwrap().epoch()
+        );
+
+        let mut reversed = fleet();
+        reversed.reverse();
+        assert_eq!(
+            baseline.epoch(),
+            AgreedPlan::from_states(&reversed).unwrap().epoch()
+        );
+    }
+
+    #[test]
+    fn epoch_changes_when_any_party_fact_changes() {
+        let baseline = AgreedPlan::from_states(&fleet()).unwrap().epoch();
+
+        // The motivating case: a peer restarts and comes back with a different
+        // persisted frontier. That must void the epoch.
+        let mut changed = fleet();
+        changed[2].max_persisted_sequence_number = Some("0000000000000011".to_string());
+        assert_ne!(
+            baseline,
+            AgreedPlan::from_states(&changed).unwrap().epoch(),
+            "a changed persisted frontier must change the epoch"
+        );
+
+        let mut changed = fleet();
+        changed[0].db_len += 1;
+        assert_ne!(baseline, AgreedPlan::from_states(&changed).unwrap().epoch());
+
+        let mut changed = fleet();
+        changed[1].modifications[0].status = "COMPLETED_WITH_ERROR".to_string();
+        assert_ne!(baseline, AgreedPlan::from_states(&changed).unwrap().epoch());
+
+        let mut changed = fleet();
+        changed[1].modifications[0].persisted = false;
+        assert_ne!(baseline, AgreedPlan::from_states(&changed).unwrap().epoch());
+
+        let mut changed = fleet();
+        changed[1].next_sns_sequence_num = None;
+        assert_ne!(baseline, AgreedPlan::from_states(&changed).unwrap().epoch());
+
+        let mut changed = fleet();
+        changed[0].graph_mutation_bytes = vec![Some(vec![0xcd; 16]), None];
+        assert_ne!(baseline, AgreedPlan::from_states(&changed).unwrap().epoch());
+    }
+
+    #[test]
+    fn duplicate_facts_are_kept_as_a_multiset() {
+        // Two parties in sync and one behind must not hash the same as three
+        // parties in sync: collapsing duplicates would erase the difference.
+        let two_agree = AgreedPlan::from_states(&fleet()).unwrap();
+        assert_eq!(two_agree.party_count(), 3);
+
+        let all_agree = vec![
+            state(100, Some("0000000000000010")),
+            state(100, Some("0000000000000010")),
+            state(100, Some("0000000000000010")),
+        ];
+        assert_ne!(
+            two_agree.epoch(),
+            AgreedPlan::from_states(&all_agree).unwrap().epoch()
+        );
+    }
+
+    #[test]
+    fn every_party_finds_its_own_facts_in_the_plan() {
+        // The rejoin check: recompute my facts, ask the plan if I belong.
+        let states = fleet();
+        let plan = AgreedPlan::from_states(&states).unwrap();
+        for state in &states {
+            assert!(plan.contains(&PartyFacts::from_sync_state(state).digest()));
+        }
+
+        let mut stranger = state(100, Some("0000000000000010"));
+        stranger.db_len = 999;
+        assert!(!plan.contains(&PartyFacts::from_sync_state(&stranger).digest()));
+    }
+
+    #[test]
+    fn party_count_is_part_of_the_epoch() {
+        let states = fleet();
+        let three = AgreedPlan::from_states(&states).unwrap();
+        let two = AgreedPlan::from_states(&states[..2]).unwrap();
+        assert_ne!(three.epoch(), two.epoch());
+    }
+
+    #[test]
+    fn a_single_state_cannot_form_a_plan() {
+        assert!(AgreedPlan::from_states(&fleet()[..1]).is_err());
+    }
+
+    #[test]
+    fn field_boundaries_are_unambiguous() {
+        // Length prefixes must stop adjacent string fields from being shifted
+        // into one another without changing the digest.
+        let mut a = state(1, None);
+        a.modifications[0].request_type = "ab".to_string();
+        a.modifications[0].status = "cd".to_string();
+
+        let mut b = state(1, None);
+        b.modifications[0].request_type = "abc".to_string();
+        b.modifications[0].status = "d".to_string();
+
+        assert_ne!(
+            PartyFacts::from_sync_state(&a).digest(),
+            PartyFacts::from_sync_state(&b).digest()
+        );
+    }
+
+    #[test]
+    fn modification_order_does_not_affect_the_digest() {
+        // `last_modifications` order is not a contract; the pairing with
+        // `graph_mutation_bytes` is.
+        let forward = state(100, None);
+        let mut reversed = forward.clone();
+        reversed.modifications.reverse();
+        reversed.graph_mutation_bytes.reverse();
+
+        assert_eq!(
+            PartyFacts::from_sync_state(&forward).digest(),
+            PartyFacts::from_sync_state(&reversed).digest()
+        );
+    }
+
+    #[test]
+    fn mispaired_graph_mutations_change_the_digest() {
+        // Reversing the modifications without reversing their WAL entries
+        // re-pairs them, which is a real divergence and must be visible.
+        let forward = state(100, None);
+        let mut mispaired = forward.clone();
+        mispaired.modifications.reverse();
+
+        assert_ne!(
+            PartyFacts::from_sync_state(&forward).digest(),
+            PartyFacts::from_sync_state(&mispaired).digest()
+        );
+    }
+
+    #[test]
+    fn digest_survives_a_json_round_trip() {
+        let plan = AgreedPlan::from_states(&fleet()).unwrap();
+        let json = serde_json::to_string(&plan).unwrap();
+        let parsed: AgreedPlan = serde_json::from_str(&json).unwrap();
+        assert_eq!(plan, parsed);
+        assert_eq!(plan.epoch(), parsed.epoch());
+    }
+
+    #[tokio::test]
+    async fn published_document_tracks_phase_and_epoch() {
+        let facts = PartyFacts::from_sync_state(&state(100, None)).digest();
+        let handle = StartupStateHandle::new(1, facts);
+
+        let initial = handle.snapshot().await;
+        assert_eq!(initial.phase, Phase::Discover);
+        assert!(initial.epoch.is_none());
+        assert!(initial.uuid.is_none());
+        assert_eq!(initial.facts, facts);
+
+        handle.set_uuid("uuid-1".to_string()).await;
+
+        let epoch = AgreedPlan::from_states(&fleet()).unwrap().epoch();
+        handle.enter(Phase::Propose).await;
+        handle.enter(Phase::Commit).await;
+        handle.set_epoch(epoch).await;
+
+        let committed = handle.snapshot().await;
+        assert_eq!(committed.phase, Phase::Commit);
+        assert_eq!(committed.epoch, Some(epoch));
+
+        // The document must survive the wire: peers parse exactly this.
+        let json = serde_json::to_string(&committed).unwrap();
+        let parsed: StartupState = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.epoch, Some(epoch));
+        assert_eq!(parsed.phase, Phase::Commit);
+        assert_eq!(parsed.party_id, 1);
+        assert_eq!(parsed.generation, 0);
+        assert_eq!(parsed.uuid.as_deref(), Some("uuid-1"));
+    }
+
+    #[test]
+    fn phases_are_ordered_by_progress() {
+        assert!(Phase::Discover < Phase::Propose);
+        assert!(Phase::Propose < Phase::Commit);
+        assert!(Phase::Commit < Phase::Converge);
+        assert!(Phase::Converge < Phase::Load);
+        assert!(Phase::Load < Phase::Serving);
+    }
+}

--- a/iris-mpc/src/server/startup_phase.rs
+++ b/iris-mpc/src/server/startup_phase.rs
@@ -1,7 +1,7 @@
 //! Startup phase tracking and the data-derived [`SyncStateDigest`] that keys it.
 //!
 //! Peer coordination during startup is keyed on a random per-boot UUID: the
-//! heartbeat's first-contact check and [`wait_for_others_ready`] reject any peer
+//! heartbeat's first-contact check and `wait_for_others_ready` reject any peer
 //! whose UUID is outside the startup-verified set. That is the right policy once
 //! a node is serving — MPC session state shared with a restarted peer is
 //! unrecoverable — but during startup it forces every party to restart and re-run

--- a/iris-mpc/src/server/startup_phase.rs
+++ b/iris-mpc/src/server/startup_phase.rs
@@ -68,15 +68,14 @@ use ampc_server_utils::{get_check_addresses, ServerCoordinationConfig};
 use axum::routing::get;
 use axum::Router;
 use chrono::{DateTime, Utc};
-use eyre::{bail, eyre, Result};
+use eyre::{bail, Result};
 use iris_mpc_common::config::CommonConfig;
 use iris_mpc_common::helpers::sha256::sha256_bytes;
 use iris_mpc_common::helpers::sync::{Modification, SyncState};
-use serde::de::Error as _;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 use sodiumoxide::hex;
 use std::collections::HashSet;
-use std::fmt;
 use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 use tokio::sync::{Mutex, RwLock};
@@ -102,8 +101,21 @@ const EPOCH_DOMAIN: &[u8] = b"iris-mpc/startup-epoch/v1";
 /// distinction the coordination server cannot express today, since `/health`
 /// answers 200 unconditionally and `/ready` only flips after the load completes.
 /// Ordered by progress: a node only ever moves forward within one epoch.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    derive_more::FromStr,
+    derive_more::Display,
+)]
+#[display(rename_all = "lowercase")]
+#[from_str(rename_all = "lowercase")]
 pub enum Phase {
     /// Coordination server up, peers not yet mutually visible.
     Discover,
@@ -124,9 +136,9 @@ pub enum Phase {
     Serving,
 }
 
+#[cfg(test)]
 impl Phase {
-    /// Every variant, in progress order.
-    pub const ALL: [Phase; 6] = [
+    const ALL: &'static [Phase] = &[
         Phase::Discover,
         Phase::Propose,
         Phase::Commit,
@@ -134,41 +146,27 @@ impl Phase {
         Phase::Load,
         Phase::Serving,
     ];
-
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Phase::Discover => "discover",
-            Phase::Propose => "propose",
-            Phase::Commit => "commit",
-            Phase::Converge => "converge",
-            Phase::Load => "load",
-            Phase::Serving => "serving",
-        }
-    }
-}
-
-impl fmt::Display for Phase {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
-
-/// Inverse of [`Phase::as_str`], for `startup_hold_at_phase`.
-impl std::str::FromStr for Phase {
-    type Err = eyre::Report;
-
-    fn from_str(value: &str) -> Result<Self> {
-        Phase::ALL
-            .into_iter()
-            .find(|phase| phase.as_str() == value)
-            .ok_or_else(|| eyre!("unknown startup phase {value:?}"))
-    }
 }
 
 /// A 32-byte SHA-256 digest, carried as a lowercase hex string in JSON so the
 /// document stays greppable in logs and readable with `curl`.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Digest([u8; 32]);
+#[derive(
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    derive_more::Debug,
+    derive_more::Display,
+)]
+#[serde_as]
+#[display("{}", hex::encode(_0))] // _0 accesses the inner [u8; 32]
+#[debug("{self}")] // Delegates Debug directly to Display
+pub struct Digest(#[serde_as(as = "Hex")] [u8; 32]);
 
 impl Digest {
     fn of(bytes: &[u8]) -> Self {
@@ -181,57 +179,28 @@ impl Digest {
     }
 }
 
-impl fmt::Debug for Digest {
-    // Hex rather than the derived byte array, so `{:?}` on anything containing a
-    // digest stays readable in errors and logs.
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{self}")
-    }
-}
-
-impl fmt::Display for Digest {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&hex::encode(self.0))
-    }
-}
-
-impl Serialize for Digest {
-    // Spelled out because `eyre::Result` is in scope for the rest of the module.
-    fn serialize<S: Serializer>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error> {
-        serializer.serialize_str(&hex::encode(self.0))
-    }
-}
-
-impl<'de> Deserialize<'de> for Digest {
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
-        let s = String::deserialize(deserializer)?;
-        let bytes = hex::decode(&s)
-            .map_err(|_| D::Error::custom(format!("digest is not valid hex: {s}")))?;
-        let bytes: [u8; 32] = bytes.try_into().map_err(|_| {
-            D::Error::custom(format!(
-                "digest must be 32 bytes, got {} hex chars",
-                s.len()
-            ))
-        })?;
-        Ok(Digest(bytes))
-    }
-}
-
 /// The epoch id: a digest over the sorted multiset of all parties' fact
 /// digests. Distinct from [`Digest`] only in the type system, to keep a facts
 /// digest from being passed where an epoch is expected.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    derive_more::Display,
+)]
+#[display("{}", _0)]
 pub struct Epoch(Digest);
 
 impl Epoch {
     pub fn short(&self) -> String {
         self.0.short()
-    }
-}
-
-impl fmt::Display for Epoch {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self.0, f)
     }
 }
 
@@ -400,7 +369,7 @@ impl StartupStateHandle {
             phase,
             elapsed.num_seconds()
         );
-        metrics::counter!("startup_phase_entered", "phase" => phase.as_str()).increment(1);
+        metrics::counter!("startup_phase_entered", "phase" => phase.to_string()).increment(1);
 
         if self.hold_at == Some(phase) {
             tracing::warn!(
@@ -1032,8 +1001,8 @@ mod tests {
     fn phase_names_round_trip() {
         // `startup_hold_at_phase` is matched against `as_str`, so the two
         // directions must not drift apart.
-        for phase in Phase::ALL {
-            assert_eq!(phase.as_str().parse::<Phase>().unwrap(), phase);
+        for &phase in Phase::ALL {
+            assert_eq!(phase.to_string().parse::<Phase>().unwrap(), phase);
         }
         assert!("laod".parse::<Phase>().is_err());
     }

--- a/iris-mpc/src/server/startup_phase.rs
+++ b/iris-mpc/src/server/startup_phase.rs
@@ -187,6 +187,23 @@ impl fmt::Display for Phase {
     }
 }
 
+/// Inverse of [`Phase::as_str`], for `startup_hold_at_phase`.
+impl std::str::FromStr for Phase {
+    type Err = eyre::Report;
+
+    fn from_str(value: &str) -> Result<Self> {
+        match value {
+            "discover" => Ok(Phase::Discover),
+            "propose" => Ok(Phase::Propose),
+            "commit" => Ok(Phase::Commit),
+            "converge" => Ok(Phase::Converge),
+            "load" => Ok(Phase::Load),
+            "serving" => Ok(Phase::Serving),
+            other => bail!("unknown startup phase {other:?}"),
+        }
+    }
+}
+
 /// A 32-byte SHA-256 digest, carried as a lowercase hex string in JSON so the
 /// document stays greppable in logs and readable with `curl`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -411,6 +428,9 @@ pub struct StartupState {
 #[derive(Debug, Clone)]
 pub struct StartupStateHandle {
     state: Arc<RwLock<StartupState>>,
+    /// Test hook from `Config::startup_hold_at_phase`; see
+    /// [`StartupStateHandle::with_hold_at`].
+    hold_at: Option<Phase>,
 }
 
 impl StartupStateHandle {
@@ -430,7 +450,22 @@ impl StartupStateHandle {
                 facts,
                 epoch: None,
             })),
+            hold_at: None,
         }
+    }
+
+    /// Park this party forever once it has entered `phase`.
+    ///
+    /// The park happens *after* the phase (and, for [`Phase::Commit`], the
+    /// epoch) is published and the state lock is released, so peers and the
+    /// coordination server keep seeing a node that is legitimately sitting in
+    /// that phase — which is precisely the state an e2e test wants to kill.
+    ///
+    /// Test-only, driven by `Config::startup_hold_at_phase`. `None` in every
+    /// production path.
+    pub fn with_hold_at(mut self, phase: Option<Phase>) -> Self {
+        self.hold_at = phase;
+        self
     }
 
     /// Router to hand to `start_coordination_server_with_extra_routes`.
@@ -494,6 +529,14 @@ impl StartupStateHandle {
             elapsed.num_seconds()
         );
         metrics::counter!("startup_phase_entered", "phase" => phase.as_str()).increment(1);
+
+        if self.hold_at == Some(phase) {
+            tracing::warn!(
+                "startup_hold_at_phase={phase}: parking in this phase indefinitely. This is a \
+                 test hook — the node will not start."
+            );
+            std::future::pending::<()>().await;
+        }
     }
 
     /// Record the derived epoch. Called once, on entering [`Phase::Commit`].
@@ -1198,6 +1241,52 @@ mod tests {
         let parsed: AgreedPlan = serde_json::from_str(&json).unwrap();
         assert_eq!(plan, parsed);
         assert_eq!(plan.epoch(), parsed.epoch());
+    }
+
+    #[test]
+    fn phase_names_round_trip() {
+        // `startup_hold_at_phase` is matched against `as_str`, so the two
+        // directions must not drift apart.
+        for phase in [
+            Phase::Discover,
+            Phase::Propose,
+            Phase::Commit,
+            Phase::Converge,
+            Phase::Load,
+            Phase::Serving,
+        ] {
+            assert_eq!(phase.as_str().parse::<Phase>().unwrap(), phase);
+        }
+        assert!("laod".parse::<Phase>().is_err());
+    }
+
+    #[tokio::test]
+    async fn a_hold_publishes_its_phase_before_parking() {
+        // The whole point of the hook: peers must see a party legitimately
+        // sitting in the held phase, so `enter` has to publish before it parks.
+        let facts = PartyFacts::from_sync_state(&state(100, None)).digest();
+        let handle = StartupStateHandle::new(1, facts).with_hold_at(Some(Phase::Propose));
+
+        let entering = tokio::spawn({
+            let handle = handle.clone();
+            async move { handle.enter(Phase::Propose).await }
+        });
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while handle.snapshot().await.phase != Phase::Propose {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("held phase never became visible");
+
+        assert!(!entering.is_finished(), "enter returned instead of parking");
+        entering.abort();
+
+        // A phase that is not the held one still advances normally.
+        let handle = StartupStateHandle::new(1, facts).with_hold_at(Some(Phase::Load));
+        handle.enter(Phase::Propose).await;
+        assert_eq!(handle.snapshot().await.phase, Phase::Propose);
     }
 
     #[tokio::test]

--- a/iris-mpc/src/server/startup_phase.rs
+++ b/iris-mpc/src/server/startup_phase.rs
@@ -2,106 +2,64 @@
 //!
 //! # Why this exists
 //!
-//! Peer coordination during startup is currently keyed on a random per-boot
-//! UUID: the heartbeat's first-contact check and [`wait_for_others_ready`]
-//! reject any peer whose UUID is outside the startup-verified set. That is the
-//! right policy once a node is serving — MPC session state shared with a
-//! restarted peer is unrecoverable — but during startup it is stricter than
-//! necessary. A peer that bounces while the fleet is still loading forces every
-//! party to restart and re-run the multi-minute DB load, even when nothing about
-//! the data changed.
+//! Peer coordination during startup is keyed on a random per-boot UUID: the
+//! heartbeat's first-contact check and [`wait_for_others_ready`] reject any peer
+//! whose UUID is outside the startup-verified set. That is the right policy once
+//! a node is serving — MPC session state shared with a restarted peer is
+//! unrecoverable — but during startup it forces every party to restart and re-run
+//! the multi-minute DB load whenever one peer bounces, even with the data
+//! unchanged.
 //!
-//! The fix is to key startup coordination on the *data* rather than on identity.
-//! An [`Epoch`] is a digest of the whole starting configuration: every party's
-//! DB length, ingest/queue frontier, modifications tail and common config. It is
-//! a deterministic function of the exchanged [`SyncState`]s, so all three
-//! parties derive the identical value with no extra round trip and no leader.
-//! Two consequences follow directly:
+//! So startup coordination is keyed on the *data* instead. An [`Epoch`] is a
+//! digest of the whole starting configuration: every party's DB length,
+//! ingest/queue frontier, modifications tail and common config. It is a
+//! deterministic function of the exchanged [`SyncState`]s, so all parties derive
+//! it with no extra round trip and no leader. A peer that restarts and recomputes
+//! the same epoch is provably resuming the same startup and may rejoin; one that
+//! comes back with different facts derives a different epoch, which is exactly
+//! the signal that the initial sync is void and the whole fleet must restart.
 //!
-//! - a peer that restarts and recomputes the same epoch is provably resuming the
-//!   same startup, so it may rejoin and its peers need never restart;
-//! - a peer that comes back with a different `max_persisted_sequence_number`
-//!   (or db length, or modifications tail) yields a different epoch, which is
-//!   exactly the signal that the initial sync is void and the whole fleet must
-//!   restart.
-//!
-//! # Attribution-free canonicalization
-//!
-//! [`SyncState`] carries no party id, and the order in which peers' states are
-//! collected is not something a party can attribute to a slot. So the epoch is
-//! built from the *sorted multiset* of per-party fact digests rather than from a
-//! party-indexed vector. Sorting makes the result independent of collection
-//! order on every party, and a party can still check its own participation by
-//! testing its own digest for membership ([`AgreedPlan::contains`]) — which is
-//! all the rejoin decision needs. Duplicate digests (the common case, where all
-//! three parties are perfectly in sync) are preserved by the multiset, so a
-//! party's facts changing from "same as peers" to "different" still moves the
-//! epoch.
+//! [`SyncState`] carries no party id and peers are polled in an arbitrary order,
+//! so the epoch digests the *sorted multiset* of per-party fact digests rather
+//! than a party-indexed vector. Duplicates are preserved, so a party's facts
+//! changing from "same as peers" to "different" still moves the epoch.
 //!
 //! # The surviving peers are the durable record
 //!
-//! There is deliberately no persisted epoch table. The authority on "which
-//! startup is in progress" is the set of peers still running it, held in their
-//! live [`StartupStateHandle`]s and served on [`STARTUP_STATE_ROUTE`]. A
-//! restarting party does not read a local record and try to prove it still
-//! matches; it simply rebuilds its [`SyncState`] from its DB and re-derives the
-//! epoch from its peers' boot snapshots. It reproduces the in-flight epoch
-//! **exactly when its own facts are unchanged**, so the rejoin condition checks
-//! itself — no durable state, no schema migration, and no generation counter to
-//! guard against stale records, because in-process state cannot go stale.
+//! There is deliberately no persisted epoch table. The authority on which startup
+//! is in progress is the set of peers still running it, published on
+//! [`STARTUP_STATE_ROUTE`] from their live [`StartupStateHandle`]s. A restarting
+//! party rebuilds its [`SyncState`] from its DB and re-derives the epoch from its
+//! peers' boot snapshots; it reproduces the in-flight epoch **exactly when its own
+//! facts are unchanged**, so the rejoin condition checks itself — no durable
+//! state, no migration, no staleness guard. If every party restarts at once there
+//! is no epoch to rejoin and all three derive a fresh one, which is the correct
+//! outcome rather than a degradation.
 //!
-//! If every party restarts at once there is no epoch to rejoin, and all three
-//! derive a fresh one from current data. That is the correct outcome, not a
-//! degradation.
+//! # What rejoin covers
 //!
-//! # What rejoin covers, and what it does not
-//!
-//! Rejoin works whenever the restarting party's facts are unchanged. That covers
+//! Rejoin works whenever the restarting party's facts are unchanged, which covers
 //! the whole [`Phase::Load`] window — the long one, and the reason any of this
-//! exists — provided [`Phase::Converge`] had no work to do, which is the normal
-//! case for a healthy fleet: nothing to roll forward, no rows to skip ahead.
+//! exists — provided [`Phase::Converge`] had no work to do, the normal case for a
+//! healthy fleet.
 //!
-//! It does not cover a restart *after* a converge that actually mutated local
-//! state. Such a party recomputes different facts, derives a different epoch, and
-//! the fleet restarts. Two consequences worth knowing:
+//! It does not cover a restart after a converge that actually mutated local
+//! state: such a party recomputes different facts and the fleet restarts, exactly
+//! as it does today unconditionally. So the crash-recovery boot, the one where
+//! converge has real work, is also the one that cannot rejoin. Same for
+//! `next_sns_sequence_num` with `db_backed_ingest` disabled, where it is a live
+//! SQS queue head that the converge-phase trim moves.
 //!
-//! - the crash-recovery boot — the one where converge has real work — is also
-//!   the one that cannot rejoin, so it behaves exactly as it does today;
-//! - with `db_backed_ingest` disabled, `next_sns_sequence_num` is a live SQS
-//!   queue head that the converge-phase queue trim moves, so rejoin after
-//!   converge is unavailable on that path for the same reason.
-//!
-//! Both fall back to a full-fleet restart, which is what happens today
-//! unconditionally. Nothing gets worse; the common case gets much better.
-//!
-//! Extending rejoin to a mutated converge means predicting each party's
-//! post-converge facts and pinning them in the plan — real work, and only worth
-//! doing if the crash-during-converge window turns out to matter in practice.
-//!
-//! # Why an unchanged epoch also means converge is safe to replay
-//!
-//! A rejoining party re-runs its own converge, so replay has to be harmless. It
-//! is, and not by luck: the facts projection was chosen to *see* every
-//! converge-phase mutation, so "facts unchanged" already implies "converge had
-//! no effect".
-//!
-//! - `sync_modifications` moves modification statuses and iris rows → visible in
-//!   `db_len` and the modifications digest;
-//! - `sync_graph_mutations` inserts graph WAL rows → visible in the modifications
-//!   digest, which folds in `graph_mutation_bytes`;
-//! - the ingest frontier skip-ahead moves the persisted frontier → visible in
-//!   `max_persisted_sequence_number`;
-//! - the SQS queue trim moves the queue head → visible in
-//!   `next_sns_sequence_num`.
-//!
-//! The one exception is releasing unpersisted ingest claims, which touches only
-//! rows above the frontier and so is invisible to the projection. That step is
-//! idempotent by construction — releasing an already-released claim is a no-op,
-//! and re-formation is deterministic — so replaying it is safe regardless.
-//!
-//! Anything added to converge later must either be fact-visible or idempotent.
-//! A mutation that is neither would let a party rejoin having silently applied it
-//! twice.
+//! Replaying converge on a rejoin is safe because the facts projection was chosen
+//! to *see* every converge-phase mutation, so "facts unchanged" already implies
+//! "converge had no effect": `sync_modifications` shows up in `db_len` and the
+//! modifications digest, `sync_graph_mutations` in that digest via
+//! `graph_mutation_bytes`, the ingest frontier skip-ahead in
+//! `max_persisted_sequence_number`, the queue trim in `next_sns_sequence_num`. The
+//! one exception, releasing unpersisted ingest claims, touches only rows above the
+//! frontier and is idempotent by construction. Anything added to converge later
+//! must be fact-visible or idempotent, or a party could rejoin having silently
+//! applied it twice.
 //!
 //! [`wait_for_others_ready`]: ampc_server_utils::wait_for_others_ready
 
@@ -110,7 +68,7 @@ use ampc_server_utils::{get_check_addresses, ServerCoordinationConfig};
 use axum::routing::get;
 use axum::Router;
 use chrono::{DateTime, Utc};
-use eyre::{bail, Result};
+use eyre::{bail, eyre, Result};
 use iris_mpc_common::config::CommonConfig;
 use iris_mpc_common::helpers::sha256::sha256_bytes;
 use iris_mpc_common::helpers::sync::{Modification, SyncState};
@@ -119,7 +77,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use sodiumoxide::hex;
 use std::collections::HashSet;
 use std::fmt;
-use std::sync::{Arc, Mutex as StdMutex};
+use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 use tokio::sync::{Mutex, RwLock};
 use tokio::task::JoinHandle;
@@ -142,10 +100,8 @@ const EPOCH_DOMAIN: &[u8] = b"iris-mpc/startup-epoch/v1";
 ///
 /// Published to peers so they can tell "still loading" from "dead" — a
 /// distinction the coordination server cannot express today, since `/health`
-/// answers 200 unconditionally and `/ready` only flips after the load
-/// completes. Variants are ordered, and a node only ever moves forward within
-/// one epoch; going backwards requires a new epoch (and, once enforcement
-/// lands, a bumped generation).
+/// answers 200 unconditionally and `/ready` only flips after the load completes.
+/// Ordered by progress: a node only ever moves forward within one epoch.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Phase {
@@ -158,17 +114,27 @@ pub enum Phase {
     /// Applying the agreed plan to local storage (modifications roll-forward,
     /// graph WAL, ingest frontier skip-ahead, queue trim).
     Converge,
-    /// The DB load. Mostly local, but NOT peer-independent: `init_hawk_actor`
-    /// runs `restart_from_checkpoint`, a cross-party consensus round with a 10s
-    /// `PEER_ROUND_TIMEOUT`, concurrently with the iris load. A peer that
-    /// vanishes here fails its peers inside the load, before the epoch layer
-    /// gets to decide anything — so rejoin does not yet cover this window.
+    /// The DB load. NOT peer-independent: `init_hawk_actor` runs
+    /// `restart_from_checkpoint`, a cross-party consensus round with a 10s
+    /// `PEER_ROUND_TIMEOUT`, concurrently with the iris load. A peer that vanishes
+    /// here fails its peers inside the load, before the epoch layer gets to decide
+    /// anything — so rejoin does not yet cover this window.
     Load,
     /// Ready, heartbeat armed, main loop running.
     Serving,
 }
 
 impl Phase {
+    /// Every variant, in progress order.
+    pub const ALL: [Phase; 6] = [
+        Phase::Discover,
+        Phase::Propose,
+        Phase::Commit,
+        Phase::Converge,
+        Phase::Load,
+        Phase::Serving,
+    ];
+
     pub fn as_str(self) -> &'static str {
         match self {
             Phase::Discover => "discover",
@@ -192,21 +158,16 @@ impl std::str::FromStr for Phase {
     type Err = eyre::Report;
 
     fn from_str(value: &str) -> Result<Self> {
-        match value {
-            "discover" => Ok(Phase::Discover),
-            "propose" => Ok(Phase::Propose),
-            "commit" => Ok(Phase::Commit),
-            "converge" => Ok(Phase::Converge),
-            "load" => Ok(Phase::Load),
-            "serving" => Ok(Phase::Serving),
-            other => bail!("unknown startup phase {other:?}"),
-        }
+        Phase::ALL
+            .into_iter()
+            .find(|phase| phase.as_str() == value)
+            .ok_or_else(|| eyre!("unknown startup phase {value:?}"))
     }
 }
 
 /// A 32-byte SHA-256 digest, carried as a lowercase hex string in JSON so the
 /// document stays greppable in logs and readable with `curl`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Digest([u8; 32]);
 
 impl Digest {
@@ -217,6 +178,14 @@ impl Digest {
     /// Short form for log lines, where the full 64 hex chars are noise.
     pub fn short(&self) -> String {
         hex::encode(&self.0[..6])
+    }
+}
+
+impl fmt::Debug for Digest {
+    // Hex rather than the derived byte array, so `{:?}` on anything containing a
+    // digest stays readable in errors and logs.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{self}")
     }
 }
 
@@ -262,129 +231,66 @@ impl Epoch {
 
 impl fmt::Display for Epoch {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
+        fmt::Display::fmt(&self.0, f)
     }
 }
 
-/// One party's startup facts: everything about its local state that the startup
-/// sync reads and that must therefore be identical across a restart for a
-/// rejoin to be safe.
+/// Canonical digest of one party's startup facts: everything about its local
+/// state that the startup sync reads, and that must therefore be identical
+/// across a restart for a rejoin to be safe.
 ///
-/// This is a projection of [`SyncState`] and deliberately *not* the whole
-/// struct: `graph_mutation_bytes` is folded into `modifications` (it is
-/// parallel-by-index to it and can be megabytes), and nothing is kept that is
-/// not part of the startup decision.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct PartyFacts {
-    pub db_len: u64,
-    pub next_sns_sequence_num: Option<u128>,
-    pub max_persisted_sequence_number: Option<String>,
-    pub common_config: Digest,
-    /// Digest over the modifications tail zipped with its graph WAL entries.
-    pub modifications: Digest,
+/// A deliberate projection of [`SyncState`], not the whole struct:
+/// `graph_mutation_bytes` is folded into the modifications digest (it is
+/// parallel-by-index to `modifications` and can be megabytes), and nothing is
+/// included that is not part of the startup decision.
+///
+/// Encoded by hand rather than via `serde_json` so the wire format of
+/// [`SyncState`] can evolve (field renames, `serde(default)` additions) without
+/// silently changing every epoch. Every variable-length field is length-prefixed,
+/// so no two distinct fact sets can encode to the same bytes by shifting a
+/// boundary.
+pub fn facts_digest(state: &SyncState) -> Digest {
+    let modifications = digest_modifications(&state.modifications, &state.graph_mutation_bytes);
+
+    let mut buf = Vec::with_capacity(128);
+    buf.extend_from_slice(FACTS_DOMAIN);
+    buf.extend_from_slice(&state.db_len.to_be_bytes());
+    push_opt_u128(&mut buf, state.next_sns_sequence_num);
+    push_opt_str(&mut buf, state.max_persisted_sequence_number.as_deref());
+    buf.extend_from_slice(&digest_common_config(&state.common_config).0);
+    buf.extend_from_slice(&modifications.0);
+    Digest::of(&buf)
 }
 
-impl PartyFacts {
-    pub fn from_sync_state(state: &SyncState) -> Self {
-        PartyFacts {
-            db_len: state.db_len,
-            next_sns_sequence_num: state.next_sns_sequence_num,
-            max_persisted_sequence_number: state.max_persisted_sequence_number.clone(),
-            common_config: digest_common_config(&state.common_config),
-            modifications: digest_modifications(&state.modifications, &state.graph_mutation_bytes),
-        }
+/// Derive this startup's epoch from all parties' states, including this party's
+/// own.
+///
+/// `states` is expected to be [`SyncResult::all_states`], which is
+/// `[my_state] ++ peers`.
+///
+/// [`SyncResult::all_states`]: iris_mpc_common::helpers::sync::SyncResult
+pub fn derive_epoch(states: &[SyncState]) -> Result<Epoch> {
+    if states.len() < 2 {
+        bail!(
+            "cannot derive a startup epoch from {} state(s): it is only meaningful over the whole \
+             fleet",
+            states.len()
+        );
     }
 
-    /// Canonical digest of these facts.
-    ///
-    /// Encoded by hand rather than via `serde_json` so the wire format of
-    /// [`SyncState`] can evolve (field renames, `serde(default)` additions)
-    /// without silently changing every epoch. Every variable-length field is
-    /// length-prefixed, so no two distinct fact sets can encode to the same
-    /// bytes by shifting a boundary.
-    pub fn digest(&self) -> Digest {
-        let mut buf = Vec::with_capacity(128);
-        buf.extend_from_slice(FACTS_DOMAIN);
-        buf.extend_from_slice(&self.db_len.to_be_bytes());
-        push_opt_u128(&mut buf, self.next_sns_sequence_num);
-        push_opt_str(&mut buf, self.max_persisted_sequence_number.as_deref());
-        buf.extend_from_slice(&self.common_config.0);
-        buf.extend_from_slice(&self.modifications.0);
-        Digest::of(&buf)
+    let mut facts: Vec<Digest> = states.iter().map(facts_digest).collect();
+    // Sort so the epoch is independent of the order peers were polled in.
+    facts.sort_unstable();
+
+    let mut buf = Vec::with_capacity(EPOCH_DOMAIN.len() + 8 + facts.len() * 32);
+    buf.extend_from_slice(EPOCH_DOMAIN);
+    // Party count is part of the preimage: a two-party and a three-party fleet
+    // that happen to share a digest prefix must not collide.
+    buf.extend_from_slice(&(facts.len() as u64).to_be_bytes());
+    for digest in &facts {
+        buf.extend_from_slice(&digest.0);
     }
-}
-
-/// The startup plan every party derives independently from the exchanged
-/// [`SyncState`]s, together with the epoch that identifies it.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct AgreedPlan {
-    /// Per-party fact digests, sorted — a multiset, not a party-indexed vector
-    /// (see the module docs on attribution-free canonicalization).
-    facts: Vec<Digest>,
-    epoch: Epoch,
-}
-
-impl AgreedPlan {
-    /// Derive the plan from all parties' states, including this party's own.
-    ///
-    /// `states` is expected to be [`SyncResult::all_states`], which is
-    /// `[my_state] ++ peers`.
-    ///
-    /// [`SyncResult::all_states`]: iris_mpc_common::helpers::sync::SyncResult
-    pub fn from_states(states: &[SyncState]) -> Result<Self> {
-        if states.len() < 2 {
-            bail!(
-                "cannot derive a startup epoch from {} state(s): the plan is only meaningful over \
-                 the whole fleet",
-                states.len()
-            );
-        }
-        let facts = states
-            .iter()
-            .map(|state| PartyFacts::from_sync_state(state).digest())
-            .collect();
-        Ok(Self::from_fact_digests(facts))
-    }
-
-    fn from_fact_digests(mut facts: Vec<Digest>) -> Self {
-        // Sort so the epoch is independent of the order peers were polled in.
-        facts.sort_unstable();
-
-        let mut buf = Vec::with_capacity(EPOCH_DOMAIN.len() + 8 + facts.len() * 32);
-        buf.extend_from_slice(EPOCH_DOMAIN);
-        // Party count is part of the preimage: a two-party and a three-party
-        // fleet that happen to share a digest prefix must not collide.
-        buf.extend_from_slice(&(facts.len() as u64).to_be_bytes());
-        for digest in &facts {
-            buf.extend_from_slice(&digest.0);
-        }
-
-        AgreedPlan {
-            epoch: Epoch(Digest::of(&buf)),
-            facts,
-        }
-    }
-
-    pub fn epoch(&self) -> Epoch {
-        self.epoch
-    }
-
-    pub fn party_count(&self) -> usize {
-        self.facts.len()
-    }
-
-    /// Whether `facts` is one of the fact sets this plan was built from.
-    ///
-    /// The basis of the future rejoin check: a restarting party recomputes its
-    /// facts from its DB and asks the persisted plan whether they still belong
-    /// to it.
-    pub fn contains(&self, facts: &Digest) -> bool {
-        self.facts.contains(facts)
-    }
-
-    pub fn fact_digests(&self) -> &[Digest] {
-        &self.facts
-    }
+    Ok(Epoch(Digest::of(&buf)))
 }
 
 /// The single document a node publishes about its own startup.
@@ -397,23 +303,12 @@ impl AgreedPlan {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StartupState {
     pub party_id: usize,
-    /// This incarnation's coordination UUID. Kept for correlation with
-    /// `/health` and the heartbeat; it is deliberately *not* what peers key
-    /// their startup decisions on.
+    /// This incarnation's coordination UUID, for correlation with `/health` and
+    /// the heartbeat; deliberately *not* what peers key startup decisions on.
     ///
-    /// `None` for the brief window before the coordination server is
-    /// constructed, since the UUID is minted inside it while this route has to
-    /// be handed to it — correlation-only data, so it is not worth inverting
-    /// that ordering upstream.
+    /// `None` for the brief window before the coordination server is constructed,
+    /// since the UUID is minted inside it while this route has to be handed to it.
     pub uuid: Option<String>,
-    /// Reserved, always 0.
-    ///
-    /// Intended as an ABA guard for a durable epoch record; the peer-memory
-    /// design made that record unnecessary (see the module docs), so nothing
-    /// sets it. Retained as a `serde(default)` field so documents stay
-    /// compatible in both directions across a rolling deploy.
-    #[serde(default)]
-    pub generation: u64,
     pub phase: Phase,
     pub phase_started_at: DateTime<Utc>,
     /// Digest of this party's own facts, known from the moment its
@@ -429,43 +324,33 @@ pub struct StartupState {
 pub struct StartupStateHandle {
     state: Arc<RwLock<StartupState>>,
     /// Test hook from `Config::startup_hold_at_phase`; see
-    /// [`StartupStateHandle::with_hold_at`].
+    /// [`StartupStateHandle::new`].
     hold_at: Option<Phase>,
 }
 
 impl StartupStateHandle {
     /// Create the handle in [`Phase::Discover`].
     ///
-    /// Must be called before the coordination server starts, since its router
-    /// is passed in as an extra route; the UUID it mints arrives afterwards via
+    /// Must be called before the coordination server starts, since its router is
+    /// passed in as an extra route; the UUID it mints arrives afterwards via
     /// [`StartupStateHandle::set_uuid`].
-    pub fn new(party_id: usize, facts: Digest) -> Self {
+    ///
+    /// `hold_at` is the test hook from `Config::startup_hold_at_phase`, `None` in
+    /// every production path: the party parks forever on entering that phase,
+    /// *after* publishing it, so peers keep seeing a node legitimately sitting
+    /// there — which is precisely the state an e2e test wants to kill.
+    pub fn new(party_id: usize, facts: Digest, hold_at: Option<Phase>) -> Self {
         StartupStateHandle {
             state: Arc::new(RwLock::new(StartupState {
                 party_id,
                 uuid: None,
-                generation: 0,
                 phase: Phase::Discover,
                 phase_started_at: Utc::now(),
                 facts,
                 epoch: None,
             })),
-            hold_at: None,
+            hold_at,
         }
-    }
-
-    /// Park this party forever once it has entered `phase`.
-    ///
-    /// The park happens *after* the phase (and, for [`Phase::Commit`], the
-    /// epoch) is published and the state lock is released, so peers and the
-    /// coordination server keep seeing a node that is legitimately sitting in
-    /// that phase — which is precisely the state an e2e test wants to kill.
-    ///
-    /// Test-only, driven by `Config::startup_hold_at_phase`. `None` in every
-    /// production path.
-    pub fn with_hold_at(mut self, phase: Option<Phase>) -> Self {
-        self.hold_at = phase;
-        self
     }
 
     /// Router to hand to `start_coordination_server_with_extra_routes`.
@@ -497,26 +382,13 @@ impl StartupStateHandle {
         self.state.write().await.uuid = Some(uuid);
     }
 
-    /// Advance to `phase`, logging the transition and the time the previous
-    /// phase took.
-    ///
-    /// A backwards transition is logged as an error rather than rejected: while
-    /// this module is observation-only, a wrong phase label must not be able to
-    /// fail a startup that would otherwise have succeeded.
+    /// Advance to `phase`, logging the transition and the time the previous phase
+    /// took.
     pub async fn enter(&self, phase: Phase) {
         let now = Utc::now();
         let mut state = self.state.write().await;
         let previous = state.phase;
         let elapsed = now.signed_duration_since(state.phase_started_at);
-
-        if phase < previous {
-            tracing::error!(
-                "Startup phase moved backwards: {} -> {} (epoch {:?})",
-                previous,
-                phase,
-                state.epoch.map(|e| e.short())
-            );
-        }
 
         state.phase = phase;
         state.phase_started_at = now;
@@ -541,39 +413,24 @@ impl StartupStateHandle {
 
     /// Record the derived epoch. Called once, on entering [`Phase::Commit`].
     pub async fn set_epoch(&self, epoch: Epoch) {
-        let mut state = self.state.write().await;
-        if let Some(previous) = state.epoch {
-            if previous != epoch {
-                tracing::error!(
-                    "Startup epoch changed within one boot: {} -> {}",
-                    previous,
-                    epoch
-                );
-            }
-        }
-        state.epoch = Some(epoch);
+        self.state.write().await.epoch = Some(epoch);
     }
 }
 
 /// Fetch and parse every peer's startup-state document, once.
 ///
-/// Deliberately does **not** use `try_get_endpoint_other_nodes`. That helper
+/// Deliberately does **not** use `try_get_endpoint_other_nodes`: that helper
 /// `tokio::spawn`s a retry task per peer and only aborts them along its own
-/// timeout path, so wrapping it in an outer `tokio::time::timeout` — which is the
-/// only way to bound it against a caller's deadline rather than its own
-/// `startup_sync_timeout_secs` — cancels the wrapper while leaving the spawned
-/// retries running. Every polling round then leaked two tasks that kept hammering
-/// a down peer at `http_query_retry_delay_ms` for the next five minutes, with the
-/// log volume to match.
-///
-/// This is a single attempt with no internal retry and nothing spawned: the
-/// callers' own loops supply the retry, and they can therefore stop it.
+/// timeout path, so bounding it against a caller's deadline with an outer
+/// `tokio::time::timeout` leaks two tasks per polling round that keep hammering a
+/// down peer for the next five minutes. This is a single attempt with nothing
+/// spawned; the callers' loops supply the retry and can therefore stop it.
 ///
 /// Returns what it managed to read plus a description of each peer it could not,
-/// rather than failing on the first unreachable one. A down peer must not blind
-/// us to the other: the reachable peer's UUID still needs recording (that is what
+/// rather than failing on the first unreachable one. A down peer must not blind us
+/// to the other: the reachable peer's UUID still needs recording (that is what
 /// lets a *restarting* peer past its visibility barrier), and its epoch is still
-/// worth checking for disagreement. Callers that need all peers — the commit
+/// worth checking for disagreement. Callers that need every peer — the commit
 /// barrier — check `failures` themselves.
 async fn poll_peer_states(
     config: &ServerCoordinationConfig,
@@ -584,7 +441,12 @@ async fn poll_peer_states(
         &config.healthcheck_ports,
         STARTUP_STATE_ENDPOINT,
     );
-    let client = reqwest::Client::new();
+    // Client-level timeout covers headers and body together, so no call site has
+    // to wrap its own.
+    let client = reqwest::Client::builder()
+        .timeout(request_timeout)
+        .build()
+        .expect("reqwest client build failed");
     let mut states = Vec::with_capacity(urls.len().saturating_sub(1));
     let mut failures = Vec::new();
 
@@ -592,7 +454,7 @@ async fn poll_peer_states(
         if party_id == config.party_id {
             continue;
         }
-        match fetch_peer_state(&client, url, request_timeout).await {
+        match fetch_peer_state(&client, url).await {
             Ok(state) => states.push(state),
             Err(failure) => failures.push(failure),
         }
@@ -602,45 +464,36 @@ async fn poll_peer_states(
 }
 
 /// One peer, one attempt. `Err` carries a ready-to-log description.
+///
+/// A document we cannot parse is a failure, never a skipped entry: a caller
+/// counting agreeing peers must not reach quorum because a disagreeing peer was
+/// quietly dropped.
 async fn fetch_peer_state(
     client: &reqwest::Client,
     url: &str,
-    request_timeout: Duration,
 ) -> std::result::Result<StartupState, String> {
-    let response = match tokio::time::timeout(request_timeout, client.get(url).send()).await {
-        Ok(Ok(response)) => response,
-        Ok(Err(err)) => return Err(format!("GET {url} failed: {err}")),
-        Err(_) => return Err(format!("GET {url} timed out after {request_timeout:?}")),
-    };
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|err| format!("GET {url} failed: {err}"))?;
+    let body = response
+        .bytes()
+        .await
+        .map_err(|err| format!("reading body of {url} failed: {err}"))?;
 
-    let status = response.status();
-    let body = match tokio::time::timeout(request_timeout, response.bytes()).await {
-        Ok(Ok(body)) => body,
-        Ok(Err(err)) => return Err(format!("reading body of {url} failed: {err}")),
-        Err(_) => {
-            return Err(format!(
-                "reading body of {url} timed out after {request_timeout:?}"
-            ))
-        }
-    };
-
-    // A document we cannot parse is a failure, never a skipped entry: a caller
-    // counting agreeing peers must not reach quorum because a disagreeing peer
-    // was quietly dropped.
-    serde_json::from_slice::<StartupState>(&body)
-        .map_err(|err| format!("unparseable startup state from {url} (status {status}): {err}"))
+    serde_json::from_slice(&body)
+        .map_err(|err| format!("unparseable startup state from {url}: {err}"))
 }
 
-/// Record a peer incarnation as seen, so the coordination server advertises it
-/// on `/health` and the `ampc-server-utils` checks downstream accept it.
+/// Record a peer incarnation as seen, so the coordination server advertises it on
+/// `/health` and the `ampc-server-utils` checks downstream accept it.
 ///
-/// This is bookkeeping, not authorization: it says "this incarnation exists and
-/// we have observed it", which is exactly what
-/// `wait_until_startup_visibility_is_complete` needs from us before a restarted
-/// peer can get far enough to publish an epoch at all. Withholding it until the
-/// epoch matched would deadlock — the peer cannot pass its visibility barrier
-/// until we list its UUID, and it cannot publish an epoch until it passes that
-/// barrier. Authorization lives entirely in the epoch comparison below.
+/// Bookkeeping, not authorization — which lives entirely in the epoch comparison.
+/// `wait_until_startup_visibility_is_complete` needs this from us before a
+/// restarted peer can get far enough to publish an epoch at all, so withholding it
+/// until the epoch matched would deadlock: the peer cannot pass its visibility
+/// barrier until we list its UUID, and cannot publish an epoch until it does.
 async fn record_peer_uuids(verified_peers: &Arc<Mutex<HashSet<String>>>, peers: &[StartupState]) {
     let mut verified = verified_peers.lock().await;
     for peer in peers {
@@ -671,10 +524,10 @@ enum EpochVerdict {
 
 /// Classify one round of peer documents against our own epoch.
 ///
-/// Shared by the commit barrier and the startup watch so the two cannot drift
-/// apart on what counts as disagreement. Fails closed in both directions:
-/// [`EpochVerdict::Void`] takes precedence over [`EpochVerdict::Pending`], and an
-/// empty peer list is `Pending` rather than a vacuous `Committed`.
+/// Shared by the commit barrier and the startup watch so the two cannot drift on
+/// what counts as disagreement. Fails closed both ways: [`EpochVerdict::Void`]
+/// beats [`EpochVerdict::Pending`], and an empty peer list is `Pending` rather
+/// than a vacuous `Committed`.
 fn classify_peers(my_epoch: Epoch, peers: &[StartupState]) -> EpochVerdict {
     let void: Vec<_> = peers
         .iter()
@@ -708,19 +561,14 @@ fn classify_peers(my_epoch: Epoch, peers: &[StartupState]) -> EpochVerdict {
 /// Nothing may mutate local storage before this returns. Converging under a plan
 /// a peer never agreed to is the failure mode the barrier exists to prevent.
 ///
-/// # What a mismatch does and does not mean
-///
-/// A mismatch is *not* "the parties' data diverged" — divergence is normal and
-/// is precisely what the modifications roll-forward exists to repair. The epoch
-/// is a digest of the whole starting configuration, differences included, so
-/// three parties that legitimately disagree about their persisted frontier still
-/// derive the same epoch from the same three fact sets.
-///
-/// A mismatch means the parties saw *different inputs*: some party's facts
-/// changed between the exchange and now, which in practice means it restarted
-/// and came back with different data. The agreed plan is then void, and every
-/// party must abandon it and re-derive from current state — the full-fleet
-/// restart this returns an error to trigger.
+/// A mismatch is *not* "the parties' data diverged" — divergence is normal, and is
+/// what the modifications roll-forward exists to repair. The epoch digests the
+/// whole starting configuration, differences included, so parties that legitimately
+/// disagree about their persisted frontier still derive the same epoch. A mismatch
+/// means the parties saw *different inputs*: some party's facts changed between the
+/// exchange and now, in practice because it restarted with different data. The
+/// agreed plan is void, and the error returned here triggers the full-fleet restart
+/// that makes every party re-derive from current state.
 pub async fn wait_for_epoch_commit(
     config: &ServerCoordinationConfig,
     verified_peers: &Arc<Mutex<HashSet<String>>>,
@@ -753,9 +601,8 @@ pub async fn wait_for_epoch_commit(
         record_peer_uuids(verified_peers, &peers).await;
 
         if !failures.is_empty() {
-            // Routine — a peer may be restarting, and we are the thing keeping the
-            // fleet from proceeding without it. The barrier requires every peer, so
-            // wait rather than classifying a partial view.
+            // Routine — a peer may be restarting. The barrier requires every peer,
+            // so wait rather than classifying a partial view.
             log_poll_failure(attempt, &failures);
             tokio::time::sleep(retry_delay.min(remaining)).await;
             continue;
@@ -768,7 +615,7 @@ pub async fn wait_for_epoch_commit(
                     "startup epoch mismatch: mine is {}, peers report {:?}. The agreed plan is \
                      void; every party must restart and re-derive from current state.",
                     my_epoch,
-                    format_epochs(&disagreeing)
+                    disagreeing
                 );
             }
             EpochVerdict::Committed => {
@@ -802,26 +649,12 @@ fn log_poll_failure(attempt: u32, failures: &[String]) {
     }
 }
 
-fn format_epochs(peers: &[(usize, Option<Epoch>)]) -> Vec<(usize, String)> {
-    peers
-        .iter()
-        .map(|(party_id, epoch)| {
-            (
-                *party_id,
-                epoch
-                    .map(|epoch| epoch.to_string())
-                    .unwrap_or_else(|| "none".to_string()),
-            )
-        })
-        .collect()
-}
-
-/// Guard for the background task that watches peers across the converge and
-/// load phases. Aborts the task when dropped.
+/// Guard for the background task that watches peers across the converge and load
+/// phases. Aborts the task when dropped.
 pub struct StartupWatch {
     task: JoinHandle<()>,
     /// Set once, to the reason the epoch was voided.
-    verdict: Arc<StdMutex<Option<String>>>,
+    verdict: Arc<OnceLock<String>>,
 }
 
 impl StartupWatch {
@@ -832,12 +665,7 @@ impl StartupWatch {
     /// cooperative, and the load does not poll it, so a verdict reached while
     /// loading is only acted on once the load returns.
     pub fn check(&self) -> Result<()> {
-        let verdict = self
-            .verdict
-            .lock()
-            .expect("startup watch verdict mutex poisoned")
-            .clone();
-        match verdict {
+        match self.verdict.get() {
             Some(reason) => bail!("{reason}"),
             None => Ok(()),
         }
@@ -877,20 +705,13 @@ impl Drop for StartupWatch {
 /// - peer publishes no epoch, or is unreachable — it is mid-restart. Tolerated:
 ///   it will either republish this epoch or a different one, and the ready
 ///   barrier still bounds how long a peer may fail to arrive.
-///
-/// Note what makes the first case work without any durable record: a restarting
-/// peer rebuilds its [`SyncState`] from its DB and re-derives the epoch from its
-/// peers' boot snapshots, so it reproduces this epoch **exactly when its own
-/// facts are unchanged** — the rejoin condition is self-checking. It therefore
-/// holds for the common case of a converge that had no work to do, and correctly
-/// fails when converge actually mutated local state (see the module docs).
 pub fn spawn_startup_watch(
     config: ServerCoordinationConfig,
     verified_peers: Arc<Mutex<HashSet<String>>>,
     shutdown_handler: Arc<ShutdownHandler>,
     epoch: Epoch,
 ) -> StartupWatch {
-    let verdict = Arc::new(StdMutex::new(None));
+    let verdict = Arc::new(OnceLock::new());
 
     let task = tokio::spawn({
         let verdict = Arc::clone(&verdict);
@@ -927,7 +748,6 @@ pub fn spawn_startup_watch(
                 record_peer_uuids(&verified_peers, &peers).await;
 
                 if let EpochVerdict::Void(disagreeing) = classify_peers(epoch, &peers) {
-                    let disagreeing = format_epochs(&disagreeing);
                     let reason = format!(
                         "startup watch found a peer on a different epoch: mine is {epoch}, peers \
                          report {disagreeing:?}. The agreed plan is void; abandoning startup so \
@@ -936,9 +756,7 @@ pub fn spawn_startup_watch(
                     tracing::error!("{}", reason);
                     metrics::counter!("startup_epoch_mismatch").increment(1);
 
-                    *verdict
-                        .lock()
-                        .expect("startup watch verdict mutex poisoned") = Some(reason);
+                    let _ = verdict.set(reason);
 
                     if !shutdown_handler.is_shutting_down() {
                         shutdown_handler.trigger_manual_shutdown();
@@ -1086,30 +904,28 @@ mod tests {
         ]
     }
 
+    fn epoch_of(states: &[SyncState]) -> Epoch {
+        derive_epoch(states).unwrap()
+    }
+
     #[test]
     fn epoch_is_independent_of_collection_order() {
         // The whole design rests on this: each party polls its peers in its own
         // order, yet all must derive the same epoch with no extra round trip.
-        let baseline = AgreedPlan::from_states(&fleet()).unwrap();
+        let baseline = epoch_of(&fleet());
 
         let mut rotated = fleet();
         rotated.rotate_left(1);
-        assert_eq!(
-            baseline.epoch(),
-            AgreedPlan::from_states(&rotated).unwrap().epoch()
-        );
+        assert_eq!(baseline, epoch_of(&rotated));
 
         let mut reversed = fleet();
         reversed.reverse();
-        assert_eq!(
-            baseline.epoch(),
-            AgreedPlan::from_states(&reversed).unwrap().epoch()
-        );
+        assert_eq!(baseline, epoch_of(&reversed));
     }
 
     #[test]
     fn epoch_changes_when_any_party_fact_changes() {
-        let baseline = AgreedPlan::from_states(&fleet()).unwrap().epoch();
+        let baseline = epoch_of(&fleet());
 
         // The motivating case: a peer restarts and comes back with a different
         // persisted frontier. That must void the epoch.
@@ -1117,74 +933,52 @@ mod tests {
         changed[2].max_persisted_sequence_number = Some("0000000000000011".to_string());
         assert_ne!(
             baseline,
-            AgreedPlan::from_states(&changed).unwrap().epoch(),
+            epoch_of(&changed),
             "a changed persisted frontier must change the epoch"
         );
 
         let mut changed = fleet();
         changed[0].db_len += 1;
-        assert_ne!(baseline, AgreedPlan::from_states(&changed).unwrap().epoch());
+        assert_ne!(baseline, epoch_of(&changed));
 
         let mut changed = fleet();
         changed[1].modifications[0].status = "COMPLETED_WITH_ERROR".to_string();
-        assert_ne!(baseline, AgreedPlan::from_states(&changed).unwrap().epoch());
+        assert_ne!(baseline, epoch_of(&changed));
 
         let mut changed = fleet();
         changed[1].modifications[0].persisted = false;
-        assert_ne!(baseline, AgreedPlan::from_states(&changed).unwrap().epoch());
+        assert_ne!(baseline, epoch_of(&changed));
 
         let mut changed = fleet();
         changed[1].next_sns_sequence_num = None;
-        assert_ne!(baseline, AgreedPlan::from_states(&changed).unwrap().epoch());
+        assert_ne!(baseline, epoch_of(&changed));
 
         let mut changed = fleet();
         changed[0].graph_mutation_bytes = vec![Some(vec![0xcd; 16]), None];
-        assert_ne!(baseline, AgreedPlan::from_states(&changed).unwrap().epoch());
+        assert_ne!(baseline, epoch_of(&changed));
     }
 
     #[test]
     fn duplicate_facts_are_kept_as_a_multiset() {
         // Two parties in sync and one behind must not hash the same as three
         // parties in sync: collapsing duplicates would erase the difference.
-        let two_agree = AgreedPlan::from_states(&fleet()).unwrap();
-        assert_eq!(two_agree.party_count(), 3);
-
         let all_agree = vec![
             state(100, Some("0000000000000010")),
             state(100, Some("0000000000000010")),
             state(100, Some("0000000000000010")),
         ];
-        assert_ne!(
-            two_agree.epoch(),
-            AgreedPlan::from_states(&all_agree).unwrap().epoch()
-        );
-    }
-
-    #[test]
-    fn every_party_finds_its_own_facts_in_the_plan() {
-        // The rejoin check: recompute my facts, ask the plan if I belong.
-        let states = fleet();
-        let plan = AgreedPlan::from_states(&states).unwrap();
-        for state in &states {
-            assert!(plan.contains(&PartyFacts::from_sync_state(state).digest()));
-        }
-
-        let mut stranger = state(100, Some("0000000000000010"));
-        stranger.db_len = 999;
-        assert!(!plan.contains(&PartyFacts::from_sync_state(&stranger).digest()));
+        assert_ne!(epoch_of(&fleet()), epoch_of(&all_agree));
     }
 
     #[test]
     fn party_count_is_part_of_the_epoch() {
         let states = fleet();
-        let three = AgreedPlan::from_states(&states).unwrap();
-        let two = AgreedPlan::from_states(&states[..2]).unwrap();
-        assert_ne!(three.epoch(), two.epoch());
+        assert_ne!(epoch_of(&states), epoch_of(&states[..2]));
     }
 
     #[test]
-    fn a_single_state_cannot_form_a_plan() {
-        assert!(AgreedPlan::from_states(&fleet()[..1]).is_err());
+    fn a_single_state_cannot_derive_an_epoch() {
+        assert!(derive_epoch(&fleet()[..1]).is_err());
     }
 
     #[test]
@@ -1199,10 +993,7 @@ mod tests {
         b.modifications[0].request_type = "abc".to_string();
         b.modifications[0].status = "d".to_string();
 
-        assert_ne!(
-            PartyFacts::from_sync_state(&a).digest(),
-            PartyFacts::from_sync_state(&b).digest()
-        );
+        assert_ne!(facts_digest(&a), facts_digest(&b));
     }
 
     #[test]
@@ -1214,10 +1005,7 @@ mod tests {
         reversed.modifications.reverse();
         reversed.graph_mutation_bytes.reverse();
 
-        assert_eq!(
-            PartyFacts::from_sync_state(&forward).digest(),
-            PartyFacts::from_sync_state(&reversed).digest()
-        );
+        assert_eq!(facts_digest(&forward), facts_digest(&reversed));
     }
 
     #[test]
@@ -1228,33 +1016,23 @@ mod tests {
         let mut mispaired = forward.clone();
         mispaired.modifications.reverse();
 
-        assert_ne!(
-            PartyFacts::from_sync_state(&forward).digest(),
-            PartyFacts::from_sync_state(&mispaired).digest()
-        );
+        assert_ne!(facts_digest(&forward), facts_digest(&mispaired));
     }
 
     #[test]
-    fn digest_survives_a_json_round_trip() {
-        let plan = AgreedPlan::from_states(&fleet()).unwrap();
-        let json = serde_json::to_string(&plan).unwrap();
-        let parsed: AgreedPlan = serde_json::from_str(&json).unwrap();
-        assert_eq!(plan, parsed);
-        assert_eq!(plan.epoch(), parsed.epoch());
+    fn epoch_survives_a_json_round_trip() {
+        // Peers parse the epoch out of each other's documents, so the hex encoding
+        // has to be exact.
+        let epoch = epoch_of(&fleet());
+        let json = serde_json::to_string(&epoch).unwrap();
+        assert_eq!(serde_json::from_str::<Epoch>(&json).unwrap(), epoch);
     }
 
     #[test]
     fn phase_names_round_trip() {
         // `startup_hold_at_phase` is matched against `as_str`, so the two
         // directions must not drift apart.
-        for phase in [
-            Phase::Discover,
-            Phase::Propose,
-            Phase::Commit,
-            Phase::Converge,
-            Phase::Load,
-            Phase::Serving,
-        ] {
+        for phase in Phase::ALL {
             assert_eq!(phase.as_str().parse::<Phase>().unwrap(), phase);
         }
         assert!("laod".parse::<Phase>().is_err());
@@ -1264,8 +1042,8 @@ mod tests {
     async fn a_hold_publishes_its_phase_before_parking() {
         // The whole point of the hook: peers must see a party legitimately
         // sitting in the held phase, so `enter` has to publish before it parks.
-        let facts = PartyFacts::from_sync_state(&state(100, None)).digest();
-        let handle = StartupStateHandle::new(1, facts).with_hold_at(Some(Phase::Propose));
+        let facts = facts_digest(&state(100, None));
+        let handle = StartupStateHandle::new(1, facts, Some(Phase::Propose));
 
         let entering = tokio::spawn({
             let handle = handle.clone();
@@ -1284,15 +1062,15 @@ mod tests {
         entering.abort();
 
         // A phase that is not the held one still advances normally.
-        let handle = StartupStateHandle::new(1, facts).with_hold_at(Some(Phase::Load));
+        let handle = StartupStateHandle::new(1, facts, Some(Phase::Load));
         handle.enter(Phase::Propose).await;
         assert_eq!(handle.snapshot().await.phase, Phase::Propose);
     }
 
     #[tokio::test]
     async fn published_document_tracks_phase_and_epoch() {
-        let facts = PartyFacts::from_sync_state(&state(100, None)).digest();
-        let handle = StartupStateHandle::new(1, facts);
+        let facts = facts_digest(&state(100, None));
+        let handle = StartupStateHandle::new(1, facts, None);
 
         let initial = handle.snapshot().await;
         assert_eq!(initial.phase, Phase::Discover);
@@ -1302,7 +1080,7 @@ mod tests {
 
         handle.set_uuid("uuid-1".to_string()).await;
 
-        let epoch = AgreedPlan::from_states(&fleet()).unwrap().epoch();
+        let epoch = epoch_of(&fleet());
         handle.enter(Phase::Propose).await;
         handle.enter(Phase::Commit).await;
         handle.set_epoch(epoch).await;
@@ -1317,7 +1095,6 @@ mod tests {
         assert_eq!(parsed.epoch, Some(epoch));
         assert_eq!(parsed.phase, Phase::Commit);
         assert_eq!(parsed.party_id, 1);
-        assert_eq!(parsed.generation, 0);
         assert_eq!(parsed.uuid.as_deref(), Some("uuid-1"));
     }
 
@@ -1325,10 +1102,9 @@ mod tests {
         StartupState {
             party_id,
             uuid: Some(format!("uuid-{party_id}")),
-            generation: 0,
             phase,
             phase_started_at: Utc::now(),
-            facts: PartyFacts::from_sync_state(&state(100, None)).digest(),
+            facts: facts_digest(&state(100, None)),
             epoch,
         }
     }
@@ -1336,12 +1112,12 @@ mod tests {
     fn other_epoch() -> Epoch {
         let mut changed = fleet();
         changed[0].db_len = 12_345;
-        AgreedPlan::from_states(&changed).unwrap().epoch()
+        epoch_of(&changed)
     }
 
     #[test]
     fn all_peers_on_my_epoch_is_committed() {
-        let mine = AgreedPlan::from_states(&fleet()).unwrap().epoch();
+        let mine = epoch_of(&fleet());
         let peers = [
             peer(1, Phase::Commit, Some(mine)),
             peer(2, Phase::Load, Some(mine)),
@@ -1353,7 +1129,7 @@ mod tests {
     fn a_peer_without_an_epoch_is_pending_not_void() {
         // Either it has not reached Commit, or it restarted and is on its way
         // back. Neither is a disagreement.
-        let mine = AgreedPlan::from_states(&fleet()).unwrap().epoch();
+        let mine = epoch_of(&fleet());
         let peers = [
             peer(1, Phase::Commit, Some(mine)),
             peer(2, Phase::Discover, None),
@@ -1367,7 +1143,7 @@ mod tests {
     #[test]
     fn a_peer_on_a_different_epoch_voids_the_plan() {
         // The motivating failure: a peer restarted with changed data.
-        let mine = AgreedPlan::from_states(&fleet()).unwrap().epoch();
+        let mine = epoch_of(&fleet());
         let theirs = other_epoch();
         let peers = [
             peer(1, Phase::Commit, Some(mine)),
@@ -1383,7 +1159,7 @@ mod tests {
     fn void_takes_precedence_over_pending() {
         // Fail closed: one peer still arriving must not mask another peer that
         // has already proven the plan void.
-        let mine = AgreedPlan::from_states(&fleet()).unwrap().epoch();
+        let mine = epoch_of(&fleet());
         let theirs = other_epoch();
         let peers = [
             peer(1, Phase::Discover, None),
@@ -1398,7 +1174,7 @@ mod tests {
     #[test]
     fn no_peers_is_pending_not_vacuously_committed() {
         // A round that saw nobody must never satisfy the commit barrier.
-        let mine = AgreedPlan::from_states(&fleet()).unwrap().epoch();
+        let mine = epoch_of(&fleet());
         assert_eq!(classify_peers(mine, &[]), EpochVerdict::Pending(Vec::new()));
     }
 
@@ -1408,7 +1184,7 @@ mod tests {
         // its own state from its DB and re-derives the epoch from its peers'
         // (unchanged) boot snapshots.
         let original = fleet();
-        let in_flight = AgreedPlan::from_states(&original).unwrap().epoch();
+        let in_flight = epoch_of(&original);
 
         // Facts unchanged across the restart — converge had no work to do — so
         // the party reproduces the in-flight epoch and rejoins.
@@ -1416,7 +1192,7 @@ mod tests {
         rebooted[0] = state(100, Some("0000000000000010"));
         assert_eq!(
             in_flight,
-            AgreedPlan::from_states(&rebooted).unwrap().epoch(),
+            epoch_of(&rebooted),
             "an unchanged party must reproduce the in-flight epoch"
         );
 
@@ -1426,17 +1202,13 @@ mod tests {
         rebooted[0] = state(101, Some("0000000000000011"));
         assert_ne!(
             in_flight,
-            AgreedPlan::from_states(&rebooted).unwrap().epoch(),
+            epoch_of(&rebooted),
             "a changed party must not be able to rejoin"
         );
     }
 
     #[test]
     fn phases_are_ordered_by_progress() {
-        assert!(Phase::Discover < Phase::Propose);
-        assert!(Phase::Propose < Phase::Commit);
-        assert!(Phase::Commit < Phase::Converge);
-        assert!(Phase::Converge < Phase::Load);
-        assert!(Phase::Load < Phase::Serving);
+        assert!(Phase::ALL.windows(2).all(|pair| pair[0] < pair[1]));
     }
 }

--- a/iris-mpc/src/server/startup_phase.rs
+++ b/iris-mpc/src/server/startup_phase.rs
@@ -298,8 +298,7 @@ impl StartupStateHandle {
         }
     }
 
-    /// Record the derived fleet sync-state digest. Called once, on entering
-    /// [`Phase::Commit`].
+    /// Record the derived fleet sync-state digest
     pub async fn set_fleet_sync_state_digest(&self, digest: SyncStateDigest) {
         self.state.write().await.fleet_sync_state_digest = Some(digest);
     }
@@ -347,6 +346,11 @@ async fn fetch_peer_state(
         .send()
         .await
         .map_err(|err| format!("GET {url} failed: {err}"))?;
+
+    if !response.status().is_success() {
+        return Err(format!("GET {url} returned {}", response.status()));
+    }
+
     let body = response
         .bytes()
         .await

--- a/iris-mpc/src/server/startup_phase.rs
+++ b/iris-mpc/src/server/startup_phase.rs
@@ -15,29 +15,28 @@
 //! length, ingest/queue frontier, modifications tail and common config. It is a
 //! deterministic function of the exchanged [`SyncState`]s, so all parties derive
 //! it with no extra round trip and no leader. A peer that restarts and recomputes
-//! the same fleet digest is provably resuming the same startup and may rejoin; one
-//! that comes back with a different [`SyncState`] computes a different fleet
-//! digest, which is exactly the signal that the initial sync is void and the whole
+//! the same fleet sync-state digest is provably resuming the same startup and may
+//! rejoin; one that comes back with a different [`SyncState`] computes a different
+//! one, which is exactly the signal that the initial sync is void and the whole
 //! fleet must restart.
 //!
-//! [`SyncState`] carries no party id and peers are polled in an arbitrary order,
-//! so the fleet digest covers the *sorted multiset* of per-party digests rather
-//! than a party-indexed vector. Duplicates are preserved, so one party's
+//! [`SyncState`] carries no party id and peers are polled in an arbitrary order, so
+//! the fleet sync-state digest covers the *sorted multiset* of per-party digests
+//! rather than a party-indexed vector. Duplicates are preserved, so one party's
 //! [`SyncState`] changing from "same as peers" to "different" still changes the
-//! fleet digest.
+//! fleet sync-state digest.
 //!
 //! # The surviving peers are the durable record
 //!
 //! There is deliberately no persisted digest table. The authority on which startup
 //! is in progress is the set of peers still running it, published on
 //! [`STARTUP_STATE_ROUTE`] from their live [`StartupStateHandle`]s. A restarting
-//! party rebuilds its [`SyncState`] from its DB and re-derives the fleet digest
-//! from its peers' boot snapshots; it reproduces the in-flight fleet digest
-//! **exactly when its own [`SyncState`] is unchanged**, so the rejoin condition
-//! checks itself — no durable state, no migration, no staleness guard. If every
-//! party restarts at once there is no in-flight fleet digest to rejoin and all
-//! three derive a fresh one, which is the correct outcome rather than a
-//! degradation.
+//! party rebuilds its [`SyncState`] from its DB and re-derives the fleet sync-state
+//! digest from its peers' boot snapshots; it reproduces the in-flight one **exactly
+//! when its own [`SyncState`] is unchanged**, so the rejoin condition checks itself
+//! — no durable state, no migration, no staleness guard. If every party restarts at
+//! once there is no in-flight digest to rejoin and all three derive a fresh one,
+//! which is the correct outcome rather than a degradation.
 //!
 //! # What rejoin covers
 //!
@@ -124,7 +123,7 @@ pub enum Phase {
     Discover,
     /// Mutual visibility established; exchanging [`SyncState`]s.
     Propose,
-    /// States exchanged and the fleet digest derived from them.
+    /// States exchanged and the fleet sync-state digest derived from them.
     Commit,
     /// Applying the synchronized [`SyncState`]s to local storage (modifications
     /// roll-forward, graph WAL, ingest frontier skip-ahead, queue trim).
@@ -132,8 +131,8 @@ pub enum Phase {
     /// The DB load. NOT peer-independent: `init_hawk_actor` runs
     /// `restart_from_checkpoint`, a cross-party consensus round with a 10s
     /// `PEER_ROUND_TIMEOUT`, concurrently with the iris load. A peer that vanishes
-    /// here fails its peers inside the load, before the fleet digest comparison
-    /// gets to decide anything — so rejoin does not yet cover this window.
+    /// here fails its peers inside the load, before the fleet sync-state digest
+    /// comparison gets to decide anything — so rejoin does not yet cover this window.
     Load,
     /// Ready, heartbeat armed, main loop running.
     Serving,
@@ -224,14 +223,14 @@ pub fn hash_sync_state(state: &SyncState) -> SyncStateDigest {
 pub fn hash_fleet_sync_states(states: &[SyncState]) -> Result<SyncStateDigest> {
     if states.len() < 2 {
         bail!(
-            "cannot digest a fleet of {} state(s): the fleet digest is only meaningful over every \
-             party",
+            "cannot digest a fleet of {} state(s): the fleet sync-state digest is only meaningful \
+             over every party",
             states.len()
         );
     }
 
     let mut digests: Vec<SyncStateDigest> = states.iter().map(hash_sync_state).collect();
-    // Sort so the fleet digest is independent of the order peers were polled in.
+    // Sort so the fleet sync-state digest is independent of the poll order.
     digests.sort_unstable();
 
     let mut buf = Vec::with_capacity(
@@ -269,10 +268,10 @@ pub struct StartupState {
     pub phase_started_at: DateTime<Utc>,
     /// Digest of this party's own [`SyncState`], known from the moment that state
     /// is built — i.e. before any peer has been contacted.
-    pub sync_state_digest: SyncStateDigest,
+    pub party_sync_state_digest: SyncStateDigest,
     /// Digest over every party's [`SyncState`], `None` until the state exchange
     /// completes and it can be derived.
-    pub fleet_digest: Option<SyncStateDigest>,
+    pub fleet_sync_state_digest: Option<SyncStateDigest>,
 }
 
 /// Live, shared handle to this node's [`StartupState`]; the write side of
@@ -298,7 +297,7 @@ impl StartupStateHandle {
     /// there — which is precisely the state an e2e test wants to kill.
     pub fn new(
         party_id: usize,
-        sync_state_digest: SyncStateDigest,
+        party_sync_state_digest: SyncStateDigest,
         hold_at: Option<Phase>,
     ) -> Self {
         StartupStateHandle {
@@ -307,8 +306,8 @@ impl StartupStateHandle {
                 uuid: None,
                 phase: Phase::Discover,
                 phase_started_at: Utc::now(),
-                sync_state_digest,
-                fleet_digest: None,
+                party_sync_state_digest,
+                fleet_sync_state_digest: None,
             })),
             hold_at,
         }
@@ -317,7 +316,7 @@ impl StartupStateHandle {
     /// Router to hand to `start_coordination_server_with_extra_routes`.
     ///
     /// Always answers 200: the document is meaningful in every phase, and a
-    /// pre-agreement node is described by `fleet_digest: null` rather than by an
+    /// pre-agreement node is described by `fleet_sync_state_digest: null` rather than by an
     /// error status. Peers distinguish the cases by reading the fields.
     pub fn router(&self) -> Router {
         let state = Arc::clone(&self.state);
@@ -372,9 +371,10 @@ impl StartupStateHandle {
         }
     }
 
-    /// Record the derived fleet digest. Called once, on entering [`Phase::Commit`].
-    pub async fn set_fleet_digest(&self, digest: SyncStateDigest) {
-        self.state.write().await.fleet_digest = Some(digest);
+    /// Record the derived fleet sync-state digest. Called once, on entering
+    /// [`Phase::Commit`].
+    pub async fn set_fleet_sync_state_digest(&self, digest: SyncStateDigest) {
+        self.state.write().await.fleet_sync_state_digest = Some(digest);
     }
 }
 
@@ -390,9 +390,9 @@ impl StartupStateHandle {
 /// Returns what it managed to read plus a description of each peer it could not,
 /// rather than failing on the first unreachable one. A down peer must not blind us
 /// to the other: the reachable peer's UUID still needs recording (that is what
-/// lets a *restarting* peer past its visibility barrier), and its fleet digest is
-/// still worth checking for disagreement. Callers that need every peer — the commit
-/// barrier — check `failures` themselves.
+/// lets a *restarting* peer past its visibility barrier), and its fleet sync-state
+/// digest is still worth checking for disagreement. Callers that need every peer —
+/// the commit barrier — check `failures` themselves.
 async fn poll_peer_states(
     config: &ServerCoordinationConfig,
     request_timeout: Duration,
@@ -450,9 +450,9 @@ async fn fetch_peer_state(
 /// Record a peer incarnation as seen, so the coordination server advertises it on
 /// `/health` and the `ampc-server-utils` checks downstream accept it.
 ///
-/// Bookkeeping, not authorization — which lives entirely in the fleet digest
-/// comparison. `wait_until_startup_visibility_is_complete` needs this from us
-/// before a restarted peer can get far enough to publish a fleet digest at all, so
+/// Bookkeeping, not authorization — which lives entirely in the fleet sync-state
+/// digest comparison. `wait_until_startup_visibility_is_complete` needs this from us
+/// before a restarted peer can get far enough to publish a digest at all, so
 /// withholding it until the digests matched would deadlock: the peer cannot pass
 /// its visibility barrier until we list its UUID, and cannot publish a digest
 /// until it does.
@@ -472,73 +472,78 @@ async fn record_peer_uuids(verified_peers: &Arc<Mutex<HashSet<String>>>, peers: 
     }
 }
 
-/// What a round of peer observations says about the fleet digest.
+/// What a round of peer observations says about the fleet sync-state digest.
 #[derive(Debug, Clone, PartialEq, Eq)]
-enum AgreementVerdict {
-    /// Every peer published this fleet digest.
+enum ConsensusVerdict {
+    /// Every peer published this fleet sync-state digest.
     Committed,
-    /// One or more peers have not published a fleet digest yet: either they have
-    /// not reached [`Phase::Commit`], or they restarted and are on their way back.
+    /// One or more peers have not published a fleet sync-state digest yet: either
+    /// they have not reached [`Phase::Commit`], or they restarted and are on their
+    /// way back.
     Pending(Vec<(usize, Phase)>),
-    /// A peer published a different fleet digest, so this startup is void.
+    /// A peer published a different fleet sync-state digest, so this startup is void.
     Void(Vec<(usize, Option<SyncStateDigest>)>),
 }
 
-/// Classify one round of peer documents against our own fleet digest.
+/// Classify one round of peer documents against our own fleet sync-state digest.
 ///
 /// Shared by the commit barrier and the startup watch so the two cannot drift on
-/// what counts as disagreement. Fails closed both ways: [`AgreementVerdict::Void`]
-/// beats [`AgreementVerdict::Pending`], and an empty peer list is `Pending` rather
+/// what counts as disagreement. Fails closed both ways: [`ConsensusVerdict::Void`]
+/// beats [`ConsensusVerdict::Pending`], and an empty peer list is `Pending` rather
 /// than a vacuous `Committed`.
-fn classify_peers(my_digest: SyncStateDigest, peers: &[StartupState]) -> AgreementVerdict {
+fn compare_peer_states(my_digest: SyncStateDigest, peers: &[StartupState]) -> ConsensusVerdict {
     let void: Vec<_> = peers
         .iter()
-        .filter(|peer| peer.fleet_digest.is_some_and(|digest| digest != my_digest))
-        .map(|peer| (peer.party_id, peer.fleet_digest))
+        .filter(|peer| {
+            peer.fleet_sync_state_digest
+                .is_some_and(|digest| digest != my_digest)
+        })
+        .map(|peer| (peer.party_id, peer.fleet_sync_state_digest))
         .collect();
 
     if !void.is_empty() {
-        return AgreementVerdict::Void(void);
+        return ConsensusVerdict::Void(void);
     }
 
     if peers.is_empty() {
-        return AgreementVerdict::Pending(Vec::new());
+        return ConsensusVerdict::Pending(Vec::new());
     }
 
     let pending: Vec<_> = peers
         .iter()
-        .filter(|peer| peer.fleet_digest.is_none())
+        .filter(|peer| peer.fleet_sync_state_digest.is_none())
         .map(|peer| (peer.party_id, peer.phase))
         .collect();
 
     if pending.is_empty() {
-        AgreementVerdict::Committed
+        ConsensusVerdict::Committed
     } else {
-        AgreementVerdict::Pending(pending)
+        ConsensusVerdict::Pending(pending)
     }
 }
 
-/// Commit barrier: hold until every peer has published *this* fleet digest.
+/// Commit barrier: hold until every peer has published *this* fleet sync-state
+/// digest.
 ///
 /// Nothing may mutate local storage before this returns. Converging over states a
 /// peer never agreed to is the failure mode the barrier exists to prevent.
 ///
 /// A mismatch is *not* "the parties' data diverged" — divergence is normal, and is
-/// what the modifications roll-forward exists to repair. The fleet digest covers
-/// the whole starting configuration, differences included, so parties that
-/// legitimately disagree about their persisted frontier still derive the same fleet
-/// digest. A mismatch means the parties saw *different inputs*: some party's
+/// what the modifications roll-forward exists to repair. The fleet sync-state digest
+/// covers the whole starting configuration, differences included, so parties that
+/// legitimately disagree about their persisted frontier still derive the same one.
+/// A mismatch means the parties saw *different inputs*: some party's
 /// [`SyncState`] changed between the exchange and now, in practice because it
 /// restarted with different data. This startup is void, and the error returned here
 /// triggers the full-fleet restart that makes every party re-derive from current
 /// state.
-pub async fn wait_for_fleet_digest_commit(
+pub async fn wait_for_fleet_sync_state_digest_commit(
     config: &ServerCoordinationConfig,
     verified_peers: &Arc<Mutex<HashSet<String>>>,
     my_digest: SyncStateDigest,
 ) -> Result<()> {
     tracing::info!(
-        "Waiting for peers to commit startup fleet digest {}",
+        "Waiting for peers to commit startup fleet sync-state digest {}",
         my_digest
     );
 
@@ -552,9 +557,9 @@ pub async fn wait_for_fleet_digest_commit(
         attempt += 1;
         let remaining = deadline.saturating_duration_since(Instant::now());
         if remaining.is_zero() {
-            metrics::counter!("startup_fleet_digest_commit_timeout").increment(1);
+            metrics::counter!("startup_fleet_sync_state_digest_commit_timeout").increment(1);
             bail!(
-                "peers did not commit startup fleet digest {} within {:?}",
+                "peers did not commit startup fleet sync-state digest {} within {:?}",
                 my_digest,
                 budget
             );
@@ -574,27 +579,31 @@ pub async fn wait_for_fleet_digest_commit(
             continue;
         }
 
-        match classify_peers(my_digest, &peers) {
-            AgreementVerdict::Void(disagreeing) => {
-                metrics::counter!("startup_fleet_digest_mismatch").increment(1);
+        match compare_peer_states(my_digest, &peers) {
+            ConsensusVerdict::Void(disagreeing) => {
+                metrics::counter!("startup_fleet_sync_state_digest_mismatch").increment(1);
                 bail!(
-                    "startup fleet digest mismatch: mine is {}, peers report {:?}. This startup \
-                     is void; every party must restart and re-derive from current state.",
+                    "startup fleet sync-state digest mismatch: mine is {}, peers report {:?}. \
+                     This startup is void; every party must restart and re-derive from current \
+                     state.",
                     my_digest,
                     disagreeing
                 );
             }
-            AgreementVerdict::Committed => {
+            ConsensusVerdict::Committed => {
                 tracing::info!(
-                    "Startup fleet digest {} committed by all {} parties",
+                    "Startup fleet sync-state digest {} committed by all {} parties",
                     my_digest,
                     peers.len() + 1
                 );
-                metrics::counter!("startup_fleet_digest_agreement").increment(1);
+                metrics::counter!("startup_fleet_sync_state_digest_agreement").increment(1);
                 return Ok(());
             }
-            AgreementVerdict::Pending(pending) => {
-                tracing::debug!("Peers have not committed a fleet digest yet: {:?}", pending);
+            ConsensusVerdict::Pending(pending) => {
+                tracing::debug!(
+                    "Peers have not committed a fleet sync-state digest yet: {:?}",
+                    pending
+                );
                 let remaining = deadline.saturating_duration_since(Instant::now());
                 tokio::time::sleep(retry_delay.min(remaining)).await;
             }
@@ -624,7 +633,7 @@ pub struct StartupWatch {
 }
 
 impl StartupWatch {
-    /// Fail if the watch observed a peer on a different fleet digest.
+    /// Fail if the watch observed a peer on a different fleet sync-state digest.
     ///
     /// Call at every point where startup can still be abandoned cheaply. In
     /// particular, call it after the DB load: `trigger_manual_shutdown` is
@@ -661,21 +670,21 @@ impl Drop for StartupWatch {
 /// `wait_for_others_ready` and the heartbeat's first-contact check both kill an
 /// otherwise healthy node.
 ///
-/// The watch replaces that identity test with the fleet digest test:
+/// The watch replaces that identity test with the fleet sync-state digest test:
 ///
-/// - peer republishes this fleet digest (whatever its UUID) — it is provably
-///   resuming the same startup, so it is recorded as verified and both parties
-///   carry on. A restart is invisible to us, which is the entire point;
-/// - peer publishes a different fleet digest — its data changed, this startup is
-///   void, and we abandon it;
-/// - peer publishes no fleet digest, or is unreachable — it is mid-restart.
-///   Tolerated: it will either republish this digest or a different one, and the
-///   ready barrier still bounds how long a peer may fail to arrive.
+/// - peer republishes this digest (whatever its UUID) — it is provably resuming the
+///   same startup, so it is recorded as verified and both parties carry on. A
+///   restart is invisible to us, which is the entire point;
+/// - peer publishes a different digest — its data changed, this startup is void, and
+///   we abandon it;
+/// - peer publishes no digest, or is unreachable — it is mid-restart. Tolerated: it
+///   will either republish this digest or a different one, and the ready barrier
+///   still bounds how long a peer may fail to arrive.
 pub fn spawn_startup_watch(
     config: ServerCoordinationConfig,
     verified_peers: Arc<Mutex<HashSet<String>>>,
     shutdown_handler: Arc<ShutdownHandler>,
-    fleet_digest: SyncStateDigest,
+    fleet_sync_state_digest: SyncStateDigest,
 ) -> StartupWatch {
     let verdict = Arc::new(OnceLock::new());
 
@@ -713,14 +722,16 @@ pub fn spawn_startup_watch(
 
                 record_peer_uuids(&verified_peers, &peers).await;
 
-                if let AgreementVerdict::Void(disagreeing) = classify_peers(fleet_digest, &peers) {
+                if let ConsensusVerdict::Void(disagreeing) =
+                    compare_peer_states(fleet_sync_state_digest, &peers)
+                {
                     let reason = format!(
-                        "startup watch found a peer on a different fleet digest: mine is \
-                         {fleet_digest}, peers report {disagreeing:?}. This startup is void; \
-                         abandoning it so every party re-derives from current state."
+                        "startup watch found a peer on a different fleet sync-state digest: mine \
+                         is {fleet_sync_state_digest}, peers report {disagreeing:?}. This startup \
+                         is void; abandoning it so every party re-derives from current state."
                     );
                     tracing::error!("{}", reason);
-                    metrics::counter!("startup_fleet_digest_mismatch").increment(1);
+                    metrics::counter!("startup_fleet_sync_state_digest_mismatch").increment(1);
 
                     let _ = verdict.set(reason);
 
@@ -732,10 +743,10 @@ pub fn spawn_startup_watch(
 
                 for peer in &peers {
                     tracing::debug!(
-                        "Startup watch: party {} in phase {} (fleet digest {})",
+                        "Startup watch: party {} in phase {} (fleet sync-state digest {})",
                         peer.party_id,
                         peer.phase,
-                        peer.fleet_digest
+                        peer.fleet_sync_state_digest
                             .map(|digest| digest.short())
                             .unwrap_or_else(|| "pending".to_string())
                     );
@@ -873,28 +884,28 @@ mod tests {
         ]
     }
 
-    fn fleet_digest_of(states: &[SyncState]) -> SyncStateDigest {
+    fn fleet_sync_state_digest_of(states: &[SyncState]) -> SyncStateDigest {
         hash_fleet_sync_states(states).unwrap()
     }
 
     #[test]
-    fn fleet_digest_is_independent_of_collection_order() {
+    fn fleet_sync_state_digest_is_independent_of_collection_order() {
         // The whole design rests on this: each party polls its peers in its own
-        // order, yet all must derive the same fleet digest with no extra round trip.
-        let baseline = fleet_digest_of(&fleet());
+        // order, yet all must derive the same digest with no extra round trip.
+        let baseline = fleet_sync_state_digest_of(&fleet());
 
         let mut rotated = fleet();
         rotated.rotate_left(1);
-        assert_eq!(baseline, fleet_digest_of(&rotated));
+        assert_eq!(baseline, fleet_sync_state_digest_of(&rotated));
 
         let mut reversed = fleet();
         reversed.reverse();
-        assert_eq!(baseline, fleet_digest_of(&reversed));
+        assert_eq!(baseline, fleet_sync_state_digest_of(&reversed));
     }
 
     #[test]
-    fn fleet_digest_changes_when_any_party_state_changes() {
-        let baseline = fleet_digest_of(&fleet());
+    fn fleet_sync_state_digest_changes_when_any_party_state_changes() {
+        let baseline = fleet_sync_state_digest_of(&fleet());
 
         // The motivating case: a peer restarts and comes back with a different
         // persisted frontier. That must void this startup.
@@ -902,29 +913,29 @@ mod tests {
         changed[2].max_persisted_sequence_number = Some("0000000000000011".to_string());
         assert_ne!(
             baseline,
-            fleet_digest_of(&changed),
-            "a changed persisted frontier must change the fleet digest"
+            fleet_sync_state_digest_of(&changed),
+            "a changed persisted frontier must change the fleet sync-state digest"
         );
 
         let mut changed = fleet();
         changed[0].db_len += 1;
-        assert_ne!(baseline, fleet_digest_of(&changed));
+        assert_ne!(baseline, fleet_sync_state_digest_of(&changed));
 
         let mut changed = fleet();
         changed[1].modifications[0].status = "COMPLETED_WITH_ERROR".to_string();
-        assert_ne!(baseline, fleet_digest_of(&changed));
+        assert_ne!(baseline, fleet_sync_state_digest_of(&changed));
 
         let mut changed = fleet();
         changed[1].modifications[0].persisted = false;
-        assert_ne!(baseline, fleet_digest_of(&changed));
+        assert_ne!(baseline, fleet_sync_state_digest_of(&changed));
 
         let mut changed = fleet();
         changed[1].next_sns_sequence_num = None;
-        assert_ne!(baseline, fleet_digest_of(&changed));
+        assert_ne!(baseline, fleet_sync_state_digest_of(&changed));
 
         let mut changed = fleet();
         changed[0].graph_mutation_bytes = vec![Some(vec![0xcd; 16]), None];
-        assert_ne!(baseline, fleet_digest_of(&changed));
+        assert_ne!(baseline, fleet_sync_state_digest_of(&changed));
     }
 
     #[test]
@@ -936,17 +947,23 @@ mod tests {
             state(100, Some("0000000000000010")),
             state(100, Some("0000000000000010")),
         ];
-        assert_ne!(fleet_digest_of(&fleet()), fleet_digest_of(&all_agree));
+        assert_ne!(
+            fleet_sync_state_digest_of(&fleet()),
+            fleet_sync_state_digest_of(&all_agree)
+        );
     }
 
     #[test]
-    fn party_count_is_part_of_the_fleet_digest() {
+    fn party_count_is_part_of_the_fleet_sync_state_digest() {
         let states = fleet();
-        assert_ne!(fleet_digest_of(&states), fleet_digest_of(&states[..2]));
+        assert_ne!(
+            fleet_sync_state_digest_of(&states),
+            fleet_sync_state_digest_of(&states[..2])
+        );
     }
 
     #[test]
-    fn a_single_state_cannot_make_a_fleet_digest() {
+    fn a_single_state_cannot_make_a_fleet_sync_state_digest() {
         assert!(hash_fleet_sync_states(&fleet()[..1]).is_err());
     }
 
@@ -990,9 +1007,9 @@ mod tests {
 
     #[test]
     fn a_digest_survives_a_json_round_trip() {
-        // Peers parse the fleet digest out of each other's documents, so the hex
-        // encoding has to be exact.
-        let digest = fleet_digest_of(&fleet());
+        // Peers parse the fleet sync-state digest out of each other's documents, so
+        // the hex encoding has to be exact.
+        let digest = fleet_sync_state_digest_of(&fleet());
         let json = serde_json::to_string(&digest).unwrap();
         assert_eq!(
             serde_json::from_str::<SyncStateDigest>(&json).unwrap(),
@@ -1040,90 +1057,105 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn published_document_tracks_phase_and_fleet_digest() {
+    async fn published_document_tracks_phase_and_fleet_sync_state_digest() {
         let digest = hash_sync_state(&state(100, None));
         let handle = StartupStateHandle::new(1, digest, None);
 
         let initial = handle.snapshot().await;
         assert_eq!(initial.phase, Phase::Discover);
-        assert!(initial.fleet_digest.is_none());
+        assert!(initial.fleet_sync_state_digest.is_none());
         assert!(initial.uuid.is_none());
-        assert_eq!(initial.sync_state_digest, digest);
+        assert_eq!(initial.party_sync_state_digest, digest);
 
         handle.set_uuid("uuid-1".to_string()).await;
 
-        let fleet_digest = fleet_digest_of(&fleet());
+        let fleet_sync_state_digest = fleet_sync_state_digest_of(&fleet());
         handle.enter(Phase::Propose).await;
         handle.enter(Phase::Commit).await;
-        handle.set_fleet_digest(fleet_digest).await;
+        handle
+            .set_fleet_sync_state_digest(fleet_sync_state_digest)
+            .await;
 
         let committed = handle.snapshot().await;
         assert_eq!(committed.phase, Phase::Commit);
-        assert_eq!(committed.fleet_digest, Some(fleet_digest));
+        assert_eq!(
+            committed.fleet_sync_state_digest,
+            Some(fleet_sync_state_digest)
+        );
 
         // The document must survive the wire: peers parse exactly this.
         let json = serde_json::to_string(&committed).unwrap();
         let parsed: StartupState = serde_json::from_str(&json).unwrap();
-        assert_eq!(parsed.fleet_digest, Some(fleet_digest));
+        assert_eq!(
+            parsed.fleet_sync_state_digest,
+            Some(fleet_sync_state_digest)
+        );
         assert_eq!(parsed.phase, Phase::Commit);
         assert_eq!(parsed.party_id, 1);
         assert_eq!(parsed.uuid.as_deref(), Some("uuid-1"));
     }
 
-    fn peer(party_id: usize, phase: Phase, fleet_digest: Option<SyncStateDigest>) -> StartupState {
+    fn peer(
+        party_id: usize,
+        phase: Phase,
+        fleet_sync_state_digest: Option<SyncStateDigest>,
+    ) -> StartupState {
         StartupState {
             party_id,
             uuid: Some(format!("uuid-{party_id}")),
             phase,
             phase_started_at: Utc::now(),
-            sync_state_digest: hash_sync_state(&state(100, None)),
-            fleet_digest,
+            party_sync_state_digest: hash_sync_state(&state(100, None)),
+            fleet_sync_state_digest,
         }
     }
 
-    fn other_fleet_digest() -> SyncStateDigest {
+    fn other_fleet_sync_state_digest() -> SyncStateDigest {
         let mut changed = fleet();
         changed[0].db_len = 12_345;
-        fleet_digest_of(&changed)
+        fleet_sync_state_digest_of(&changed)
     }
 
     #[test]
-    fn all_peers_on_my_fleet_digest_is_committed() {
-        let mine = fleet_digest_of(&fleet());
+    fn all_peers_on_my_fleet_sync_state_digest_is_committed() {
+        let mine = fleet_sync_state_digest_of(&fleet());
         let peers = [
             peer(1, Phase::Commit, Some(mine)),
             peer(2, Phase::Load, Some(mine)),
         ];
-        assert_eq!(classify_peers(mine, &peers), AgreementVerdict::Committed);
+        assert_eq!(
+            compare_peer_states(mine, &peers),
+            ConsensusVerdict::Committed
+        );
     }
 
     #[test]
-    fn a_peer_without_a_fleet_digest_is_pending_not_void() {
+    fn a_peer_without_a_fleet_sync_state_digest_is_pending_not_void() {
         // Either it has not reached Commit, or it restarted and is on its way
         // back. Neither is a disagreement.
-        let mine = fleet_digest_of(&fleet());
+        let mine = fleet_sync_state_digest_of(&fleet());
         let peers = [
             peer(1, Phase::Commit, Some(mine)),
             peer(2, Phase::Discover, None),
         ];
         assert_eq!(
-            classify_peers(mine, &peers),
-            AgreementVerdict::Pending(vec![(2, Phase::Discover)])
+            compare_peer_states(mine, &peers),
+            ConsensusVerdict::Pending(vec![(2, Phase::Discover)])
         );
     }
 
     #[test]
-    fn a_peer_on_a_different_fleet_digest_voids_the_startup() {
+    fn a_peer_on_a_different_fleet_sync_state_digest_voids_the_startup() {
         // The motivating failure: a peer restarted with changed data.
-        let mine = fleet_digest_of(&fleet());
-        let theirs = other_fleet_digest();
+        let mine = fleet_sync_state_digest_of(&fleet());
+        let theirs = other_fleet_sync_state_digest();
         let peers = [
             peer(1, Phase::Commit, Some(mine)),
             peer(2, Phase::Commit, Some(theirs)),
         ];
         assert_eq!(
-            classify_peers(mine, &peers),
-            AgreementVerdict::Void(vec![(2, Some(theirs))])
+            compare_peer_states(mine, &peers),
+            ConsensusVerdict::Void(vec![(2, Some(theirs))])
         );
     }
 
@@ -1131,44 +1163,44 @@ mod tests {
     fn void_takes_precedence_over_pending() {
         // Fail closed: one peer still arriving must not mask another peer that
         // has already proven this startup void.
-        let mine = fleet_digest_of(&fleet());
-        let theirs = other_fleet_digest();
+        let mine = fleet_sync_state_digest_of(&fleet());
+        let theirs = other_fleet_sync_state_digest();
         let peers = [
             peer(1, Phase::Discover, None),
             peer(2, Phase::Commit, Some(theirs)),
         ];
         assert_eq!(
-            classify_peers(mine, &peers),
-            AgreementVerdict::Void(vec![(2, Some(theirs))])
+            compare_peer_states(mine, &peers),
+            ConsensusVerdict::Void(vec![(2, Some(theirs))])
         );
     }
 
     #[test]
     fn no_peers_is_pending_not_vacuously_committed() {
         // A round that saw nobody must never satisfy the commit barrier.
-        let mine = fleet_digest_of(&fleet());
+        let mine = fleet_sync_state_digest_of(&fleet());
         assert_eq!(
-            classify_peers(mine, &[]),
-            AgreementVerdict::Pending(Vec::new())
+            compare_peer_states(mine, &[]),
+            ConsensusVerdict::Pending(Vec::new())
         );
     }
 
     #[test]
     fn rejoin_condition_is_self_checking() {
         // The core claim of the peer-memory design. A restarting party rebuilds
-        // its own state from its DB and re-derives the fleet digest from its peers'
-        // (unchanged) boot snapshots.
+        // its own state from its DB and re-derives the fleet sync-state digest from
+        // its peers' (unchanged) boot snapshots.
         let original = fleet();
-        let in_flight = fleet_digest_of(&original);
+        let in_flight = fleet_sync_state_digest_of(&original);
 
         // State unchanged across the restart — converge had no work to do — so
-        // the party reproduces the in-flight fleet digest and rejoins.
+        // the party reproduces the in-flight digest and rejoins.
         let mut rebooted = original.clone();
         rebooted[0] = state(100, Some("0000000000000010"));
         assert_eq!(
             in_flight,
-            fleet_digest_of(&rebooted),
-            "an unchanged party must reproduce the in-flight fleet digest"
+            fleet_sync_state_digest_of(&rebooted),
+            "an unchanged party must reproduce the in-flight digest"
         );
 
         // State changed across the restart — converge mutated local state, or the
@@ -1177,7 +1209,7 @@ mod tests {
         rebooted[0] = state(101, Some("0000000000000011"));
         assert_ne!(
             in_flight,
-            fleet_digest_of(&rebooted),
+            fleet_sync_state_digest_of(&rebooted),
             "a changed party must not be able to rejoin"
         );
     }

--- a/iris-mpc/src/server/startup_phase.rs
+++ b/iris-mpc/src/server/startup_phase.rs
@@ -1,7 +1,5 @@
 //! Startup phase tracking and the data-derived [`SyncStateDigest`] that keys it.
 //!
-//! # Why this exists
-//!
 //! Peer coordination during startup is keyed on a random per-boot UUID: the
 //! heartbeat's first-contact check and [`wait_for_others_ready`] reject any peer
 //! whose UUID is outside the startup-verified set. That is the right policy once
@@ -19,51 +17,6 @@
 //! rejoin; one that comes back with a different [`SyncState`] computes a different
 //! one, which is exactly the signal that the initial sync is void and the whole
 //! fleet must restart.
-//!
-//! [`SyncState`] carries no party id and peers are polled in an arbitrary order, so
-//! the fleet sync-state digest covers the *sorted multiset* of per-party digests
-//! rather than a party-indexed vector. Duplicates are preserved, so one party's
-//! [`SyncState`] changing from "same as peers" to "different" still changes the
-//! fleet sync-state digest.
-//!
-//! # The surviving peers are the durable record
-//!
-//! There is deliberately no persisted digest table. The authority on which startup
-//! is in progress is the set of peers still running it, published on
-//! [`STARTUP_STATE_ROUTE`] from their live [`StartupStateHandle`]s. A restarting
-//! party rebuilds its [`SyncState`] from its DB and re-derives the fleet sync-state
-//! digest from its peers' boot snapshots; it reproduces the in-flight one **exactly
-//! when its own [`SyncState`] is unchanged**, so the rejoin condition checks itself
-//! — no durable state, no migration, no staleness guard. If every party restarts at
-//! once there is no in-flight digest to rejoin and all three derive a fresh one,
-//! which is the correct outcome rather than a degradation.
-//!
-//! # What rejoin covers
-//!
-//! Rejoin works whenever the restarting party's [`SyncState`] is unchanged, which
-//! covers the whole [`Phase::Load`] window — the long one, and the reason any of
-//! this exists — provided [`Phase::Converge`] had no work to do, the normal case
-//! for a healthy fleet.
-//!
-//! It does not cover a restart after a converge that actually mutated local
-//! state: such a party computes a different digest and the fleet restarts, exactly
-//! as it does today unconditionally. So the crash-recovery boot, the one where
-//! converge has real work, is also the one that cannot rejoin. Same for
-//! `next_sns_sequence_num` with `db_backed_ingest` disabled, where it is a live
-//! SQS queue head that the converge-phase trim moves.
-//!
-//! Replaying converge on a rejoin is safe because [`hash_sync_state`] projects
-//! [`SyncState`] so as to *see* every converge-phase mutation, so "same digest"
-//! already implies "converge had no effect": `sync_modifications` shows up in
-//! `db_len` and the modifications digest, `sync_graph_mutations` in that digest via
-//! `graph_mutation_bytes`, the ingest frontier skip-ahead in
-//! `max_persisted_sequence_number`, the queue trim in `next_sns_sequence_num`. The
-//! one exception, releasing unpersisted ingest claims, touches only rows above the
-//! frontier and is idempotent by construction. Anything added to converge later
-//! must be visible to [`hash_sync_state`] or idempotent, or a party could rejoin
-//! having silently applied it twice.
-//!
-//! [`wait_for_others_ready`]: ampc_server_utils::wait_for_others_ready
 
 use ampc_server_utils::shutdown_handler::ShutdownHandler;
 use ampc_server_utils::{get_check_addresses, ServerCoordinationConfig};
@@ -100,7 +53,7 @@ const FLEET_DOMAIN: &[u8] = b"iris-mpc/startup-fleet-sync-state/v1";
 /// Where a node is in its startup sequence.
 ///
 /// Published to peers so they can tell "still loading" from "dead" — a
-/// distinction the coordination server cannot express today, since `/health`
+/// distinction the coordination server cannot express, since `/health`
 /// answers 200 unconditionally and `/ready` only flips after the load completes.
 /// Ordered by progress: a node only ever moves forward within one startup.
 #[derive(
@@ -188,17 +141,6 @@ impl SyncStateDigest {
 /// Canonical digest of one party's [`SyncState`]: everything about its local
 /// state that the startup sync reads, and that must therefore be identical
 /// across a restart for a rejoin to be safe.
-///
-/// A deliberate projection of [`SyncState`], not the whole struct:
-/// `graph_mutation_bytes` is folded into the modifications digest (it is
-/// parallel-by-index to `modifications` and can be megabytes), and nothing is
-/// included that is not part of the startup decision.
-///
-/// Encoded by hand rather than via `serde_json` so the wire format of
-/// [`SyncState`] can evolve (field renames, `serde(default)` additions) without
-/// silently changing every digest. Every variable-length field is
-/// length-prefixed, so no two distinct states can encode to the same bytes by
-/// shifting a boundary.
 pub fn hash_sync_state(state: &SyncState) -> SyncStateDigest {
     let mut buf = Vec::with_capacity(128);
     buf.extend_from_slice(SYNC_STATE_DOMAIN);
@@ -213,13 +155,8 @@ pub fn hash_sync_state(state: &SyncState) -> SyncStateDigest {
     SyncStateDigest::from_bytes(&buf)
 }
 
-/// Digest all parties' states, including this party's own, into the one value
+/// Hash all parties' states, including this party's own, into the one value
 /// they all key this startup on.
-///
-/// `states` is expected to be [`SyncResult::all_states`], which is
-/// `[my_state] ++ peers`.
-///
-/// [`SyncResult::all_states`]: iris_mpc_common::helpers::sync::SyncResult
 pub fn hash_fleet_sync_states(states: &[SyncState]) -> Result<SyncStateDigest> {
     if states.len() < 2 {
         bail!(
@@ -248,13 +185,6 @@ pub fn hash_fleet_sync_states(states: &[SyncState]) -> Result<SyncStateDigest> {
     Ok(SyncStateDigest::from_bytes(&buf))
 }
 
-/// The single document a node publishes about its own startup.
-///
-/// Consolidates what is spread across `/health`, `/ready` and `/startup-sync`
-/// today, and unlike `/startup-sync` — which serves a `my_state` clone captured
-/// when the coordination server was constructed — it is read live from
-/// [`StartupStateHandle`], so it reflects the node's current phase rather than
-/// its state at boot.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StartupState {
     pub party_id: usize,
@@ -291,10 +221,7 @@ impl StartupStateHandle {
     /// passed in as an extra route; the UUID it mints arrives afterwards via
     /// [`StartupStateHandle::set_uuid`].
     ///
-    /// `hold_at` is the test hook from `Config::startup_hold_at_phase`, `None` in
-    /// every production path: the party parks forever on entering that phase,
-    /// *after* publishing it, so peers keep seeing a node legitimately sitting
-    /// there — which is precisely the state an e2e test wants to kill.
+    /// `hold_at` is the test hook from `Config::startup_hold_at_phase`,
     pub fn new(
         party_id: usize,
         party_sync_state_digest: SyncStateDigest,
@@ -378,21 +305,8 @@ impl StartupStateHandle {
     }
 }
 
-/// Fetch and parse every peer's startup-state document, once.
-///
-/// Deliberately does **not** use `try_get_endpoint_other_nodes`: that helper
-/// `tokio::spawn`s a retry task per peer and only aborts them along its own
-/// timeout path, so bounding it against a caller's deadline with an outer
-/// `tokio::time::timeout` leaks two tasks per polling round that keep hammering a
-/// down peer for the next five minutes. This is a single attempt with nothing
-/// spawned; the callers' loops supply the retry and can therefore stop it.
-///
-/// Returns what it managed to read plus a description of each peer it could not,
-/// rather than failing on the first unreachable one. A down peer must not blind us
-/// to the other: the reachable peer's UUID still needs recording (that is what
-/// lets a *restarting* peer past its visibility barrier), and its fleet sync-state
-/// digest is still worth checking for disagreement. Callers that need every peer —
-/// the commit barrier — check `failures` themselves.
+/// Fetch and parse every peer's startup-state.
+/// Returns what it managed to read plus a description of each peer it could not.
 async fn poll_peer_states(
     config: &ServerCoordinationConfig,
     request_timeout: Duration,
@@ -424,11 +338,6 @@ async fn poll_peer_states(
     (states, failures)
 }
 
-/// One peer, one attempt. `Err` carries a ready-to-log description.
-///
-/// A document we cannot parse is a failure, never a skipped entry: a caller
-/// counting agreeing peers must not reach quorum because a disagreeing peer was
-/// quietly dropped.
 async fn fetch_peer_state(
     client: &reqwest::Client,
     url: &str,
@@ -447,15 +356,6 @@ async fn fetch_peer_state(
         .map_err(|err| format!("unparseable startup state from {url}: {err}"))
 }
 
-/// Record a peer incarnation as seen, so the coordination server advertises it on
-/// `/health` and the `ampc-server-utils` checks downstream accept it.
-///
-/// Bookkeeping, not authorization — which lives entirely in the fleet sync-state
-/// digest comparison. `wait_until_startup_visibility_is_complete` needs this from us
-/// before a restarted peer can get far enough to publish a digest at all, so
-/// withholding it until the digests matched would deadlock: the peer cannot pass
-/// its visibility barrier until we list its UUID, and cannot publish a digest
-/// until it does.
 async fn record_peer_uuids(verified_peers: &Arc<Mutex<HashSet<String>>>, peers: &[StartupState]) {
     let mut verified = verified_peers.lock().await;
     for peer in peers {
@@ -611,11 +511,6 @@ pub async fn wait_for_fleet_sync_state_digest_commit(
     }
 }
 
-/// Log polling failures at WARN on the first attempt and every tenth after that,
-/// DEBUG otherwise.
-///
-/// Mirrors `wait_for_others_unready`'s cadence: a recoverable peer outage polled
-/// every second or two must not flood the log pipeline for the whole outage.
 fn log_poll_failure(attempt: u32, failures: &[String]) {
     if attempt == 1 || attempt.is_multiple_of(10) {
         tracing::warn!("Could not poll peer startup state (attempt {attempt}): {failures:?}");
@@ -626,13 +521,13 @@ fn log_poll_failure(attempt: u32, failures: &[String]) {
 
 /// Guard for the background task that watches peers across the converge and load
 /// phases. Aborts the task when dropped.
-pub struct StartupWatch {
+pub struct DesyncWatch {
     task: JoinHandle<()>,
     /// Set once, to the reason this startup was voided.
     verdict: Arc<OnceLock<String>>,
 }
 
-impl StartupWatch {
+impl DesyncWatch {
     /// Fail if the watch observed a peer on a different fleet sync-state digest.
     ///
     /// Call at every point where startup can still be abandoned cheaply. In
@@ -654,38 +549,26 @@ impl StartupWatch {
     }
 }
 
-impl Drop for StartupWatch {
+impl Drop for DesyncWatch {
     fn drop(&mut self) {
         self.task.abort();
     }
 }
 
-/// Watch peers for the duration of converge and load — the window in which no
-/// *coordination* check is looking.
-///
-/// This closes the gap that forces today's full-fleet restarts. The heartbeat is
-/// only armed after the load, so a peer that dies during the load is invisible
-/// until the ready barrier, and a peer that *restarts* during it is rejected
-/// outright: its new UUID is absent from the frozen `verified_peers` set, so
-/// `wait_for_others_ready` and the heartbeat's first-contact check both kill an
-/// otherwise healthy node.
-///
-/// The watch replaces that identity test with the fleet sync-state digest test:
-///
+/// Handles the following conditions:
 /// - peer republishes this digest (whatever its UUID) — it is provably resuming the
-///   same startup, so it is recorded as verified and both parties carry on. A
-///   restart is invisible to us, which is the entire point;
+///   same startup, so it is recorded as verified and both parties carry on.
 /// - peer publishes a different digest — its data changed, this startup is void, and
-///   we abandon it;
+///   we abandon it.
 /// - peer publishes no digest, or is unreachable — it is mid-restart. Tolerated: it
 ///   will either republish this digest or a different one, and the ready barrier
 ///   still bounds how long a peer may fail to arrive.
-pub fn spawn_startup_watch(
+pub fn spawn_desync_watch(
     config: ServerCoordinationConfig,
     verified_peers: Arc<Mutex<HashSet<String>>>,
     shutdown_handler: Arc<ShutdownHandler>,
     fleet_sync_state_digest: SyncStateDigest,
-) -> StartupWatch {
+) -> DesyncWatch {
     let verdict = Arc::new(OnceLock::new());
 
     let task = tokio::spawn({
@@ -711,11 +594,6 @@ pub fn spawn_startup_watch(
                 if poll_failures.is_empty() {
                     failures = 0;
                 } else {
-                    // Expected while a peer restarts — the case this watch exists
-                    // to absorb — so it is rate-limited rather than warned on every
-                    // round. The ready barrier and the heartbeat bound the terminal
-                    // cases. Unlike the commit barrier we carry on with a partial
-                    // view: a reachable peer on the wrong digest is still a verdict.
                     failures += 1;
                     log_poll_failure(failures, &poll_failures);
                 }
@@ -755,17 +633,12 @@ pub fn spawn_startup_watch(
         }
     });
 
-    StartupWatch { task, verdict }
+    DesyncWatch { task, verdict }
 }
 
 /// SHA-256 of the common config, as bytes to fold into [`hash_sync_state`]'s
 /// preimage.
 fn digest_common_config(config: &CommonConfig) -> Vec<u8> {
-    // `CommonConfig` is all scalars, `Vec`s and `Option`s — no maps — so
-    // `serde_json` field order is the declaration order and the encoding is
-    // deterministic. It is also already compared field-by-field across parties
-    // by `SyncResult::check_common_config`, so any difference the digest sees
-    // is a difference that check would reject anyway.
     let bytes = serde_json::to_vec(config).expect("CommonConfig serialization to JSON failed");
     sha256_bytes(&bytes).to_vec()
 }

--- a/iris-mpc/src/server/startup_phase.rs
+++ b/iris-mpc/src/server/startup_phase.rs
@@ -106,11 +106,11 @@
 //! [`wait_for_others_ready`]: ampc_server_utils::wait_for_others_ready
 
 use ampc_server_utils::shutdown_handler::ShutdownHandler;
-use ampc_server_utils::{try_get_endpoint_other_nodes, ServerCoordinationConfig};
+use ampc_server_utils::{get_check_addresses, ServerCoordinationConfig};
 use axum::routing::get;
 use axum::Router;
 use chrono::{DateTime, Utc};
-use eyre::{bail, eyre, Result, WrapErr};
+use eyre::{bail, Result};
 use iris_mpc_common::config::CommonConfig;
 use iris_mpc_common::helpers::sha256::sha256_bytes;
 use iris_mpc_common::helpers::sync::{Modification, SyncState};
@@ -127,8 +127,8 @@ use tokio::task::JoinHandle;
 /// Axum path serving the live startup-state document.
 pub const STARTUP_STATE_ROUTE: &str = "/startup-state";
 
-/// The same route as an endpoint name, for
-/// [`try_get_endpoint_other_nodes`]-style peer polling.
+/// The same route without its leading slash, which is the form
+/// `get_check_addresses` wants when building peer URLs.
 pub const STARTUP_STATE_ENDPOINT: &str = "startup-state";
 
 /// Domain separators. Every digest in this module is tagged so that a byte
@@ -158,7 +158,11 @@ pub enum Phase {
     /// Applying the agreed plan to local storage (modifications roll-forward,
     /// graph WAL, ingest frontier skip-ahead, queue trim).
     Converge,
-    /// Local-only heavy work: the iris/graph DB load.
+    /// The DB load. Mostly local, but NOT peer-independent: `init_hawk_actor`
+    /// runs `restart_from_checkpoint`, a cross-party consensus round with a 10s
+    /// `PEER_ROUND_TIMEOUT`, concurrently with the iris load. A peer that
+    /// vanishes here fails its peers inside the load, before the epoch layer
+    /// gets to decide anything — so rejoin does not yet cover this window.
     Load,
     /// Ready, heartbeat armed, main loop running.
     Serving,
@@ -508,33 +512,80 @@ impl StartupStateHandle {
     }
 }
 
-/// Fetch and parse every peer's startup-state document.
+/// Fetch and parse every peer's startup-state document, once.
 ///
-/// A peer whose document cannot be parsed is an error rather than a skipped
-/// entry: a caller counting agreeing peers must not be able to reach quorum
-/// because a disagreeing peer was quietly dropped.
+/// Deliberately does **not** use `try_get_endpoint_other_nodes`. That helper
+/// `tokio::spawn`s a retry task per peer and only aborts them along its own
+/// timeout path, so wrapping it in an outer `tokio::time::timeout` — which is the
+/// only way to bound it against a caller's deadline rather than its own
+/// `startup_sync_timeout_secs` — cancels the wrapper while leaving the spawned
+/// retries running. Every polling round then leaked two tasks that kept hammering
+/// a down peer at `http_query_retry_delay_ms` for the next five minutes, with the
+/// log volume to match.
+///
+/// This is a single attempt with no internal retry and nothing spawned: the
+/// callers' own loops supply the retry, and they can therefore stop it.
+///
+/// Returns what it managed to read plus a description of each peer it could not,
+/// rather than failing on the first unreachable one. A down peer must not blind
+/// us to the other: the reachable peer's UUID still needs recording (that is what
+/// lets a *restarting* peer past its visibility barrier), and its epoch is still
+/// worth checking for disagreement. Callers that need all peers — the commit
+/// barrier — check `failures` themselves.
 async fn poll_peer_states(
     config: &ServerCoordinationConfig,
-    budget: Duration,
-) -> Result<Vec<StartupState>> {
-    // `try_get_endpoint_other_nodes` retries internally against its own
-    // `startup_sync_timeout_secs` budget, which is unrelated to the caller's,
-    // so cap it here rather than inheriting it.
-    let responses = tokio::time::timeout(
-        budget,
-        try_get_endpoint_other_nodes(config, STARTUP_STATE_ENDPOINT),
-    )
-    .await
-    .map_err(|_| eyre!("timed out polling peer startup state after {:?}", budget))??;
+    request_timeout: Duration,
+) -> (Vec<StartupState>, Vec<String>) {
+    let urls = get_check_addresses(
+        &config.node_hostnames,
+        &config.healthcheck_ports,
+        STARTUP_STATE_ENDPOINT,
+    );
+    let client = reqwest::Client::new();
+    let mut states = Vec::with_capacity(urls.len().saturating_sub(1));
+    let mut failures = Vec::new();
 
-    responses
-        .into_iter()
-        .map(|(status, body)| {
-            serde_json::from_slice::<StartupState>(&body).wrap_err_with(|| {
-                format!("failed to deserialize peer startup state (status {status})")
-            })
-        })
-        .collect()
+    for (party_id, url) in urls.iter().enumerate() {
+        if party_id == config.party_id {
+            continue;
+        }
+        match fetch_peer_state(&client, url, request_timeout).await {
+            Ok(state) => states.push(state),
+            Err(failure) => failures.push(failure),
+        }
+    }
+
+    (states, failures)
+}
+
+/// One peer, one attempt. `Err` carries a ready-to-log description.
+async fn fetch_peer_state(
+    client: &reqwest::Client,
+    url: &str,
+    request_timeout: Duration,
+) -> std::result::Result<StartupState, String> {
+    let response = match tokio::time::timeout(request_timeout, client.get(url).send()).await {
+        Ok(Ok(response)) => response,
+        Ok(Err(err)) => return Err(format!("GET {url} failed: {err}")),
+        Err(_) => return Err(format!("GET {url} timed out after {request_timeout:?}")),
+    };
+
+    let status = response.status();
+    let body = match tokio::time::timeout(request_timeout, response.bytes()).await {
+        Ok(Ok(body)) => body,
+        Ok(Err(err)) => return Err(format!("reading body of {url} failed: {err}")),
+        Err(_) => {
+            return Err(format!(
+                "reading body of {url} timed out after {request_timeout:?}"
+            ))
+        }
+    };
+
+    // A document we cannot parse is a failure, never a skipped entry: a caller
+    // counting agreeing peers must not reach quorum because a disagreeing peer
+    // was quietly dropped.
+    serde_json::from_slice::<StartupState>(&body)
+        .map_err(|err| format!("unparseable startup state from {url} (status {status}): {err}"))
 }
 
 /// Record a peer incarnation as seen, so the coordination server advertises it
@@ -636,9 +687,12 @@ pub async fn wait_for_epoch_commit(
 
     let budget = Duration::from_secs(config.startup_sync_timeout_secs);
     let retry_delay = Duration::from_millis(config.http_query_retry_delay_ms);
+    let request_timeout = Duration::from_millis(config.http_query_timeout_ms);
     let deadline = Instant::now() + budget;
+    let mut attempt: u32 = 0;
 
     loop {
+        attempt += 1;
         let remaining = deadline.saturating_duration_since(Instant::now());
         if remaining.is_zero() {
             metrics::counter!("startup_epoch_commit_timeout").increment(1);
@@ -649,16 +703,20 @@ pub async fn wait_for_epoch_commit(
             );
         }
 
-        let peers = match poll_peer_states(config, remaining).await {
-            Ok(peers) => peers,
-            Err(err) => {
-                tracing::warn!("Failed to poll peer startup state: {:?}", err);
-                tokio::time::sleep(retry_delay.min(remaining)).await;
-                continue;
-            }
-        };
+        let (peers, failures) = poll_peer_states(config, request_timeout.min(remaining)).await;
 
+        // Record before deciding: a peer that is still coming back needs its new
+        // UUID published by us before it can pass its own visibility barrier.
         record_peer_uuids(verified_peers, &peers).await;
+
+        if !failures.is_empty() {
+            // Routine — a peer may be restarting, and we are the thing keeping the
+            // fleet from proceeding without it. The barrier requires every peer, so
+            // wait rather than classifying a partial view.
+            log_poll_failure(attempt, &failures);
+            tokio::time::sleep(retry_delay.min(remaining)).await;
+            continue;
+        }
 
         match classify_peers(my_epoch, &peers) {
             EpochVerdict::Void(disagreeing) => {
@@ -685,6 +743,19 @@ pub async fn wait_for_epoch_commit(
                 tokio::time::sleep(retry_delay.min(remaining)).await;
             }
         }
+    }
+}
+
+/// Log polling failures at WARN on the first attempt and every tenth after that,
+/// DEBUG otherwise.
+///
+/// Mirrors `wait_for_others_unready`'s cadence: a recoverable peer outage polled
+/// every second or two must not flood the log pipeline for the whole outage.
+fn log_poll_failure(attempt: u32, failures: &[String]) {
+    if attempt == 1 || attempt.is_multiple_of(10) {
+        tracing::warn!("Could not poll peer startup state (attempt {attempt}): {failures:?}");
+    } else {
+        tracing::debug!("Could not poll peer startup state (attempt {attempt}): {failures:?}");
     }
 }
 
@@ -743,8 +814,8 @@ impl Drop for StartupWatch {
     }
 }
 
-/// Watch peers for the duration of converge and load — the window in which
-/// nothing else is looking.
+/// Watch peers for the duration of converge and load — the window in which no
+/// *coordination* check is looking.
 ///
 /// This closes the gap that forces today's full-fleet restarts. The heartbeat is
 /// only armed after the load, so a peer that dies during the load is invisible
@@ -783,8 +854,11 @@ pub fn spawn_startup_watch(
         // Reuse the heartbeat cadence: this is the same job, over the phase of
         // startup where the heartbeat itself cannot yet run.
         let poll_interval = Duration::from_secs(config.heartbeat_interval_secs);
+        let request_timeout = Duration::from_millis(config.http_query_timeout_ms);
 
         async move {
+            let mut failures: u32 = 0;
+
             loop {
                 tokio::time::sleep(poll_interval).await;
 
@@ -793,15 +867,19 @@ pub fn spawn_startup_watch(
                     return;
                 }
 
-                let peers = match poll_peer_states(&config, poll_interval).await {
-                    Ok(peers) => peers,
-                    Err(err) => {
-                        // Expected while a peer restarts; the ready barrier and
-                        // heartbeat bound the terminal cases.
-                        tracing::warn!("Startup watch could not poll peers: {:?}", err);
-                        continue;
-                    }
-                };
+                let (peers, poll_failures) = poll_peer_states(&config, request_timeout).await;
+
+                if poll_failures.is_empty() {
+                    failures = 0;
+                } else {
+                    // Expected while a peer restarts — the case this watch exists
+                    // to absorb — so it is rate-limited rather than warned on every
+                    // round. The ready barrier and the heartbeat bound the terminal
+                    // cases. Unlike the commit barrier we carry on with a partial
+                    // view: a reachable peer on the wrong epoch is still a verdict.
+                    failures += 1;
+                    log_poll_failure(failures, &poll_failures);
+                }
 
                 record_peer_uuids(&verified_peers, &peers).await;
 

--- a/iris-mpc/tests/e2e_hawk_init.rs
+++ b/iris-mpc/tests/e2e_hawk_init.rs
@@ -174,12 +174,12 @@ fn test_wal_111() -> eyre::Result<()> {
 
 // ---------------------------------------------------------------------------
 // startup_120 – startup_121: single-party restart during the startup handshake,
-// exercising the data-derived startup epoch.
+// exercising the data-derived startup fleet digest.
 // ---------------------------------------------------------------------------
 
-/// Rejoin: one party restarts mid-handshake with unchanged data. It rejoins the
-/// same startup epoch; the other two neither restart nor advance past the commit
-/// barrier while it is gone.
+/// Rejoin: one party restarts mid-handshake with unchanged data. It recomputes the
+/// same fleet digest and rejoins; the other two neither restart nor advance past the
+/// commit barrier while it is gone.
 #[test]
 #[serial]
 #[ignore = "requires external setup"]
@@ -188,7 +188,7 @@ fn test_startup_120() -> eyre::Result<()> {
 }
 
 /// Mismatch: one party restarts mid-handshake with changed data, so it derives a
-/// different epoch than its peers hold. No party may come up.
+/// different fleet digest than its peers hold. No party may come up.
 #[test]
 #[serial]
 #[ignore = "requires external setup"]

--- a/iris-mpc/tests/e2e_hawk_init.rs
+++ b/iris-mpc/tests/e2e_hawk_init.rs
@@ -20,8 +20,8 @@ use crate::utils::runner::TestRun;
 use eyre::bail;
 use serial_test::serial;
 use workflows::{
-    startup_120::Startup120, startup_121::Startup121, wal_104::Wal104, wal_105::Wal105,
-    wal_106::Wal106, wal_109::Wal109, wal_110::Wal110, wal_111::Wal111,
+    startup_120::Startup120, startup_121::Startup121, startup_122::Startup122, wal_104::Wal104,
+    wal_105::Wal105, wal_106::Wal106, wal_109::Wal109, wal_110::Wal110, wal_111::Wal111,
 };
 
 const RUST_LOG: &str = "info";
@@ -173,8 +173,9 @@ fn test_wal_111() -> eyre::Result<()> {
 }
 
 // ---------------------------------------------------------------------------
-// startup_120 – startup_121: single-party restart during the startup handshake,
-// exercising the data-derived startup fleet sync-state digest.
+// startup_120 – startup_122: single-party restart around the startup handshake,
+// exercising the data-derived startup fleet sync-state digest and the boundary
+// past which it no longer permits a rejoin.
 // ---------------------------------------------------------------------------
 
 /// Rejoin: one party restarts mid-handshake with unchanged data. It recomputes the
@@ -194,4 +195,14 @@ fn test_startup_120() -> eyre::Result<()> {
 #[ignore = "requires external setup"]
 fn test_startup_121() -> eyre::Result<()> {
     run_test!(121, 1, Startup121::new())
+}
+
+/// Too late: one party restarts after the fleet is serving, with unchanged data and
+/// so an unchanged sync state. The rejoin is scoped to startup, so it must still be
+/// refused and no party may be left serving.
+#[test]
+#[serial]
+#[ignore = "requires external setup"]
+fn test_startup_122() -> eyre::Result<()> {
+    run_test!(122, 1, Startup122::new())
 }

--- a/iris-mpc/tests/e2e_hawk_init.rs
+++ b/iris-mpc/tests/e2e_hawk_init.rs
@@ -56,70 +56,81 @@ macro_rules! run_test {
             bail!("A previous test has failed, aborting further tests.");
         }
 
-        // Not `Runtime::new()`: the parties run as spawned tasks on this runtime and
-        // want more than the 2 MB default. See `utils::TEST_THREAD_STACK_SIZE`.
-        let rt = tokio::runtime::Builder::new_multi_thread()
-            .enable_all()
-            .thread_stack_size(utils::TEST_THREAD_STACK_SIZE)
-            .build()?;
-        rt.block_on(async {
-            let ctx = utils::runner::CpuTestContext::new($kind, $idx).await;
+        // Run the body on a thread we own. The party futures are `tokio::spawn`ed onto
+        // the runtime's workers, but the test body — context construction plus the
+        // composed setup/execute/teardown future — is polled by `block_on` on the
+        // calling thread, and libtest picks that thread's stack size, not us. That
+        // future is large enough to blow it.
+        let body = std::thread::Builder::new()
+            .name(format!("test-{}-{}", $kind, $idx))
+            .stack_size(utils::TEST_THREAD_STACK_SIZE)
+            .spawn(move || -> eyre::Result<()> {
+                let rt = tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .thread_stack_size(utils::TEST_THREAD_STACK_SIZE)
+                    .build()?;
+                rt.block_on(async {
+                    let ctx = utils::runner::CpuTestContext::new($kind, $idx).await;
 
-            // One-time global setup: runs only for the first test in the suite.
-            // Tests are serial so there is no concurrent access concern here.
-            if !GLOBAL_SETUP_DONE.load(Ordering::SeqCst) {
-                match utils::key_rotation::global_setup(ctx.env.s3_endpoint()).await {
-                    Ok(()) => GLOBAL_SETUP_DONE.store(true, Ordering::SeqCst),
-                    Err(e) => {
+                    // One-time global setup: runs only for the first test in the suite.
+                    // Tests are serial so there is no concurrent access concern here.
+                    if !GLOBAL_SETUP_DONE.load(Ordering::SeqCst) {
+                        match utils::key_rotation::global_setup(ctx.env.s3_endpoint()).await {
+                            Ok(()) => GLOBAL_SETUP_DONE.store(true, Ordering::SeqCst),
+                            Err(e) => {
+                                TEST_FAILED.store(true, Ordering::SeqCst);
+                                return Err(e.wrap_err("global setup failed"));
+                            }
+                        }
+                    }
+
+                    // Cancel ctx.abort on Ctrl+C so that run_hawk!/run_sidecar! can
+                    // shut down their services cleanly rather than being dropped
+                    // mid-flight.
+                    //
+                    // Keeps listening rather than firing once.
+                    {
+                        let abort = ctx.abort.clone();
+                        tokio::spawn(async move {
+                            loop {
+                                if tokio::signal::ctrl_c().await.is_err() {
+                                    return;
+                                }
+                                if abort.is_cancelled() {
+                                    tracing::error!("Ctrl+C again — exiting immediately");
+                                    std::process::exit(130);
+                                }
+                                tracing::warn!(
+                                    "Ctrl+C received — aborting test (press again to force exit)"
+                                );
+                                abort.cancel();
+                            }
+                        });
+                    }
+
+                    let mut test = $test;
+                    let r = test.run(&ctx).await;
+
+                    let aborted = ctx.abort.is_cancelled();
+                    if r.is_err() || aborted {
                         TEST_FAILED.store(true, Ordering::SeqCst);
-                        return Err(e.wrap_err("global setup failed"));
                     }
-                }
-            }
-
-            // Cancel ctx.abort on Ctrl+C so that run_hawk!/run_sidecar! can
-            // shut down their services cleanly rather than being dropped mid-flight.
-            //
-            // Keeps listening rather than firing once. Tokio installs the process-wide
-            // SIGINT handler on first use and never removes it, so from the moment this
-            // task runs the default "terminate the process" action is gone for good. A
-            // one-shot listener therefore leaves every later Ctrl+C with nothing
-            // listening AND no default behaviour — the binary becomes unkillable from
-            // the terminal. The second press is a hard exit, which is the only escape
-            // from a wedged teardown.
-            {
-                let abort = ctx.abort.clone();
-                tokio::spawn(async move {
-                    loop {
-                        if tokio::signal::ctrl_c().await.is_err() {
-                            return;
-                        }
-                        if abort.is_cancelled() {
-                            tracing::error!("Ctrl+C again — exiting immediately");
-                            std::process::exit(130);
-                        }
-                        tracing::warn!(
-                            "Ctrl+C received — aborting test (press again to force exit)"
-                        );
-                        abort.cancel();
+                    // A real phase error is the more informative one, so it wins; the
+                    // abort only has to supply a failure when every phase happened to
+                    // return `Ok`.
+                    if aborted && r.is_ok() {
+                        bail!("aborted by Ctrl+C");
                     }
-                });
-            }
+                    r
+                })
+            })?;
 
-            let mut test = $test;
-            let r = test.run(&ctx).await;
-
-            let aborted = ctx.abort.is_cancelled();
-            if r.is_err() || aborted {
-                TEST_FAILED.store(true, Ordering::SeqCst);
-            }
-            // A real phase error is the more informative one, so it wins; the abort
-            // only has to supply a failure when every phase happened to return `Ok`.
-            if aborted && r.is_ok() {
-                bail!("aborted by Ctrl+C");
-            }
-            r
-        })
+        // Re-raise a panic as a panic so the harness still prints the assertion
+        // message and location instead of an opaque join error.
+        match body.join() {
+            Ok(r) => r,
+            Err(payload) => std::panic::resume_unwind(payload),
+        }
     }};
 }
 

--- a/iris-mpc/tests/e2e_hawk_init.rs
+++ b/iris-mpc/tests/e2e_hawk_init.rs
@@ -56,8 +56,8 @@ macro_rules! run_test {
             bail!("A previous test has failed, aborting further tests.");
         }
 
-        // Not `Runtime::new()`: its 2 MB blocking-thread stacks are too small for
-        // `server_main`'s future. See `utils::TEST_THREAD_STACK_SIZE`.
+        // Not `Runtime::new()`: the parties run as spawned tasks on this runtime and
+        // want more than the 2 MB default. See `utils::TEST_THREAD_STACK_SIZE`.
         let rt = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .thread_stack_size(utils::TEST_THREAD_STACK_SIZE)

--- a/iris-mpc/tests/e2e_hawk_init.rs
+++ b/iris-mpc/tests/e2e_hawk_init.rs
@@ -20,14 +20,8 @@ use crate::utils::runner::TestRun;
 use eyre::bail;
 use serial_test::serial;
 use workflows::{
-    startup_120::Startup120,
-    startup_121::Startup121,
-    wal_104::Wal104,
-    wal_105::Wal105,
-    wal_106::Wal106,
-    wal_109::Wal109,
-    wal_110::Wal110,
-    wal_111::Wal111,
+    startup_120::Startup120, startup_121::Startup121, wal_104::Wal104, wal_105::Wal105,
+    wal_106::Wal106, wal_109::Wal109, wal_110::Wal110, wal_111::Wal111,
 };
 
 const RUST_LOG: &str = "info";

--- a/iris-mpc/tests/e2e_hawk_init.rs
+++ b/iris-mpc/tests/e2e_hawk_init.rs
@@ -79,11 +79,28 @@ macro_rules! run_test {
 
             // Cancel ctx.abort on Ctrl+C so that run_hawk!/run_sidecar! can
             // shut down their services cleanly rather than being dropped mid-flight.
+            //
+            // Keeps listening rather than firing once. Tokio installs the process-wide
+            // SIGINT handler on first use and never removes it, so from the moment this
+            // task runs the default "terminate the process" action is gone for good. A
+            // one-shot listener therefore leaves every later Ctrl+C with nothing
+            // listening AND no default behaviour — the binary becomes unkillable from
+            // the terminal. The second press is a hard exit, which is the only escape
+            // from a wedged teardown.
             {
                 let abort = ctx.abort.clone();
                 tokio::spawn(async move {
-                    if tokio::signal::ctrl_c().await.is_ok() {
-                        tracing::warn!("Ctrl+C received — aborting test");
+                    loop {
+                        if tokio::signal::ctrl_c().await.is_err() {
+                            return;
+                        }
+                        if abort.is_cancelled() {
+                            tracing::error!("Ctrl+C again — exiting immediately");
+                            std::process::exit(130);
+                        }
+                        tracing::warn!(
+                            "Ctrl+C received — aborting test (press again to force exit)"
+                        );
                         abort.cancel();
                     }
                 });
@@ -92,8 +109,14 @@ macro_rules! run_test {
             let mut test = $test;
             let r = test.run(&ctx).await;
 
-            if r.is_err() && !ctx.abort.is_cancelled() {
+            let aborted = ctx.abort.is_cancelled();
+            if r.is_err() || aborted {
                 TEST_FAILED.store(true, Ordering::SeqCst);
+            }
+            // A real phase error is the more informative one, so it wins; the abort
+            // only has to supply a failure when every phase happened to return `Ok`.
+            if aborted && r.is_ok() {
+                bail!("aborted by Ctrl+C");
             }
             r
         })

--- a/iris-mpc/tests/e2e_hawk_init.rs
+++ b/iris-mpc/tests/e2e_hawk_init.rs
@@ -174,11 +174,11 @@ fn test_wal_111() -> eyre::Result<()> {
 
 // ---------------------------------------------------------------------------
 // startup_120 – startup_121: single-party restart during the startup handshake,
-// exercising the data-derived startup fleet digest.
+// exercising the data-derived startup fleet sync-state digest.
 // ---------------------------------------------------------------------------
 
 /// Rejoin: one party restarts mid-handshake with unchanged data. It recomputes the
-/// same fleet digest and rejoins; the other two neither restart nor advance past the
+/// same fleet sync-state digest and rejoins; the other two neither restart nor advance past the
 /// commit barrier while it is gone.
 #[test]
 #[serial]
@@ -188,7 +188,7 @@ fn test_startup_120() -> eyre::Result<()> {
 }
 
 /// Mismatch: one party restarts mid-handshake with changed data, so it derives a
-/// different fleet digest than its peers hold. No party may come up.
+/// different fleet sync-state digest than its peers hold. No party may come up.
 #[test]
 #[serial]
 #[ignore = "requires external setup"]

--- a/iris-mpc/tests/e2e_hawk_init.rs
+++ b/iris-mpc/tests/e2e_hawk_init.rs
@@ -20,7 +20,13 @@ use crate::utils::runner::TestRun;
 use eyre::bail;
 use serial_test::serial;
 use workflows::{
-    wal_104::Wal104, wal_105::Wal105, wal_106::Wal106, wal_109::Wal109, wal_110::Wal110,
+    startup_120::Startup120,
+    startup_121::Startup121,
+    wal_104::Wal104,
+    wal_105::Wal105,
+    wal_106::Wal106,
+    wal_109::Wal109,
+    wal_110::Wal110,
     wal_111::Wal111,
 };
 
@@ -56,7 +62,12 @@ macro_rules! run_test {
             bail!("A previous test has failed, aborting further tests.");
         }
 
-        let rt = tokio::runtime::Runtime::new()?;
+        // Not `Runtime::new()`: its 2 MB blocking-thread stacks are too small for
+        // `server_main`'s future. See `utils::TEST_THREAD_STACK_SIZE`.
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .thread_stack_size(utils::TEST_THREAD_STACK_SIZE)
+            .build()?;
         rt.block_on(async {
             let ctx = utils::runner::CpuTestContext::new($kind, $idx).await;
 
@@ -165,4 +176,28 @@ fn test_wal_110() -> eyre::Result<()> {
 #[ignore = "requires external setup"]
 fn test_wal_111() -> eyre::Result<()> {
     run_test!(111, 1, Wal111::new())
+}
+
+// ---------------------------------------------------------------------------
+// startup_120 – startup_121: single-party restart during the startup handshake,
+// exercising the data-derived startup epoch.
+// ---------------------------------------------------------------------------
+
+/// Rejoin: one party restarts mid-handshake with unchanged data. It rejoins the
+/// same startup epoch; the other two neither restart nor advance past the commit
+/// barrier while it is gone.
+#[test]
+#[serial]
+#[ignore = "requires external setup"]
+fn test_startup_120() -> eyre::Result<()> {
+    run_test!(120, 1, Startup120::new())
+}
+
+/// Mismatch: one party restarts mid-handshake with changed data, so it derives a
+/// different epoch than its peers hold. No party may come up.
+#[test]
+#[serial]
+#[ignore = "requires external setup"]
+fn test_startup_121() -> eyre::Result<()> {
+    run_test!(121, 1, Startup121::new())
 }

--- a/iris-mpc/tests/utils/hawk_fleet.rs
+++ b/iris-mpc/tests/utils/hawk_fleet.rs
@@ -13,17 +13,17 @@
 //! The startup workflows have to stop a party *in* a named phase. Polling
 //! `/startup-state` for that cannot work: on an empty local fleet `propose -> load`
 //! takes ~180 ms end to end, so a 100 ms poll grid routinely first observes the
-//! party already past the intended kill point, having published its fleet digest
-//! and released its peers' commit barrier. So the party is *held* instead:
+//! party already past the intended kill point, having published its fleet sync-state
+//! digest and released its peers' commit barrier. So the party is *held* instead:
 //! [`HawkFleet::start_party`] sets `Config::startup_hold_at_phase` and the party
 //! parks there until stopped; the restart is spawned without the hold. The hold is
 //! excluded from `CommonConfig`, so it does not perturb the derived digest.
 //!
 //! # Why the commit-barrier budget is overridable
 //!
-//! `wait_for_fleet_digest_commit` treats an unreachable peer as "it is restarting,
-//! keep waiting" — which is what makes rejoin work, and why a party that *dies*
-//! is indistinguishable from one coming back. The survivors then wait out the whole
+//! `wait_for_fleet_sync_state_digest_commit` treats an unreachable peer as "it is
+//! restarting, keep waiting" — which is what makes rejoin work, and why a party that
+//! *dies* is indistinguishable from one coming back. The survivors then wait out the whole
 //! 300s `startup_sync_timeout_secs`, longer than [`FLEET_TIMEOUT`], so a workflow
 //! whose expected outcome is "the fleet gives up" would hit the harness deadline
 //! instead of the behaviour it asserts. [`FleetOptions::startup_sync_timeout_secs`]
@@ -35,7 +35,8 @@
 //! `init_hawk_actor` runs `restart_from_checkpoint` — a cross-party consensus round
 //! with a 10s `PEER_ROUND_TIMEOUT` — concurrently with the iris load via
 //! `try_join!`. A party that disappears during the load therefore fails its peers
-//! *inside* the load, whatever the fleet digest comparison would have decided.
+//! *inside* the load, whatever the fleet sync-state digest comparison would have
+//! decided.
 //! Killing during the handshake parks the survivors in the commit barrier, where
 //! the outcome is determined entirely by the digest logic under test. A load-window
 //! rejoin test becomes meaningful once the checkpoint round tolerates a peer
@@ -367,21 +368,21 @@ impl HawkFleet {
             .phase)
     }
 
-    /// Every party's published fleet digest. Fails if any party has not derived one,
-    /// or if they do not all agree.
-    pub async fn agreed_fleet_digest(&self) -> eyre::Result<SyncStateDigest> {
+    /// Every party's published fleet sync-state digest. Fails if any party has not
+    /// derived one, or if they do not all agree.
+    pub async fn agreed_fleet_sync_state_digest(&self) -> eyre::Result<SyncStateDigest> {
         let mut digests = Vec::with_capacity(COUNT_OF_PARTIES);
         for party in 0..COUNT_OF_PARTIES {
             let state = fetch_startup_state(self.configs[party].healthcheck_port).await?;
-            digests.push(state.fleet_digest.ok_or_else(|| {
+            digests.push(state.fleet_sync_state_digest.ok_or_else(|| {
                 eyre!(
-                    "party {party} has not derived a fleet digest (phase {})",
+                    "party {party} has not derived a fleet sync-state digest (phase {})",
                     state.phase
                 )
             })?);
         }
         if digests.iter().any(|digest| *digest != digests[0]) {
-            bail!("parties disagree on the startup fleet digest: {digests:?}");
+            bail!("parties disagree on the startup fleet sync-state digest: {digests:?}");
         }
         Ok(digests[0])
     }

--- a/iris-mpc/tests/utils/hawk_fleet.rs
+++ b/iris-mpc/tests/utils/hawk_fleet.rs
@@ -1,0 +1,406 @@
+//! Per-party control over the three `server_main` instances.
+//!
+//! [`super::wait_conditions`] treats the fleet as a unit: one
+//! `CancellationToken` for all three parties and a `JoinSet` that only reports
+//! *that* something exited. The startup-epoch tests need finer control — stop
+//! exactly one party, prove the other two are still running, restart the first
+//! — so this module keeps a `JoinHandle` and a token per party, and exposes the
+//! `/startup-state` document so a test can act on a party's real phase instead
+//! of guessing with sleeps.
+//!
+//! # Why the startup-epoch workflows kill during the handshake
+//!
+//! `startup_120` and `startup_121` stop a party during the startup *handshake*,
+//! never during the DB load. That is a deliberate limit, not convenience.
+//!
+//! `init_hawk_actor` runs `restart_from_checkpoint` — a cross-party consensus
+//! round with a 10s `PEER_ROUND_TIMEOUT` — concurrently with the iris load via
+//! `try_join!`. A party that disappears during the load therefore fails its peers
+//! *inside* the load, whatever the epoch layer would have decided. Killing during
+//! the handshake parks the survivors in the commit barrier, where the outcome is
+//! determined entirely by the epoch logic under test.
+//!
+//! A load-window rejoin test becomes meaningful once the checkpoint round
+//! tolerates a peer restart, or once `Phase::Load` is split into a local iris
+//! phase and a cross-party graph phase.
+
+use std::time::Duration;
+
+use ampc_server_utils::ReadyProbeResponse;
+use eyre::{bail, eyre, WrapErr};
+use iris_mpc::server::startup_phase::{Epoch, Phase, StartupState};
+use tokio::net::TcpStream;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use tracing::{info_span, Instrument};
+
+use super::runner::CpuTestContext;
+use super::{CpuConfigs, COUNT_OF_PARTIES, TEST_THREAD_STACK_SIZE};
+
+/// Party the startup-epoch workflows restart. Arbitrary — nothing in the design
+/// distinguishes the parties and the commit barrier is symmetric.
+pub const RESTARTED_PARTY: usize = 2;
+
+/// Wall-clock allowance for a fleet to reach ready, or to give up. Generous:
+/// covers three parties' migrations, coordination barriers and DB load on a cold
+/// CI machine.
+pub const FLEET_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Spawn `server_main` for one party.
+///
+/// `server_main` holds `!Send` state, so the party runs on its own OS thread via
+/// `spawn_blocking` with a dedicated multi-thread runtime.
+///
+/// Mirrors the per-party body of [`crate::workflows::run_hawk`], which spawns
+/// all three into a `JoinSet` under one shared token. That function is left
+/// alone because every `wal_*` test depends on its cancellation semantics; the
+/// two must be kept in sync.
+pub fn spawn_hawk_party(
+    party: usize,
+    configs: &CpuConfigs,
+    shutdown: CancellationToken,
+    ctx: &CpuTestContext,
+) -> JoinHandle<eyre::Result<()>> {
+    let config = crate::utils::configs::make_hawk_config(&configs[party], configs, &ctx.env);
+    let abort = ctx.abort.clone();
+
+    tokio::spawn(async move {
+        tokio::task::spawn_blocking(move || {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .thread_stack_size(TEST_THREAD_STACK_SIZE)
+                .build()
+                .expect("failed to build server runtime");
+            let span = info_span!("mpc_node", idx = party);
+            rt.block_on(async move {
+                tokio::select! {
+                    res = iris_mpc::server::server_main(config).instrument(span) => res,
+                    _ = shutdown.cancelled() => Ok(()),
+                    _ = abort.cancelled() => Ok(()),
+                }
+            })
+        })
+        .await
+        .map_err(|e| eyre!("server task panicked: {e}"))
+        .and_then(|r| r)
+    })
+}
+
+/// Read one party's `/startup-state` document.
+pub async fn fetch_startup_state(port: u16) -> eyre::Result<StartupState> {
+    let url = format!("http://127.0.0.1:{port}/startup-state");
+    let body = reqwest::get(&url)
+        .await
+        .wrap_err_with(|| format!("GET {url} failed"))?
+        .bytes()
+        .await
+        .wrap_err_with(|| format!("reading body of {url} failed"))?;
+    serde_json::from_slice(&body).wrap_err_with(|| format!("deserializing {url} failed"))
+}
+
+/// The three parties, each independently stoppable.
+pub struct HawkFleet {
+    tasks: [Option<JoinHandle<eyre::Result<()>>>; COUNT_OF_PARTIES],
+    tokens: [Option<CancellationToken>; COUNT_OF_PARTIES],
+    configs: CpuConfigs,
+}
+
+/// Cancel and abort every party when the fleet goes out of scope.
+///
+/// Essential, not tidiness. Dropping a `JoinHandle` *detaches* its task, so
+/// without this a workflow that fails partway through `exec` — before it hands
+/// the fleet to `self` — leaves three `server_main` instances running with their
+/// coordination ports held, and the next workflow in the same test process dies
+/// with `Address already in use`.
+///
+/// Cancelling the token is the part that matters: the party runs inside
+/// `spawn_blocking`, which cannot be aborted once started, so it only stops when
+/// `server_main`'s `select!` observes the cancellation. The port is therefore
+/// freed shortly *after* the drop, not during it — which is why
+/// [`HawkFleet::start_all`] waits for ports rather than assuming they are free.
+impl Drop for HawkFleet {
+    fn drop(&mut self) {
+        for party in 0..COUNT_OF_PARTIES {
+            if let Some(token) = self.tokens[party].take() {
+                token.cancel();
+            }
+            if let Some(task) = self.tasks[party].take() {
+                task.abort();
+            }
+        }
+    }
+}
+
+/// Poll until nothing accepts connections on `port`.
+async fn wait_for_port_free(port: u16, dur: Duration) -> eyre::Result<()> {
+    let deadline = tokio::time::Instant::now() + dur;
+    loop {
+        match TcpStream::connect(("127.0.0.1", port)).await {
+            Err(_) => return Ok(()),
+            Ok(stream) => drop(stream),
+        }
+        if tokio::time::Instant::now() >= deadline {
+            bail!("something is still listening on port {port} after {dur:?}");
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+impl HawkFleet {
+    /// Start all three parties, once their coordination ports are free.
+    ///
+    /// The wait covers a previous fleet still shutting down: `Drop` cancels but
+    /// cannot join, so ports may be released a moment later. Failing here with
+    /// "still listening" is also a far better diagnostic than letting one party
+    /// die of `Address already in use` several seconds into its startup.
+    pub async fn start_all(configs: &CpuConfigs, ctx: &CpuTestContext) -> eyre::Result<Self> {
+        for config in configs.iter() {
+            wait_for_port_free(config.healthcheck_port, Duration::from_secs(30))
+                .await
+                .wrap_err("a previous fleet has not released its coordination port")?;
+        }
+
+        let mut fleet = HawkFleet {
+            tasks: [None, None, None],
+            tokens: [None, None, None],
+            configs: configs.clone(),
+        };
+        for party in 0..COUNT_OF_PARTIES {
+            fleet.start_party(party, ctx);
+        }
+        Ok(fleet)
+    }
+
+    /// Start (or restart) one party. The party must not currently be running.
+    pub fn start_party(&mut self, party: usize, ctx: &CpuTestContext) {
+        assert!(
+            self.tasks[party].is_none(),
+            "party {party} is already running"
+        );
+        let token = CancellationToken::new();
+        let task = spawn_hawk_party(party, &self.configs, token.clone(), ctx);
+        self.tokens[party] = Some(token);
+        self.tasks[party] = Some(task);
+        tracing::info!("fleet: started party {party}");
+    }
+
+    /// Stop one party and wait until its coordination port is free again, so a
+    /// restart cannot race the old listener's teardown.
+    pub async fn stop_party(&mut self, party: usize) -> eyre::Result<()> {
+        let Some(token) = self.tokens[party].take() else {
+            bail!("party {party} is not running");
+        };
+        token.cancel();
+
+        let mut task = self.tasks[party]
+            .take()
+            .ok_or_else(|| eyre!("party {party} has a token but no task"))?;
+
+        // `&mut task` so the handle survives a timeout and can be aborted. Letting
+        // it drop would detach the task instead of stopping it.
+        match tokio::time::timeout(Duration::from_secs(60), &mut task).await {
+            Ok(Ok(Ok(()))) => {}
+            Ok(Ok(Err(err))) => {
+                tracing::warn!("party {party} returned an error while stopping: {err:#}")
+            }
+            Ok(Err(join_err)) if join_err.is_cancelled() => {}
+            Ok(Err(join_err)) => bail!("party {party} panicked while stopping: {join_err}"),
+            Err(_) => {
+                task.abort();
+                bail!("party {party} did not stop within 60s");
+            }
+        }
+
+        self.wait_for_port_closed(party, Duration::from_secs(30))
+            .await?;
+        tracing::info!("fleet: stopped party {party}");
+        Ok(())
+    }
+
+    /// Wait for a stopped party's coordination port to be released.
+    ///
+    /// `server_main`'s `TaskMonitor` aborts the coordination listener when the
+    /// future is dropped, but the socket close is not synchronous with the task
+    /// returning; binding too early would fail the restarted party's listener.
+    async fn wait_for_port_closed(&self, party: usize, dur: Duration) -> eyre::Result<()> {
+        let port = self.configs[party].healthcheck_port;
+        wait_for_port_free(port, dur)
+            .await
+            .wrap_err_with(|| format!("party {party} did not release its coordination port"))
+    }
+
+    /// Fail if a party is not running, or if its task has already exited.
+    ///
+    /// This is the assertion the rejoin test rests on: the parties that were
+    /// never touched must still be in their original process.
+    pub fn assert_still_running(&self, party: usize) -> eyre::Result<()> {
+        match &self.tasks[party] {
+            None => bail!("party {party} is not running"),
+            Some(task) if task.is_finished() => {
+                bail!("party {party} exited when it should have kept running")
+            }
+            Some(_) => Ok(()),
+        }
+    }
+
+    /// Wait until a party's phase reaches at least `at_least`.
+    ///
+    /// Tolerates connection failures while the party's coordination server is
+    /// still coming up.
+    pub async fn wait_for_phase(
+        &self,
+        party: usize,
+        at_least: Phase,
+        dur: Duration,
+    ) -> eyre::Result<StartupState> {
+        let port = self.configs[party].healthcheck_port;
+        let deadline = tokio::time::Instant::now() + dur;
+        let mut last: Option<Phase> = None;
+
+        loop {
+            match fetch_startup_state(port).await {
+                Ok(state) if state.phase >= at_least => return Ok(state),
+                Ok(state) => last = Some(state.phase),
+                Err(err) => tracing::debug!("party {party} startup state unavailable: {err:#}"),
+            }
+
+            self.assert_still_running(party)?;
+
+            if tokio::time::Instant::now() >= deadline {
+                bail!(
+                    "party {party} did not reach phase {at_least} within {dur:?} (last seen {:?})",
+                    last
+                );
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    }
+
+    /// Current phase of a running party.
+    pub async fn phase(&self, party: usize) -> eyre::Result<Phase> {
+        Ok(fetch_startup_state(self.configs[party].healthcheck_port)
+            .await?
+            .phase)
+    }
+
+    /// Every party's published epoch. Fails if any party has not derived one.
+    pub async fn epochs(&self) -> eyre::Result<[Epoch; COUNT_OF_PARTIES]> {
+        let mut epochs = Vec::with_capacity(COUNT_OF_PARTIES);
+        for party in 0..COUNT_OF_PARTIES {
+            let state = fetch_startup_state(self.configs[party].healthcheck_port).await?;
+            let epoch = state
+                .epoch
+                .ok_or_else(|| eyre!("party {party} has not derived an epoch (phase {})", state.phase))?;
+            epochs.push(epoch);
+        }
+        Ok([epochs[0], epochs[1], epochs[2]])
+    }
+
+    /// Wait until all three parties report `is_ready` on `/health`.
+    ///
+    /// Fails fast if any party's task exits first — a party that dies is never
+    /// going to become ready, and the exit is the interesting diagnostic.
+    pub async fn wait_all_ready(&self, dur: Duration) -> eyre::Result<()> {
+        let deadline = tokio::time::Instant::now() + dur;
+
+        loop {
+            let mut all_ready = true;
+            for party in 0..COUNT_OF_PARTIES {
+                self.assert_still_running(party)?;
+
+                let port = self.configs[party].healthcheck_port;
+                let url = format!("http://127.0.0.1:{port}/health");
+                match reqwest::get(&url).await {
+                    Ok(response) => match response.json::<ReadyProbeResponse>().await {
+                        Ok(probe) if probe.is_ready => {}
+                        Ok(_) => all_ready = false,
+                        Err(err) => {
+                            tracing::debug!("party {party} health body unreadable: {err:#}");
+                            all_ready = false;
+                        }
+                    },
+                    Err(err) => {
+                        tracing::debug!("party {party} health unreachable: {err:#}");
+                        all_ready = false;
+                    }
+                }
+            }
+
+            if all_ready {
+                return Ok(());
+            }
+            if tokio::time::Instant::now() >= deadline {
+                bail!("parties did not all become ready within {dur:?}");
+            }
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+    }
+
+    /// Wait until every running party's task has exited, returning one outcome
+    /// description per party.
+    ///
+    /// Used by the mismatch workflow: a peer returning with changed data must stop
+    /// the whole fleet, not just itself.
+    ///
+    /// Fails if any party died of a port conflict. That is a harness failure — a
+    /// previous fleet leaked — and it is indistinguishable from success to a
+    /// caller that only asserts "nobody came up", so it has to be rejected here
+    /// rather than silently passing a workflow for the wrong reason.
+    pub async fn wait_all_exited(&mut self, dur: Duration) -> eyre::Result<Vec<String>> {
+        let deadline = tokio::time::Instant::now() + dur;
+        let mut errors = Vec::new();
+
+        for party in 0..COUNT_OF_PARTIES {
+            let Some(mut task) = self.tasks[party].take() else {
+                continue;
+            };
+            let token = self.tokens[party].take();
+
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            match tokio::time::timeout(remaining, &mut task).await {
+                Ok(Ok(Ok(()))) => errors.push(format!("party {party} exited without an error")),
+                Ok(Ok(Err(err))) => errors.push(format!("party {party}: {err:#}")),
+                Ok(Err(join_err)) => {
+                    task.abort();
+                    bail!("party {party} panicked: {join_err}")
+                }
+                Err(_) => {
+                    // A party still running is the failure this reports, but it must
+                    // not be left detached holding its port for the next workflow.
+                    if let Some(token) = token {
+                        token.cancel();
+                    }
+                    task.abort();
+                    bail!("party {party} was still running after {dur:?}");
+                }
+            }
+        }
+
+        for outcome in &errors {
+            if outcome.contains("Address already in use") {
+                bail!(
+                    "a party died of a port conflict, not of the condition under test — a \
+                     previous fleet leaked its ports: {errors:?}"
+                );
+            }
+        }
+
+        Ok(errors)
+    }
+
+    /// Stop every still-running party. Safe to call in teardown regardless of
+    /// what the test already stopped.
+    pub async fn stop_all(&mut self) -> eyre::Result<()> {
+        let mut first_err: Option<eyre::Report> = None;
+        for party in 0..COUNT_OF_PARTIES {
+            if self.tasks[party].is_none() {
+                continue;
+            }
+            if let Err(err) = self.stop_party(party).await {
+                tracing::warn!("error stopping party {party}: {err:#}");
+                first_err.get_or_insert(err);
+            }
+        }
+        first_err.map_or(Ok(()), Err)
+    }
+}

--- a/iris-mpc/tests/utils/hawk_fleet.rs
+++ b/iris-mpc/tests/utils/hawk_fleet.rs
@@ -8,6 +8,33 @@
 //! `/startup-state` document so a test can act on a party's real phase instead
 //! of guessing with sleeps.
 //!
+//! # Why the kill point is a configured hold, not a poll
+//!
+//! `startup_120` and `startup_121` have to stop a party *in* a named startup
+//! phase. Polling `/startup-state` for that cannot work: on an empty local fleet
+//! `propose -> load` takes ~180 ms end to end, so a 100 ms poll grid (stretched
+//! further by three parties saturating every core with worker pools) routinely
+//! first observes the party already several phases past the intended kill point,
+//! by which time it has published its epoch and released its peers' commit
+//! barrier — and the survivors are then correctly, not wrongly, in `load`.
+//!
+//! So the party is *held* instead: [`HawkFleet::start_party_holding_at`] sets
+//! `Config::startup_hold_at_phase`, and the party parks in that phase until it is
+//! stopped. The restart is spawned without the hold. The hold is excluded from
+//! `CommonConfig`, so it does not perturb the startup epoch either party derives.
+//!
+//! # Why the commit-barrier budget is overridable
+//!
+//! `wait_for_epoch_commit` treats an unreachable peer as "it is restarting, keep
+//! waiting" — which is exactly what makes rejoin work, and exactly why a party
+//! that *dies* is indistinguishable from one that is coming back. The survivors
+//! then wait out the whole `startup_sync_timeout_secs` budget, 300s by default,
+//! which is longer than [`FLEET_TIMEOUT`]: a workflow whose expected outcome is
+//! "the fleet gives up" would hit the harness deadline instead of the behaviour
+//! it is asserting. [`FleetOptions::startup_sync_timeout_secs`] shortens the
+//! budget for those workflows. Rejoin workflows leave it at the default, since
+//! there the survivors *must* outlast a peer restart.
+//!
 //! # Why the startup-epoch workflows kill during the handshake
 //!
 //! `startup_120` and `startup_121` stop a party during the startup *handshake*,
@@ -46,7 +73,28 @@ pub const RESTARTED_PARTY: usize = 2;
 /// CI machine.
 pub const FLEET_TIMEOUT: Duration = Duration::from_secs(120);
 
-/// Spawn `server_main` for one party.
+/// Startup-config overrides for one party.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PartyOverrides {
+    /// Park on entering this phase and stay there until stopped.
+    pub hold_at: Option<Phase>,
+    /// Replaces `ServerCoordinationConfig::startup_sync_timeout_secs`, which
+    /// bounds the startup barriers — including the commit barrier.
+    pub startup_sync_timeout_secs: Option<u64>,
+}
+
+/// Startup-config overrides for a whole fleet.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct FleetOptions {
+    /// Phase each party parks in, if any. Applies to the parties' first boot;
+    /// a restart via [`HawkFleet::start_party`] is always hold-free.
+    pub holds: [Option<Phase>; COUNT_OF_PARTIES],
+    /// Barrier budget for every party, inherited by restarts. See the module
+    /// docs for when a workflow needs to shorten it.
+    pub startup_sync_timeout_secs: Option<u64>,
+}
+
+/// Spawn `server_main` for one party, applying `overrides` to its config.
 ///
 /// `server_main` holds `!Send` state, so the party runs on its own OS thread via
 /// `spawn_blocking` with a dedicated multi-thread runtime.
@@ -60,8 +108,17 @@ pub fn spawn_hawk_party(
     configs: &CpuConfigs,
     shutdown: CancellationToken,
     ctx: &CpuTestContext,
+    overrides: PartyOverrides,
 ) -> JoinHandle<eyre::Result<()>> {
-    let config = crate::utils::configs::make_hawk_config(&configs[party], configs, &ctx.env);
+    let mut config = crate::utils::configs::make_hawk_config(&configs[party], configs, &ctx.env);
+    config.startup_hold_at_phase = overrides.hold_at.map(|phase| phase.as_str().to_string());
+    if let Some(secs) = overrides.startup_sync_timeout_secs {
+        config
+            .server_coordination
+            .as_mut()
+            .expect("test configs always set server_coordination")
+            .startup_sync_timeout_secs = secs;
+    }
     let abort = ctx.abort.clone();
 
     tokio::spawn(async move {
@@ -103,6 +160,9 @@ pub struct HawkFleet {
     tasks: [Option<JoinHandle<eyre::Result<()>>>; COUNT_OF_PARTIES],
     tokens: [Option<CancellationToken>; COUNT_OF_PARTIES],
     configs: CpuConfigs,
+    /// Kept so restarts get the same barrier budget as the first boot; the
+    /// holds deliberately are not kept.
+    startup_sync_timeout_secs: Option<u64>,
 }
 
 /// Cancel and abort every party when the fleet goes out of scope.
@@ -154,6 +214,19 @@ impl HawkFleet {
     /// "still listening" is also a far better diagnostic than letting one party
     /// die of `Address already in use` several seconds into its startup.
     pub async fn start_all(configs: &CpuConfigs, ctx: &CpuTestContext) -> eyre::Result<Self> {
+        Self::start_all_with(configs, ctx, FleetOptions::default()).await
+    }
+
+    /// Start all three parties under `options`.
+    ///
+    /// A hold has to be in place from the party's *first* boot: it is the only
+    /// way to be sure the party has not already run past the phase the workflow
+    /// means to stop it in. See [`HawkFleet::start_party_holding_at`].
+    pub async fn start_all_with(
+        configs: &CpuConfigs,
+        ctx: &CpuTestContext,
+        options: FleetOptions,
+    ) -> eyre::Result<Self> {
         for config in configs.iter() {
             wait_for_port_free(config.healthcheck_port, Duration::from_secs(30))
                 .await
@@ -164,21 +237,44 @@ impl HawkFleet {
             tasks: [None, None, None],
             tokens: [None, None, None],
             configs: configs.clone(),
+            startup_sync_timeout_secs: options.startup_sync_timeout_secs,
         };
         for party in 0..COUNT_OF_PARTIES {
-            fleet.start_party(party, ctx);
+            match options.holds[party] {
+                Some(phase) => fleet.start_party_holding_at(party, ctx, phase),
+                None => fleet.start_party(party, ctx),
+            }
         }
         Ok(fleet)
     }
 
     /// Start (or restart) one party. The party must not currently be running.
     pub fn start_party(&mut self, party: usize, ctx: &CpuTestContext) {
+        self.spawn(party, ctx, None);
+    }
+
+    /// Start one party that parks on entering `phase` and stays there until it is
+    /// stopped, so a test can kill it at an exact point in the handshake.
+    ///
+    /// See the module docs for why this is a configured hold rather than a
+    /// well-timed poll. A held party never becomes ready, so every workflow using
+    /// this must stop it — [`HawkFleet::stop_party`] or the `Drop` backstop.
+    pub fn start_party_holding_at(&mut self, party: usize, ctx: &CpuTestContext, phase: Phase) {
+        self.spawn(party, ctx, Some(phase));
+        tracing::info!("fleet: party {party} will hold at phase {phase}");
+    }
+
+    fn spawn(&mut self, party: usize, ctx: &CpuTestContext, hold_at: Option<Phase>) {
         assert!(
             self.tasks[party].is_none(),
             "party {party} is already running"
         );
         let token = CancellationToken::new();
-        let task = spawn_hawk_party(party, &self.configs, token.clone(), ctx);
+        let overrides = PartyOverrides {
+            hold_at,
+            startup_sync_timeout_secs: self.startup_sync_timeout_secs,
+        };
+        let task = spawn_hawk_party(party, &self.configs, token.clone(), ctx, overrides);
         self.tokens[party] = Some(token);
         self.tasks[party] = Some(task);
         tracing::info!("fleet: started party {party}");
@@ -243,14 +339,22 @@ impl HawkFleet {
         }
     }
 
-    /// Wait until a party's phase reaches at least `at_least`.
+    /// Wait until a party is sitting in exactly `phase`.
+    ///
+    /// Exact, not `>=`: the callers stop the party at this point, and a party
+    /// already past it has published state its peers have acted on, which makes
+    /// the rest of the workflow assert against a different scenario than the one
+    /// it describes. Overshoot therefore fails here — loudly, naming the phase
+    /// actually seen — instead of surfacing later as a confusing assertion about
+    /// a peer that behaved correctly. Pair with
+    /// [`HawkFleet::start_party_holding_at`], which makes overshoot impossible.
     ///
     /// Tolerates connection failures while the party's coordination server is
     /// still coming up.
     pub async fn wait_for_phase(
         &self,
         party: usize,
-        at_least: Phase,
+        phase: Phase,
         dur: Duration,
     ) -> eyre::Result<StartupState> {
         let port = self.configs[party].healthcheck_port;
@@ -259,7 +363,12 @@ impl HawkFleet {
 
         loop {
             match fetch_startup_state(port).await {
-                Ok(state) if state.phase >= at_least => return Ok(state),
+                Ok(state) if state.phase == phase => return Ok(state),
+                Ok(state) if state.phase > phase => bail!(
+                    "party {party} ran past phase {phase} to {} before it could be observed — \
+                     it should have been started with a hold at {phase}",
+                    state.phase
+                ),
                 Ok(state) => last = Some(state.phase),
                 Err(err) => tracing::debug!("party {party} startup state unavailable: {err:#}"),
             }
@@ -268,7 +377,7 @@ impl HawkFleet {
 
             if tokio::time::Instant::now() >= deadline {
                 bail!(
-                    "party {party} did not reach phase {at_least} within {dur:?} (last seen {:?})",
+                    "party {party} did not reach phase {phase} within {dur:?} (last seen {:?})",
                     last
                 );
             }

--- a/iris-mpc/tests/utils/hawk_fleet.rs
+++ b/iris-mpc/tests/utils/hawk_fleet.rs
@@ -10,46 +10,36 @@
 //!
 //! # Why the kill point is a configured hold, not a poll
 //!
-//! `startup_120` and `startup_121` have to stop a party *in* a named startup
-//! phase. Polling `/startup-state` for that cannot work: on an empty local fleet
-//! `propose -> load` takes ~180 ms end to end, so a 100 ms poll grid (stretched
-//! further by three parties saturating every core with worker pools) routinely
-//! first observes the party already several phases past the intended kill point,
-//! by which time it has published its epoch and released its peers' commit
-//! barrier — and the survivors are then correctly, not wrongly, in `load`.
-//!
-//! So the party is *held* instead: [`HawkFleet::start_party_holding_at`] sets
-//! `Config::startup_hold_at_phase`, and the party parks in that phase until it is
-//! stopped. The restart is spawned without the hold. The hold is excluded from
-//! `CommonConfig`, so it does not perturb the startup epoch either party derives.
+//! The startup workflows have to stop a party *in* a named phase. Polling
+//! `/startup-state` for that cannot work: on an empty local fleet `propose -> load`
+//! takes ~180 ms end to end, so a 100 ms poll grid routinely first observes the
+//! party already past the intended kill point, having published its epoch and
+//! released its peers' commit barrier. So the party is *held* instead:
+//! [`HawkFleet::start_party`] sets `Config::startup_hold_at_phase` and the party
+//! parks there until stopped; the restart is spawned without the hold. The hold is
+//! excluded from `CommonConfig`, so it does not perturb the derived epoch.
 //!
 //! # Why the commit-barrier budget is overridable
 //!
 //! `wait_for_epoch_commit` treats an unreachable peer as "it is restarting, keep
-//! waiting" — which is exactly what makes rejoin work, and exactly why a party
-//! that *dies* is indistinguishable from one that is coming back. The survivors
-//! then wait out the whole `startup_sync_timeout_secs` budget, 300s by default,
-//! which is longer than [`FLEET_TIMEOUT`]: a workflow whose expected outcome is
-//! "the fleet gives up" would hit the harness deadline instead of the behaviour
-//! it is asserting. [`FleetOptions::startup_sync_timeout_secs`] shortens the
-//! budget for those workflows. Rejoin workflows leave it at the default, since
-//! there the survivors *must* outlast a peer restart.
+//! waiting" — which is what makes rejoin work, and why a party that *dies* is
+//! indistinguishable from one coming back. The survivors then wait out the whole
+//! 300s `startup_sync_timeout_secs`, longer than [`FLEET_TIMEOUT`], so a workflow
+//! whose expected outcome is "the fleet gives up" would hit the harness deadline
+//! instead of the behaviour it asserts. [`FleetOptions::startup_sync_timeout_secs`]
+//! shortens it for those. Rejoin workflows leave the default, since there the
+//! survivors *must* outlast a peer restart.
 //!
-//! # Why the startup-epoch workflows kill during the handshake
+//! # Why the startup workflows kill during the handshake
 //!
-//! `startup_120` and `startup_121` stop a party during the startup *handshake*,
-//! never during the DB load. That is a deliberate limit, not convenience.
-//!
-//! `init_hawk_actor` runs `restart_from_checkpoint` — a cross-party consensus
-//! round with a 10s `PEER_ROUND_TIMEOUT` — concurrently with the iris load via
+//! `init_hawk_actor` runs `restart_from_checkpoint` — a cross-party consensus round
+//! with a 10s `PEER_ROUND_TIMEOUT` — concurrently with the iris load via
 //! `try_join!`. A party that disappears during the load therefore fails its peers
 //! *inside* the load, whatever the epoch layer would have decided. Killing during
 //! the handshake parks the survivors in the commit barrier, where the outcome is
-//! determined entirely by the epoch logic under test.
-//!
-//! A load-window rejoin test becomes meaningful once the checkpoint round
-//! tolerates a peer restart, or once `Phase::Load` is split into a local iris
-//! phase and a cross-party graph phase.
+//! determined entirely by the epoch logic under test. A load-window rejoin test
+//! becomes meaningful once the checkpoint round tolerates a peer restart, or once
+//! `Phase::Load` is split into local iris and cross-party graph phases.
 
 use std::time::Duration;
 
@@ -73,46 +63,38 @@ pub const RESTARTED_PARTY: usize = 2;
 /// CI machine.
 pub const FLEET_TIMEOUT: Duration = Duration::from_secs(120);
 
-/// Startup-config overrides for one party.
-#[derive(Debug, Clone, Copy, Default)]
-pub struct PartyOverrides {
-    /// Park on entering this phase and stay there until stopped.
-    pub hold_at: Option<Phase>,
-    /// Replaces `ServerCoordinationConfig::startup_sync_timeout_secs`, which
-    /// bounds the startup barriers — including the commit barrier.
-    pub startup_sync_timeout_secs: Option<u64>,
-}
-
 /// Startup-config overrides for a whole fleet.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct FleetOptions {
-    /// Phase each party parks in, if any. Applies to the parties' first boot;
-    /// a restart via [`HawkFleet::start_party`] is always hold-free.
+    /// Phase each party parks in, if any. Applies to the parties' first boot; a
+    /// restart is spawned by the workflow and passes its own hold (normally none).
     pub holds: [Option<Phase>; COUNT_OF_PARTIES],
-    /// Barrier budget for every party, inherited by restarts. See the module
-    /// docs for when a workflow needs to shorten it.
+    /// Replaces `ServerCoordinationConfig::startup_sync_timeout_secs`, which bounds
+    /// the startup barriers — including the commit barrier. Inherited by restarts.
+    /// See the module docs for when a workflow needs to shorten it.
     pub startup_sync_timeout_secs: Option<u64>,
 }
 
-/// Spawn `server_main` for one party, applying `overrides` to its config.
+/// Spawn `server_main` for one party.
 ///
 /// `server_main` holds `!Send` state, so the party runs on its own OS thread via
 /// `spawn_blocking` with a dedicated multi-thread runtime.
 ///
-/// Mirrors the per-party body of [`crate::workflows::run_hawk`], which spawns
-/// all three into a `JoinSet` under one shared token. That function is left
-/// alone because every `wal_*` test depends on its cancellation semantics; the
-/// two must be kept in sync.
-pub fn spawn_hawk_party(
+/// Mirrors the per-party body of [`crate::workflows::run_hawk`], which spawns all
+/// three into a `JoinSet` under one shared token. That function is left alone
+/// because every `wal_*` test depends on its cancellation semantics; the two must
+/// be kept in sync.
+fn spawn_hawk_party(
     party: usize,
     configs: &CpuConfigs,
     shutdown: CancellationToken,
     ctx: &CpuTestContext,
-    overrides: PartyOverrides,
+    hold_at: Option<Phase>,
+    startup_sync_timeout_secs: Option<u64>,
 ) -> JoinHandle<eyre::Result<()>> {
     let mut config = crate::utils::configs::make_hawk_config(&configs[party], configs, &ctx.env);
-    config.startup_hold_at_phase = overrides.hold_at.map(|phase| phase.as_str().to_string());
-    if let Some(secs) = overrides.startup_sync_timeout_secs {
+    config.startup_hold_at_phase = hold_at.map(|phase| phase.as_str().to_string());
+    if let Some(secs) = startup_sync_timeout_secs {
         config
             .server_coordination
             .as_mut()
@@ -144,7 +126,7 @@ pub fn spawn_hawk_party(
 }
 
 /// Read one party's `/startup-state` document.
-pub async fn fetch_startup_state(port: u16) -> eyre::Result<StartupState> {
+async fn fetch_startup_state(port: u16) -> eyre::Result<StartupState> {
     let url = format!("http://127.0.0.1:{port}/startup-state");
     let body = reqwest::get(&url)
         .await
@@ -219,9 +201,9 @@ impl HawkFleet {
 
     /// Start all three parties under `options`.
     ///
-    /// A hold has to be in place from the party's *first* boot: it is the only
-    /// way to be sure the party has not already run past the phase the workflow
-    /// means to stop it in. See [`HawkFleet::start_party_holding_at`].
+    /// A hold has to be in place from a party's *first* boot: it is the only way to
+    /// be sure it has not already run past the phase the workflow means to stop it
+    /// in. See [`HawkFleet::start_party`].
     pub async fn start_all_with(
         configs: &CpuConfigs,
         ctx: &CpuTestContext,
@@ -240,44 +222,35 @@ impl HawkFleet {
             startup_sync_timeout_secs: options.startup_sync_timeout_secs,
         };
         for party in 0..COUNT_OF_PARTIES {
-            match options.holds[party] {
-                Some(phase) => fleet.start_party_holding_at(party, ctx, phase),
-                None => fleet.start_party(party, ctx),
-            }
+            fleet.start_party(party, ctx, options.holds[party]);
         }
         Ok(fleet)
     }
 
-    /// Start (or restart) one party. The party must not currently be running.
-    pub fn start_party(&mut self, party: usize, ctx: &CpuTestContext) {
-        self.spawn(party, ctx, None);
-    }
-
-    /// Start one party that parks on entering `phase` and stays there until it is
-    /// stopped, so a test can kill it at an exact point in the handshake.
+    /// Start (or restart) one party, which must not currently be running.
     ///
-    /// See the module docs for why this is a configured hold rather than a
-    /// well-timed poll. A held party never becomes ready, so every workflow using
-    /// this must stop it — [`HawkFleet::stop_party`] or the `Drop` backstop.
-    pub fn start_party_holding_at(&mut self, party: usize, ctx: &CpuTestContext, phase: Phase) {
-        self.spawn(party, ctx, Some(phase));
-        tracing::info!("fleet: party {party} will hold at phase {phase}");
-    }
-
-    fn spawn(&mut self, party: usize, ctx: &CpuTestContext, hold_at: Option<Phase>) {
+    /// With `hold_at` set the party parks on entering that phase and stays there
+    /// until stopped, so a test can kill it at an exact point in the handshake (see
+    /// the module docs for why this is a hold rather than a well-timed poll). A held
+    /// party never becomes ready, so the workflow must stop it — via
+    /// [`HawkFleet::stop_party`] or the `Drop` backstop.
+    pub fn start_party(&mut self, party: usize, ctx: &CpuTestContext, hold_at: Option<Phase>) {
         assert!(
             self.tasks[party].is_none(),
             "party {party} is already running"
         );
         let token = CancellationToken::new();
-        let overrides = PartyOverrides {
+        let task = spawn_hawk_party(
+            party,
+            &self.configs,
+            token.clone(),
+            ctx,
             hold_at,
-            startup_sync_timeout_secs: self.startup_sync_timeout_secs,
-        };
-        let task = spawn_hawk_party(party, &self.configs, token.clone(), ctx, overrides);
+            self.startup_sync_timeout_secs,
+        );
         self.tokens[party] = Some(token);
         self.tasks[party] = Some(task);
-        tracing::info!("fleet: started party {party}");
+        tracing::info!("fleet: started party {party} (hold_at {hold_at:?})");
     }
 
     /// Stop one party and wait until its coordination port is free again, so a
@@ -307,28 +280,23 @@ impl HawkFleet {
             }
         }
 
-        self.wait_for_port_closed(party, Duration::from_secs(30))
-            .await?;
+        // `server_main`'s `TaskMonitor` aborts the coordination listener when the
+        // future is dropped, but the socket close is not synchronous with the task
+        // returning; binding too early would fail the restarted party's listener.
+        wait_for_port_free(
+            self.configs[party].healthcheck_port,
+            Duration::from_secs(30),
+        )
+        .await
+        .wrap_err_with(|| format!("party {party} did not release its coordination port"))?;
         tracing::info!("fleet: stopped party {party}");
         Ok(())
     }
 
-    /// Wait for a stopped party's coordination port to be released.
-    ///
-    /// `server_main`'s `TaskMonitor` aborts the coordination listener when the
-    /// future is dropped, but the socket close is not synchronous with the task
-    /// returning; binding too early would fail the restarted party's listener.
-    async fn wait_for_port_closed(&self, party: usize, dur: Duration) -> eyre::Result<()> {
-        let port = self.configs[party].healthcheck_port;
-        wait_for_port_free(port, dur)
-            .await
-            .wrap_err_with(|| format!("party {party} did not release its coordination port"))
-    }
-
     /// Fail if a party is not running, or if its task has already exited.
     ///
-    /// This is the assertion the rejoin test rests on: the parties that were
-    /// never touched must still be in their original process.
+    /// This is the assertion the rejoin test rests on: the parties that were never
+    /// touched must still be in their original process.
     pub fn assert_still_running(&self, party: usize) -> eyre::Result<()> {
         match &self.tasks[party] {
             None => bail!("party {party} is not running"),
@@ -339,18 +307,24 @@ impl HawkFleet {
         }
     }
 
+    /// [`HawkFleet::assert_still_running`] for every party but `except`.
+    pub fn assert_others_running(&self, except: usize) -> eyre::Result<()> {
+        (0..COUNT_OF_PARTIES)
+            .filter(|party| *party != except)
+            .try_for_each(|party| self.assert_still_running(party))
+    }
+
     /// Wait until a party is sitting in exactly `phase`.
     ///
-    /// Exact, not `>=`: the callers stop the party at this point, and a party
-    /// already past it has published state its peers have acted on, which makes
-    /// the rest of the workflow assert against a different scenario than the one
-    /// it describes. Overshoot therefore fails here — loudly, naming the phase
-    /// actually seen — instead of surfacing later as a confusing assertion about
-    /// a peer that behaved correctly. Pair with
-    /// [`HawkFleet::start_party_holding_at`], which makes overshoot impossible.
+    /// Exact, not `>=`: the callers act on the party at this point, and one already
+    /// past it has published state its peers have acted on, so the rest of the
+    /// workflow would assert against a different scenario than the one it describes.
+    /// Overshoot therefore fails here, naming the phase actually seen, rather than
+    /// surfacing later as a confusing assertion about a peer that behaved correctly.
+    /// Pair with a `hold_at`, which makes overshoot impossible.
     ///
-    /// Tolerates connection failures while the party's coordination server is
-    /// still coming up.
+    /// Tolerates connection failures while the party's coordination server is still
+    /// coming up.
     pub async fn wait_for_phase(
         &self,
         party: usize,
@@ -392,17 +366,23 @@ impl HawkFleet {
             .phase)
     }
 
-    /// Every party's published epoch. Fails if any party has not derived one.
-    pub async fn epochs(&self) -> eyre::Result<[Epoch; COUNT_OF_PARTIES]> {
+    /// Every party's published epoch. Fails if any party has not derived one, or if
+    /// they do not all agree.
+    pub async fn agreed_epoch(&self) -> eyre::Result<Epoch> {
         let mut epochs = Vec::with_capacity(COUNT_OF_PARTIES);
         for party in 0..COUNT_OF_PARTIES {
             let state = fetch_startup_state(self.configs[party].healthcheck_port).await?;
-            let epoch = state
-                .epoch
-                .ok_or_else(|| eyre!("party {party} has not derived an epoch (phase {})", state.phase))?;
-            epochs.push(epoch);
+            epochs.push(state.epoch.ok_or_else(|| {
+                eyre!(
+                    "party {party} has not derived an epoch (phase {})",
+                    state.phase
+                )
+            })?);
         }
-        Ok([epochs[0], epochs[1], epochs[2]])
+        if epochs.iter().any(|epoch| *epoch != epochs[0]) {
+            bail!("parties disagree on the startup epoch: {epochs:?}");
+        }
+        Ok(epochs[0])
     }
 
     /// Wait until all three parties report `is_ready` on `/health`.
@@ -448,13 +428,9 @@ impl HawkFleet {
     /// Wait until every running party's task has exited, returning one outcome
     /// description per party.
     ///
-    /// Used by the mismatch workflow: a peer returning with changed data must stop
-    /// the whole fleet, not just itself.
-    ///
-    /// Fails if any party died of a port conflict. That is a harness failure — a
-    /// previous fleet leaked — and it is indistinguishable from success to a
-    /// caller that only asserts "nobody came up", so it has to be rejected here
-    /// rather than silently passing a workflow for the wrong reason.
+    /// Fails if any party died of a port conflict: that is a harness failure (a
+    /// previous fleet leaked) and is indistinguishable from success to a caller that
+    /// only asserts "nobody came up", so it must not silently pass a workflow.
     pub async fn wait_all_exited(&mut self, dur: Duration) -> eyre::Result<Vec<String>> {
         let deadline = tokio::time::Instant::now() + dur;
         let mut errors = Vec::new();

--- a/iris-mpc/tests/utils/hawk_fleet.rs
+++ b/iris-mpc/tests/utils/hawk_fleet.rs
@@ -86,7 +86,13 @@ pub async fn hawk_party(
 /// Read one party's `/health` document.
 async fn fetch_health(port: u16) -> eyre::Result<ReadyProbeResponse> {
     let url = format!("http://127.0.0.1:{port}/health");
-    reqwest::get(&url)
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(2))
+        .build()
+        .wrap_err("building reqwest client failed")?;
+    client
+        .get(&url)
+        .send()
         .await
         .wrap_err_with(|| format!("GET {url} failed"))?
         .json::<ReadyProbeResponse>()
@@ -97,7 +103,14 @@ async fn fetch_health(port: u16) -> eyre::Result<ReadyProbeResponse> {
 /// Read one party's `/startup-state` document.
 async fn fetch_startup_state(port: u16) -> eyre::Result<StartupState> {
     let url = format!("http://127.0.0.1:{port}/startup-state");
-    let body = reqwest::get(&url)
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(2))
+        .build()
+        .wrap_err("building reqwest client failed")?;
+
+    let body = client
+        .get(&url)
+        .send()
         .await
         .wrap_err_with(|| format!("GET {url} failed"))?
         .bytes()

--- a/iris-mpc/tests/utils/hawk_fleet.rs
+++ b/iris-mpc/tests/utils/hawk_fleet.rs
@@ -95,6 +95,17 @@ pub async fn hawk_party(
     .and_then(|r| r)
 }
 
+/// Read one party's `/health` document.
+async fn fetch_health(port: u16) -> eyre::Result<ReadyProbeResponse> {
+    let url = format!("http://127.0.0.1:{port}/health");
+    reqwest::get(&url)
+        .await
+        .wrap_err_with(|| format!("GET {url} failed"))?
+        .json::<ReadyProbeResponse>()
+        .await
+        .wrap_err_with(|| format!("deserializing {url} failed"))
+}
+
 /// Read one party's `/startup-state` document.
 async fn fetch_startup_state(port: u16) -> eyre::Result<StartupState> {
     let url = format!("http://127.0.0.1:{port}/startup-state");
@@ -309,28 +320,30 @@ impl HawkFleet {
             .phase)
     }
 
-    /// One party's own sync-state digest, once it is publishing `/startup-state`.
+    /// Wait until a party publishes `/startup-state` with its coordination UUID set,
+    /// and return the whole document.
     ///
-    /// Polls rather than reading once: the digest is computed *before* the
-    /// coordination server exists (it is an argument to `StartupStateHandle::new`),
-    /// so after a restart there is a window — the migrations plus the ~10s
-    /// empty-queue long poll in `build_sync_state` — where nothing answers the port.
-    /// Once the route answers, the digest is already there.
+    /// Polls rather than reading once: `party_sync_state_digest` is computed *before*
+    /// the coordination server exists (it is an argument to `StartupStateHandle::new`)
+    /// and the UUID is set just after, so on a fresh boot there is a window — the
+    /// migrations plus the ~10s empty-queue long poll in `build_sync_state` — where
+    /// nothing answers the port, then a brief one where `uuid` is still `None`.
     ///
-    /// Unlike [`HawkFleet::agreed_fleet_sync_state_digest`] this is peer-independent,
-    /// which is what lets a workflow compare a party's state across a restart
-    /// without needing its peers to be alive.
-    pub async fn wait_for_party_sync_state_digest(
+    /// Unlike [`HawkFleet::agreed_fleet_sync_state_digest`] this reads one party in
+    /// isolation, which is what lets a workflow compare a party against itself across
+    /// a restart without needing its peers to be alive.
+    pub async fn wait_for_startup_state(
         &self,
         party: usize,
         dur: Duration,
-    ) -> eyre::Result<SyncStateDigest> {
+    ) -> eyre::Result<StartupState> {
         let port = self.configs[party].healthcheck_port;
         let deadline = tokio::time::Instant::now() + dur;
 
         loop {
             match fetch_startup_state(port).await {
-                Ok(state) => return Ok(state.party_sync_state_digest),
+                Ok(state) if state.uuid.is_some() => return Ok(state),
+                Ok(_) => tracing::debug!("party {party} has not minted a UUID yet"),
                 Err(err) => tracing::debug!("party {party} startup state unavailable: {err:#}"),
             }
 
@@ -340,6 +353,45 @@ impl HawkFleet {
                 bail!("party {party} did not publish a startup state within {dur:?}");
             }
             tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    }
+
+    /// One party's `/health` document.
+    pub async fn health(&self, party: usize) -> eyre::Result<ReadyProbeResponse> {
+        fetch_health(self.configs[party].healthcheck_port).await
+    }
+
+    /// Wait until a party has committed to tearing itself down: either it reports
+    /// `shutting_down` on `/health`, or its task has already exited.
+    ///
+    /// Deciding and finishing are separate events here, and only the decision is on
+    /// a bounded clock — `trigger_manual_shutdown` flips the flag immediately, while
+    /// `server_main` does not currently return on it, so a party can outlive its own
+    /// decision indefinitely. Either observation settles the question a workflow is
+    /// asking, and accepting both means a workflow written against today's behaviour
+    /// keeps passing if the exit path is later fixed.
+    pub async fn wait_for_teardown(&self, party: usize, dur: Duration) -> eyre::Result<()> {
+        let deadline = tokio::time::Instant::now() + dur;
+
+        loop {
+            if self.assert_still_running(party).is_err() {
+                tracing::info!("party {party} exited rather than only flagging shutdown");
+                return Ok(());
+            }
+
+            match self.health(party).await {
+                Ok(probe) if probe.shutting_down => return Ok(()),
+                Ok(_) => {}
+                Err(err) => tracing::debug!("party {party} health unreadable: {err:#}"),
+            }
+
+            if tokio::time::Instant::now() >= deadline {
+                bail!(
+                    "party {party} neither flagged shutdown nor exited within {dur:?}; it is still \
+                     serving after a peer restarted"
+                );
+            }
+            tokio::time::sleep(Duration::from_millis(200)).await;
         }
     }
 

--- a/iris-mpc/tests/utils/hawk_fleet.rs
+++ b/iris-mpc/tests/utils/hawk_fleet.rs
@@ -95,7 +95,7 @@ fn spawn_hawk_party(
     startup_sync_timeout_secs: Option<u64>,
 ) -> JoinHandle<eyre::Result<()>> {
     let mut config = crate::utils::configs::make_hawk_config(&configs[party], configs, &ctx.env);
-    config.startup_hold_at_phase = hold_at.map(|phase| phase.as_str().to_string());
+    config.startup_hold_at_phase = hold_at.map(|phase| phase.to_string());
     if let Some(secs) = startup_sync_timeout_secs {
         config
             .server_coordination
@@ -191,16 +191,6 @@ async fn wait_for_port_free(port: u16, dur: Duration) -> eyre::Result<()> {
 }
 
 impl HawkFleet {
-    /// Start all three parties, once their coordination ports are free.
-    ///
-    /// The wait covers a previous fleet still shutting down: `Drop` cancels but
-    /// cannot join, so ports may be released a moment later. Failing here with
-    /// "still listening" is also a far better diagnostic than letting one party
-    /// die of `Address already in use` several seconds into its startup.
-    pub async fn start_all(configs: &CpuConfigs, ctx: &CpuTestContext) -> eyre::Result<Self> {
-        Self::start_all_with(configs, ctx, FleetOptions::default()).await
-    }
-
     /// Start all three parties under `options`.
     ///
     /// A hold has to be in place from a party's *first* boot: it is the only way to

--- a/iris-mpc/tests/utils/hawk_fleet.rs
+++ b/iris-mpc/tests/utils/hawk_fleet.rs
@@ -309,6 +309,40 @@ impl HawkFleet {
             .phase)
     }
 
+    /// One party's own sync-state digest, once it is publishing `/startup-state`.
+    ///
+    /// Polls rather than reading once: the digest is computed *before* the
+    /// coordination server exists (it is an argument to `StartupStateHandle::new`),
+    /// so after a restart there is a window — the migrations plus the ~10s
+    /// empty-queue long poll in `build_sync_state` — where nothing answers the port.
+    /// Once the route answers, the digest is already there.
+    ///
+    /// Unlike [`HawkFleet::agreed_fleet_sync_state_digest`] this is peer-independent,
+    /// which is what lets a workflow compare a party's state across a restart
+    /// without needing its peers to be alive.
+    pub async fn wait_for_party_sync_state_digest(
+        &self,
+        party: usize,
+        dur: Duration,
+    ) -> eyre::Result<SyncStateDigest> {
+        let port = self.configs[party].healthcheck_port;
+        let deadline = tokio::time::Instant::now() + dur;
+
+        loop {
+            match fetch_startup_state(port).await {
+                Ok(state) => return Ok(state.party_sync_state_digest),
+                Err(err) => tracing::debug!("party {party} startup state unavailable: {err:#}"),
+            }
+
+            self.assert_still_running(party)?;
+
+            if tokio::time::Instant::now() >= deadline {
+                bail!("party {party} did not publish a startup state within {dur:?}");
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    }
+
     /// Every party's published fleet sync-state digest. Fails if any party has not
     /// derived one, or if they do not all agree.
     pub async fn agreed_fleet_sync_state_digest(&self) -> eyre::Result<SyncStateDigest> {

--- a/iris-mpc/tests/utils/hawk_fleet.rs
+++ b/iris-mpc/tests/utils/hawk_fleet.rs
@@ -48,6 +48,7 @@ use std::time::Duration;
 use ampc_server_utils::ReadyProbeResponse;
 use eyre::{bail, eyre, WrapErr};
 use iris_mpc::server::startup_phase::{Phase, StartupState, SyncStateDigest};
+use iris_mpc_common::config::Config;
 use tokio::net::TcpStream;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
@@ -77,54 +78,39 @@ pub struct FleetOptions {
     pub startup_sync_timeout_secs: Option<u64>,
 }
 
-/// Spawn `server_main` for one party.
+/// One party's `server_main`, ended by whichever of `shutdown` or `abort` fires
+/// first.
 ///
 /// `server_main` holds `!Send` state, so the party runs on its own OS thread via
-/// `spawn_blocking` with a dedicated multi-thread runtime.
-///
-/// Mirrors the per-party body of [`crate::workflows::run_hawk`], which spawns all
-/// three into a `JoinSet` under one shared token. That function is left alone
-/// because every `wal_*` test depends on its cancellation semantics; the two must
-/// be kept in sync.
-fn spawn_hawk_party(
+/// `spawn_blocking` with a dedicated multi-thread runtime. The returned future is
+/// `Send`, which leaves supervision to the caller: [`HawkFleet::start_party`]
+/// spawns one task per party so it can stop them individually, while
+/// [`crate::workflows::run_hawk`] collects all three into a `JoinSet` under one
+/// shared token.
+pub async fn hawk_party(
     party: usize,
-    configs: &CpuConfigs,
+    config: Config,
     shutdown: CancellationToken,
-    ctx: &CpuTestContext,
-    hold_at: Option<Phase>,
-    startup_sync_timeout_secs: Option<u64>,
-) -> JoinHandle<eyre::Result<()>> {
-    let mut config = crate::utils::configs::make_hawk_config(&configs[party], configs, &ctx.env);
-    config.startup_hold_at_phase = hold_at.map(|phase| phase.to_string());
-    if let Some(secs) = startup_sync_timeout_secs {
-        config
-            .server_coordination
-            .as_mut()
-            .expect("test configs always set server_coordination")
-            .startup_sync_timeout_secs = secs;
-    }
-    let abort = ctx.abort.clone();
-
-    tokio::spawn(async move {
-        tokio::task::spawn_blocking(move || {
-            let rt = tokio::runtime::Builder::new_multi_thread()
-                .enable_all()
-                .thread_stack_size(TEST_THREAD_STACK_SIZE)
-                .build()
-                .expect("failed to build server runtime");
-            let span = info_span!("mpc_node", idx = party);
-            rt.block_on(async move {
-                tokio::select! {
-                    res = iris_mpc::server::server_main(config).instrument(span) => res,
-                    _ = shutdown.cancelled() => Ok(()),
-                    _ = abort.cancelled() => Ok(()),
-                }
-            })
+    abort: CancellationToken,
+) -> eyre::Result<()> {
+    tokio::task::spawn_blocking(move || {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .thread_stack_size(TEST_THREAD_STACK_SIZE)
+            .build()
+            .expect("failed to build server runtime");
+        let span = info_span!("mpc_node", idx = party);
+        rt.block_on(async move {
+            tokio::select! {
+                res = iris_mpc::server::server_main(config).instrument(span) => res,
+                _ = shutdown.cancelled() => Ok(()),
+                _ = abort.cancelled() => Ok(()),
+            }
         })
-        .await
-        .map_err(|e| eyre!("server task panicked: {e}"))
-        .and_then(|r| r)
     })
+    .await
+    .map_err(|e| eyre!("server task panicked: {e}"))
+    .and_then(|r| r)
 }
 
 /// Read one party's `/startup-state` document.
@@ -231,15 +217,19 @@ impl HawkFleet {
             self.tasks[party].is_none(),
             "party {party} is already running"
         );
+        let mut config =
+            crate::utils::configs::make_hawk_config(&self.configs[party], &self.configs, &ctx.env);
+        config.startup_hold_at_phase = hold_at.map(|phase| phase.to_string());
+        if let Some(secs) = self.startup_sync_timeout_secs {
+            config
+                .server_coordination
+                .as_mut()
+                .expect("test configs always set server_coordination")
+                .startup_sync_timeout_secs = secs;
+        }
+
         let token = CancellationToken::new();
-        let task = spawn_hawk_party(
-            party,
-            &self.configs,
-            token.clone(),
-            ctx,
-            hold_at,
-            self.startup_sync_timeout_secs,
-        );
+        let task = tokio::spawn(hawk_party(party, config, token.clone(), ctx.abort.clone()));
         self.tokens[party] = Some(token);
         self.tasks[party] = Some(task);
         tracing::info!("fleet: started party {party} (hold_at {hold_at:?})");

--- a/iris-mpc/tests/utils/hawk_fleet.rs
+++ b/iris-mpc/tests/utils/hawk_fleet.rs
@@ -44,7 +44,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{info_span, Instrument};
 
 use super::runner::CpuTestContext;
-use super::{CpuConfigs, COUNT_OF_PARTIES, TEST_THREAD_STACK_SIZE};
+use super::{CpuConfigs, COUNT_OF_PARTIES};
 
 /// Party the startup-sync workflows restart. Arbitrary — nothing in the design
 /// distinguishes the parties and the commit barrier is symmetric.
@@ -75,24 +75,12 @@ pub async fn hawk_party(
     shutdown: CancellationToken,
     abort: CancellationToken,
 ) -> eyre::Result<()> {
-    tokio::task::spawn_blocking(move || {
-        let rt = tokio::runtime::Builder::new_multi_thread()
-            .enable_all()
-            .thread_stack_size(TEST_THREAD_STACK_SIZE)
-            .build()
-            .expect("failed to build server runtime");
-        let span = info_span!("mpc_node", idx = party);
-        rt.block_on(async move {
-            tokio::select! {
-                res = iris_mpc::server::server_main(config).instrument(span) => res,
-                _ = shutdown.cancelled() => Ok(()),
-                _ = abort.cancelled() => Ok(()),
-            }
-        })
-    })
-    .await
-    .map_err(|e| eyre!("server task panicked: {e}"))
-    .and_then(|r| r)
+    let span = info_span!("mpc_node", idx = party);
+    tokio::select! {
+        res = iris_mpc::server::server_main(config).instrument(span) => res,
+        _ = shutdown.cancelled() => Ok(()),
+        _ = abort.cancelled() => Ok(()),
+    }
 }
 
 /// Read one party's `/health` document.

--- a/iris-mpc/tests/utils/hawk_fleet.rs
+++ b/iris-mpc/tests/utils/hawk_fleet.rs
@@ -1,13 +1,5 @@
 //! Per-party control over the three `server_main` instances.
 //!
-//! [`super::wait_conditions`] treats the fleet as a unit: one
-//! `CancellationToken` for all three parties and a `JoinSet` that only reports
-//! *that* something exited. The startup-sync tests need finer control — stop
-//! exactly one party, prove the other two are still running, restart the first
-//! — so this module keeps a `JoinHandle` and a token per party, and exposes the
-//! `/startup-state` document so a test can act on a party's real phase instead
-//! of guessing with sleeps.
-//!
 //! # Why the kill point is a configured hold, not a poll
 //!
 //! The startup workflows have to stop a party *in* a named phase. Polling
@@ -38,10 +30,7 @@
 //! *inside* the load, whatever the fleet sync-state digest comparison would have
 //! decided.
 //! Killing during the handshake parks the survivors in the commit barrier, where
-//! the outcome is determined entirely by the digest logic under test. A load-window
-//! rejoin test becomes meaningful once the checkpoint round tolerates a peer
-//! restart, or once `Phase::Load` is split into local iris and cross-party graph
-//! phases.
+//! the outcome is determined entirely by the digest logic under test.
 
 use std::time::Duration;
 
@@ -80,13 +69,6 @@ pub struct FleetOptions {
 
 /// One party's `server_main`, ended by whichever of `shutdown` or `abort` fires
 /// first.
-///
-/// `server_main` holds `!Send` state, so the party runs on its own OS thread via
-/// `spawn_blocking` with a dedicated multi-thread runtime. The returned future is
-/// `Send`, which leaves supervision to the caller: [`HawkFleet::start_party`]
-/// spawns one task per party so it can stop them individually, while
-/// [`crate::workflows::run_hawk`] collects all three into a `JoinSet` under one
-/// shared token.
 pub async fn hawk_party(
     party: usize,
     config: Config,
@@ -136,18 +118,6 @@ pub struct HawkFleet {
 }
 
 /// Cancel and abort every party when the fleet goes out of scope.
-///
-/// Essential, not tidiness. Dropping a `JoinHandle` *detaches* its task, so
-/// without this a workflow that fails partway through `exec` — before it hands
-/// the fleet to `self` — leaves three `server_main` instances running with their
-/// coordination ports held, and the next workflow in the same test process dies
-/// with `Address already in use`.
-///
-/// Cancelling the token is the part that matters: the party runs inside
-/// `spawn_blocking`, which cannot be aborted once started, so it only stops when
-/// `server_main`'s `select!` observes the cancellation. The port is therefore
-/// freed shortly *after* the drop, not during it — which is why
-/// [`HawkFleet::start_all`] waits for ports rather than assuming they are free.
 impl Drop for HawkFleet {
     fn drop(&mut self) {
         for party in 0..COUNT_OF_PARTIES {
@@ -247,8 +217,6 @@ impl HawkFleet {
             .take()
             .ok_or_else(|| eyre!("party {party} has a token but no task"))?;
 
-        // `&mut task` so the handle survives a timeout and can be aborted. Letting
-        // it drop would detach the task instead of stopping it.
         match tokio::time::timeout(Duration::from_secs(60), &mut task).await {
             Ok(Ok(Ok(()))) => {}
             Ok(Ok(Err(err))) => {
@@ -262,9 +230,6 @@ impl HawkFleet {
             }
         }
 
-        // `server_main`'s `TaskMonitor` aborts the coordination listener when the
-        // future is dropped, but the socket close is not synchronous with the task
-        // returning; binding too early would fail the restarted party's listener.
         wait_for_port_free(
             self.configs[party].healthcheck_port,
             Duration::from_secs(30),
@@ -275,10 +240,6 @@ impl HawkFleet {
         Ok(())
     }
 
-    /// Fail if a party is not running, or if its task has already exited.
-    ///
-    /// This is the assertion the rejoin test rests on: the parties that were never
-    /// touched must still be in their original process.
     pub fn assert_still_running(&self, party: usize) -> eyre::Result<()> {
         match &self.tasks[party] {
             None => bail!("party {party} is not running"),

--- a/iris-mpc/tests/utils/hawk_fleet.rs
+++ b/iris-mpc/tests/utils/hawk_fleet.rs
@@ -2,7 +2,7 @@
 //!
 //! [`super::wait_conditions`] treats the fleet as a unit: one
 //! `CancellationToken` for all three parties and a `JoinSet` that only reports
-//! *that* something exited. The startup-epoch tests need finer control — stop
+//! *that* something exited. The startup-sync tests need finer control — stop
 //! exactly one party, prove the other two are still running, restart the first
 //! — so this module keeps a `JoinHandle` and a token per party, and exposes the
 //! `/startup-state` document so a test can act on a party's real phase instead
@@ -13,17 +13,17 @@
 //! The startup workflows have to stop a party *in* a named phase. Polling
 //! `/startup-state` for that cannot work: on an empty local fleet `propose -> load`
 //! takes ~180 ms end to end, so a 100 ms poll grid routinely first observes the
-//! party already past the intended kill point, having published its epoch and
-//! released its peers' commit barrier. So the party is *held* instead:
+//! party already past the intended kill point, having published its fleet digest
+//! and released its peers' commit barrier. So the party is *held* instead:
 //! [`HawkFleet::start_party`] sets `Config::startup_hold_at_phase` and the party
 //! parks there until stopped; the restart is spawned without the hold. The hold is
-//! excluded from `CommonConfig`, so it does not perturb the derived epoch.
+//! excluded from `CommonConfig`, so it does not perturb the derived digest.
 //!
 //! # Why the commit-barrier budget is overridable
 //!
-//! `wait_for_epoch_commit` treats an unreachable peer as "it is restarting, keep
-//! waiting" — which is what makes rejoin work, and why a party that *dies* is
-//! indistinguishable from one coming back. The survivors then wait out the whole
+//! `wait_for_fleet_digest_commit` treats an unreachable peer as "it is restarting,
+//! keep waiting" — which is what makes rejoin work, and why a party that *dies*
+//! is indistinguishable from one coming back. The survivors then wait out the whole
 //! 300s `startup_sync_timeout_secs`, longer than [`FLEET_TIMEOUT`], so a workflow
 //! whose expected outcome is "the fleet gives up" would hit the harness deadline
 //! instead of the behaviour it asserts. [`FleetOptions::startup_sync_timeout_secs`]
@@ -35,17 +35,18 @@
 //! `init_hawk_actor` runs `restart_from_checkpoint` — a cross-party consensus round
 //! with a 10s `PEER_ROUND_TIMEOUT` — concurrently with the iris load via
 //! `try_join!`. A party that disappears during the load therefore fails its peers
-//! *inside* the load, whatever the epoch layer would have decided. Killing during
-//! the handshake parks the survivors in the commit barrier, where the outcome is
-//! determined entirely by the epoch logic under test. A load-window rejoin test
-//! becomes meaningful once the checkpoint round tolerates a peer restart, or once
-//! `Phase::Load` is split into local iris and cross-party graph phases.
+//! *inside* the load, whatever the fleet digest comparison would have decided.
+//! Killing during the handshake parks the survivors in the commit barrier, where
+//! the outcome is determined entirely by the digest logic under test. A load-window
+//! rejoin test becomes meaningful once the checkpoint round tolerates a peer
+//! restart, or once `Phase::Load` is split into local iris and cross-party graph
+//! phases.
 
 use std::time::Duration;
 
 use ampc_server_utils::ReadyProbeResponse;
 use eyre::{bail, eyre, WrapErr};
-use iris_mpc::server::startup_phase::{Epoch, Phase, StartupState};
+use iris_mpc::server::startup_phase::{Phase, StartupState, SyncStateDigest};
 use tokio::net::TcpStream;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
@@ -54,7 +55,7 @@ use tracing::{info_span, Instrument};
 use super::runner::CpuTestContext;
 use super::{CpuConfigs, COUNT_OF_PARTIES, TEST_THREAD_STACK_SIZE};
 
-/// Party the startup-epoch workflows restart. Arbitrary — nothing in the design
+/// Party the startup-sync workflows restart. Arbitrary — nothing in the design
 /// distinguishes the parties and the commit barrier is symmetric.
 pub const RESTARTED_PARTY: usize = 2;
 
@@ -366,23 +367,23 @@ impl HawkFleet {
             .phase)
     }
 
-    /// Every party's published epoch. Fails if any party has not derived one, or if
-    /// they do not all agree.
-    pub async fn agreed_epoch(&self) -> eyre::Result<Epoch> {
-        let mut epochs = Vec::with_capacity(COUNT_OF_PARTIES);
+    /// Every party's published fleet digest. Fails if any party has not derived one,
+    /// or if they do not all agree.
+    pub async fn agreed_fleet_digest(&self) -> eyre::Result<SyncStateDigest> {
+        let mut digests = Vec::with_capacity(COUNT_OF_PARTIES);
         for party in 0..COUNT_OF_PARTIES {
             let state = fetch_startup_state(self.configs[party].healthcheck_port).await?;
-            epochs.push(state.epoch.ok_or_else(|| {
+            digests.push(state.fleet_digest.ok_or_else(|| {
                 eyre!(
-                    "party {party} has not derived an epoch (phase {})",
+                    "party {party} has not derived a fleet digest (phase {})",
                     state.phase
                 )
             })?);
         }
-        if epochs.iter().any(|epoch| *epoch != epochs[0]) {
-            bail!("parties disagree on the startup epoch: {epochs:?}");
+        if digests.iter().any(|digest| *digest != digests[0]) {
+            bail!("parties disagree on the startup fleet digest: {digests:?}");
         }
-        Ok(epochs[0])
+        Ok(digests[0])
     }
 
     /// Wait until all three parties report `is_ready` on `/health`.

--- a/iris-mpc/tests/utils/mod.rs
+++ b/iris-mpc/tests/utils/mod.rs
@@ -2,6 +2,7 @@ use iris_mpc_cpu::graph_checkpoint::{PruningMode, TieredPruningConfig};
 
 pub mod configs;
 pub mod cpu_node;
+pub mod hawk_fleet;
 pub mod key_rotation;
 pub mod runner;
 pub mod wait_conditions;
@@ -9,6 +10,22 @@ pub mod wal_builder;
 
 /// Number of MPC parties.
 pub const COUNT_OF_PARTIES: usize = 3;
+
+/// Stack size for every thread that may poll a `server_main` future.
+///
+/// `server_main` is a very large async fn — large enough that both it and this
+/// test binary need `#![recursion_limit = "256"]` — and its future lives on the
+/// stack of whichever thread polls it. Production polls it with
+/// `runtime.block_on` on the **main** thread, which gets the 8 MB Linux default.
+/// The harness instead polls it on a tokio **blocking-pool** thread
+/// (`spawn_blocking` → inner `rt.block_on`), and those default to 2 MB
+/// (`thread_stack_size`, honoured by the blocking pool as well as by workers).
+///
+/// That 4x gap means the harness overflows on futures production handles
+/// comfortably: adding a handful of locals to `server_main` was enough to abort
+/// a worker with "has overflowed its stack" partway through converge. Give the
+/// harness more headroom than production rather than budgeting to the byte.
+pub const TEST_THREAD_STACK_SIZE: usize = 16 * 1024 * 1024;
 
 pub const MIN_MUTATIONS_PER_SIDECAR_CYCLE: usize = 5;
 

--- a/iris-mpc/tests/utils/mod.rs
+++ b/iris-mpc/tests/utils/mod.rs
@@ -13,17 +13,13 @@ pub const COUNT_OF_PARTIES: usize = 3;
 
 /// Stack size for every thread that may poll a `server_main` future.
 ///
-/// `server_main` is a very large async fn — large enough that both it and this
-/// test binary need `#![recursion_limit = "256"]` — and its future lives on the
-/// stack of whichever thread polls it. Production polls it with
-/// `runtime.block_on` on the **main** thread, which gets the 8 MB Linux default.
-/// The harness instead polls it on a tokio **blocking-pool** thread
-/// (`spawn_blocking` → inner `rt.block_on`), and those default to 2 MB
-/// (`thread_stack_size`, honoured by the blocking pool as well as by workers).
-///
-/// That 4x gap means the harness overflows on futures production handles
-/// comfortably: adding a handful of locals to `server_main` was enough to abort
-/// a worker with "has overflowed its stack" partway through converge. Give the
+/// `server_main`'s future is very large and lives on the stack of whichever thread
+/// polls it. Production polls it with `runtime.block_on` on the **main** thread,
+/// which gets the 8 MB Linux default; the harness polls it on a tokio
+/// blocking-pool thread (`spawn_blocking` → inner `rt.block_on`), which defaults to
+/// 2 MB. That 4x gap means the harness overflows on futures production handles
+/// comfortably — adding a handful of locals to `server_main` was enough to abort a
+/// worker with "has overflowed its stack" partway through converge — so give the
 /// harness more headroom than production rather than budgeting to the byte.
 pub const TEST_THREAD_STACK_SIZE: usize = 16 * 1024 * 1024;
 

--- a/iris-mpc/tests/utils/mod.rs
+++ b/iris-mpc/tests/utils/mod.rs
@@ -11,16 +11,12 @@ pub mod wal_builder;
 /// Number of MPC parties.
 pub const COUNT_OF_PARTIES: usize = 3;
 
-/// Stack size for every thread that may poll a `server_main` future.
+/// Stack size for every thread the harness owns: the runtime's workers and the
+/// thread `run_test!` polls the test body on.
 ///
-/// Stack size for the harness runtime's threads.
-///
-/// `server_main`'s future is very large. It no longer lives on a thread stack —
+/// `server_main`'s future is very large, but it no longer lives on a thread stack —
 /// [`hawk_fleet::hawk_party`] is `tokio::spawn`ed, which moves the future into a
-/// heap-allocated task — so this is no longer load-bearing for that. It is kept as
-/// headroom for the deep poll chains under `server_main`, which historically
-/// overflowed the 2 MB tokio default ("has overflowed its stack" partway through
-/// converge) back when `rt.block_on` polled the whole future on the stack.
+/// heap-allocated task.
 pub const TEST_THREAD_STACK_SIZE: usize = 16 * 1024 * 1024;
 
 pub const MIN_MUTATIONS_PER_SIDECAR_CYCLE: usize = 5;

--- a/iris-mpc/tests/utils/mod.rs
+++ b/iris-mpc/tests/utils/mod.rs
@@ -13,14 +13,14 @@ pub const COUNT_OF_PARTIES: usize = 3;
 
 /// Stack size for every thread that may poll a `server_main` future.
 ///
-/// `server_main`'s future is very large and lives on the stack of whichever thread
-/// polls it. Production polls it with `runtime.block_on` on the **main** thread,
-/// which gets the 8 MB Linux default; the harness polls it on a tokio
-/// blocking-pool thread (`spawn_blocking` → inner `rt.block_on`), which defaults to
-/// 2 MB. That 4x gap means the harness overflows on futures production handles
-/// comfortably — adding a handful of locals to `server_main` was enough to abort a
-/// worker with "has overflowed its stack" partway through converge — so give the
-/// harness more headroom than production rather than budgeting to the byte.
+/// Stack size for the harness runtime's threads.
+///
+/// `server_main`'s future is very large. It no longer lives on a thread stack —
+/// [`hawk_fleet::hawk_party`] is `tokio::spawn`ed, which moves the future into a
+/// heap-allocated task — so this is no longer load-bearing for that. It is kept as
+/// headroom for the deep poll chains under `server_main`, which historically
+/// overflowed the 2 MB tokio default ("has overflowed its stack" partway through
+/// converge) back when `rt.block_on` polled the whole future on the stack.
 pub const TEST_THREAD_STACK_SIZE: usize = 16 * 1024 * 1024;
 
 pub const MIN_MUTATIONS_PER_SIDECAR_CYCLE: usize = 5;

--- a/iris-mpc/tests/utils/runner.rs
+++ b/iris-mpc/tests/utils/runner.rs
@@ -1,6 +1,19 @@
 use super::CpuConfigs;
 use aws_config;
+use std::future::Future;
 use tokio_util::sync::CancellationToken;
+
+/// Run one lifecycle phase, giving up as soon as `abort` fires.
+async fn until_abort<T>(
+    abort: &CancellationToken,
+    phase: impl Future<Output = eyre::Result<T>>,
+) -> eyre::Result<T> {
+    tokio::select! {
+        biased;
+        _ = abort.cancelled() => eyre::bail!("aborted by Ctrl+C"),
+        res = phase => res,
+    }
+}
 
 /// Lifecycle trait implemented by each `wal_NNN` test struct.
 ///
@@ -18,24 +31,24 @@ pub trait TestRun {
 
         // Capture the first failure from setup → exec → exec_assert without
         // short-circuiting out of `run`, so teardown always gets a chance to run.
-        let setup_res = async {
+        let setup_res = until_abort(&ctx.abort, async {
             tracing::info!("[{}] Starting phase: setup", test_id);
             self.setup(ctx).await?;
             tracing::info!("[{}] Starting phase: setup_assert", test_id);
             self.setup_assert(ctx).await
-        }
+        })
         .await;
 
         let phase_res = if let Err(ref e) = setup_res {
             tracing::error!("[{}] Setup error: {}", test_id, e);
             setup_res
         } else {
-            let exec_res = async {
+            let exec_res = until_abort(&ctx.abort, async {
                 tracing::info!("[{}] Starting phase: exec", test_id);
                 self.exec(ctx).await?;
                 tracing::info!("[{}] Starting phase: exec_assert", test_id);
                 self.exec_assert(ctx).await
-            }
+            })
             .await;
 
             if let Err(ref e) = exec_res {
@@ -44,7 +57,7 @@ pub trait TestRun {
             exec_res
         };
 
-        // Teardown always runs, even if an earlier phase failed.
+        // Teardown always runs, even if an earlier phase failed
         let teardown_res = self.teardown(ctx).await;
         if let Err(ref e) = teardown_res {
             tracing::error!(

--- a/iris-mpc/tests/workflows/mod.rs
+++ b/iris-mpc/tests/workflows/mod.rs
@@ -1,5 +1,6 @@
 pub mod startup_120;
 pub mod startup_121;
+pub mod startup_122;
 
 #[allow(dead_code)]
 pub mod wal_102;

--- a/iris-mpc/tests/workflows/mod.rs
+++ b/iris-mpc/tests/workflows/mod.rs
@@ -1,3 +1,6 @@
+pub mod startup_120;
+pub mod startup_121;
+
 #[allow(dead_code)]
 pub mod wal_102;
 pub mod wal_104;
@@ -20,7 +23,7 @@ use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::{info_span, Instrument};
 
-use crate::utils::{runner::CpuTestContext, CpuNodeConfig};
+use crate::utils::{runner::CpuTestContext, CpuNodeConfig, TEST_THREAD_STACK_SIZE};
 
 /// Spawn `server_main` (hawk_main) for all 3 parties concurrently.
 ///
@@ -48,6 +51,7 @@ pub fn run_hawk(
             tokio::task::spawn_blocking(move || {
                 let rt = tokio::runtime::Builder::new_multi_thread()
                     .enable_all()
+                    .thread_stack_size(TEST_THREAD_STACK_SIZE)
                     .build()
                     .expect("failed to build server runtime");
                 let span = info_span!("mpc_node", idx = party_idx);

--- a/iris-mpc/tests/workflows/mod.rs
+++ b/iris-mpc/tests/workflows/mod.rs
@@ -30,8 +30,7 @@ use crate::utils::{hawk_fleet::hawk_party, runner::CpuTestContext, CpuNodeConfig
 /// `shutdown` and joined as a unit.
 ///
 /// Per-party control — stopping one party while the others keep running — is
-/// [`crate::utils::hawk_fleet::HawkFleet`] instead; both build on
-/// [`hawk_party`], which owns the `!Send` thread-per-party detail.
+/// [`crate::utils::hawk_fleet::HawkFleet`] instead; both build on [`hawk_party`].
 pub fn run_hawk(
     configs: &[CpuNodeConfig; 3],
     shutdown: CancellationToken,

--- a/iris-mpc/tests/workflows/mod.rs
+++ b/iris-mpc/tests/workflows/mod.rs
@@ -23,50 +23,29 @@ use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::{info_span, Instrument};
 
-use crate::utils::{runner::CpuTestContext, CpuNodeConfig, TEST_THREAD_STACK_SIZE};
+use crate::utils::{hawk_fleet::hawk_party, runner::CpuTestContext, CpuNodeConfig};
 
-/// Spawn `server_main` (hawk_main) for all 3 parties concurrently.
+/// Spawn `server_main` (hawk_main) for all 3 parties concurrently, all under
+/// `shutdown` and joined as a unit.
 ///
-/// `server_main` holds `!Send` state, so each party runs in its own OS thread
-/// via `spawn_blocking` with a dedicated multi-thread runtime.
-/// `CancellationToken` is cloned directly into each
-/// `spawn_blocking` closure and selected on inside the new runtime.
+/// Per-party control — stopping one party while the others keep running — is
+/// [`crate::utils::hawk_fleet::HawkFleet`] instead; both build on
+/// [`hawk_party`], which owns the `!Send` thread-per-party detail.
 pub fn run_hawk(
     configs: &[CpuNodeConfig; 3],
     shutdown: CancellationToken,
     ctx: &CpuTestContext,
 ) -> JoinSet<eyre::Result<()>> {
-    use iris_mpc::server::server_main;
-
     let mut join_set: JoinSet<eyre::Result<()>> = JoinSet::new();
 
     for (party_idx, cpu_cfg) in configs.iter().enumerate() {
         let config = crate::utils::configs::make_hawk_config(cpu_cfg, configs, &ctx.env);
-        let shutdown = shutdown.clone();
-        let abort = ctx.abort.clone();
-
-        // server_main is !Send; block_on inside spawn_blocking avoids Send requirements.
-        // CancellationToken is Send + Sync and runtime-agnostic: clone it directly.
-        join_set.spawn(async move {
-            tokio::task::spawn_blocking(move || {
-                let rt = tokio::runtime::Builder::new_multi_thread()
-                    .enable_all()
-                    .thread_stack_size(TEST_THREAD_STACK_SIZE)
-                    .build()
-                    .expect("failed to build server runtime");
-                let span = info_span!("mpc_node", idx = party_idx);
-                rt.block_on(async move {
-                    tokio::select! {
-                        res = server_main(config).instrument(span) => res,
-                        _ = shutdown.cancelled() => Ok(()),
-                        _ = abort.cancelled() => Ok(()),
-                    }
-                })
-            })
-            .await
-            .map_err(|e| eyre::eyre!("server task panicked: {e}"))
-            .and_then(|r| r)
-        });
+        join_set.spawn(hawk_party(
+            party_idx,
+            config,
+            shutdown.clone(),
+            ctx.abort.clone(),
+        ));
     }
 
     join_set

--- a/iris-mpc/tests/workflows/startup_120.rs
+++ b/iris-mpc/tests/workflows/startup_120.rs
@@ -7,15 +7,15 @@
 /// must come ready.
 ///
 /// Asserts the point of keying startup on the data — the restart is absorbed.
-/// Before the fleet digest this could not work at all: the returning party minted a
-/// fresh UUID, absent from the survivors' startup-verified set, so
+/// Before the fleet sync-state digest this could not work at all: the returning party
+/// minted a fresh UUID, absent from the survivors' startup-verified set, so
 /// `wait_for_others_ready` and the heartbeat's first-contact check killed two
 /// healthy nodes.
 ///
 /// Also covers a potential deadlock: party 2's visibility barrier needs the
 /// survivors to publish its *new* UUID, and they can only do that from inside
-/// `wait_for_fleet_digest_commit`, which records peer UUIDs *before* it evaluates
-/// the digest. Reverse that ordering and this workflow hangs.
+/// `wait_for_fleet_sync_state_digest_commit`, which records peer UUIDs *before* it
+/// evaluates the digest. Reverse that ordering and this workflow hangs.
 ///
 /// See [`crate::utils::hawk_fleet`] for why the kill point is the handshake rather
 /// than the DB load.
@@ -59,9 +59,10 @@ impl TestRun for Startup120 {
         let fleet = self.fleet.as_mut().unwrap();
 
         // Kill at Propose — after the mutual-visibility barriers, before the party
-        // has published a fleet digest. That ordering makes this deterministic: with
-        // no digest from this party the survivors cannot satisfy their commit barrier,
-        // so they cannot have moved on whatever interleaving they were in.
+        // has published a fleet sync-state digest. That ordering makes this
+        // deterministic: with no digest from this party the survivors cannot satisfy
+        // their commit barrier, so they cannot have moved on whatever interleaving
+        // they were in.
         fleet
             .wait_for_phase(RESTARTED_PARTY, Phase::Propose, FLEET_TIMEOUT)
             .await?;
@@ -94,11 +95,11 @@ impl TestRun for Startup120 {
         // absorbed a peer restart instead of reloading.
         fleet.assert_others_running(RESTARTED_PARTY)?;
 
-        // All three converged on one fleet digest, so the restarted party rejoined
-        // the fleet's startup rather than forming a separate one.
+        // All three converged on one fleet sync-state digest, so the restarted party
+        // rejoined the fleet's startup rather than forming a separate one.
         tracing::info!(
-            "all parties agree on startup fleet digest {}",
-            fleet.agreed_fleet_digest().await?
+            "all parties agree on startup fleet sync-state digest {}",
+            fleet.agreed_fleet_sync_state_digest().await?
         );
         Ok(())
     }

--- a/iris-mpc/tests/workflows/startup_120.rs
+++ b/iris-mpc/tests/workflows/startup_120.rs
@@ -6,20 +6,15 @@
 /// [`Phase::Converge`], then party 2 is restarted without the hold and the fleet
 /// must come ready.
 ///
-/// Asserts the point of the epoch design — the restart is absorbed. The surviving
-/// parties stay in their original processes, and because they wait in the commit
-/// barrier rather than racing ahead, they never mutate storage while a peer is
-/// missing.
+/// Asserts the point of the epoch design — the restart is absorbed. Before the
+/// epoch layer this could not work at all: the returning party minted a fresh UUID,
+/// absent from the survivors' startup-verified set, so `wait_for_others_ready` and
+/// the heartbeat's first-contact check killed two healthy nodes.
 ///
-/// Before the epoch layer this could not work at all: the returning party minted a
-/// fresh UUID, absent from the survivors' startup-verified set, so
-/// `wait_for_others_ready` and the heartbeat's first-contact check killed two
-/// healthy nodes.
-///
-/// This also covers a potential deadlock in the implementation: party 2's
-/// visibility barrier needs the survivors to publish its *new* UUID, and they can
-/// only do that from inside `wait_for_epoch_commit`, which records peer UUIDs
-/// *before* it evaluates the epoch. Reverse that ordering and this workflow hangs.
+/// Also covers a potential deadlock: party 2's visibility barrier needs the
+/// survivors to publish its *new* UUID, and they can only do that from inside
+/// `wait_for_epoch_commit`, which records peer UUIDs *before* it evaluates the
+/// epoch. Reverse that ordering and this workflow hangs.
 ///
 /// See [`crate::utils::hawk_fleet`] for why the kill point is the handshake rather
 /// than the DB load.
@@ -52,11 +47,9 @@ impl TestRun for Startup120 {
 
     async fn exec(&mut self, ctx: &CpuTestContext) -> eyre::Result<()> {
         // Hand the fleet to `self` before anything can fail, so `teardown` always
-        // gets a chance to stop it. `HawkFleet::drop` is the backstop, but a
-        // graceful stop leaves the ports free for the next workflow sooner.
-        // Party 2 holds in Propose from its first boot; the survivors are not held.
-        // The barrier budget stays at its default: the survivors have to outlast a
-        // peer restart here, which is the whole point of the workflow.
+        // gets a chance to stop it (`HawkFleet::drop` is the backstop). The barrier
+        // budget stays at its default: the survivors have to outlast a peer restart
+        // here, which is the whole point of the workflow.
         let options = FleetOptions {
             holds: array::from_fn(|party| (party == RESTARTED_PARTY).then_some(Phase::Propose)),
             startup_sync_timeout_secs: None,
@@ -65,11 +58,9 @@ impl TestRun for Startup120 {
         let fleet = self.fleet.as_mut().unwrap();
 
         // Kill at Propose — after the mutual-visibility barriers, before the party
-        // has published an epoch. That ordering is what makes this deterministic:
-        // with no epoch from this party the survivors cannot satisfy their commit
-        // barrier, so they cannot have moved on, whichever interleaving they were
-        // in when it died. The hold is what guarantees the kill actually lands
-        // there; see [`crate::utils::hawk_fleet`].
+        // has published an epoch. That ordering makes this deterministic: with no
+        // epoch from this party the survivors cannot satisfy their commit barrier, so
+        // they cannot have moved on whatever interleaving they were in.
         fleet
             .wait_for_phase(RESTARTED_PARTY, Phase::Propose, FLEET_TIMEOUT)
             .await?;
@@ -78,11 +69,8 @@ impl TestRun for Startup120 {
         // The survivors must be parked, not progressing. At or past Converge would
         // mean a party started mutating local storage under a plan its peers never
         // agreed to.
-        for party in 0..COUNT_OF_PARTIES {
-            if party == RESTARTED_PARTY {
-                continue;
-            }
-            fleet.assert_still_running(party)?;
+        fleet.assert_others_running(RESTARTED_PARTY)?;
+        for party in (0..COUNT_OF_PARTIES).filter(|p| *p != RESTARTED_PARTY) {
             let phase = fleet.phase(party).await?;
             if phase >= Phase::Converge {
                 eyre::bail!(
@@ -93,7 +81,7 @@ impl TestRun for Startup120 {
         }
 
         // Restarted without the hold, so it runs the handshake through to serving.
-        fleet.start_party(RESTARTED_PARTY, ctx);
+        fleet.start_party(RESTARTED_PARTY, ctx, None);
         fleet.wait_all_ready(FLEET_TIMEOUT).await?;
         Ok(())
     }
@@ -103,20 +91,14 @@ impl TestRun for Startup120 {
 
         // The two untouched parties are still in their original processes — they
         // absorbed a peer restart instead of reloading.
-        for party in 0..COUNT_OF_PARTIES {
-            if party == RESTARTED_PARTY {
-                continue;
-            }
-            fleet.assert_still_running(party)?;
-        }
+        fleet.assert_others_running(RESTARTED_PARTY)?;
 
         // All three converged on one epoch, so the restarted party rejoined the
         // fleet's startup rather than forming a separate one.
-        let epochs = fleet.epochs().await?;
-        if epochs[0] != epochs[1] || epochs[1] != epochs[2] {
-            eyre::bail!("parties disagree on the startup epoch: {epochs:?}");
-        }
-        tracing::info!("all parties agree on startup epoch {}", epochs[0]);
+        tracing::info!(
+            "all parties agree on startup epoch {}",
+            fleet.agreed_epoch().await?
+        );
         Ok(())
     }
 

--- a/iris-mpc/tests/workflows/startup_120.rs
+++ b/iris-mpc/tests/workflows/startup_120.rs
@@ -1,9 +1,10 @@
 /// startup_120 — one party restarts during the startup handshake with unchanged
 /// data and rejoins the fleet's startup epoch.
 ///
-/// Setup: three empty parties. Exec: party 2 is stopped once it reaches
-/// [`Phase::Propose`], the survivors are checked to be parked below
-/// [`Phase::Converge`], then party 2 is restarted and the fleet must come ready.
+/// Setup: three empty parties, party 2 configured to hold in [`Phase::Propose`].
+/// Exec: party 2 is stopped there, the survivors are checked to be parked below
+/// [`Phase::Converge`], then party 2 is restarted without the hold and the fleet
+/// must come ready.
 ///
 /// Asserts the point of the epoch design — the restart is absorbed. The surviving
 /// parties stay in their original processes, and because they wait in the commit
@@ -24,11 +25,12 @@
 /// than the DB load.
 use crate::utils::{
     cpu_node::CpuNodes,
-    hawk_fleet::{HawkFleet, FLEET_TIMEOUT, RESTARTED_PARTY},
+    hawk_fleet::{FleetOptions, HawkFleet, FLEET_TIMEOUT, RESTARTED_PARTY},
     runner::{CpuTestContext, TestRun},
     COUNT_OF_PARTIES,
 };
 use iris_mpc::server::startup_phase::Phase;
+use std::array;
 
 #[derive(Default)]
 pub struct Startup120 {
@@ -52,14 +54,22 @@ impl TestRun for Startup120 {
         // Hand the fleet to `self` before anything can fail, so `teardown` always
         // gets a chance to stop it. `HawkFleet::drop` is the backstop, but a
         // graceful stop leaves the ports free for the next workflow sooner.
-        self.fleet = Some(HawkFleet::start_all(&ctx.configs, ctx).await?);
+        // Party 2 holds in Propose from its first boot; the survivors are not held.
+        // The barrier budget stays at its default: the survivors have to outlast a
+        // peer restart here, which is the whole point of the workflow.
+        let options = FleetOptions {
+            holds: array::from_fn(|party| (party == RESTARTED_PARTY).then_some(Phase::Propose)),
+            startup_sync_timeout_secs: None,
+        };
+        self.fleet = Some(HawkFleet::start_all_with(&ctx.configs, ctx, options).await?);
         let fleet = self.fleet.as_mut().unwrap();
 
         // Kill at Propose — after the mutual-visibility barriers, before the party
         // has published an epoch. That ordering is what makes this deterministic:
         // with no epoch from this party the survivors cannot satisfy their commit
         // barrier, so they cannot have moved on, whichever interleaving they were
-        // in when it died.
+        // in when it died. The hold is what guarantees the kill actually lands
+        // there; see [`crate::utils::hawk_fleet`].
         fleet
             .wait_for_phase(RESTARTED_PARTY, Phase::Propose, FLEET_TIMEOUT)
             .await?;
@@ -82,6 +92,7 @@ impl TestRun for Startup120 {
             }
         }
 
+        // Restarted without the hold, so it runs the handshake through to serving.
         fleet.start_party(RESTARTED_PARTY, ctx);
         fleet.wait_all_ready(FLEET_TIMEOUT).await?;
         Ok(())

--- a/iris-mpc/tests/workflows/startup_120.rs
+++ b/iris-mpc/tests/workflows/startup_120.rs
@@ -1,0 +1,121 @@
+/// startup_120 — one party restarts during the startup handshake with unchanged
+/// data and rejoins the fleet's startup epoch.
+///
+/// Setup: three empty parties. Exec: party 2 is stopped once it reaches
+/// [`Phase::Propose`], the survivors are checked to be parked below
+/// [`Phase::Converge`], then party 2 is restarted and the fleet must come ready.
+///
+/// Asserts the point of the epoch design — the restart is absorbed. The surviving
+/// parties stay in their original processes, and because they wait in the commit
+/// barrier rather than racing ahead, they never mutate storage while a peer is
+/// missing.
+///
+/// Before the epoch layer this could not work at all: the returning party minted a
+/// fresh UUID, absent from the survivors' startup-verified set, so
+/// `wait_for_others_ready` and the heartbeat's first-contact check killed two
+/// healthy nodes.
+///
+/// This also covers a potential deadlock in the implementation: party 2's
+/// visibility barrier needs the survivors to publish its *new* UUID, and they can
+/// only do that from inside `wait_for_epoch_commit`, which records peer UUIDs
+/// *before* it evaluates the epoch. Reverse that ordering and this workflow hangs.
+///
+/// See [`crate::utils::hawk_fleet`] for why the kill point is the handshake rather
+/// than the DB load.
+use crate::utils::{
+    cpu_node::CpuNodes,
+    hawk_fleet::{HawkFleet, FLEET_TIMEOUT, RESTARTED_PARTY},
+    runner::{CpuTestContext, TestRun},
+    COUNT_OF_PARTIES,
+};
+use iris_mpc::server::startup_phase::Phase;
+
+#[derive(Default)]
+pub struct Startup120 {
+    nodes: Option<CpuNodes>,
+    fleet: Option<HawkFleet>,
+}
+
+impl Startup120 {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl TestRun for Startup120 {
+    async fn setup(&mut self, ctx: &CpuTestContext) -> eyre::Result<()> {
+        self.nodes = Some(CpuNodes::new_clean(&ctx.configs, ctx.s3_client.clone()).await?);
+        Ok(())
+    }
+
+    async fn exec(&mut self, ctx: &CpuTestContext) -> eyre::Result<()> {
+        // Hand the fleet to `self` before anything can fail, so `teardown` always
+        // gets a chance to stop it. `HawkFleet::drop` is the backstop, but a
+        // graceful stop leaves the ports free for the next workflow sooner.
+        self.fleet = Some(HawkFleet::start_all(&ctx.configs, ctx).await?);
+        let fleet = self.fleet.as_mut().unwrap();
+
+        // Kill at Propose — after the mutual-visibility barriers, before the party
+        // has published an epoch. That ordering is what makes this deterministic:
+        // with no epoch from this party the survivors cannot satisfy their commit
+        // barrier, so they cannot have moved on, whichever interleaving they were
+        // in when it died.
+        fleet
+            .wait_for_phase(RESTARTED_PARTY, Phase::Propose, FLEET_TIMEOUT)
+            .await?;
+        fleet.stop_party(RESTARTED_PARTY).await?;
+
+        // The survivors must be parked, not progressing. At or past Converge would
+        // mean a party started mutating local storage under a plan its peers never
+        // agreed to.
+        for party in 0..COUNT_OF_PARTIES {
+            if party == RESTARTED_PARTY {
+                continue;
+            }
+            fleet.assert_still_running(party)?;
+            let phase = fleet.phase(party).await?;
+            if phase >= Phase::Converge {
+                eyre::bail!(
+                    "party {party} reached phase {phase} while party {RESTARTED_PARTY} was down; \
+                     the commit barrier should have held it"
+                );
+            }
+        }
+
+        fleet.start_party(RESTARTED_PARTY, ctx);
+        fleet.wait_all_ready(FLEET_TIMEOUT).await?;
+        Ok(())
+    }
+
+    async fn exec_assert(&mut self, _ctx: &CpuTestContext) -> eyre::Result<()> {
+        let fleet = self.fleet.as_ref().unwrap();
+
+        // The two untouched parties are still in their original processes — they
+        // absorbed a peer restart instead of reloading.
+        for party in 0..COUNT_OF_PARTIES {
+            if party == RESTARTED_PARTY {
+                continue;
+            }
+            fleet.assert_still_running(party)?;
+        }
+
+        // All three converged on one epoch, so the restarted party rejoined the
+        // fleet's startup rather than forming a separate one.
+        let epochs = fleet.epochs().await?;
+        if epochs[0] != epochs[1] || epochs[1] != epochs[2] {
+            eyre::bail!("parties disagree on the startup epoch: {epochs:?}");
+        }
+        tracing::info!("all parties agree on startup epoch {}", epochs[0]);
+        Ok(())
+    }
+
+    async fn teardown(&mut self, _ctx: &CpuTestContext) -> eyre::Result<()> {
+        if let Some(fleet) = self.fleet.as_mut() {
+            fleet.stop_all().await?;
+        }
+        if let Some(nodes) = &self.nodes {
+            nodes.truncate_checkpoint_tables().await?;
+        }
+        Ok(())
+    }
+}

--- a/iris-mpc/tests/workflows/startup_120.rs
+++ b/iris-mpc/tests/workflows/startup_120.rs
@@ -1,20 +1,21 @@
 /// startup_120 — one party restarts during the startup handshake with unchanged
-/// data and rejoins the fleet's startup epoch.
+/// data and rejoins the fleet's startup.
 ///
 /// Setup: three empty parties, party 2 configured to hold in [`Phase::Propose`].
 /// Exec: party 2 is stopped there, the survivors are checked to be parked below
 /// [`Phase::Converge`], then party 2 is restarted without the hold and the fleet
 /// must come ready.
 ///
-/// Asserts the point of the epoch design — the restart is absorbed. Before the
-/// epoch layer this could not work at all: the returning party minted a fresh UUID,
-/// absent from the survivors' startup-verified set, so `wait_for_others_ready` and
-/// the heartbeat's first-contact check killed two healthy nodes.
+/// Asserts the point of keying startup on the data — the restart is absorbed.
+/// Before the fleet digest this could not work at all: the returning party minted a
+/// fresh UUID, absent from the survivors' startup-verified set, so
+/// `wait_for_others_ready` and the heartbeat's first-contact check killed two
+/// healthy nodes.
 ///
 /// Also covers a potential deadlock: party 2's visibility barrier needs the
 /// survivors to publish its *new* UUID, and they can only do that from inside
-/// `wait_for_epoch_commit`, which records peer UUIDs *before* it evaluates the
-/// epoch. Reverse that ordering and this workflow hangs.
+/// `wait_for_fleet_digest_commit`, which records peer UUIDs *before* it evaluates
+/// the digest. Reverse that ordering and this workflow hangs.
 ///
 /// See [`crate::utils::hawk_fleet`] for why the kill point is the handshake rather
 /// than the DB load.
@@ -58,16 +59,16 @@ impl TestRun for Startup120 {
         let fleet = self.fleet.as_mut().unwrap();
 
         // Kill at Propose — after the mutual-visibility barriers, before the party
-        // has published an epoch. That ordering makes this deterministic: with no
-        // epoch from this party the survivors cannot satisfy their commit barrier, so
-        // they cannot have moved on whatever interleaving they were in.
+        // has published a fleet digest. That ordering makes this deterministic: with
+        // no digest from this party the survivors cannot satisfy their commit barrier,
+        // so they cannot have moved on whatever interleaving they were in.
         fleet
             .wait_for_phase(RESTARTED_PARTY, Phase::Propose, FLEET_TIMEOUT)
             .await?;
         fleet.stop_party(RESTARTED_PARTY).await?;
 
         // The survivors must be parked, not progressing. At or past Converge would
-        // mean a party started mutating local storage under a plan its peers never
+        // mean a party started mutating local storage over states its peers never
         // agreed to.
         fleet.assert_others_running(RESTARTED_PARTY)?;
         for party in (0..COUNT_OF_PARTIES).filter(|p| *p != RESTARTED_PARTY) {
@@ -93,11 +94,11 @@ impl TestRun for Startup120 {
         // absorbed a peer restart instead of reloading.
         fleet.assert_others_running(RESTARTED_PARTY)?;
 
-        // All three converged on one epoch, so the restarted party rejoined the
-        // fleet's startup rather than forming a separate one.
+        // All three converged on one fleet digest, so the restarted party rejoined
+        // the fleet's startup rather than forming a separate one.
         tracing::info!(
-            "all parties agree on startup epoch {}",
-            fleet.agreed_epoch().await?
+            "all parties agree on startup fleet digest {}",
+            fleet.agreed_fleet_digest().await?
         );
         Ok(())
     }

--- a/iris-mpc/tests/workflows/startup_121.rs
+++ b/iris-mpc/tests/workflows/startup_121.rs
@@ -2,22 +2,23 @@
 /// data, and the whole fleet must refuse to come up.
 ///
 /// Setup: three empty parties, party 2 configured to hold in [`Phase::Propose`].
-/// Exec: once the survivors have committed an epoch derived from party 2's facts,
-/// party 2 is stopped, an extra iris row is inserted into its database, and it is
-/// restarted without the hold. Every party must exit and none may report ready.
+/// Exec: once the survivors have committed a fleet digest derived from party 2's
+/// `SyncState`, party 2 is stopped, an extra iris row is inserted into its database,
+/// and it is restarted without the hold. Every party must exit and none may report
+/// ready.
 ///
 /// Only *some* party has to name the mismatch. The one that comes back always
-/// detects it: its first barrier round sees both peers on the old epoch. Its peers
-/// usually do not — it publishes the new epoch and bails within milliseconds, far
-/// inside their poll interval, after which their polls only see a closed port, which
+/// detects it: its first barrier round sees both peers on the old fleet digest. Its
+/// peers usually do not — it publishes the new digest and bails within milliseconds,
+/// far inside their poll interval, after which their polls only see a closed port, which
 /// the barrier correctly reads as "a peer is restarting" rather than as
 /// disagreement, so they exit on their own timeout. Both routes satisfy what this
 /// workflow needs: nobody serves, and the fleet tears itself down. Hence
 /// [`BARRIER_TIMEOUT_SECS`] — with the 300s default the survivors would still be
 /// waiting long after `FLEET_TIMEOUT`.
 ///
-/// The hold is at `Propose`, i.e. *before* party 2 publishes an epoch, which keeps
-/// the survivors parked in the commit barrier. Holding at `Commit` instead would
+/// The hold is at `Propose`, i.e. *before* party 2 publishes a fleet digest, which
+/// keeps the survivors parked in the commit barrier. Holding at `Commit` instead would
 /// release them into the DB load while party 2 has no MPC listener, and they would
 /// die of a checkpoint peer timeout before the data was even changed — a pass for
 /// entirely the wrong reason.
@@ -37,21 +38,21 @@ use std::array;
 /// Commit-barrier budget for every party in this workflow.
 ///
 /// Long enough that the returning party gets its chance to publish a mismatched
-/// epoch — a restart costs about eleven seconds here, ten of them the empty-queue
+/// digest — a restart costs about eleven seconds here, ten of them the empty-queue
 /// long poll in `build_sync_state` — and short enough that a fleet which never
 /// observes it still gives up well inside `FLEET_TIMEOUT`. Whichever way it goes,
 /// `exec` finishes in under a minute instead of waiting out the 300s default.
 const BARRIER_TIMEOUT_SECS: u64 = 30;
 
-/// Substrings identifying a party that failed *on the epoch comparison* rather
-/// than on a barrier timeout. The two checks that can reach an
-/// `EpochVerdict::Void` word it differently, and either one proves the
+/// Substrings identifying a party that failed *on the fleet digest comparison*
+/// rather than on a barrier timeout. The two checks that can reach an
+/// `AgreementVerdict::Void` word it differently, and either one proves the
 /// comparison under test actually ran.
-const EPOCH_MISMATCH_ERRORS: [&str; 2] = [
-    // wait_for_epoch_commit
-    "startup epoch mismatch",
+const FLEET_DIGEST_MISMATCH_ERRORS: [&str; 2] = [
+    // wait_for_fleet_digest_commit
+    "startup fleet digest mismatch",
     // spawn_startup_watch
-    "startup watch found a peer on a different epoch",
+    "startup watch found a peer on a different fleet digest",
 ];
 
 #[derive(Default)]
@@ -87,12 +88,12 @@ impl TestRun for Startup121 {
             .wait_for_phase(RESTARTED_PARTY, Phase::Propose, FLEET_TIMEOUT)
             .await?;
 
-        // The survivors must already hold an epoch derived from this party's *old*
-        // facts before it goes away — otherwise they would read the new ones on
-        // restart and legitimately agree, which is correct behaviour but not the case
-        // under test. Reaching Commit is exactly that, and leaves them parked in the
-        // commit barrier waiting for party 2, which never publishes an epoch because
-        // it is held in Propose.
+        // The survivors must already hold a fleet digest derived from this party's
+        // *old* SyncState before it goes away — otherwise they would read the new one
+        // on restart and legitimately agree, which is correct behaviour but not the
+        // case under test. Reaching Commit is exactly that, and leaves them parked in
+        // the commit barrier waiting for party 2, which never publishes a digest
+        // because it is held in Propose.
         for party in (0..COUNT_OF_PARTIES).filter(|p| *p != RESTARTED_PARTY) {
             fleet
                 .wait_for_phase(party, Phase::Commit, FLEET_TIMEOUT)
@@ -102,9 +103,9 @@ impl TestRun for Startup121 {
         fleet.stop_party(RESTARTED_PARTY).await?;
 
         // Change the party's data while it is down. One extra iris row moves
-        // `db_len`, which is part of the fact digest; appending at `count + 1` keeps
-        // the `COUNT(*) == MAX(id)` store invariant intact so the party fails on the
-        // epoch, not on `check_store_consistency`.
+        // `db_len`, which is part of the sync-state digest; appending at `count + 1`
+        // keeps the `COUNT(*) == MAX(id)` store invariant intact so the party fails on
+        // the digest, not on `check_store_consistency`.
         let node = &nodes.0[RESTARTED_PARTY];
         let next_id = node.store.iris_store.count_irises().await? as i64 + 1;
         let code = vec![0u16; IRIS_CODE_LENGTH];
@@ -112,10 +113,11 @@ impl TestRun for Startup121 {
         node.insert_iris_share(next_id, &code, &mask, &code, &mask)
             .await?;
         tracing::info!(
-            "inserted iris {next_id} into party {RESTARTED_PARTY} to change its startup facts"
+            "inserted iris {next_id} into party {RESTARTED_PARTY} to change its SyncState"
         );
 
-        // Restarted without the hold: it re-derives an epoch, now a different one.
+        // Restarted without the hold: it re-derives a fleet digest, now a different
+        // one.
         fleet.start_party(RESTARTED_PARTY, ctx, None);
 
         // Every party must exit. `wait_all_exited` fails if any is still running at
@@ -126,15 +128,15 @@ impl TestRun for Startup121 {
         // Some party must have named the mismatch. This ties the workflow to the
         // check under test: the survivors' own error is a barrier *timeout*, which a
         // peer that never came back at all would produce just as well, so "the fleet
-        // exited" alone would pass even with the epoch comparison broken.
+        // exited" alone would pass even with the digest comparison broken.
         let detected = outcomes.iter().any(|outcome| {
-            EPOCH_MISMATCH_ERRORS
+            FLEET_DIGEST_MISMATCH_ERRORS
                 .iter()
                 .any(|reason| outcome.contains(reason))
         });
         if !detected {
             eyre::bail!(
-                "no party detected the epoch mismatch; the fleet stopped for some other \
+                "no party detected the fleet digest mismatch; the fleet stopped for some other \
                  reason: {outcomes:?}"
             );
         }
@@ -149,7 +151,7 @@ impl TestRun for Startup121 {
             if let Ok(response) = reqwest::get(&url).await {
                 if response.status().is_success() {
                     eyre::bail!(
-                        "party {} reports ready after an epoch mismatch",
+                        "party {} reports ready after a fleet digest mismatch",
                         config.party_id
                     );
                 }

--- a/iris-mpc/tests/workflows/startup_121.rs
+++ b/iris-mpc/tests/workflows/startup_121.rs
@@ -6,22 +6,15 @@
 /// party 2 is stopped, an extra iris row is inserted into its database, and it is
 /// restarted without the hold. Every party must exit and none may report ready.
 ///
-/// The surviving parties hold an epoch derived from party 2's previous facts; it
-/// now derives a different one. Nobody may proceed, because the agreed plan
-/// describes a fleet state that no longer exists.
-///
-/// Deliberately does not assert the error text, and deliberately does not require
-/// every party to name the mismatch. The party that comes back always detects it:
-/// its first barrier round sees both peers on the old epoch. Its *peers* usually do
-/// not — it publishes the new epoch and then bails within milliseconds, far inside
-/// their poll interval, after which their polls only see a closed port, which the
-/// barrier correctly reads as "a peer is restarting" rather than as disagreement.
-/// They therefore exit on the barrier's own timeout. Both routes satisfy what this
-/// workflow actually needs: nobody serves, and the fleet tears itself down.
-///
-/// Hence [`BARRIER_TIMEOUT_SECS`]. With the 300s default, the survivors would still
-/// be waiting long after `FLEET_TIMEOUT`, and the workflow would fail on the
-/// harness deadline while the fleet was behaving exactly as designed.
+/// Only *some* party has to name the mismatch. The one that comes back always
+/// detects it: its first barrier round sees both peers on the old epoch. Its peers
+/// usually do not — it publishes the new epoch and bails within milliseconds, far
+/// inside their poll interval, after which their polls only see a closed port, which
+/// the barrier correctly reads as "a peer is restarting" rather than as
+/// disagreement, so they exit on their own timeout. Both routes satisfy what this
+/// workflow needs: nobody serves, and the fleet tears itself down. Hence
+/// [`BARRIER_TIMEOUT_SECS`] — with the 300s default the survivors would still be
+/// waiting long after `FLEET_TIMEOUT`.
 ///
 /// The hold is at `Propose`, i.e. *before* party 2 publishes an epoch, which keeps
 /// the survivors parked in the commit barrier. Holding at `Commit` instead would
@@ -82,9 +75,7 @@ impl TestRun for Startup121 {
     async fn exec(&mut self, ctx: &CpuTestContext) -> eyre::Result<()> {
         let nodes = self.nodes.as_ref().unwrap();
         // Hand the fleet to `self` before anything can fail, so `teardown` always
-        // gets a chance to stop it. `HawkFleet::drop` is the backstop, but a
-        // graceful stop leaves the ports free for the next workflow sooner.
-        // Party 2 holds in Propose from its first boot; the survivors are not held.
+        // gets a chance to stop it (`HawkFleet::drop` is the backstop).
         let options = FleetOptions {
             holds: array::from_fn(|party| (party == RESTARTED_PARTY).then_some(Phase::Propose)),
             startup_sync_timeout_secs: Some(BARRIER_TIMEOUT_SECS),
@@ -98,14 +89,11 @@ impl TestRun for Startup121 {
 
         // The survivors must already hold an epoch derived from this party's *old*
         // facts before it goes away — otherwise they would read the new ones on
-        // restart and legitimately agree, which is correct behaviour but not the
-        // case under test. Reaching Commit is exactly that: the epoch is derived
-        // and published, and they are now parked in the commit barrier waiting for
-        // party 2, which never publishes one because it is held in Propose.
-        for party in 0..COUNT_OF_PARTIES {
-            if party == RESTARTED_PARTY {
-                continue;
-            }
+        // restart and legitimately agree, which is correct behaviour but not the case
+        // under test. Reaching Commit is exactly that, and leaves them parked in the
+        // commit barrier waiting for party 2, which never publishes an epoch because
+        // it is held in Propose.
+        for party in (0..COUNT_OF_PARTIES).filter(|p| *p != RESTARTED_PARTY) {
             fleet
                 .wait_for_phase(party, Phase::Commit, FLEET_TIMEOUT)
                 .await?;
@@ -128,22 +116,17 @@ impl TestRun for Startup121 {
         );
 
         // Restarted without the hold: it re-derives an epoch, now a different one.
-        fleet.start_party(RESTARTED_PARTY, ctx);
+        fleet.start_party(RESTARTED_PARTY, ctx, None);
 
         // Every party must exit. `wait_all_exited` fails if any is still running at
         // the deadline, which is what a silently-accepted mismatch would look like.
         let outcomes = fleet.wait_all_exited(FLEET_TIMEOUT).await?;
         tracing::info!("fleet refused to start: {outcomes:?}");
 
-        // Some party must have named the mismatch. This is the assertion that ties
-        // the workflow to the check under test: the survivors' own error is a
-        // barrier *timeout*, which a peer that never came back at all would produce
-        // just as well, so "the fleet exited" on its own would pass this workflow
-        // even with the epoch comparison broken.
-        //
-        // Deterministic despite the timing: the returning party's first barrier
-        // round reads both peers still publishing the old epoch, so it is always
-        // the one to report this. Its peers usually do not — see the doc comment.
+        // Some party must have named the mismatch. This ties the workflow to the
+        // check under test: the survivors' own error is a barrier *timeout*, which a
+        // peer that never came back at all would produce just as well, so "the fleet
+        // exited" alone would pass even with the epoch comparison broken.
         let detected = outcomes.iter().any(|outcome| {
             EPOCH_MISMATCH_ERRORS
                 .iter()

--- a/iris-mpc/tests/workflows/startup_121.rs
+++ b/iris-mpc/tests/workflows/startup_121.rs
@@ -2,13 +2,13 @@
 /// data, and the whole fleet must refuse to come up.
 ///
 /// Setup: three empty parties, party 2 configured to hold in [`Phase::Propose`].
-/// Exec: once the survivors have committed a fleet digest derived from party 2's
-/// `SyncState`, party 2 is stopped, an extra iris row is inserted into its database,
+/// Exec: once the survivors have committed a fleet sync-state digest derived from
+/// party 2's `SyncState`, party 2 is stopped, an extra iris row is inserted into its database,
 /// and it is restarted without the hold. Every party must exit and none may report
 /// ready.
 ///
 /// Only *some* party has to name the mismatch. The one that comes back always
-/// detects it: its first barrier round sees both peers on the old fleet digest. Its
+/// detects it: its first barrier round sees both peers on the old digest. Its
 /// peers usually do not — it publishes the new digest and bails within milliseconds,
 /// far inside their poll interval, after which their polls only see a closed port, which
 /// the barrier correctly reads as "a peer is restarting" rather than as
@@ -17,8 +17,9 @@
 /// [`BARRIER_TIMEOUT_SECS`] — with the 300s default the survivors would still be
 /// waiting long after `FLEET_TIMEOUT`.
 ///
-/// The hold is at `Propose`, i.e. *before* party 2 publishes a fleet digest, which
-/// keeps the survivors parked in the commit barrier. Holding at `Commit` instead would
+/// The hold is at `Propose`, i.e. *before* party 2 publishes a fleet sync-state
+/// digest, which keeps the survivors parked in the commit barrier. Holding at
+/// `Commit` instead would
 /// release them into the DB load while party 2 has no MPC listener, and they would
 /// die of a checkpoint peer timeout before the data was even changed — a pass for
 /// entirely the wrong reason.
@@ -44,15 +45,15 @@ use std::array;
 /// `exec` finishes in under a minute instead of waiting out the 300s default.
 const BARRIER_TIMEOUT_SECS: u64 = 30;
 
-/// Substrings identifying a party that failed *on the fleet digest comparison*
-/// rather than on a barrier timeout. The two checks that can reach an
+/// Substrings identifying a party that failed *on the fleet sync-state digest
+/// comparison* rather than on a barrier timeout. The two checks that can reach an
 /// `AgreementVerdict::Void` word it differently, and either one proves the
 /// comparison under test actually ran.
-const FLEET_DIGEST_MISMATCH_ERRORS: [&str; 2] = [
-    // wait_for_fleet_digest_commit
-    "startup fleet digest mismatch",
+const FLEET_SYNC_STATE_DIGEST_MISMATCH_ERRORS: [&str; 2] = [
+    // wait_for_fleet_sync_state_digest_commit
+    "startup fleet sync-state digest mismatch",
     // spawn_startup_watch
-    "startup watch found a peer on a different fleet digest",
+    "startup watch found a peer on a different fleet sync-state digest",
 ];
 
 #[derive(Default)]
@@ -88,8 +89,8 @@ impl TestRun for Startup121 {
             .wait_for_phase(RESTARTED_PARTY, Phase::Propose, FLEET_TIMEOUT)
             .await?;
 
-        // The survivors must already hold a fleet digest derived from this party's
-        // *old* SyncState before it goes away — otherwise they would read the new one
+        // The survivors must already hold a fleet sync-state digest derived from this
+        // party's *old* SyncState before it goes away — otherwise they would read the new one
         // on restart and legitimately agree, which is correct behaviour but not the
         // case under test. Reaching Commit is exactly that, and leaves them parked in
         // the commit barrier waiting for party 2, which never publishes a digest
@@ -116,8 +117,8 @@ impl TestRun for Startup121 {
             "inserted iris {next_id} into party {RESTARTED_PARTY} to change its SyncState"
         );
 
-        // Restarted without the hold: it re-derives a fleet digest, now a different
-        // one.
+        // Restarted without the hold: it re-derives a fleet sync-state digest, now a
+        // different one.
         fleet.start_party(RESTARTED_PARTY, ctx, None);
 
         // Every party must exit. `wait_all_exited` fails if any is still running at
@@ -130,14 +131,14 @@ impl TestRun for Startup121 {
         // peer that never came back at all would produce just as well, so "the fleet
         // exited" alone would pass even with the digest comparison broken.
         let detected = outcomes.iter().any(|outcome| {
-            FLEET_DIGEST_MISMATCH_ERRORS
+            FLEET_SYNC_STATE_DIGEST_MISMATCH_ERRORS
                 .iter()
                 .any(|reason| outcome.contains(reason))
         });
         if !detected {
             eyre::bail!(
-                "no party detected the fleet digest mismatch; the fleet stopped for some other \
-                 reason: {outcomes:?}"
+                "no party detected the fleet sync-state digest mismatch; the fleet stopped for \
+                 some other reason: {outcomes:?}"
             );
         }
         Ok(())
@@ -151,7 +152,7 @@ impl TestRun for Startup121 {
             if let Ok(response) = reqwest::get(&url).await {
                 if response.status().is_success() {
                     eyre::bail!(
-                        "party {} reports ready after a fleet digest mismatch",
+                        "party {} reports ready after a fleet sync-state digest mismatch",
                         config.party_id
                     );
                 }

--- a/iris-mpc/tests/workflows/startup_121.rs
+++ b/iris-mpc/tests/workflows/startup_121.rs
@@ -1,30 +1,65 @@
 /// startup_121 — one party restarts during the startup handshake with *changed*
 /// data, and the whole fleet must refuse to come up.
 ///
-/// Setup: three empty parties. Exec: party 2 is stopped once it reaches
-/// [`Phase::Commit`], an extra iris row is inserted into its database, and it is
-/// restarted. Every party must exit and none may report ready.
+/// Setup: three empty parties, party 2 configured to hold in [`Phase::Propose`].
+/// Exec: once the survivors have committed an epoch derived from party 2's facts,
+/// party 2 is stopped, an extra iris row is inserted into its database, and it is
+/// restarted without the hold. Every party must exit and none may report ready.
 ///
 /// The surviving parties hold an epoch derived from party 2's previous facts; it
 /// now derives a different one. Nobody may proceed, because the agreed plan
 /// describes a fleet state that no longer exists.
 ///
-/// Deliberately does not assert the error text. The mismatch is caught by whichever
-/// check the survivors reach first — the commit barrier if they are still parked,
-/// the startup watch if they had already moved into converge/load — and in the
-/// latter case the cross-party checkpoint round inside the load can surface its own
-/// peer timeout first. What is invariant, and all this workflow needs, is that
-/// nobody serves.
+/// Deliberately does not assert the error text, and deliberately does not require
+/// every party to name the mismatch. The party that comes back always detects it:
+/// its first barrier round sees both peers on the old epoch. Its *peers* usually do
+/// not — it publishes the new epoch and then bails within milliseconds, far inside
+/// their poll interval, after which their polls only see a closed port, which the
+/// barrier correctly reads as "a peer is restarting" rather than as disagreement.
+/// They therefore exit on the barrier's own timeout. Both routes satisfy what this
+/// workflow actually needs: nobody serves, and the fleet tears itself down.
+///
+/// Hence [`BARRIER_TIMEOUT_SECS`]. With the 300s default, the survivors would still
+/// be waiting long after `FLEET_TIMEOUT`, and the workflow would fail on the
+/// harness deadline while the fleet was behaving exactly as designed.
+///
+/// The hold is at `Propose`, i.e. *before* party 2 publishes an epoch, which keeps
+/// the survivors parked in the commit barrier. Holding at `Commit` instead would
+/// release them into the DB load while party 2 has no MPC listener, and they would
+/// die of a checkpoint peer timeout before the data was even changed — a pass for
+/// entirely the wrong reason.
 ///
 /// See [`crate::utils::hawk_fleet`] for why the kill point is the handshake rather
 /// than the DB load.
 use crate::utils::{
     cpu_node::CpuNodes,
-    hawk_fleet::{HawkFleet, FLEET_TIMEOUT, RESTARTED_PARTY},
+    hawk_fleet::{FleetOptions, HawkFleet, FLEET_TIMEOUT, RESTARTED_PARTY},
     runner::{CpuTestContext, TestRun},
+    COUNT_OF_PARTIES,
 };
 use iris_mpc::server::startup_phase::Phase;
 use iris_mpc_common::{IRIS_CODE_LENGTH, MASK_CODE_LENGTH};
+use std::array;
+
+/// Commit-barrier budget for every party in this workflow.
+///
+/// Long enough that the returning party gets its chance to publish a mismatched
+/// epoch — a restart costs about eleven seconds here, ten of them the empty-queue
+/// long poll in `build_sync_state` — and short enough that a fleet which never
+/// observes it still gives up well inside `FLEET_TIMEOUT`. Whichever way it goes,
+/// `exec` finishes in under a minute instead of waiting out the 300s default.
+const BARRIER_TIMEOUT_SECS: u64 = 30;
+
+/// Substrings identifying a party that failed *on the epoch comparison* rather
+/// than on a barrier timeout. The two checks that can reach an
+/// `EpochVerdict::Void` word it differently, and either one proves the
+/// comparison under test actually ran.
+const EPOCH_MISMATCH_ERRORS: [&str; 2] = [
+    // wait_for_epoch_commit
+    "startup epoch mismatch",
+    // spawn_startup_watch
+    "startup watch found a peer on a different epoch",
+];
 
 #[derive(Default)]
 pub struct Startup121 {
@@ -49,16 +84,33 @@ impl TestRun for Startup121 {
         // Hand the fleet to `self` before anything can fail, so `teardown` always
         // gets a chance to stop it. `HawkFleet::drop` is the backstop, but a
         // graceful stop leaves the ports free for the next workflow sooner.
-        self.fleet = Some(HawkFleet::start_all(&ctx.configs, ctx).await?);
+        // Party 2 holds in Propose from its first boot; the survivors are not held.
+        let options = FleetOptions {
+            holds: array::from_fn(|party| (party == RESTARTED_PARTY).then_some(Phase::Propose)),
+            startup_sync_timeout_secs: Some(BARRIER_TIMEOUT_SECS),
+        };
+        self.fleet = Some(HawkFleet::start_all_with(&ctx.configs, ctx, options).await?);
         let fleet = self.fleet.as_mut().unwrap();
 
-        // Kill at Commit, not Propose: the survivors must already have derived an
-        // epoch from this party's *old* facts. Otherwise they would simply read the
-        // new ones on restart and legitimately agree — correct behaviour, but not
-        // the case under test.
         fleet
-            .wait_for_phase(RESTARTED_PARTY, Phase::Commit, FLEET_TIMEOUT)
+            .wait_for_phase(RESTARTED_PARTY, Phase::Propose, FLEET_TIMEOUT)
             .await?;
+
+        // The survivors must already hold an epoch derived from this party's *old*
+        // facts before it goes away — otherwise they would read the new ones on
+        // restart and legitimately agree, which is correct behaviour but not the
+        // case under test. Reaching Commit is exactly that: the epoch is derived
+        // and published, and they are now parked in the commit barrier waiting for
+        // party 2, which never publishes one because it is held in Propose.
+        for party in 0..COUNT_OF_PARTIES {
+            if party == RESTARTED_PARTY {
+                continue;
+            }
+            fleet
+                .wait_for_phase(party, Phase::Commit, FLEET_TIMEOUT)
+                .await?;
+        }
+
         fleet.stop_party(RESTARTED_PARTY).await?;
 
         // Change the party's data while it is down. One extra iris row moves
@@ -75,6 +127,7 @@ impl TestRun for Startup121 {
             "inserted iris {next_id} into party {RESTARTED_PARTY} to change its startup facts"
         );
 
+        // Restarted without the hold: it re-derives an epoch, now a different one.
         fleet.start_party(RESTARTED_PARTY, ctx);
 
         // Every party must exit. `wait_all_exited` fails if any is still running at
@@ -82,12 +135,25 @@ impl TestRun for Startup121 {
         let outcomes = fleet.wait_all_exited(FLEET_TIMEOUT).await?;
         tracing::info!("fleet refused to start: {outcomes:?}");
 
-        // At least one party must have *failed*, not merely stopped. All-clean
-        // exits would mean the fleet wound down for some other reason — the test
-        // process aborting, say — and this workflow would pass without ever having
-        // exercised a mismatch.
-        if outcomes.iter().all(|o| o.contains("without an error")) {
-            eyre::bail!("no party reported an error; the mismatch was never detected: {outcomes:?}");
+        // Some party must have named the mismatch. This is the assertion that ties
+        // the workflow to the check under test: the survivors' own error is a
+        // barrier *timeout*, which a peer that never came back at all would produce
+        // just as well, so "the fleet exited" on its own would pass this workflow
+        // even with the epoch comparison broken.
+        //
+        // Deterministic despite the timing: the returning party's first barrier
+        // round reads both peers still publishing the old epoch, so it is always
+        // the one to report this. Its peers usually do not — see the doc comment.
+        let detected = outcomes.iter().any(|outcome| {
+            EPOCH_MISMATCH_ERRORS
+                .iter()
+                .any(|reason| outcome.contains(reason))
+        });
+        if !detected {
+            eyre::bail!(
+                "no party detected the epoch mismatch; the fleet stopped for some other \
+                 reason: {outcomes:?}"
+            );
         }
         Ok(())
     }

--- a/iris-mpc/tests/workflows/startup_121.rs
+++ b/iris-mpc/tests/workflows/startup_121.rs
@@ -1,0 +1,122 @@
+/// startup_121 — one party restarts during the startup handshake with *changed*
+/// data, and the whole fleet must refuse to come up.
+///
+/// Setup: three empty parties. Exec: party 2 is stopped once it reaches
+/// [`Phase::Commit`], an extra iris row is inserted into its database, and it is
+/// restarted. Every party must exit and none may report ready.
+///
+/// The surviving parties hold an epoch derived from party 2's previous facts; it
+/// now derives a different one. Nobody may proceed, because the agreed plan
+/// describes a fleet state that no longer exists.
+///
+/// Deliberately does not assert the error text. The mismatch is caught by whichever
+/// check the survivors reach first — the commit barrier if they are still parked,
+/// the startup watch if they had already moved into converge/load — and in the
+/// latter case the cross-party checkpoint round inside the load can surface its own
+/// peer timeout first. What is invariant, and all this workflow needs, is that
+/// nobody serves.
+///
+/// See [`crate::utils::hawk_fleet`] for why the kill point is the handshake rather
+/// than the DB load.
+use crate::utils::{
+    cpu_node::CpuNodes,
+    hawk_fleet::{HawkFleet, FLEET_TIMEOUT, RESTARTED_PARTY},
+    runner::{CpuTestContext, TestRun},
+};
+use iris_mpc::server::startup_phase::Phase;
+use iris_mpc_common::{IRIS_CODE_LENGTH, MASK_CODE_LENGTH};
+
+#[derive(Default)]
+pub struct Startup121 {
+    nodes: Option<CpuNodes>,
+    fleet: Option<HawkFleet>,
+}
+
+impl Startup121 {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl TestRun for Startup121 {
+    async fn setup(&mut self, ctx: &CpuTestContext) -> eyre::Result<()> {
+        self.nodes = Some(CpuNodes::new_clean(&ctx.configs, ctx.s3_client.clone()).await?);
+        Ok(())
+    }
+
+    async fn exec(&mut self, ctx: &CpuTestContext) -> eyre::Result<()> {
+        let nodes = self.nodes.as_ref().unwrap();
+        // Hand the fleet to `self` before anything can fail, so `teardown` always
+        // gets a chance to stop it. `HawkFleet::drop` is the backstop, but a
+        // graceful stop leaves the ports free for the next workflow sooner.
+        self.fleet = Some(HawkFleet::start_all(&ctx.configs, ctx).await?);
+        let fleet = self.fleet.as_mut().unwrap();
+
+        // Kill at Commit, not Propose: the survivors must already have derived an
+        // epoch from this party's *old* facts. Otherwise they would simply read the
+        // new ones on restart and legitimately agree — correct behaviour, but not
+        // the case under test.
+        fleet
+            .wait_for_phase(RESTARTED_PARTY, Phase::Commit, FLEET_TIMEOUT)
+            .await?;
+        fleet.stop_party(RESTARTED_PARTY).await?;
+
+        // Change the party's data while it is down. One extra iris row moves
+        // `db_len`, which is part of the fact digest; appending at `count + 1` keeps
+        // the `COUNT(*) == MAX(id)` store invariant intact so the party fails on the
+        // epoch, not on `check_store_consistency`.
+        let node = &nodes.0[RESTARTED_PARTY];
+        let next_id = node.store.iris_store.count_irises().await? as i64 + 1;
+        let code = vec![0u16; IRIS_CODE_LENGTH];
+        let mask = vec![0u16; MASK_CODE_LENGTH];
+        node.insert_iris_share(next_id, &code, &mask, &code, &mask)
+            .await?;
+        tracing::info!(
+            "inserted iris {next_id} into party {RESTARTED_PARTY} to change its startup facts"
+        );
+
+        fleet.start_party(RESTARTED_PARTY, ctx);
+
+        // Every party must exit. `wait_all_exited` fails if any is still running at
+        // the deadline, which is what a silently-accepted mismatch would look like.
+        let outcomes = fleet.wait_all_exited(FLEET_TIMEOUT).await?;
+        tracing::info!("fleet refused to start: {outcomes:?}");
+
+        // At least one party must have *failed*, not merely stopped. All-clean
+        // exits would mean the fleet wound down for some other reason — the test
+        // process aborting, say — and this workflow would pass without ever having
+        // exercised a mismatch.
+        if outcomes.iter().all(|o| o.contains("without an error")) {
+            eyre::bail!("no party reported an error; the mismatch was never detected: {outcomes:?}");
+        }
+        Ok(())
+    }
+
+    async fn exec_assert(&mut self, ctx: &CpuTestContext) -> eyre::Result<()> {
+        // No party may be serving. Ready here would mean a party accepted a fleet
+        // state its peers had not agreed to.
+        for config in ctx.configs.iter() {
+            let url = format!("http://127.0.0.1:{}/ready", config.healthcheck_port);
+            if let Ok(response) = reqwest::get(&url).await {
+                if response.status().is_success() {
+                    eyre::bail!(
+                        "party {} reports ready after an epoch mismatch",
+                        config.party_id
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn teardown(&mut self, _ctx: &CpuTestContext) -> eyre::Result<()> {
+        if let Some(fleet) = self.fleet.as_mut() {
+            fleet.stop_all().await?;
+        }
+        // Drop the extra iris row so the next workflow starts from a clean fleet.
+        if let Some(nodes) = &self.nodes {
+            nodes.truncate_checkpoint_tables().await?;
+        }
+        Ok(())
+    }
+}

--- a/iris-mpc/tests/workflows/startup_122.rs
+++ b/iris-mpc/tests/workflows/startup_122.rs
@@ -3,60 +3,117 @@
 ///
 /// Setup: three empty parties, no holds — the fleet boots all the way to ready.
 /// Exec: party 2 is stopped and restarted without touching its database, so it
-/// re-derives exactly the sync state it had before. Every party must still exit and
-/// none may report ready.
+/// re-derives exactly the sync state it had before. The survivors must decide to
+/// tear down, must never re-admit party 2's new incarnation, and party 2 must never
+/// reach [`Phase::Serving`].
 ///
 /// This is the mirror image of [`crate::workflows::startup_120`], and the pair is
 /// the point: an identical sync state makes a restart absorbable *during* the
 /// handshake and must not make it absorbable once sessions exist. The digest-keyed
-/// rejoin is scoped to startup — `DesyncWatch::stop` is called on reaching
-/// [`Phase::Serving`], after which the heartbeat's UUID check owns peer supervision
-/// — because the MPC session state the parties share by then is tied to a peer's
-/// incarnation, not to its data, and cannot be reconstructed from a matching
-/// digest. A returning party carries none of it. So the whole fleet has to come
-/// down and re-run startup together.
+/// rejoin is scoped to startup — `DesyncWatch::stop` is called on entering
+/// `Phase::Serving`, after which the heartbeat's UUID check owns peer supervision —
+/// because the MPC session state the parties share by then is tied to a peer's
+/// incarnation, not to its data, and a returning party carries none of it. So the
+/// whole fleet has to come down and re-run startup together.
 ///
-/// What breaks this test is precisely that scoping going wrong: a rejoin path still
-/// live at `Serving` would let the survivors read party 2's unchanged digest,
-/// re-verify it and carry on serving over stale sessions — the fleet would return
-/// to all-ready with the survivors in their original processes, and
-/// `wait_all_exited` would fail.
+/// # What this asserts, and what it deliberately does not
 ///
-/// The exit route is not asserted, only the outcome. In practice the survivors go
-/// first and on the *absence*: three consecutive 2s heartbeat failures fire at
-/// ~6s, well before party 2 finishes rebuilding its sync state, so they trigger
-/// graceful shutdown without ever seeing the new UUID. Party 2 then finds no peer
-/// to sync with and dies on its own barrier. Absence and return are two halves of
-/// one restart and there is no interleaving in which only one of them is visible,
-/// so pinning the workflow to a particular error string would only make it brittle;
-/// the invariant under test is that nobody keeps serving.
+/// The survivors *decide* to shut down within about six seconds and never finish:
+/// `trigger_manual_shutdown` flips `shutting_down` on `/health` immediately, but
+/// `server_main` does not return, so the processes are still heartbeating minutes
+/// later (observed 2026-08-07). Requiring them to exit therefore proves nothing
+/// about the behaviour under test and hangs the workflow instead, so this asserts
+/// on the *decision* and on the peer set, both of which are readable over HTTP
+/// while the parties are still up. `wait_for_teardown` accepts an exit too, so
+/// fixing the propagation later does not turn this red. Teardown's `stop_all`
+/// cancels the tasks directly, which is the path that does work.
+///
+/// The decision itself is not attributable to the return, only to the restart as a
+/// whole: the survivors' three consecutive 2s heartbeat failures fire while party 2
+/// is still rebuilding its sync state, so in practice they act on its *absence*
+/// before ever seeing the new UUID. That is why [`Startup122`] also asserts the
+/// peer set — `verified_peers` is frozen at startup and nothing writes to it once a
+/// node is serving, so party 2's new UUID appearing there is exactly the signature
+/// of a rejoin path that leaked past `Serving`, and it is a claim about the return
+/// rather than about the gap.
 use crate::utils::{
     cpu_node::CpuNodes,
     hawk_fleet::{FleetOptions, HawkFleet, FLEET_TIMEOUT, RESTARTED_PARTY},
     runner::{CpuTestContext, TestRun},
+    COUNT_OF_PARTIES,
 };
 use iris_mpc::server::startup_phase::Phase;
+use std::time::Duration;
 
 /// Startup-barrier budget for every party in this workflow.
 ///
-/// Bounds the returning party: its peers are gone, so its first barrier round just
-/// retries a refused connection until this budget expires, and only then does it
-/// exit. The 300s default would put that well past [`FLEET_TIMEOUT`] and `exec`
-/// would fail on the harness deadline instead of on the behaviour it asserts. Ample
-/// for the initial boot, where all three parties enter the barriers within
-/// milliseconds of each other and clear them in a couple of one-second retry
-/// rounds.
+/// Bounds the returning party's in-process retry: it finds its peers ready but no
+/// longer holding its UUID, and `wait_for_others_unready` deliberately retries that
+/// case without exiting, so with the 300s default it would still be looping long
+/// after the workflow is done with it. Ample for the initial boot, where all three
+/// parties enter the barriers within milliseconds of each other.
 const BARRIER_TIMEOUT_SECS: u64 = 30;
+
+/// How long the survivors get to notice the restart.
+///
+/// Three consecutive failures at `heartbeat_interval_secs = 2` is ~6s; the rest is
+/// slack for a loaded CI machine.
+const TEARDOWN_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// How long party 2 is watched for an illegitimate rejoin after the survivors have
+/// committed to tearing down.
+///
+/// Nothing is expected to happen here — this is the window in which a leaked rejoin
+/// path would have its chance, and the workflow needs to have looked.
+const REJOIN_WATCH: Duration = Duration::from_secs(15);
 
 #[derive(Default)]
 pub struct Startup122 {
     nodes: Option<CpuNodes>,
     fleet: Option<HawkFleet>,
+    /// Coordination UUID of party 2's *new* incarnation, for `exec_assert`.
+    restarted_uuid: Option<String>,
 }
 
 impl Startup122 {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Fail if any surviving party has admitted `uuid` to its startup-verified peer
+    /// set, or if party 2 has talked its way to ready.
+    async fn assert_not_rejoined(&self, uuid: &str) -> eyre::Result<()> {
+        let fleet = self.fleet.as_ref().unwrap();
+
+        for party in (0..COUNT_OF_PARTIES).filter(|p| *p != RESTARTED_PARTY) {
+            // A survivor that has stopped answering has certainly not re-admitted
+            // anyone; only a live answer can carry the failure.
+            if let Ok(probe) = fleet.health(party).await {
+                if probe.verified_peers.contains(uuid) {
+                    eyre::bail!(
+                        "party {party} admitted party {RESTARTED_PARTY}'s new incarnation {uuid} \
+                         to its verified peers after it restarted post-serving; the startup \
+                         rejoin must not apply once sessions exist"
+                    );
+                }
+            }
+        }
+
+        // Likewise for party 2's own view: unreachable means it is gone, which is a
+        // pass. Reaching Serving, or reporting ready, would mean it rejoined.
+        if let Ok(phase) = fleet.phase(RESTARTED_PARTY).await {
+            if phase >= Phase::Serving {
+                eyre::bail!(
+                    "party {RESTARTED_PARTY} reached phase {phase} after restarting post-serving"
+                );
+            }
+        }
+        if let Ok(probe) = fleet.health(RESTARTED_PARTY).await {
+            if probe.is_ready {
+                eyre::bail!("party {RESTARTED_PARTY} reports ready after restarting post-serving");
+            }
+        }
+        Ok(())
     }
 }
 
@@ -86,68 +143,80 @@ impl TestRun for Startup122 {
             fleet.agreed_fleet_sync_state_digest().await?
         );
 
-        // Party 2's own sync state, as it stands while serving. Nothing below
-        // touches its database, so the restart has to reproduce this exactly — that
-        // is the "even though the data is unchanged" in the workflow name, and
-        // without it this would be startup_121 (a mismatch) wearing a different hat.
-        let digest_before = fleet
-            .wait_for_party_sync_state_digest(RESTARTED_PARTY, FLEET_TIMEOUT)
+        // Party 2's own sync state, as it stands while serving. Nothing below touches
+        // its database, so the restart has to reproduce this exactly — that is the
+        // "even though the data is unchanged" in the workflow name, and without it
+        // this would be startup_121 (a mismatch) wearing a different hat.
+        let before = fleet
+            .wait_for_startup_state(RESTARTED_PARTY, FLEET_TIMEOUT)
             .await?;
 
         fleet.stop_party(RESTARTED_PARTY).await?;
         fleet.start_party(RESTARTED_PARTY, ctx, None);
 
-        let digest_after = fleet
-            .wait_for_party_sync_state_digest(RESTARTED_PARTY, FLEET_TIMEOUT)
+        let after = fleet
+            .wait_for_startup_state(RESTARTED_PARTY, FLEET_TIMEOUT)
             .await?;
-        if digest_after != digest_before {
+        if after.party_sync_state_digest != before.party_sync_state_digest {
             eyre::bail!(
-                "party {RESTARTED_PARTY} came back on sync state {digest_after}, not the \
-                 {digest_before} it left on — something mutated its state across the restart, so \
-                 this run exercises a sync-state mismatch (startup_121) rather than the \
-                 unchanged-state rejoin this workflow is about"
+                "party {RESTARTED_PARTY} came back on sync state {}, not the {} it left on — \
+                 something mutated its state across the restart, so this run exercises a \
+                 sync-state mismatch (startup_121) rather than the unchanged-state rejoin this \
+                 workflow is about",
+                after.party_sync_state_digest,
+                before.party_sync_state_digest
             );
         }
-        tracing::info!(
-            "party {RESTARTED_PARTY} restarted on its original sync state {digest_after}"
-        );
 
-        // Party 2 must not talk its way back into a serving fleet on the strength of
-        // that digest, and the survivors must not keep serving without it. Both are
-        // the same assertion here: every party exits. `wait_all_exited` fails if any
-        // is still running at the deadline, which is what a silently-absorbed restart
-        // would look like.
-        let outcomes = fleet.wait_all_exited(FLEET_TIMEOUT).await?;
-        tracing::info!("fleet tore itself down after the post-ready restart: {outcomes:?}");
+        let restarted_uuid = after
+            .uuid
+            .clone()
+            .ok_or_else(|| eyre::eyre!("party {RESTARTED_PARTY} restarted without a UUID"))?;
+        tracing::info!(
+            "party {RESTARTED_PARTY} restarted on its original sync state {} as {restarted_uuid} \
+             (was {:?})",
+            after.party_sync_state_digest,
+            before.uuid
+        );
+        self.restarted_uuid = Some(restarted_uuid.clone());
+
+        // Every survivor must commit to tearing down. Not "must have exited": the
+        // decision is what the fleet owes us here, and it is the only part that
+        // happens on a bounded clock. See the module docs.
+        for party in (0..COUNT_OF_PARTIES).filter(|p| *p != RESTARTED_PARTY) {
+            fleet.wait_for_teardown(party, TEARDOWN_TIMEOUT).await?;
+            tracing::info!("party {party} committed to tearing down");
+        }
+
+        // Then watch for the thing that must not happen. A leaked rejoin would land
+        // in this window: party 2 is up, publishing a digest its peers recognise, and
+        // the peers are still alive to act on it.
+        let watch_until = tokio::time::Instant::now() + REJOIN_WATCH;
+        while tokio::time::Instant::now() < watch_until {
+            self.assert_not_rejoined(&restarted_uuid).await?;
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
         Ok(())
     }
 
-    async fn exec_assert(&mut self, ctx: &CpuTestContext) -> eyre::Result<()> {
-        // No party may be left serving. A survivor still ready here would be one
-        // holding MPC session state shared with an incarnation that no longer exists;
-        // a ready party 2 would be one that rejoined a fleet it has no session state
-        // for.
-        for config in ctx.configs.iter() {
-            let url = format!("http://127.0.0.1:{}/ready", config.healthcheck_port);
-            if let Ok(response) = reqwest::get(&url).await {
-                if response.status().is_success() {
-                    eyre::bail!(
-                        "party {} reports ready after a peer restarted post-{}",
-                        config.party_id,
-                        Phase::Serving
-                    );
-                }
-            }
-        }
-        Ok(())
+    async fn exec_assert(&mut self, _ctx: &CpuTestContext) -> eyre::Result<()> {
+        // Re-check once more at the end of the workflow, after the survivors have had
+        // the whole of `exec` to change their minds.
+        let uuid = self
+            .restarted_uuid
+            .clone()
+            .ok_or_else(|| eyre::eyre!("exec did not record the restarted party's UUID"))?;
+        self.assert_not_rejoined(&uuid).await
     }
 
     async fn teardown(&mut self, _ctx: &CpuTestContext) -> eyre::Result<()> {
+        // Cancels each party's task directly. The parties do not exit on their own
+        // graceful shutdown, so this is what actually frees the ports for the next
+        // workflow.
         if let Some(fleet) = self.fleet.as_mut() {
             fleet.stop_all().await?;
         }
-        // The fleet reached the load, so it left checkpoint state behind; clear it so
-        // the next workflow starts from a clean fleet.
+        // The fleet reached the load, so it left checkpoint state behind.
         if let Some(nodes) = &self.nodes {
             nodes.truncate_checkpoint_tables().await?;
         }

--- a/iris-mpc/tests/workflows/startup_122.rs
+++ b/iris-mpc/tests/workflows/startup_122.rs
@@ -1,0 +1,156 @@
+/// startup_122 — one party restarts *after* the fleet is serving, with unchanged
+/// data, and must not be allowed back in.
+///
+/// Setup: three empty parties, no holds — the fleet boots all the way to ready.
+/// Exec: party 2 is stopped and restarted without touching its database, so it
+/// re-derives exactly the sync state it had before. Every party must still exit and
+/// none may report ready.
+///
+/// This is the mirror image of [`crate::workflows::startup_120`], and the pair is
+/// the point: an identical sync state makes a restart absorbable *during* the
+/// handshake and must not make it absorbable once sessions exist. The digest-keyed
+/// rejoin is scoped to startup — `DesyncWatch::stop` is called on reaching
+/// [`Phase::Serving`], after which the heartbeat's UUID check owns peer supervision
+/// — because the MPC session state the parties share by then is tied to a peer's
+/// incarnation, not to its data, and cannot be reconstructed from a matching
+/// digest. A returning party carries none of it. So the whole fleet has to come
+/// down and re-run startup together.
+///
+/// What breaks this test is precisely that scoping going wrong: a rejoin path still
+/// live at `Serving` would let the survivors read party 2's unchanged digest,
+/// re-verify it and carry on serving over stale sessions — the fleet would return
+/// to all-ready with the survivors in their original processes, and
+/// `wait_all_exited` would fail.
+///
+/// The exit route is not asserted, only the outcome. In practice the survivors go
+/// first and on the *absence*: three consecutive 2s heartbeat failures fire at
+/// ~6s, well before party 2 finishes rebuilding its sync state, so they trigger
+/// graceful shutdown without ever seeing the new UUID. Party 2 then finds no peer
+/// to sync with and dies on its own barrier. Absence and return are two halves of
+/// one restart and there is no interleaving in which only one of them is visible,
+/// so pinning the workflow to a particular error string would only make it brittle;
+/// the invariant under test is that nobody keeps serving.
+use crate::utils::{
+    cpu_node::CpuNodes,
+    hawk_fleet::{FleetOptions, HawkFleet, FLEET_TIMEOUT, RESTARTED_PARTY},
+    runner::{CpuTestContext, TestRun},
+};
+use iris_mpc::server::startup_phase::Phase;
+
+/// Startup-barrier budget for every party in this workflow.
+///
+/// Bounds the returning party: its peers are gone, so its first barrier round just
+/// retries a refused connection until this budget expires, and only then does it
+/// exit. The 300s default would put that well past [`FLEET_TIMEOUT`] and `exec`
+/// would fail on the harness deadline instead of on the behaviour it asserts. Ample
+/// for the initial boot, where all three parties enter the barriers within
+/// milliseconds of each other and clear them in a couple of one-second retry
+/// rounds.
+const BARRIER_TIMEOUT_SECS: u64 = 30;
+
+#[derive(Default)]
+pub struct Startup122 {
+    nodes: Option<CpuNodes>,
+    fleet: Option<HawkFleet>,
+}
+
+impl Startup122 {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl TestRun for Startup122 {
+    async fn setup(&mut self, ctx: &CpuTestContext) -> eyre::Result<()> {
+        self.nodes = Some(CpuNodes::new_clean(&ctx.configs, ctx.s3_client.clone()).await?);
+        Ok(())
+    }
+
+    async fn exec(&mut self, ctx: &CpuTestContext) -> eyre::Result<()> {
+        // Hand the fleet to `self` before anything can fail, so `teardown` always
+        // gets a chance to stop it (`HawkFleet::drop` is the backstop).
+        let options = FleetOptions {
+            startup_sync_timeout_secs: Some(BARRIER_TIMEOUT_SECS),
+            ..Default::default()
+        };
+        self.fleet = Some(HawkFleet::start_all_with(&ctx.configs, ctx, options).await?);
+        let fleet = self.fleet.as_mut().unwrap();
+
+        // No holds: the restart under test is post-handshake, so the fleet has to be
+        // fully serving first. Ready is what arms the heartbeat and retires the
+        // startup watch, and it is the state whose session data a returning party
+        // cannot reconstruct.
+        fleet.wait_all_ready(FLEET_TIMEOUT).await?;
+        tracing::info!(
+            "fleet serving on fleet sync-state digest {}",
+            fleet.agreed_fleet_sync_state_digest().await?
+        );
+
+        // Party 2's own sync state, as it stands while serving. Nothing below
+        // touches its database, so the restart has to reproduce this exactly — that
+        // is the "even though the data is unchanged" in the workflow name, and
+        // without it this would be startup_121 (a mismatch) wearing a different hat.
+        let digest_before = fleet
+            .wait_for_party_sync_state_digest(RESTARTED_PARTY, FLEET_TIMEOUT)
+            .await?;
+
+        fleet.stop_party(RESTARTED_PARTY).await?;
+        fleet.start_party(RESTARTED_PARTY, ctx, None);
+
+        let digest_after = fleet
+            .wait_for_party_sync_state_digest(RESTARTED_PARTY, FLEET_TIMEOUT)
+            .await?;
+        if digest_after != digest_before {
+            eyre::bail!(
+                "party {RESTARTED_PARTY} came back on sync state {digest_after}, not the \
+                 {digest_before} it left on — something mutated its state across the restart, so \
+                 this run exercises a sync-state mismatch (startup_121) rather than the \
+                 unchanged-state rejoin this workflow is about"
+            );
+        }
+        tracing::info!(
+            "party {RESTARTED_PARTY} restarted on its original sync state {digest_after}"
+        );
+
+        // Party 2 must not talk its way back into a serving fleet on the strength of
+        // that digest, and the survivors must not keep serving without it. Both are
+        // the same assertion here: every party exits. `wait_all_exited` fails if any
+        // is still running at the deadline, which is what a silently-absorbed restart
+        // would look like.
+        let outcomes = fleet.wait_all_exited(FLEET_TIMEOUT).await?;
+        tracing::info!("fleet tore itself down after the post-ready restart: {outcomes:?}");
+        Ok(())
+    }
+
+    async fn exec_assert(&mut self, ctx: &CpuTestContext) -> eyre::Result<()> {
+        // No party may be left serving. A survivor still ready here would be one
+        // holding MPC session state shared with an incarnation that no longer exists;
+        // a ready party 2 would be one that rejoined a fleet it has no session state
+        // for.
+        for config in ctx.configs.iter() {
+            let url = format!("http://127.0.0.1:{}/ready", config.healthcheck_port);
+            if let Ok(response) = reqwest::get(&url).await {
+                if response.status().is_success() {
+                    eyre::bail!(
+                        "party {} reports ready after a peer restarted post-{}",
+                        config.party_id,
+                        Phase::Serving
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn teardown(&mut self, _ctx: &CpuTestContext) -> eyre::Result<()> {
+        if let Some(fleet) = self.fleet.as_mut() {
+            fleet.stop_all().await?;
+        }
+        // The fleet reached the load, so it left checkpoint state behind; clear it so
+        // the next workflow starts from a clean fleet.
+        if let Some(nodes) = &self.nodes {
+            nodes.truncate_checkpoint_tables().await?;
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
Before the peers reach `ready`, rather than ensure a peer hasn't restarted (via a `uuid` check), ensure that the `SyncState` has not changed.

Tested on the dev cluster where
- one peer comes up later than the others
- one peer restarts during the db load (`init_hawk_actor`)


Integration tests added:
- a party restarts before the ready signal with unchanged SyncState (sync passes)
- a party restarts before the ready signal with changed SyncState (sync fails)
- a party restarts after the ready signal with unchanged SyncState (sync fails)