### PR TITLE
Scale down iris deployment

### DIFF
--- a/deploy/prod/common-values-iris-mpc.yaml
+++ b/deploy/prod/common-values-iris-mpc.yaml
@@ -1,7 +1,7 @@
 image: "ghcr.io/worldcoin/iris-mpc:v0.32.6@sha256:99b3487eaf6e41f24770f54d60dd6e66dc249c4a4523c3c783215c28719a9970"
 
 environment: prod
-replicaCount: 1
+replicaCount: 0
 
 # Common environment variables shared across all iris-mpc nodes.
 # Defined as a map so Helm deep-merges with per-node env maps.


### PR DESCRIPTION
This pull request makes a small change to the deployment configuration for the `iris-mpc` service in production. The only change is setting the `replicaCount` to 0, which will scale down this service and stop any running instances.

- Scaled down `iris-mpc` in production by setting `replicaCount` to 0 in `deploy/prod/common-values-iris-mpc.yaml`