### PR TITLE
Deploy linear scan cold-eye prefetch improvements

### DIFF
--- a/deploy/prod/common-values-ampc-hnsw.yaml
+++ b/deploy/prod/common-values-ampc-hnsw.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc-linear-scan:da96de54d04f7d5e214064bb582ecab9f1ca4581"
+image: "ghcr.io/worldcoin/iris-mpc-linear-scan:bead695a9a1b1d0eaa24d99da07c579ae9a1b776"
 
 environment: prod
 replicaCount: 1
@@ -79,7 +79,7 @@ env:
   SMPC__ENABLE_RECOVERY: "true"
   SMPC__LUC_ENABLED: "false"
   SMPC__LUC_LOOKBACK_RECORDS: "50"
-  SMPC__COLD_EYE_LFU_CACHE_RECORDS: "4096"
+  SMPC__COLD_EYE_LFU_CACHE_RECORDS: "12288"
   SMPC__LUC_SERIAL_IDS_FROM_SMPC_REQUEST: "true"
   SMPC__SERVICE__METRICS__HOST:
     valueFrom:


### PR DESCRIPTION
## Summary

Updates the production linear-scan shadow deployment to a new image containing:

- #2367 cold-eye prefetch coalescing, merged through #2351 → #2348.
- Existing #2358 certificate/image changes.
- `SMPC__COLD_EYE_LFU_CACHE_RECORDS` increased from `4096` to `12288`.

## Rollout

Deploy in shadow mode and monitor SuperMatcher spikes, scan latency, cache/prefetch metrics

## Out of scope
Network IRQ affinity will be handled separately through node provisioning, in a next step