### PR TITLE
chore(iris-mpc-store): Try fetching missing serial ids as last resort

### DIFF
--- a/iris-mpc-store/src/lib.rs
+++ b/iris-mpc-store/src/lib.rs
@@ -276,6 +276,24 @@ impl Store {
         Ok(iris)
     }
 
+    /// Stream irises by explicit serial id, without a particular order.
+    ///
+    /// Primary-key driven, so unlike [`Store::stream_irises_par`] this depends on
+    /// neither `count_irises()` nor `last_modified_at`. Ids with no row are simply
+    /// not yielded; the caller decides whether that is fatal.
+    pub fn stream_irises_by_ids<'a>(
+        &'a self,
+        ids: &'a [i64],
+    ) -> impl Stream<Item = Result<DbStoredIris>> + 'a {
+        sqlx::query_as::<_, DbStoredIris>(
+            "SELECT id, version_id, left_code, left_mask, right_code, right_mask FROM irises \
+             WHERE id = ANY($1)",
+        )
+        .bind(ids)
+        .fetch(&self.pool)
+        .map_err(Into::into)
+    }
+
     /// Stream irises in parallel, without a particular order.
     pub async fn stream_irises_par(
         &self,
@@ -1417,6 +1435,53 @@ pub mod tests {
             got_par.sort_by_key(|iris| iris.id);
             assert_eq!(got, got_par);
         }
+
+        cleanup(&postgres_client, &schema_name).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_stream_irises_by_ids() -> Result<()> {
+        let schema_name = temporary_name();
+        let postgres_client =
+            PostgresClient::new(test_db_url()?.as_str(), &schema_name, AccessMode::ReadWrite)
+                .await?;
+        run_migrations(&postgres_client.pool, false).await?;
+        let store = Store::new(&postgres_client).await?;
+
+        // Distinct left_code per row so a mixed-up id would show up as wrong content.
+        let codes: Vec<Vec<u16>> = (1..=5).map(|id| vec![id as u16, 2, 3, 4]).collect();
+        let irises = codes
+            .iter()
+            .enumerate()
+            .map(|(i, left_code)| StoredIrisRef {
+                id: i as i64 + 1,
+                left_code,
+                left_mask: &[5, 6, 7, 8],
+                right_code: &[9, 10, 11, 12],
+                right_mask: &[13, 14, 15, 16],
+            })
+            .collect::<Vec<_>>();
+        let mut tx = store.tx().await?;
+        store.insert_irises(&mut tx, &irises).await?;
+        tx.commit().await?;
+
+        // Requested ids are returned; an id with no row is skipped rather than erroring.
+        let mut got: Vec<DbStoredIris> = store
+            .stream_irises_by_ids(&[2, 4, 99])
+            .try_collect()
+            .await?;
+        got.sort_by_key(|iris| iris.id);
+        assert_eq!(got.iter().map(|i| i.id).collect::<Vec<_>>(), vec![2, 4]);
+
+        // Rows match the single-row accessor byte for byte, version_id included.
+        for iris in &got {
+            assert_eq!(*iris, store.get_iris_data_by_id(iris.id).await?);
+        }
+
+        // Empty input yields nothing.
+        let empty: Vec<DbStoredIris> = store.stream_irises_by_ids(&[]).try_collect().await?;
+        assert!(empty.is_empty());
 
         cleanup(&postgres_client, &schema_name).await?;
         Ok(())

--- a/iris-mpc-store/src/loader.rs
+++ b/iris-mpc-store/src/loader.rs
@@ -5,7 +5,7 @@ use crate::{
 use ampc_server_utils::shutdown_handler::ShutdownHandler;
 use aws_config::Region;
 use eyre::{bail, Result};
-use futures::stream::BoxStream;
+use futures::stream::{self, BoxStream};
 use futures::StreamExt;
 use iris_mpc_common::config::Config;
 use iris_mpc_common::helpers::inmemory_store::InMemoryStore;
@@ -13,6 +13,15 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
+
+/// Serial ids per `WHERE id = ANY($1)` round trip in the last-chance fetch below.
+/// A row is ~75 KB of code and mask blobs, so this bounds one query at ~38 MB.
+const MISSING_SERIAL_IDS_CHUNK_SIZE: usize = 512;
+
+/// Above this many missing serial ids, don't attempt the last-chance fetch. A gap
+/// this size means the snapshot is broken, and pulling gigabytes off the writer on
+/// every restart would not change the outcome.
+const MAX_MISSING_SERIAL_IDS_TO_FETCH: usize = 10_000;
 
 /// Helper function to load Aurora db records from the stream into memory
 #[allow(clippy::needless_lifetimes)]
@@ -287,6 +296,51 @@ async fn load_iris_db_internal(
             .boxed();
         load_db_records_from_aurora(actor, &mut record_counter, &mut all_serial_ids, stream_db)
             .await?;
+    }
+
+    // Last-chance fetch before the integrity check: whatever the S3 snapshot and the
+    // `last_modified_at` tail window both missed is requested here by serial id, which
+    // depends on neither watermark. Reached only when the alternative is a hard bail, so
+    // a failure here is logged and falls through to that bail rather than replacing it.
+    if !all_serial_ids.is_empty() {
+        if all_serial_ids.len() > MAX_MISSING_SERIAL_IDS_TO_FETCH {
+            tracing::error!(
+                "Not fetching {} missing serial_ids by id: above the {} cap, the snapshot is \
+                 likely incomplete rather than stale",
+                all_serial_ids.len(),
+                MAX_MISSING_SERIAL_IDS_TO_FETCH,
+            );
+        } else {
+            let mut missing: Vec<i64> = all_serial_ids.iter().copied().collect();
+            missing.sort_unstable();
+            tracing::warn!(
+                "S3 and tail load left {} serial_ids unloaded; fetching them by id",
+                missing.len(),
+            );
+
+            let chunks: Vec<&[i64]> = missing.chunks(MISSING_SERIAL_IDS_CHUNK_SIZE).collect();
+            // `flat_map` polls one chunk at a time, which is what we want here: the
+            // repair is bounded by the cap above, not racing for throughput.
+            let stream_db = stream::iter(chunks)
+                .flat_map(|ids| store.stream_irises_by_ids(ids))
+                .boxed();
+
+            match load_db_records_from_aurora(
+                actor,
+                &mut record_counter,
+                &mut all_serial_ids,
+                stream_db,
+            )
+            .await
+            {
+                Ok(()) => tracing::warn!(
+                    "Fetched {} missing serial_ids by id, {} still unloaded",
+                    missing.len() - all_serial_ids.len(),
+                    all_serial_ids.len(),
+                ),
+                Err(e) => tracing::error!("Failed to fetch missing serial_ids by id: {:?}", e),
+            }
+        }
     }
 
     if !all_serial_ids.is_empty() {

--- a/iris-mpc-store/src/loader.rs
+++ b/iris-mpc-store/src/loader.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use ampc_server_utils::shutdown_handler::ShutdownHandler;
 use aws_config::Region;
-use eyre::{bail, Result, WrapErr};
+use eyre::{bail, Result};
 use futures::stream::{self, BoxStream};
 use futures::StreamExt;
 use iris_mpc_common::config::Config;
@@ -110,7 +110,7 @@ async fn load_iris_db_internal(
     let now = Instant::now();
 
     let mut record_counter = 0;
-    let mut max_missing_serial_ids_to_fetch = 10_000; // Aurora-only fallback.
+    let mut max_missing_serial_ids_to_fetch = 16_000; // Default chunk size in iris-mpc-db-exporter
     let mut all_serial_ids: HashSet<i64> = HashSet::from_iter(1..=(max_serial_id_to_load as i64));
     actor.reserve(max_serial_id_to_load);
 
@@ -315,18 +315,8 @@ async fn load_iris_db_internal(
             let stream_db = stream::iter(missing.chunks(MISSING_SERIAL_IDS_CHUNK_SIZE))
                 .flat_map(|ids| store.stream_irises_by_ids(ids))
                 .boxed();
-            tokio::time::timeout(
-                Duration::from_secs(120),
-                load_db_records_from_aurora(
-                    actor,
-                    &mut record_counter,
-                    &mut all_serial_ids,
-                    stream_db,
-                ),
-            )
-            .await
-            .wrap_err("Missing-ID fetch timed out after 120s")?
-            .wrap_err("Failed to fetch missing serial_ids by id")?;
+            load_db_records_from_aurora(actor, &mut record_counter, &mut all_serial_ids, stream_db)
+                .await?;
         }
     }
 

--- a/iris-mpc-store/src/loader.rs
+++ b/iris-mpc-store/src/loader.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use ampc_server_utils::shutdown_handler::ShutdownHandler;
 use aws_config::Region;
-use eyre::{bail, Result};
+use eyre::{bail, Result, WrapErr};
 use futures::stream::{self, BoxStream};
 use futures::StreamExt;
 use iris_mpc_common::config::Config;
@@ -17,11 +17,6 @@ use tokio::sync::mpsc;
 /// Serial ids per `WHERE id = ANY($1)` round trip in the last-chance fetch below.
 /// A row is ~75 KB of code and mask blobs, so this bounds one query at ~38 MB.
 const MISSING_SERIAL_IDS_CHUNK_SIZE: usize = 512;
-
-/// Above this many missing serial ids, don't attempt the last-chance fetch. A gap
-/// this size means the snapshot is broken, and pulling gigabytes off the writer on
-/// every restart would not change the outcome.
-const MAX_MISSING_SERIAL_IDS_TO_FETCH: usize = 10_000;
 
 /// Helper function to load Aurora db records from the stream into memory
 #[allow(clippy::needless_lifetimes)]
@@ -115,6 +110,7 @@ async fn load_iris_db_internal(
     let now = Instant::now();
 
     let mut record_counter = 0;
+    let mut max_missing_serial_ids_to_fetch = 10_000; // Aurora-only fallback.
     let mut all_serial_ids: HashSet<i64> = HashSet::from_iter(1..=(max_serial_id_to_load as i64));
     actor.reserve(max_serial_id_to_load);
 
@@ -140,6 +136,9 @@ async fn load_iris_db_internal(
         // First fetch last snapshot from S3
         let last_snapshot_details =
             last_snapshot_timestamp(s3_arc.as_ref(), s3_chunks_folder_name.clone()).await?;
+
+        // When loading from S3, setting the recovery max to the chunk_size
+        max_missing_serial_ids_to_fetch = last_snapshot_details.chunk_size as usize;
 
         let min_last_modified_at = last_snapshot_details.timestamp - s3_load_safety_overlap_seconds;
         tracing::info!(
@@ -298,48 +297,36 @@ async fn load_iris_db_internal(
             .await?;
     }
 
-    // Last-chance fetch before the integrity check: whatever the S3 snapshot and the
-    // `last_modified_at` tail window both missed is requested here by serial id, which
-    // depends on neither watermark. Reached only when the alternative is a hard bail, so
-    // a failure here is logged and falls through to that bail rather than replacing it.
+    // Fetch missing IDs once before the final completeness check.
     if !all_serial_ids.is_empty() {
-        if all_serial_ids.len() > MAX_MISSING_SERIAL_IDS_TO_FETCH {
+        if all_serial_ids.len() > max_missing_serial_ids_to_fetch {
             tracing::error!(
-                "Not fetching {} missing serial_ids by id: above the {} cap, the snapshot is \
-                 likely incomplete rather than stale",
+                "Not fetching {} missing serial_ids by id: above the {} recovery cap",
                 all_serial_ids.len(),
-                MAX_MISSING_SERIAL_IDS_TO_FETCH,
+                max_missing_serial_ids_to_fetch,
             );
         } else {
-            let mut missing: Vec<i64> = all_serial_ids.iter().copied().collect();
-            missing.sort_unstable();
+            let missing: Vec<i64> = all_serial_ids.iter().copied().collect();
             tracing::warn!(
-                "S3 and tail load left {} serial_ids unloaded; fetching them by id",
+                "Initial load left {} serial_ids unloaded; fetching them by id",
                 missing.len(),
             );
 
-            let chunks: Vec<&[i64]> = missing.chunks(MISSING_SERIAL_IDS_CHUNK_SIZE).collect();
-            // `flat_map` polls one chunk at a time, which is what we want here: the
-            // repair is bounded by the cap above, not racing for throughput.
-            let stream_db = stream::iter(chunks)
+            let stream_db = stream::iter(missing.chunks(MISSING_SERIAL_IDS_CHUNK_SIZE))
                 .flat_map(|ids| store.stream_irises_by_ids(ids))
                 .boxed();
-
-            match load_db_records_from_aurora(
-                actor,
-                &mut record_counter,
-                &mut all_serial_ids,
-                stream_db,
+            tokio::time::timeout(
+                Duration::from_secs(120),
+                load_db_records_from_aurora(
+                    actor,
+                    &mut record_counter,
+                    &mut all_serial_ids,
+                    stream_db,
+                ),
             )
             .await
-            {
-                Ok(()) => tracing::warn!(
-                    "Fetched {} missing serial_ids by id, {} still unloaded",
-                    missing.len() - all_serial_ids.len(),
-                    all_serial_ids.len(),
-                ),
-                Err(e) => tracing::error!("Failed to fetch missing serial_ids by id: {:?}", e),
-            }
+            .wrap_err("Missing-ID fetch timed out after 120s")?
+            .wrap_err("Failed to fetch missing serial_ids by id")?;
         }
     }
 


### PR DESCRIPTION
This pull request introduces a new method to stream iris records by explicit serial IDs and integrates it into the database loader for improved recovery of missing records. It also adds comprehensive tests for the new streaming method and enhances error handling and logging when recovering missing data.

**New streaming method for irises by ID:**

* Added `Store::stream_irises_by_ids`, allowing efficient streaming of iris records by a list of explicit serial IDs, with missing IDs simply skipped rather than causing an error.

**Database loader improvements:**

* Integrated the new streaming method into the loader (`load_iris_db_internal`), enabling a final recovery step that fetches missing records by their IDs, with chunking and a configurable cap to avoid large queries. [[1]](diffhunk://#diff-9c01d04dc62629dff03f715d69e08432d32f64581199c1510b4a457865762a24R300-R322) [[2]](diffhunk://#diff-9c01d04dc62629dff03f715d69e08432d32f64581199c1510b4a457865762a24R113) [[3]](diffhunk://#diff-9c01d04dc62629dff03f715d69e08432d32f64581199c1510b4a457865762a24R140-R142) [[4]](diffhunk://#diff-9c01d04dc62629dff03f715d69e08432d32f64581199c1510b4a457865762a24R17-R20)

**Testing and validation:**

* Added a dedicated test (`test_stream_irises_by_ids`) to verify correct results, handling of missing IDs, and empty input for the new streaming method.

**Code organization:**

* Improved imports and chunking logic in the loader to support the new streaming approach. [[1]](diffhunk://#diff-9c01d04dc62629dff03f715d69e08432d32f64581199c1510b4a457865762a24L8-R8) [[2]](diffhunk://#diff-9c01d04dc62629dff03f715d69e08432d32f64581199c1510b4a457865762a24R17-R20)