### PR TITLE
POP-4255: bump wal-sidecar prod image (pick up checkpoint metrics)

### DIFF
--- a/deploy/prod/common-values-ampc-hnsw-graph-persistence-job.yaml
+++ b/deploy/prod/common-values-ampc-hnsw-graph-persistence-job.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc-cpu:v0.32.9@sha256:ab5c08b4ed3b0328a13341a3560ea70447be6b9229cbed34a37b42eb31ccac12"
+image: "ghcr.io/worldcoin/iris-mpc-cpu:20d1c45bbee20672312a45101cec3b765df6f95b@sha256:15dbad33611f1f05c18c1556ea2a33ddb99bb02dcf47efd77f864606fd6c56d9"
 
 environment: prod
 schedule: "0 11 * * *"


### PR DESCRIPTION
Bumps the prod wal-sidecar (`ampc-hnsw-graph-persistence-job`) image pin to the build from #2353's merge commit — the checkpoint metrics + Datadog sink wiring don't take effect until this deploys.

Digest is the multi-arch manifest index for `20d1c45b`, verified via `docker buildx imagetools inspect` (matches the same index-digest convention as the current `v0.32.9` pin).

Prod only — dev's pin is a separate, unrelated tag scheme and dev's wal-sidecar has its own pre-existing crash-loop bug (unrelated, not touched here).