### PR TITLE
Commit startup modifications sync and graph WAL sync in one transaction

### DIFF
--- a/iris-mpc-bins/bin/iris-mpc/server.rs
+++ b/iris-mpc-bins/bin/iris-mpc/server.rs
@@ -385,7 +385,7 @@ async fn server_main(config: Config) -> Result<()> {
 
     // Handle modifications sync
     if config.enable_modifications_sync {
-        sync_modifications(
+        let tx = sync_modifications(
             &config,
             &store,
             &aws_clients,
@@ -393,6 +393,7 @@ async fn server_main(config: Config) -> Result<()> {
             sync_result,
         )
         .await?;
+        tx.commit().await?;
     }
 
     if config.enable_modifications_replay {

--- a/iris-mpc-cpu/src/graph_checkpoint/synchronize.rs
+++ b/iris-mpc-cpu/src/graph_checkpoint/synchronize.rs
@@ -4,6 +4,7 @@ use aws_sdk_s3::Client;
 use eyre::{bail, eyre, Result};
 use iris_mpc_common::helpers::sync::{SyncResult, SyncState};
 use itertools::izip;
+use sqlx::{Postgres, Transaction};
 
 use super::{download_graph_checkpoint, GraphCheckpointState};
 use crate::{
@@ -27,10 +28,12 @@ use crate::{
 /// in to_update, the peer will search SyncResult.all_states for a Some(graph_mutation)
 /// to roll forward.
 ///
-/// The graph mutations are applied all together in a transaction.
+/// The graph mutations are written through the caller's transaction, so they
+/// commit atomically with the modifications rollforward.
 pub async fn sync_graph_mutations(
     sync_result: &SyncResult,
     graph_pg: &GraphPg<Aby3Store<HawkOps>>,
+    tx: &mut Transaction<'_, Postgres>,
 ) -> Result<()> {
     // assuming that compare_modifications() does not return duplicate ids in to_update
     let (to_update, _) = sync_result.compare_modifications();
@@ -40,7 +43,6 @@ pub async fn sync_graph_mutations(
 
     let mutation_bytes = build_mutation_bytes(&sync_result.all_states)?;
 
-    let mut tx = graph_pg.begin_tx().await?;
     for modification in &to_update {
         let Some(mutation) = mutation_bytes.get(&modification.id) else {
             bail!(
@@ -53,7 +55,7 @@ pub async fn sync_graph_mutations(
         // mutation would be None
         if let Some(mutation) = mutation {
             graph_pg
-                .upsert_hawk_graph_mutations(&mut tx, modification.id, mutation)
+                .upsert_hawk_graph_mutations(tx, modification.id, mutation)
                 .await
                 .map_err(|e| {
                     eyre!(
@@ -63,7 +65,6 @@ pub async fn sync_graph_mutations(
                 })?;
         }
     }
-    tx.commit().await?;
     tracing::info!("synced graph mutations per party");
 
     Ok(())

--- a/iris-mpc/src/server/mod.rs
+++ b/iris-mpc/src/server/mod.rs
@@ -147,7 +147,7 @@ pub async fn server_main(config: Config) -> Result<()> {
 
     // Handle modifications sync
     if config.enable_modifications_sync {
-        sync_modifications(
+        let mut tx = sync_modifications(
             &config,
             &iris_store,
             &aws_clients,
@@ -156,8 +156,10 @@ pub async fn server_main(config: Config) -> Result<()> {
         )
         .await?;
         // insert the WAL entries so that init_hawk_actor rolls the graph forward to
-        // the correct height.
-        sync_graph_mutations(&sync_result, &graph_store).await?;
+        // the correct height. Shares the modifications-sync transaction so a crash
+        // cannot leave the iris store ahead of the WAL.
+        sync_graph_mutations(&sync_result, &graph_store, &mut tx).await?;
+        tx.commit().await?;
     }
 
     if config.enable_modifications_replay {

--- a/iris-mpc/src/services/processors/modifications_sync.rs
+++ b/iris-mpc/src/services/processors/modifications_sync.rs
@@ -15,19 +15,21 @@ use iris_mpc_common::helpers::smpc_response::create_message_type_attribute_map;
 use iris_mpc_common::helpers::sync::{Modification, SyncResult};
 use iris_mpc_common::iris_db::get_dummy_shares_for_deletion;
 use iris_mpc_store::{Store, StoredIrisRef};
+use sqlx::{Postgres, Transaction};
 use std::sync::Arc;
 use tokio::sync::Semaphore;
 
 // Graph mutations are already in the WAL (hawk_graph_mutations table) from when
 // they were originally committed, keyed by modification_id. Actual mutation application
 // to GraphMem happens during startup delta replay (checkpoint load → WAL replay), not here.
-pub async fn sync_modifications(
+/// Rolls modifications forward; the caller must commit the returned transaction.
+pub async fn sync_modifications<'a>(
     config: &Config,
-    store: &Store,
+    store: &'a Store,
     aws_clients: &AwsClients,
     shares_encryption_key_pair: &SharesEncryptionKeyPairs,
     sync_result: SyncResult,
-) -> eyre::Result<(), Report> {
+) -> eyre::Result<Transaction<'a, Postgres>, Report> {
     let (mut to_update, to_delete) = sync_result.compare_modifications();
     tracing::info!(
         "Modifications to update: {:?}, to delete: {:?}",
@@ -124,8 +126,7 @@ pub async fn sync_modifications(
             .await?;
     }
 
-    iris_tx.commit().await?;
-    Ok(())
+    Ok(iris_tx)
 }
 
 pub async fn send_last_modifications_to_sns(


### PR DESCRIPTION
`sync_modifications` committed its iris-store transaction before `sync_graph_mutations` opened a separate transaction for the WAL upserts. A crash between the two commits leaves the iris store ahead of `hawk_graph_mutations`, and since both derive their work list from the modifications-table comparison, the gap is not re-detected on later boots.

This threads a single transaction across both steps, mirroring the live persistence path: `sync_modifications` now returns its open transaction, `sync_graph_mutations` writes the WAL rows through it, and the caller commits once. The second `sync_modifications` caller (GPU server) commits the returned transaction directly.
