### PR TITLE
[POP-4274] surface database error upon anon stats retention job failure

### DIFF
--- a/iris-mpc-bins/bin/retention-reaper/main.rs
+++ b/iris-mpc-bins/bin/retention-reaper/main.rs
@@ -131,6 +131,10 @@ impl ReaperConfig {
     }
 }
 
+fn format_error_chain(error: &eyre::Report) -> String {
+    format!("{error:#}")
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
@@ -186,6 +190,9 @@ async fn main() -> Result<()> {
                 }
             }
             Err(error) => {
+                // Alternate Display includes the full eyre error chain. Datadog surfaces this
+                // field, so keep the originating database/timeout error with the job context.
+                let error = format_error_chain(&error);
                 error!(table = %job.table, error = %error, "retention job failed");
                 failed = true; // keep going: one bad table shouldn't skip the others
             }


### PR DESCRIPTION
### Description
We had some failures on stage env for di anon stats retention reaper jobs that did not surface the database error
<img width="499" height="278" alt="Screenshot 2026-08-26 at 20 37 51" src="https://github.com/user-attachments/assets/afb5028d-2fec-4dbf-8cd3-369a7c8ed845" />

