### PR TITLE
fix: correct off-by-one in serial ID logging and gauge

### DIFF
--- a/iris-mpc-bins/bin/iris-mpc/server.rs
+++ b/iris-mpc-bins/bin/iris-mpc/server.rs
@@ -974,8 +974,8 @@ async fn server_main(config: Config) -> Result<()> {
             tx.commit().await?;
 
             for memory_serial_id in memory_serial_ids {
-                tracing::info!("Inserted serial_id: {}", memory_serial_id+1);
-                metrics::gauge!("results_inserted.latest_serial_id").set((memory_serial_id +1) as f64);
+                tracing::info!("Inserted serial_id: {}", memory_serial_id);
+                metrics::gauge!("results_inserted.latest_serial_id").set(memory_serial_id as f64);
             }
 
             tracing::info!("Sending {} uniqueness results", uniqueness_results.len());


### PR DESCRIPTION
memory_serial_id is already 1-indexed (computed as merged_results[idx] + 1). The log and gauge were adding an additional +1, reporting serial_id + 1 instead of the actual inserted serial_id on every uniqueness insert.

Fixes tracing::info!("Inserted serial_id") and
results_inserted.latest_serial_id gauge to reflect the value actually written to the database.