### PR TITLE
Scale up iris deployment

### DIFF
--- a/deploy/prod/common-values-iris-mpc.yaml
+++ b/deploy/prod/common-values-iris-mpc.yaml
@@ -1,7 +1,7 @@
 image: "ghcr.io/worldcoin/iris-mpc:v0.32.6@sha256:99b3487eaf6e41f24770f54d60dd6e66dc249c4a4523c3c783215c28719a9970"
 
 environment: prod
-replicaCount: 0
+replicaCount: 1
 
 # Common environment variables shared across all iris-mpc nodes.
 # Defined as a map so Helm deep-merges with per-node env maps.


### PR DESCRIPTION
This pull request updates the deployment configuration for the `iris-mpc` service in the production environment. The main change is to ensure that at least one replica of the service is running.

Deployment configuration update:

* Increased the `replicaCount` from 0 to 1 in `deploy/prod/common-values-iris-mpc.yaml`, ensuring the `iris-mpc` service is deployed with one active instance.