### PR TITLE
Linear scan hnsw deployment

### DIFF
--- a/deploy/stage/common-values-ampc-hnsw.yaml
+++ b/deploy/stage/common-values-ampc-hnsw.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc-cpu:6429fa5c3cd96ca5e1839da651588d6807c0c6ff"
+image: "ghcr.io/worldcoin/iris-mpc-linear-scan:2310cf142cb8e512acb07c16cf592865b55591fa"
 
 environment: stage
 replicaCount: 1
@@ -7,53 +7,28 @@ replicaCount: 1
 # Defined as a map (keyed by variable name) so Helm deep-merges these with the
 # per-node `env` maps in each ampc-hnsw-N-stage/values-ampc-hnsw.yaml.
 env:
-  RUST_LOG: "info"
+  RUST_LOG: "debug"
   RUST_BACKTRACE: "full"
-  SMPC__PPROF_FLAME_ONLY: "true"
-  SMPC__ENABLE_PPROF_PER_BATCH: "true"
-  # Optional overrides (uncomment/customize as needed)
-  SMPC__PPROF_S3_BUCKET: "wf-smpcv2-stage-hnsw-performance-reports"
-  SMPC__PPROF_PREFIX: "stage/hnsw"
-  SMPC__PPROF_SECONDS: "180"
-  SMPC__PPROF_FREQUENCY: "49"
-  # Use Pod annotation as run-id (set via `podAnnotations` above)
-  SMPC__PPROF_RUN_ID:
-    valueFrom:
-      fieldRef:
-        fieldPath: metadata.annotations['loadtest/run-id']
   SMPC__ENVIRONMENT: "stage"
-  SMPC__CPU_DATABASE__URL:
+  SMPC__DATABASE__URL:
     valueFrom:
       secretKeyRef:
-        key: DATABASE_AURORA_HNSW_URL
+        key: DATABASE_AURORA_HNWS_URL
         name: application
-  SMPC__DB_BACKED_INGEST: "true" # POP-4051 DB-backed ingest (stage rollout 2026-07)
-  SMPC__MAX_DB_SIZE: "2000000"
-  SMPC__MAX_BATCH_SIZE: "1"
-  SMPC__BATCH_SYNC_POLLING_TIMEOUT_SECS: "30"
-  SMPC__PROCESSING_TIMEOUT_SECS: "1240"  # 2 minutes per batch in stage, bump to 4 in prod
-  SMPC__HAWK_REQUEST_PARALLELISM: "1024"
-  SMPC__HAWK_CONNECTION_PARALLELISM: "48"
-  SMPC__HAWK_STREAM_PARALLELISM: "32"
-  SMPC__OVERRIDE_MAX_BATCH_SIZE: "false"
+  SMPC__DATABASE__MIGRATE: "true"
+  SMPC__DATABASE__CREATE: "true"
+  SMPC__DATABASE__LOAD_PARALLELISM: "8"
   SMPC__DISABLE_PERSISTENCE: "false"
-  SMPC__ENABLE_REAUTH: "true"
-  SMPC__ENABLE_RESET: "true"
-  SMPC__ENABLE_RECOVERY: "true"
-  SMPC__ENABLE_DELETION: "true"
-  SMPC__LUC_ENABLED: "true"
-  SMPC__LUC_LOOKBACK_RECORDS: "500"
-  SMPC__LUC_SERIAL_IDS_FROM_SMPC_REQUEST: "true"
+  SMPC__DB_BACKED_INGEST: "true"
+  SMPC__ANON_STATS_DATABASE__URL:
+    valueFrom:
+      secretKeyRef:
+        key: DATABASE_AURORA_HNWS_URL
+        name: application
+  SMPC__ANON_STATS_DATABASE__MIGRATE: "false"
+  SMPC__ANON_STATS_DATABASE__CREATE: "false"
+  SMPC__ANON_STATS_DATABASE__LOAD_PARALLELISM: "8"
   SMPC__AWS__REGION: "eu-north-1"
-  SMPC__SERVICE_PORTS: '["4000","4001","4002"]'
-  SMPC__SERVER_COORDINATION__IMAGE_NAME: $(IMAGE_NAME)
-  SMPC__SERVER_COORDINATION__HEARTBEAT_INITIAL_RETRIES: "65"
-  SMPC__SERVER_COORDINATION__HEARTBEAT_INTERVAL_SECS: "3"
-  SMPC__SHARES_BUCKET_NAME: "wf-smpcv2-stage-sns-requests"
-  SMPC__ENABLE_S3_IMPORTER: "false"
-  SMPC__DB_CHUNKS_FOLDER_NAME: "hnsw_even_odd_with_version_id_output_16k"
-  SMPC__LOAD_CHUNKS_PARALLELISM: "64"
-  SMPC__LOAD_CHUNKS_BUFFER_SIZE: "1024"
   SMPC__REQUESTS_QUEUE_URL:
     valueFrom:
       secretKeyRef:
@@ -64,11 +39,46 @@ env:
       secretKeyRef:
         key: SNS_RESULTS_ARN
         name: application
+  SMPC__PROCESSING_TIMEOUT_SECS: "120"
+  SMPC__PATH: "/data/"
   SMPC__KMS_KEY_ARNS:
     valueFrom:
       secretKeyRef:
         key: KMS_KEYS
         name: application
+  SMPC__SERVER_COORDINATION__IMAGE_NAME: $(IMAGE_NAME)
+  SMPC__SERVER_COORDINATION__HEARTBEAT_INITIAL_RETRIES: "65"
+  SMPC__SERVER_COORDINATION__HEARTBEAT_INTERVAL_SECS: "3"
+  SMPC__PUBLIC_KEY_BASE_URL: "https://pki-smpcv2-stage.worldcoin.org"
+  SMPC__SHARES_BUCKET_NAME: "wf-smpcv2-stage-sns-requests"
+  SMPC__ENABLE_S3_IMPORTER: "true"
+  SMPC__DB_CHUNKS_FOLDER_NAME: "hnsw_even_odd_with_version_id_output_16k"
+  SMPC__LOAD_CHUNKS_PARALLELISM: "64"
+  SMPC__LOAD_CHUNKS_BUFFER_SIZE: "1024"
+  SMPC__CLEAR_DB_BEFORE_INIT: "true"
+  SMPC__INIT_DB_SIZE: "0"
+  SMPC__MAX_DB_SIZE: "100000"
+  SMPC__FAKE_DB_SIZE: "0"
+  # Linear scan serializes requests. This makes the preceding mutation visible
+  # before the next scan and removes the need for intra-batch matching.
+  SMPC__MAX_BATCH_SIZE: "1"
+  # Match the r8g.24xlarge production tuning: 3 * 48 search sessions for each
+  # concurrently running normal/mirror orientation.
+  SMPC__HAWK_REQUEST_PARALLELISM: "48"
+  SMPC__HAWK_CONNECTION_PARALLELISM: "16"
+  SMPC__SEPARATE_TOKIO_CORES_PER_NODE: "11"
+  SMPC__FULL_SCAN_SIDE: "Left"
+  SMPC__FULL_SCAN_SIDE_SWITCHING_ENABLED: "false"
+  SMPC__MATCH_DISTANCES_BUFFER_SIZE_EXTRA_PERCENT: "500"
+  SMPC__MATCH_DISTANCES_BUFFER_SIZE: "64"
+  SMPC__MATCH_DISTANCES_2D_BUFFER_SIZE: "64"
+  SMPC__ENABLE_REAUTH: "true"
+  SMPC__ENABLE_RESET: "true"
+  SMPC__ENABLE_RECOVERY: "true"
+  SMPC__LUC_ENABLED: "false"
+  SMPC__LUC_LOOKBACK_RECORDS: "50"
+  SMPC__COLD_EYE_LFU_CACHE_RECORDS: "4096"
+  SMPC__LUC_SERIAL_IDS_FROM_SMPC_REQUEST: "true"
   SMPC__SERVICE__METRICS__HOST:
     valueFrom:
       fieldRef:
@@ -76,8 +86,11 @@ env:
   SMPC__SERVICE__METRICS__PORT: "8125"
   SMPC__SERVICE__METRICS__QUEUE_SIZE: "5000"
   SMPC__SERVICE__METRICS__BUFFER_SIZE: "256"
+  SMPC__RETURN_PARTIAL_RESULTS: "true"
   SMPC__ENABLE_MODIFICATIONS_SYNC: "true"
   SMPC__ENABLE_MODIFICATIONS_REPLAY: "true"
+  SMPC__ENABLE_DEBUG_TIMING: "true"
+  SMPC__SERVICE_PORTS: '["4000","4001","4002"]'
   SMPC__TLS__PRIVATE_KEY: "/etc/ssl/private/key.pem"
   SMPC__TLS__LEAF_CERT: "/etc/ssl/private/certificate.crt"
   SMPC__TLS__ROOT_CERTS: '["/usr/local/share/ca-certificates/ca_party_stage_0.crt", "/usr/local/share/ca-certificates/ca_party_stage_1.crt", "/usr/local/share/ca-certificates/ca_party_stage_2.crt"]'

--- a/deploy/stage/common-values-ampc-hnsw.yaml
+++ b/deploy/stage/common-values-ampc-hnsw.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc-linear-scan:8697ac2f0dae96af85aa33e1e5b74f1858c67b6a"
+image: "ghcr.io/worldcoin/iris-mpc-linear-scan:f5b38fe3439e7ebd3b05f03adba8b44e5c4bda16"
 
 environment: stage
 replicaCount: 1
@@ -7,7 +7,7 @@ replicaCount: 1
 # Defined as a map (keyed by variable name) so Helm deep-merges these with the
 # per-node `env` maps in each ampc-hnsw-N-stage/values-ampc-hnsw.yaml.
 env:
-  RUST_LOG: "debug"
+  RUST_LOG: "info"
   RUST_BACKTRACE: "full"
   SMPC__ENVIRONMENT: "stage"
   SMPC__DATABASE__URL:

--- a/deploy/stage/common-values-ampc-hnsw.yaml
+++ b/deploy/stage/common-values-ampc-hnsw.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc-linear-scan:2310cf142cb8e512acb07c16cf592865b55591fa"
+image: "ghcr.io/worldcoin/iris-mpc-linear-scan:8697ac2f0dae96af85aa33e1e5b74f1858c67b6a"
 
 environment: stage
 replicaCount: 1
@@ -13,7 +13,7 @@ env:
   SMPC__DATABASE__URL:
     valueFrom:
       secretKeyRef:
-        key: DATABASE_AURORA_HNWS_URL
+        key: DATABASE_AURORA_HNSW_URL
         name: application
   SMPC__DATABASE__MIGRATE: "true"
   SMPC__DATABASE__CREATE: "true"
@@ -23,7 +23,7 @@ env:
   SMPC__ANON_STATS_DATABASE__URL:
     valueFrom:
       secretKeyRef:
-        key: DATABASE_AURORA_HNWS_URL
+        key: DATABASE_AURORA_HNSW_URL
         name: application
   SMPC__ANON_STATS_DATABASE__MIGRATE: "false"
   SMPC__ANON_STATS_DATABASE__CREATE: "false"
@@ -138,10 +138,10 @@ startupProbe:
 
 resources:
   limits:
-    cpu: "1"
+    cpu: "12"
     memory: 16Gi
   requests:
-    cpu: "1"
+    cpu: "12"
     memory: 16Gi
 
 imagePullSecrets:
@@ -162,7 +162,7 @@ affinity:
         - matchExpressions:
             - key: karpenter.k8s.aws/instance-family
               operator: In
-              values: ["r8g", "c8g", "m8g"]
+              values: ["r8g"]
 
 podSecurityContext:
   runAsUser: 65534


### PR DESCRIPTION
This pull request makes significant changes to the deployment configuration for the `ampc-hnsw` service in the staging environment. The main updates include switching the service image to a new linear scan implementation, overhauling environment variables to match the new backend, tuning resource allocations, and updating node affinity and logging. These changes are aimed at supporting the new linear scan architecture and optimizing the deployment for its requirements.

Key changes:

**Service Image and Core Architecture:**
* Switched the container image from `iris-mpc-cpu` to the new `iris-mpc-linear-scan`, reflecting a move from HNSW to linear scan for the backend.

**Environment Variables and Feature Flags:**
* Replaced and reorganized environment variables to support the linear scan backend, including new database configuration, parallelism settings, batch sizes, feature flags, and enabling detailed debugging. Many HNSW-specific and profiling-related variables were removed, while new ones for linear scan, database migration, and chunk loading were added. [[1]](diffhunk://#diff-6144d2be6d608ab3f5c5969416e034cb6281ca68f40670a93b56a5a2a7000e56L10-L56) [[2]](diffhunk://#diff-6144d2be6d608ab3f5c5969416e034cb6281ca68f40670a93b56a5a2a7000e56R42-R93)
* Increased logging verbosity from `"info"` to `"debug"`.

**Resource Allocation:**
* Increased CPU resource requests and limits from 1 to 12 cores to accommodate the more demanding linear scan workload.

**Node Affinity:**
* Restricted node affinity to only allow scheduling on the `r8g` instance family, removing `c8g` and `m8g` from the list.

Let me know if you want to discuss any of these changes in more detail!