### PR TITLE
Init fake db with mln shares

### DIFF
--- a/.github/workflows/temp-branch-build-and-push.yaml
+++ b/.github/workflows/temp-branch-build-and-push.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - "dev"
-      - "elenagryaznova/pop-4122-iris-mpc-poison-message-block-at-ingest-head-crashloops-both"
+      - "fake-db"
 
 concurrency:
   group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"

--- a/iris-mpc-bins/bin/iris-mpc/server.rs
+++ b/iris-mpc-bins/bin/iris-mpc/server.rs
@@ -239,8 +239,9 @@ async fn server_main(config: Config) -> Result<()> {
     tracing::info!("Size of the database before init: {}", store_len);
 
     // Seed the persistent storage with random shares if configured and db is still
-    // empty.
-    if store_len == 0 && config.init_db_size > 0 {
+    // empty. Skipped when fake_db_size is set — that path generates into GPU
+    // memory only and must not touch Postgres.
+    if store_len == 0 && config.init_db_size > 0 && config.fake_db_size == 0 {
         tracing::info!(
             "Initialize persistent iris DB with {} randomly generated shares",
             config.init_db_size
@@ -254,6 +255,13 @@ async fn server_main(config: Config) -> Result<()> {
                 config.clear_db_before_init,
             )
             .await?;
+    } else if config.fake_db_size > 0 && config.init_db_size > 0 {
+        tracing::warn!(
+            "Both fake_db_size ({}) and init_db_size ({}) are set; skipping Postgres init \
+             and generating into GPU memory only",
+            config.fake_db_size,
+            config.init_db_size
+        );
     }
 
     // Fetch again in case we've just initialized the DB
@@ -493,9 +501,24 @@ async fn server_main(config: Config) -> Result<()> {
             Ok((mut actor, handle)) => {
                 tracing::info!("⚓️ ANCHOR: Load the database");
                 let res = if config.fake_db_size > 0 {
-                    // TODO: does this even still work, since we do not page-lock the memory here?
-                    actor.fake_db(config.fake_db_size);
-                    Ok(())
+                    if config.fake_db_size > config.max_db_size {
+                        Err(eyre!(
+                            "fake_db_size ({}) exceeds max_db_size ({})",
+                            config.fake_db_size,
+                            config.max_db_size
+                        ))
+                    } else {
+                        if store_len > 0 {
+                            tracing::warn!(
+                                "fake_db_size={} but Postgres already has {} irises; \
+                                 prefer an empty iris table so sync/persistence stay consistent",
+                                config.fake_db_size,
+                                store_len
+                            );
+                        }
+                        actor.fake_db(config.fake_db_size);
+                        Ok(())
+                    }
                 } else {
                     tracing::info!(
                         "Initialize iris db: Loading from DB (parallelism: {})",

--- a/iris-mpc-common/src/helpers/inmemory_store.rs
+++ b/iris-mpc-common/src/helpers/inmemory_store.rs
@@ -113,7 +113,10 @@ pub trait InMemoryStore {
     /// logs.
     fn current_db_sizes(&self) -> impl std::fmt::Debug;
 
-    /// Initialize the DB with fake data of a given size, data may be random and
-    /// unpredictable.
+    /// Initialize the in-memory DB with generated shares of a given size.
+    ///
+    /// Data is seeded/deterministic across parties when implementations use a
+    /// shared RNG seed, but is not persisted to durable storage. Intended for
+    /// load testing large DB sizes without Postgres init.
     fn fake_db(&mut self, size: usize);
 }

--- a/iris-mpc-gpu/src/server/actor.rs
+++ b/iris-mpc-gpu/src/server/actor.rs
@@ -48,7 +48,7 @@ use iris_mpc_common::{
             UNIQUENESS_MESSAGE_TYPE,
         },
     },
-    iris_db::get_dummy_shares_for_deletion,
+    iris_db::{get_dummy_shares_for_deletion, iris::IrisCode},
     job::{JobSubmissionHandle, ServerJobResult},
     VectorId,
 };
@@ -57,6 +57,7 @@ use iris_mpc_cpu::shares::{
     RingElement,
 };
 use itertools::{izip, Itertools};
+use rand::{rngs::StdRng, Rng, SeedableRng};
 use ring::hkdf::{Algorithm, Okm, Salt, HKDF_SHA256};
 use std::{
     collections::{HashMap, HashSet},
@@ -3739,11 +3740,80 @@ impl InMemoryStore for ServerActor {
     }
 
     fn fake_db(&mut self, fake_db_size: usize) {
+        // Same seed as iris-mpc-bins `RNG_SEED_INIT_DB` so all parties generate
+        // consistent shares without writing to Postgres.
+        const RNG_SEED: u64 = 42;
+
         tracing::warn!(
-            "Faking db with {} entries, returned results will be random.",
+            "Generating fake db with {} entries in GPU memory (not persisted). \
+             Match results use seeded random shares.",
             fake_db_size
         );
-        self.current_db_sizes =
-            vec![fake_db_size / self.current_db_sizes.len(); self.current_db_sizes.len()];
+
+        if fake_db_size > self.max_db_size {
+            panic!(
+                "fake_db_size ({}) exceeds max_db_size ({})",
+                fake_db_size, self.max_db_size
+            );
+        }
+
+        self.current_db_sizes = vec![0; self.device_manager.device_count()];
+
+        let mut rng = StdRng::seed_from_u64(RNG_SEED);
+        let party_id = self.party_id;
+        let started = Instant::now();
+
+        for i in 0..fake_db_size {
+            if i % 100_000 == 0 {
+                tracing::info!(
+                    "Fake iris db: generated {} / {} entries ({:.2} entries/s)",
+                    i,
+                    fake_db_size,
+                    if i == 0 {
+                        0.0
+                    } else {
+                        i as f64 / started.elapsed().as_secs_f64()
+                    }
+                );
+            }
+
+            let mut iris_rng = StdRng::from_seed(rng.gen());
+            let iris = IrisCode::random_rng(&mut iris_rng);
+
+            let share = GaloisRingIrisCodeShare::encode_iris_code(
+                &iris.code,
+                &iris.mask,
+                &mut StdRng::seed_from_u64(RNG_SEED),
+            )[party_id]
+                .clone();
+
+            let mask: GaloisRingTrimmedMaskCodeShare = GaloisRingIrisCodeShare::encode_mask_code(
+                &iris.mask,
+                &mut StdRng::seed_from_u64(RNG_SEED),
+            )[party_id]
+                .clone()
+                .into();
+
+            self.load_single_record_from_db(
+                i,
+                VectorId::from_serial_id((i + 1) as u32),
+                &share.coefs,
+                &mask.coefs,
+                &share.coefs,
+                &mask.coefs,
+            );
+            self.increment_db_size(i);
+        }
+
+        tracing::info!(
+            "Fake iris db: generated {} entries in {:?}; preprocessing",
+            fake_db_size,
+            started.elapsed()
+        );
+        self.preprocess_db();
+        tracing::info!(
+            "Fake iris db ready [DB sizes: {:?}]",
+            self.current_db_sizes()
+        );
     }
 }


### PR DESCRIPTION
This pull request improves the initialization and handling of the in-memory "fake" database used for load testing in the iris MPC server. It ensures that fake database generation is deterministic, does not interfere with persistent storage, and adds safety checks and clearer logging. The most important changes are grouped below:

**Initialization Logic and Safety Checks:**

* Updated the server initialization (`server.rs`) to skip persistent Postgres DB seeding when `fake_db_size` is set, ensuring fake DB generation only affects GPU memory and not durable storage. Also, a warning is logged if both `fake_db_size` and `init_db_size` are set, and fake DB generation takes precedence. [[1]](diffhunk://#diff-ce487da4b837e22aba6b9a76fe4930f91613617bc4e0df40937a8f335e9169f2L242-R244) [[2]](diffhunk://#diff-ce487da4b837e22aba6b9a76fe4930f91613617bc4e0df40937a8f335e9169f2R258-R264)
* Added a check to prevent `fake_db_size` from exceeding `max_db_size`, returning an error if this occurs. Also, a warning is logged if there is already data in Postgres while using a fake DB, to highlight potential inconsistencies.

**In-Memory Store and Fake DB Generation:**

* Refined the `InMemoryStore` trait and its documentation to clarify that `fake_db` generates deterministic, non-persistent data for load testing, seeded for consistency across parties.
* Overhauled the `fake_db` implementation in `ServerActor` to use a fixed RNG seed for deterministic share generation, log progress, enforce size limits, and ensure all parties generate the same fake data. The fake DB is now generated in GPU memory only, with preprocessing and final status logging.

**Supporting Imports and Dependencies:**

* Added necessary imports for random number generation and iris code construction to support deterministic fake DB generation. [[1]](diffhunk://#diff-77cac235798db8ade19132c38bae041dff8424c6e4d1c5c8f358ec73152b21a8L51-R51) [[2]](diffhunk://#diff-77cac235798db8ade19132c38bae041dff8424c6e4d1c5c8f358ec73152b21a8R60)