### PR TITLE
Export the chunks in sorted order

### DIFF
--- a/.github/workflows/test-db-exporter.yaml
+++ b/.github/workflows/test-db-exporter.yaml
@@ -89,6 +89,11 @@ jobs:
         working-directory: iris-mpc-db-exporter
         run: godotenv -f .env.ci go test -v ./src/...
 
+      - name: Run PostgreSQL store tests
+        if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
+        working-directory: iris-mpc-db-exporter
+        run: godotenv -f .env.ci go test -v test/e2e_postgres_store_test.go
+
       - name: Run e2e populate test
         if: steps.changed-files-yaml.outputs.src_any_changed == 'true'
         working-directory: iris-mpc-db-exporter

--- a/iris-mpc-db-exporter/src/iris/store.go
+++ b/iris-mpc-db-exporter/src/iris/store.go
@@ -37,6 +37,10 @@ type Store struct {
 	schema string
 }
 
+func storedIrisesByRangeQuery(schema string) string {
+	return fmt.Sprintf(`SELECT id, last_modified_at, left_code, left_mask, right_code, right_mask, version_id FROM "%s".irises WHERE id >= $1 AND id <= $2 ORDER BY id ASC;`, schema)
+}
+
 func NewStore(ctx context.Context, db *sql.DB, config config.Config) *Store {
 	var schema string
 	if config.ForceOverrideSchemaName {
@@ -89,7 +93,7 @@ func (s *Store) GetStoredIrisesByRange(ctx context.Context, startIndex, endIndex
 	span.SetTag("startIndex", startIndex)
 	span.SetTag("endIndex", endIndex)
 
-	query := fmt.Sprintf(`SELECT id, last_modified_at, left_code, left_mask, right_code, right_mask, version_id FROM "%s".irises WHERE id >= $1 AND id <= $2;`, s.schema)
+	query := storedIrisesByRangeQuery(s.schema)
 	rows, err := s.db.Query(query, startIndex, endIndex)
 	if err != nil {
 		o11y.S(ctx).With(zap.Error(err)).Errorf("Failed to fetch irises in range %d, %d. Error: %v", startIndex, endIndex, err)
@@ -122,7 +126,7 @@ func (s *Store) StreamStoredIrisesByRange(ctx context.Context, startIndex, endIn
 	span.SetTag("endIndex", endIndex)
 	outputChannel := make(chan StoredIris, chanBufferLen)
 
-	query := fmt.Sprintf(`SELECT id, last_modified_at, left_code, left_mask, right_code, right_mask, version_id FROM "%s".irises WHERE id >= $1 AND id <= $2;`, s.schema)
+	query := storedIrisesByRangeQuery(s.schema)
 	rows, err := s.db.Query(query, startIndex, endIndex)
 	if err != nil {
 		o11y.S(ctx).With(zap.Error(err)).Errorf("Failed to fetch irises in range %d, %d. Error: %v", startIndex, endIndex, err)

--- a/iris-mpc-db-exporter/test/e2e_binary_hdd_export_test.go
+++ b/iris-mpc-db-exporter/test/e2e_binary_hdd_export_test.go
@@ -10,6 +10,8 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -41,6 +43,24 @@ func getFilesWithExtension(dir, extension string) ([]string, error) {
 	})
 
 	return files, err
+}
+
+// sortChunkFilesByStartID orders concurrently exported chunks by their numeric starting ID.
+func sortChunkFilesByStartID(files []string) error {
+	startIDs := make(map[string]int64, len(files))
+	for _, file := range files {
+		filename := filepath.Base(file)
+		startID, err := strconv.ParseInt(strings.TrimSuffix(filename, filepath.Ext(filename)), 10, 64)
+		if err != nil {
+			return fmt.Errorf("parse chunk start ID from %q: %w", filename, err)
+		}
+		startIDs[file] = startID
+	}
+
+	sort.Slice(files, func(i, j int) bool {
+		return startIDs[files[i]] < startIDs[files[j]]
+	})
+	return nil
 }
 
 type BinaryReader struct {
@@ -220,15 +240,23 @@ func TestDBExporting(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get files in test_output with extension .bin: %v", err)
 	}
+	if err := sortChunkFilesByStartID(files); err != nil {
+		t.Fatalf("failed to sort exported chunks: %v", err)
+	}
 	binaryReader := NewBinaryReader(cfg.SingleCodeSize, cfg.SingleMaskSize, 4, 2)
 
 	var exportIrises []iris.StoredIris
+	expectedID := int64(1)
 	for _, file := range files {
 		storedIrisList, err := binaryReader.Read(file)
 		if err != nil {
 			t.Fatalf("failed to read file: %v", err)
 		}
 
+		for _, storedIris := range storedIrisList {
+			assert.Equal(t, expectedID, storedIris.ID, "records in exported chunks must be ordered by ID")
+			expectedID++
+		}
 		exportIrises = append(exportIrises, storedIrisList...)
 	}
 

--- a/iris-mpc-db-exporter/test/e2e_postgres_store_test.go
+++ b/iris-mpc-db-exporter/test/e2e_postgres_store_test.go
@@ -1,0 +1,81 @@
+package test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/worldcoin/iris-mpc-db-exporter/src/config"
+	"github.com/worldcoin/iris-mpc-db-exporter/src/iris"
+)
+
+func TestPostgresRangeReadsAreOrderedByID(t *testing.T) {
+	ctx := context.Background()
+	cfg := config.Load()
+
+	db, err := sql.Open("postgres", cfg.PgSQLConnectionString)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+	require.NoError(t, db.PingContext(ctx))
+
+	schema := fmt.Sprintf("exporter_order_test_%d", time.Now().UnixNano())
+	cfg.Environment = "CI"
+	cfg.ForceOverrideSchemaName = true
+	cfg.OverriddenSchemaName = schema
+	store := iris.NewStore(ctx, db, cfg)
+
+	t.Cleanup(func() {
+		_, cleanupErr := db.ExecContext(context.Background(), fmt.Sprintf(`DROP SCHEMA IF EXISTS "%s" CASCADE;`, schema))
+		require.NoError(t, cleanupErr)
+	})
+
+	_, err = db.ExecContext(ctx, fmt.Sprintf(`
+		CREATE TABLE "%s".irises (
+			id BIGINT NOT NULL,
+			last_modified_at BIGINT,
+			left_code BYTEA,
+			left_mask BYTEA,
+			right_code BYTEA,
+			right_mask BYTEA,
+			version_id SMALLINT
+		);`, schema))
+	require.NoError(t, err)
+
+	insertQuery := fmt.Sprintf(`
+		INSERT INTO "%s".irises
+			(id, last_modified_at, left_code, left_mask, right_code, right_mask, version_id)
+		VALUES ($1, $2, $3, $4, $5, $6, $7);`, schema)
+	for _, id := range []int64{3, 1, 4, 2} {
+		payload := []byte{byte(id)}
+		_, err = db.ExecContext(ctx, insertQuery, id, int64(0), payload, payload, payload, payload, int16(0))
+		require.NoError(t, err)
+	}
+
+	t.Run("buffered range", func(t *testing.T) {
+		records, err := store.GetStoredIrisesByRange(ctx, 1, 4)
+		require.NoError(t, err)
+
+		ids := make([]int64, 0, len(records))
+		for _, record := range records {
+			ids = append(ids, record.ID)
+		}
+		require.Equal(t, []int64{1, 2, 3, 4}, ids)
+	})
+
+	t.Run("streaming range", func(t *testing.T) {
+		records, err := store.StreamStoredIrisesByRange(ctx, 1, 4, 4)
+		require.NoError(t, err)
+
+		var ids []int64
+		for record := range records {
+			ids = append(ids, record.ID)
+		}
+		require.Equal(t, []int64{1, 2, 3, 4}, ids)
+	})
+}


### PR DESCRIPTION
## Background
- Exporter runs periodically. Reads from Postgres, writes into s3 in chunks. With current config, each s3 object can contain up to 16k items. The last chunk contains less than 16k items - based on the db size during the export. When an exporter run successfully finishes, it writes a metadata file for importer to know what to expect from the export. This contains timestamp, last serial id, etc. 
- Exporter seems to be writing s3 chunks in an unordered manner. Meaning that a chunk containing serial ids in range [1-16k] can be in an arbitrary form in the export. Eg. [5, 10, 10k, 1, ...]
- However, importer expects a sorted order. This importer <> exporter contract disagreement causes problems on the last chunk. Importer reads the first `N` items from the last chunk where `N` is determined based on the metadata file. But if there is another export updating the chunk before the metadata file is updated, there will be `N + M` items in the last chunk in unordered form. Yet, importer will still read the first `N` and skip the last `M`. Since Aurora loading only loads the serial ids modified after last export metadata timestamp, some serial ids will never be loaded in the last chunk.

## Change
- This PR updates exporter to export chunks in an ascending order by serial id. So, this will adhere to the importer contract. No matter of in progress exports, the first `N` items will always contain the expected serial ids and the importer will fetch the rest from db