### PR TITLE
POP-4255: instrument wal-sidecar checkpoint cycle with metrics

### DIFF
--- a/deploy/dev/ampc-hnsw-0-dev/values-ampc-hnsw-graph-persistence-job.yaml
+++ b/deploy/dev/ampc-hnsw-0-dev/values-ampc-hnsw-graph-persistence-job.yaml
@@ -11,6 +11,7 @@ env:
   SMPC__CPU_DATABASE__SCHEMA: "SMPC_minfhd_SMALL_JUNE_2026_dev_0"
   SMPC__GRAPH_CHECKPOINT_BUCKET_NAME: "ampc-hnsw-graph-store-node-0-dev-eu-central-1"
   SMPC__SERVICE__SERVICE_NAME: "wal-sidecar-hnsw-0"
+  SMPC__SERVICE__METRICS__PREFIX: "wal-sidecar-hnsw-0"
 
 initContainer:
   enabled: true

--- a/deploy/dev/ampc-hnsw-1-dev/values-ampc-hnsw-graph-persistence-job.yaml
+++ b/deploy/dev/ampc-hnsw-1-dev/values-ampc-hnsw-graph-persistence-job.yaml
@@ -11,6 +11,7 @@ env:
   SMPC__CPU_DATABASE__SCHEMA: "SMPC_minfhd_SMALL_JUNE_2026_dev_1"
   SMPC__GRAPH_CHECKPOINT_BUCKET_NAME: "ampc-hnsw-graph-store-node-1-dev-eu-central-1"
   SMPC__SERVICE__SERVICE_NAME: "wal-sidecar-hnsw-1"
+  SMPC__SERVICE__METRICS__PREFIX: "wal-sidecar-hnsw-1"
 
 initContainer:
   enabled: true

--- a/deploy/dev/ampc-hnsw-2-dev/values-ampc-hnsw-graph-persistence-job.yaml
+++ b/deploy/dev/ampc-hnsw-2-dev/values-ampc-hnsw-graph-persistence-job.yaml
@@ -11,6 +11,7 @@ env:
   SMPC__CPU_DATABASE__SCHEMA: "SMPC_minfhd_SMALL_JUNE_2026_dev_2"
   SMPC__GRAPH_CHECKPOINT_BUCKET_NAME: "ampc-hnsw-graph-store-node-2-dev-eu-central-1"
   SMPC__SERVICE__SERVICE_NAME: "wal-sidecar-hnsw-2"
+  SMPC__SERVICE__METRICS__PREFIX: "wal-sidecar-hnsw-2"
 
 initContainer:
   enabled: true

--- a/deploy/dev/common-values-ampc-hnsw-graph-persistence-job.yaml
+++ b/deploy/dev/common-values-ampc-hnsw-graph-persistence-job.yaml
@@ -8,6 +8,13 @@ env:
   AWS_REGION: "eu-central-1"
   RUST_LOG: "info"
   RUST_BACKTRACE: "full"
+  SMPC__SERVICE__METRICS__HOST:
+    valueFrom:
+      fieldRef:
+        fieldPath: status.hostIP
+  SMPC__SERVICE__METRICS__PORT: "8125"
+  SMPC__SERVICE__METRICS__QUEUE_SIZE: "5000"
+  SMPC__SERVICE__METRICS__BUFFER_SIZE: "256"
   SMPC__CPU_DATABASE__URL:
     valueFrom:
       secretKeyRef:

--- a/deploy/prod/ampc-hnsw-0-prod/values-ampc-hnsw-graph-persistence-job.yaml
+++ b/deploy/prod/ampc-hnsw-0-prod/values-ampc-hnsw-graph-persistence-job.yaml
@@ -12,6 +12,7 @@ env:
   SMPC__CPU_DATABASE__SCHEMA: "SMPC_rerand_genesis_restored_v2_prod_0"
   SMPC__GRAPH_CHECKPOINT_BUCKET_NAME: "ampc-hnsw-graph-store-node-0-prod-eu-central-1"
   SMPC__SERVICE__SERVICE_NAME: "wal-sidecar-0"
+  SMPC__SERVICE__METRICS__PREFIX: "wal-sidecar-0"
 
 initContainer:
   enabled: true

--- a/deploy/prod/ampc-hnsw-1-prod/values-ampc-hnsw-graph-persistence-job.yaml
+++ b/deploy/prod/ampc-hnsw-1-prod/values-ampc-hnsw-graph-persistence-job.yaml
@@ -12,6 +12,7 @@ env:
   SMPC__CPU_DATABASE__SCHEMA: "SMPC_rerand_genesis_restored_v2_prod_1"
   SMPC__GRAPH_CHECKPOINT_BUCKET_NAME: "ampc-hnsw-graph-store-node-1-prod-eu-central-1"
   SMPC__SERVICE__SERVICE_NAME: "wal-sidecar-1"
+  SMPC__SERVICE__METRICS__PREFIX: "wal-sidecar-1"
 
 initContainer:
   enabled: true

--- a/deploy/prod/ampc-hnsw-2-prod/values-ampc-hnsw-graph-persistence-job.yaml
+++ b/deploy/prod/ampc-hnsw-2-prod/values-ampc-hnsw-graph-persistence-job.yaml
@@ -12,6 +12,7 @@ env:
   SMPC__CPU_DATABASE__SCHEMA: "SMPC_rerand_genesis_restored_v2_prod_2"
   SMPC__GRAPH_CHECKPOINT_BUCKET_NAME: "ampc-hnsw-graph-store-node-2-prod-eu-central-1"
   SMPC__SERVICE__SERVICE_NAME: "wal-sidecar-2"
+  SMPC__SERVICE__METRICS__PREFIX: "wal-sidecar-2"
 
 initContainer:
   enabled: true

--- a/deploy/prod/common-values-ampc-hnsw-graph-persistence-job.yaml
+++ b/deploy/prod/common-values-ampc-hnsw-graph-persistence-job.yaml
@@ -8,6 +8,13 @@ env:
   AWS_REGION: "eu-central-1"
   RUST_LOG: "info"
   RUST_BACKTRACE: "full"
+  SMPC__SERVICE__METRICS__HOST:
+    valueFrom:
+      fieldRef:
+        fieldPath: status.hostIP
+  SMPC__SERVICE__METRICS__PORT: "8125"
+  SMPC__SERVICE__METRICS__QUEUE_SIZE: "5000"
+  SMPC__SERVICE__METRICS__BUFFER_SIZE: "256"
   SMPC__CPU_DATABASE__URL:
     valueFrom:
       secretKeyRef:

--- a/iris-mpc-cpu/src/checkpoint_protocol/terminal.rs
+++ b/iris-mpc-cpu/src/checkpoint_protocol/terminal.rs
@@ -132,6 +132,8 @@ impl<V: VectorStore + Send + Sync> TerminalAction for UploadAndRecord<'_, V> {
             .commit()
             .await
             .map_err(|e| CycleError::Transient(format!("commit tx: {e}")))?;
+        metrics::counter!("graph_checkpoint_db_row_committed_total", "party" => self.party_id.to_string())
+            .increment(1);
 
         let graph_checkpoint = GraphCheckpointState {
             s3_key,
@@ -157,10 +159,24 @@ impl<V: VectorStore + Send + Sync> TerminalAction for UploadAndRecord<'_, V> {
         .await
         {
             tracing::warn!("failed to clean up old s3 checkpoints: {e}");
+            metrics::counter!("graph_checkpoint_cleanup_failed_total", "party" => self.party_id.to_string())
+                .increment(1);
         }
 
-        if let Err(e) = prune_wal_before_earliest_checkpoint(self.graph_store).await {
-            tracing::warn!("failed to prune the WAL below the oldest checkpoint: {e}");
+        match prune_wal_before_earliest_checkpoint(self.graph_store).await {
+            Ok(rows_pruned) => {
+                // Distinguishes healthy pruning (varying counts) from the
+                // silent-forever-zero case (no live checkpoint, or the oldest
+                // one predates graph_mutation_id tracking) — both log at
+                // `info` today with no other externally visible signal.
+                metrics::gauge!("graph_checkpoint_wal_rows_pruned", "party" => self.party_id.to_string())
+                    .set(rows_pruned as f64);
+            }
+            Err(e) => {
+                tracing::warn!("failed to prune the WAL below the oldest checkpoint: {e}");
+                metrics::counter!("graph_checkpoint_wal_prune_failed_total", "party" => self.party_id.to_string())
+                    .increment(1);
+            }
         }
 
         Ok(())


### PR DESCRIPTION
Adds 4 metrics to `UploadAndRecord::finalize`: `graph_checkpoint_db_row_committed_total` right after the Postgres commit, `graph_checkpoint_cleanup_failed_total`/`graph_checkpoint_wal_prune_failed_total` on the two error paths that currently only `tracing::warn!`, and `graph_checkpoint_wal_rows_pruned` (the WAL-prune row count, previously discarded — distinguishes healthy pruning from the silent no-live-checkpoint case).

The wal-sidecar CronJob had no Datadog metrics sink configured at all (unlike every sibling ampc-hnsw workload), so wires up `SMPC__SERVICE__METRICS__{HOST,PORT,QUEUE_SIZE,BUFFER_SIZE}` for prod + dev — otherwise none of these emit anywhere.

Part of POP-4255. Terraform monitors in a separate infra PR.

Extra:
- `checkpoint_cleanup_failed_total` is currently a no-op in prod (`--pruning-mode=none`), shipped as forward cover.