### PR TITLE
POP-4239: CI guard for ampc-common pin ancestry

### DIFF
--- a/.github/workflows/check-ampc-common-pin.yaml
+++ b/.github/workflows/check-ampc-common-pin.yaml
@@ -22,4 +22,4 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
 
       - name: ampc-common pin is on main
-        run: bash scripts/check-ampc-common-pin.sh Cargo.lock
+        run: bash scripts/check-ampc-common-pin.sh

--- a/.github/workflows/check-ampc-common-pin.yaml
+++ b/.github/workflows/check-ampc-common-pin.yaml
@@ -1,0 +1,21 @@
+name: Check ampc-common pin
+
+on:
+  pull_request:
+
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  # Deliberately no paths filter. A skipped job never reports a status, so a
+  # required check with a paths filter blocks every PR that does not touch the
+  # lockfile. The script is a shallow fetch and finishes in seconds.
+  ancestry:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+
+      - name: ampc-common pin is on main
+        run: bash scripts/check-ampc-common-pin.sh Cargo.lock

--- a/.github/workflows/check-ampc-common-pin.yaml
+++ b/.github/workflows/check-ampc-common-pin.yaml
@@ -7,6 +7,10 @@ concurrency:
   group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
   cancel-in-progress: true
 
+# Checkout only. The ampc-common fetch is an unauthenticated read of a public repo.
+permissions:
+  contents: read
+
 jobs:
   # Deliberately no paths filter. A skipped job never reports a status, so a
   # required check with a paths filter blocks every PR that does not touch the

--- a/scripts/check-ampc-common-pin.sh
+++ b/scripts/check-ampc-common-pin.sh
@@ -1,50 +1,74 @@
 #!/usr/bin/env bash
 #
 # Fails if this repo pins an ampc-common revision that is not reachable from
-# ampc-common's main branch. Two states it catches:
+# ampc-common's main branch. Three states it catches:
 #
 #   1. The pin is a commit on an unmerged ampc-common branch, so main here would
 #      build against a dependency that does not exist upstream.
 #   2. The pin went stale while the PR waited. ampc-common squash-merges, so the
 #      pre-merge commit is genuinely not reachable from main afterwards, and
 #      restoring such a pin downgrades this repo's dependency.
+#   3. Cargo.toml moved to a new rev but Cargo.lock was not regenerated. The
+#      builds run cargo without --locked, so they resolve the manifest and
+#      succeed while the lockfile still holds a valid old pin.
 #
-# Reads Cargo.lock rather than Cargo.toml: the lockfile carries the resolved
-# source for every ampc-common crate in one place, and a branch or tag pin shows
-# up there as a source without a rev.
+# Both files are read for that reason. Ancestry is checked against the full
+# commit hash the lockfile records after '#', because Cargo permits abbreviated
+# revs and a remote cannot resolve an abbreviated object id.
 #
-# Runs standalone: bash scripts/check-ampc-common-pin.sh [path/to/Cargo.lock]
+# Runs standalone: bash scripts/check-ampc-common-pin.sh [Cargo.lock] [Cargo.toml]
 
 set -euo pipefail
 
 LOCK="${1:-Cargo.lock}"
+MANIFEST="${2:-Cargo.toml}"
 UPSTREAM="https://github.com/worldcoin/ampc-common.git"
 
-sources=$(grep -o 'git+[^"]*ampc-common[^"]*' "$LOCK" | sort -u || true)
-if [[ -z "$sources" ]]; then
+fail=0
+full_hashes=()
+
+lock_sources=$(grep -o 'git+[^"]*ampc-common[^"]*' "$LOCK" | sort -u || true)
+if [[ -z "$lock_sources" ]]; then
   echo "No ampc-common dependency in $LOCK — nothing to check."
   exit 0
 fi
 
-fail=0
-revs=()
 while IFS= read -r src; do
-  if [[ "$src" =~ \?rev=([0-9a-f]{7,40}) ]]; then
-    revs+=("${BASH_REMATCH[1]}")
+  if [[ "$src" =~ \#([0-9a-f]{40})$ ]]; then
+    full_hashes+=("${BASH_REMATCH[1]}")
   else
-    echo "::error::ampc-common is not pinned to a revision: $src"
+    echo "::error::$LOCK has an ampc-common source with no resolved commit — a branch or tag pin, not a rev: $src"
     fail=1
   fi
-done <<<"$sources"
+done <<<"$lock_sources"
 
-unique_revs=$(printf '%s\n' "${revs[@]:-}" | sort -u | grep -v '^$' || true)
-if [[ -z "$unique_revs" ]]; then
-  exit 1
-fi
+# Cargo.toml is the file cargo actually resolves when --locked is absent, so a
+# manifest rev the lockfile does not know about means the lockfile is stale.
+while IFS= read -r line; do
+  if [[ "$line" =~ rev[[:space:]]*=[[:space:]]*\"([0-9a-f]{7,40})\" ]]; then
+    manifest_rev="${BASH_REMATCH[1]}"
+    matched=0
+    for full in "${full_hashes[@]:-}"; do
+      [[ "$full" == "$manifest_rev"* ]] && matched=1
+    done
+    if [[ $matched -eq 0 ]]; then
+      echo "::error::$MANIFEST pins ampc-common at $manifest_rev but $LOCK does not resolve to it."
+      echo "         Regenerate the lockfile — the builds do not use --locked, so they"
+      echo "         would silently resolve the manifest pin instead."
+      fail=1
+    fi
+  else
+    echo "::error::$MANIFEST has an ampc-common dependency that is not pinned to a rev: $line"
+    fail=1
+  fi
+done < <(grep -E 'ampc-common' "$MANIFEST" | grep -E '\bgit\b' || true)
 
-if [[ $(wc -l <<<"$unique_revs") -gt 1 ]]; then
-  echo "::error::ampc-common crates disagree on a revision:"
-  printf '  %s\n' $unique_revs
+unique=$(printf '%s\n' "${full_hashes[@]:-}" | sort -u | grep -v '^$' || true)
+[[ -n "$unique" ]] || exit 1
+
+if [[ $(wc -l <<<"$unique") -gt 1 ]]; then
+  echo "::error::ampc-common crates resolve to different commits:"
+  printf '  %s\n' $unique
   fail=1
 fi
 
@@ -56,19 +80,19 @@ git -C "$work" fetch --quiet --filter=blob:none origin main:refs/remotes/origin/
 
 while IFS= read -r rev; do
   if ! git -C "$work" fetch --quiet --filter=blob:none origin "$rev" 2>/dev/null; then
-    echo "::error::ampc-common revision $rev does not exist upstream."
+    echo "::error::ampc-common commit $rev does not exist upstream."
     fail=1
     continue
   fi
   if git -C "$work" merge-base --is-ancestor "$rev" refs/remotes/origin/main; then
     echo "ok: ampc-common $rev is on main"
   else
-    echo "::error::ampc-common revision $rev is not an ancestor of main."
+    echo "::error::ampc-common commit $rev is not an ancestor of main."
     echo "         Either the ampc-common PR has not merged yet, or it was"
-    echo "         squash-merged and this pin now points at the pre-merge commit."
+    echo "         squash-merged and this pin points at the pre-merge commit."
     echo "         Re-pin to the commit that landed on ampc-common main."
     fail=1
   fi
-done <<<"$unique_revs"
+done <<<"$unique"
 
 exit "$fail"

--- a/scripts/check-ampc-common-pin.sh
+++ b/scripts/check-ampc-common-pin.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# Fails if this repo pins an ampc-common revision that is not reachable from
+# ampc-common's main branch. Two states it catches:
+#
+#   1. The pin is a commit on an unmerged ampc-common branch, so main here would
+#      build against a dependency that does not exist upstream.
+#   2. The pin went stale while the PR waited. ampc-common squash-merges, so the
+#      pre-merge commit is genuinely not reachable from main afterwards, and
+#      restoring such a pin downgrades this repo's dependency.
+#
+# Reads Cargo.lock rather than Cargo.toml: the lockfile carries the resolved
+# source for every ampc-common crate in one place, and a branch or tag pin shows
+# up there as a source without a rev.
+#
+# Runs standalone: bash scripts/check-ampc-common-pin.sh [path/to/Cargo.lock]
+
+set -euo pipefail
+
+LOCK="${1:-Cargo.lock}"
+UPSTREAM="https://github.com/worldcoin/ampc-common.git"
+
+sources=$(grep -o 'git+[^"]*ampc-common[^"]*' "$LOCK" | sort -u || true)
+if [[ -z "$sources" ]]; then
+  echo "No ampc-common dependency in $LOCK — nothing to check."
+  exit 0
+fi
+
+fail=0
+revs=()
+while IFS= read -r src; do
+  if [[ "$src" =~ \?rev=([0-9a-f]{7,40}) ]]; then
+    revs+=("${BASH_REMATCH[1]}")
+  else
+    echo "::error::ampc-common is not pinned to a revision: $src"
+    fail=1
+  fi
+done <<<"$sources"
+
+unique_revs=$(printf '%s\n' "${revs[@]:-}" | sort -u | grep -v '^$' || true)
+if [[ -z "$unique_revs" ]]; then
+  exit 1
+fi
+
+if [[ $(wc -l <<<"$unique_revs") -gt 1 ]]; then
+  echo "::error::ampc-common crates disagree on a revision:"
+  printf '  %s\n' $unique_revs
+  fail=1
+fi
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+git init --quiet "$work"
+git -C "$work" remote add origin "$UPSTREAM"
+git -C "$work" fetch --quiet --filter=blob:none origin main:refs/remotes/origin/main
+
+while IFS= read -r rev; do
+  if ! git -C "$work" fetch --quiet --filter=blob:none origin "$rev" 2>/dev/null; then
+    echo "::error::ampc-common revision $rev does not exist upstream."
+    fail=1
+    continue
+  fi
+  if git -C "$work" merge-base --is-ancestor "$rev" refs/remotes/origin/main; then
+    echo "ok: ampc-common $rev is on main"
+  else
+    echo "::error::ampc-common revision $rev is not an ancestor of main."
+    echo "         Either the ampc-common PR has not merged yet, or it was"
+    echo "         squash-merged and this pin now points at the pre-merge commit."
+    echo "         Re-pin to the commit that landed on ampc-common main."
+    fail=1
+  fi
+done <<<"$unique_revs"
+
+exit "$fail"


### PR DESCRIPTION
Fails a PR whose pinned `ampc-common` revision is not reachable from `ampc-common`'s `main`. Three states it catches, all of which have actually happened or are reachable today: the pin is a commit on an unmerged branch; the pin went stale while the PR waited and `ampc-common` squash-merged past it, so restoring the "fix" downgrades main; or `Cargo.toml` moved to a new rev without regenerating `Cargo.lock`.

Both files are read. Ancestry is checked against the 40-char hash the lockfile records after `#`, because Cargo permits abbreviated revs and a remote can't resolve an abbreviated object id — this repo already has a 7-char rev for `tracing-forest`.

25 lines of workflow, ~70 lines of bash plus its header. No token: `ampc-common` is public, so the check is a shallow fetch.

Verified locally against the real repo and six synthetic pairs:

| case | result |
|---|---|
| current pin `3faee93`, lock and manifest in sync | passes |
| `60fbf131` — the pre-squash head of ampc-common#132, which merged as `3faee93` | fails |
| manifest moved to `60fbf131`, lockfile still on `3faee93` | fails |
| abbreviated `rev = "3faee93"` with the full hash resolved in the lockfile | passes |
| `branch = "wip"` in the manifest | fails |
| two crates resolving to different commits | fails |
| no ampc-common dependency | skips, exit 0 |

The `ancestry` check also passed on this PR itself in 6s.

Two choices worth a second opinion:

- **No `paths:` filter.** A skipped job never reports a status, so a required check with a paths filter blocks every PR that doesn't touch the lockfile. The script is a shallow fetch and takes seconds, so it just runs everywhere.
- **This only helps once it's a required check** on the branch protection rule. The PR can't do that part.

If this shape looks right I'll mirror it into `deep-identifier-ampc` and `face-ampc`.
