### PR TITLE
ci: move CPU E2E image to Bookworm

### DIFF
--- a/Dockerfile.hnsw.test.e2e
+++ b/Dockerfile.hnsw.test.e2e
@@ -1,5 +1,5 @@
 # Set base image.
-FROM public.ecr.aws/docker/library/rust:1.89-slim-bullseye AS build-image
+FROM public.ecr.aws/docker/library/rust:1.89-slim-bookworm AS build-image
 
 # Install pre-requisites.
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Bullseye LTS ended on 2026-08-31, which leaves both CPU E2E jobs failing during apt-get update before tests run.

Moves their shared Rust 1.89 test image to Bookworm. The full image builds locally with package signature and expiry checks unchanged.