### PR TITLE
[POP-4319] Make database exports fail closed

### DIFF
--- a/iris-mpc-db-exporter/go.mod
+++ b/iris-mpc-db-exporter/go.mod
@@ -3,6 +3,7 @@ module github.com/worldcoin/iris-mpc-db-exporter
 go 1.23.11
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/DataDog/datadog-go/v5 v5.6.0
 	github.com/aws/aws-sdk-go-v2 v1.36.3
 	github.com/aws/aws-sdk-go-v2/config v1.29.14

--- a/iris-mpc-db-exporter/go.sum
+++ b/iris-mpc-db-exporter/go.sum
@@ -1,3 +1,5 @@
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/DataDog/appsec-internal-go v1.11.2 h1:Q00pPMQzqMIw7jT2ObaORIxBzSly+deS0Ely9OZ/Bj0=
 github.com/DataDog/appsec-internal-go v1.11.2/go.mod h1:9YppRCpElfGX+emXOKruShFYsdPq7WEPq/Fen4tYYpk=
 github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.65.1 h1:AyQ12vFx5cK4K3yIW3QSrtij+v3Up3K0HIKS7BrXJHs=
@@ -131,6 +133,7 @@ github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNU
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/iris-mpc-db-exporter/main.go
+++ b/iris-mpc-db-exporter/main.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"log"
+	"os"
 	"slices"
 	"syscall"
 	"time"
@@ -72,7 +73,7 @@ func exportCommand() *cobra.Command {
 	var exportCmd = &cobra.Command{
 		Use:   "export-db",
 		Short: "Export iris-mpc participant database",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancelMainCtxFn := context.WithCancel(context.Background()) // mainCtx
 			defer cancelMainCtxFn()
 
@@ -119,7 +120,7 @@ func exportCommand() *cobra.Command {
 			// Avoid blocking producers by defining a chan buffer in case consumers are slower
 			chanBufferLen := cfg.MaxItemsPerUploadPart * 2
 
-			commands.ExportCommand(ctx, exportMode, outputFolder, *store, converter.NewBinaryConverter(CodeSize, MaskSize, IdSize, VersionIdSize), writer, reader, batchSize, parallelism, endIndex, chanBufferLen)
+			return commands.ExportCommand(ctx, exportMode, outputFolder, *store, converter.NewBinaryConverter(CodeSize, MaskSize, IdSize, VersionIdSize), writer, reader, batchSize, parallelism, endIndex, chanBufferLen)
 		},
 	}
 
@@ -136,6 +137,10 @@ func exportCommand() *cobra.Command {
 }
 
 func main() {
+	os.Exit(run())
+}
+
+func run() int {
 	rootCmd := &cobra.Command{Use: "app"}
 	cfg := config.Load()
 	ctx := context.Background()
@@ -182,6 +187,7 @@ func main() {
 	err = rootCmd.Execute()
 	if err != nil {
 		o11y.S(ctx).With(zap.Error(err)).Error("Error executing command")
-		return
+		return 1
 	}
+	return 0
 }

--- a/iris-mpc-db-exporter/main_test.go
+++ b/iris-mpc-db-exporter/main_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRootCommandFailureExitsNonzero(t *testing.T) {
+	if os.Getenv("EXPORTER_TEST_ROOT_FAILURE") == "1" {
+		os.Args = []string{"app", "unknown-command"}
+		main()
+		return
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=^TestRootCommandFailureExitsNonzero$")
+	cmd.Env = append(os.Environ(), "EXPORTER_TEST_ROOT_FAILURE=1", "SLEEP_BEFORE_SHUTDOWN_SECONDS=0", "DD_TRACE_ENABLED=false")
+	output, err := cmd.CombinedOutput()
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr, string(output))
+	require.Equal(t, 1, exitErr.ExitCode(), string(output))
+	require.Contains(t, string(output), "unknown command")
+}

--- a/iris-mpc-db-exporter/src/commands/exportCommand.go
+++ b/iris-mpc-db-exporter/src/commands/exportCommand.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"strings"
@@ -33,19 +34,24 @@ func runCompleteExportCommand(ctx context.Context, mode, outputFolder string, st
 
 	o11y.S(ctx).Infof("Starting %s from %d to %d", mode, startIndex, endIndex)
 
-	irisesStream, err := store.StreamStoredIrisesByRange(ctx, startIndex, endIndex, chanBufferLen)
+	irisesStream, streamError, err := store.StreamStoredIrisesByRange(ctx, startIndex, endIndex, chanBufferLen)
 	if err != nil {
 		return err
 	}
 
 	outputChannel := make(chan []byte, chanBufferLen)
+	conversionError := make(chan error, 1)
 	go func() {
 		defer close(outputChannel)
+		defer close(conversionError)
 		for item := range irisesStream {
 			convertedIrises, err := converter.ConvertSingle(item)
 			if err != nil {
-				o11y.S(ctx).With(zap.Error(err)).Error("Failed to convert iris")
-				panic(err)
+				conversionError <- fmt.Errorf("convert iris %d: %w", item.ID, err)
+				// Let the database producer finish even when conversion stops.
+				for range irisesStream {
+				}
+				return
 			}
 			outputChannel <- convertedIrises
 		}
@@ -55,8 +61,11 @@ func runCompleteExportCommand(ctx context.Context, mode, outputFolder string, st
 
 	persistStart := time.Now()
 	err = writer.PersistStream(ctx, path, outputChannel)
-	if err != nil {
-		return err
+	// Persistence may return before consuming the stream; unblock the producer.
+	for range outputChannel {
+	}
+	if err = errors.Join(err, <-conversionError, <-streamError); err != nil {
+		return fmt.Errorf("export chunk %s: %w", path, err)
 	}
 	elapsedPersist := time.Since(persistStart)
 	o11y.S(ctx).Infof("Persisting irises in chunk from %d to %d took %f", startIndex, endIndex, elapsedPersist.Seconds())
@@ -120,10 +129,9 @@ func runIncrementalExportCommand(ctx context.Context, outputFolder string, expor
 	return nil
 }
 
-func ExportCommand(ctx context.Context, mode, outputFolder string, store iris.Store, converter converter.Converter, writer persistence.Writer, reader persistence.Reader, batchSize, parallelism, endIndex, chanBufferLen int) {
+func ExportCommand(ctx context.Context, mode, outputFolder string, store iris.Store, converter converter.Converter, writer persistence.Writer, reader persistence.Reader, batchSize, parallelism, endIndex, chanBufferLen int) error {
 	if mode != CompleteExport && mode != IncrementalExport {
-		o11y.S(ctx).Errorf("Invalid mode: %s", mode)
-		return
+		return fmt.Errorf("invalid mode: %s", mode)
 	}
 
 	startTime := time.Now()
@@ -134,12 +142,12 @@ func ExportCommand(ctx context.Context, mode, outputFolder string, store iris.St
 	var wg sync.WaitGroup
 	totalIrises, err := store.GetCount(ctx)
 	if err != nil {
-		o11y.S(ctx).With(zap.Error(err)).Fatal("Error getting count of irises")
+		return fmt.Errorf("get iris count: %w", err)
 	}
 
 	if totalIrises == 0 {
 		o11y.S(ctx).Info("No irises to export")
-		return
+		return nil
 	}
 
 	if endIndex != 0 {
@@ -148,7 +156,7 @@ func ExportCommand(ctx context.Context, mode, outputFolder string, store iris.St
 			o11y.S(ctx).Infof("End index has been provided %d", totalIrises)
 		} else {
 			o11y.S(ctx).Infof("End index provided is greater than total irises %d", totalIrises)
-			return
+			return nil
 		}
 	}
 
@@ -165,6 +173,8 @@ func ExportCommand(ctx context.Context, mode, outputFolder string, store iris.St
 
 	var runningCoroutines atomic.Int32
 	var successfulBatches atomic.Int32
+	var firstBatchError error
+	var recordBatchError sync.Once
 
 	var exportNewerThan *int64
 	if mode == IncrementalExport {
@@ -193,36 +203,26 @@ func ExportCommand(ctx context.Context, mode, outputFolder string, store iris.St
 		runningCoroutines.Add(1)
 		go func(start, count int) {
 			defer wg.Done()
-			success := true
+			defer runningCoroutines.Add(-1)
+			var batchErr error
 
 			if mode == CompleteExport {
-				err = runCompleteExportCommand(ctx, mode, outputFolder, store, converter, writer, start, start+count, chanBufferLen)
-				if err != nil {
-					o11y.S(ctx).With(zap.Error(err)).Errorf("Failed to run export command on interval %d-%d", start, start+count)
-					success = false
-				}
+				batchErr = runCompleteExportCommand(ctx, mode, outputFolder, store, converter, writer, start, start+count, chanBufferLen)
 			}
 
 			if mode == IncrementalExport {
-				err = runIncrementalExportCommand(ctx, outputFolder, *exportNewerThan, store, converter, writer, start, start+count)
-				if err != nil {
-					o11y.S(ctx).With(zap.Error(err)).Errorf("Failed to run export command on interval %d-%d", start, start+count)
-					success = false
-				}
+				batchErr = runIncrementalExportCommand(ctx, outputFolder, *exportNewerThan, store, converter, writer, start, start+count)
 			}
 
-			if err != nil {
-				o11y.S(ctx).With(zap.Error(err)).Errorf("Failed to run export command on interval %d-%d", start, start+count)
-				success = false
+			if batchErr != nil {
+				o11y.S(ctx).With(zap.Error(batchErr)).Errorf("Failed to run export command on interval %d-%d", start, start+count)
+				recordBatchError.Do(func() {
+					firstBatchError = fmt.Errorf("export interval %d-%d: %w", start, start+count, batchErr)
+				})
 			} else {
 				o11y.S(ctx).Infof("Batch %d/%d completed", i+1, batchesCount)
-			}
-
-			if success {
 				successfulBatches.Add(1)
 			}
-
-			runningCoroutines.Add(-1)
 		}(start, batchSize-1)
 	}
 
@@ -240,9 +240,13 @@ func ExportCommand(ctx context.Context, mode, outputFolder string, store iris.St
 
 	if !exportSuccess {
 		o11y.S(ctx).Error("Export did not fully succeed, skipping timestamp marker to avoid advancing the checkpoint")
-		return
+		return firstBatchError
 	}
 
 	// Create the file with the date of the beginning of the export to mark the completion of the export
 	err = writer.Persist(timestampFilePath, []byte{})
+	if err != nil {
+		return fmt.Errorf("persist completion marker %s: %w", timestampFilePath, err)
+	}
+	return nil
 }

--- a/iris-mpc-db-exporter/src/commands/exportCommand_test.go
+++ b/iris-mpc-db-exporter/src/commands/exportCommand_test.go
@@ -1,0 +1,226 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/DataDog/datadog-go/v5/statsd"
+	"github.com/stretchr/testify/require"
+
+	"github.com/worldcoin/iris-mpc-db-exporter/src/config"
+	"github.com/worldcoin/iris-mpc-db-exporter/src/iris"
+	"github.com/worldcoin/iris-mpc-db-exporter/src/metrics"
+)
+
+type discardMetrics struct{ io.Writer }
+
+func (discardMetrics) Close() error { return nil }
+
+func exportStore(t *testing.T, count int) (iris.Store, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	db.SetMaxIdleConns(3)
+	mock.MatchExpectationsInOrder(false)
+	mock.ExpectQuery(`SELECT count\(\*\)`).WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(count)).RowsWillBeClosed()
+	client, err := statsd.NewWithWriter(discardMetrics{io.Discard})
+	require.NoError(t, err)
+	previous := metrics.Client
+	metrics.Client = client
+	t.Cleanup(func() {
+		require.NoError(t, mock.ExpectationsWereMet())
+		for i := 0; i < db.Stats().OpenConnections; i++ {
+			mock.ExpectClose()
+		}
+		require.NoError(t, db.Close())
+		require.NoError(t, client.Close())
+		metrics.Client = previous
+	})
+	return *iris.NewStore(context.Background(), db, config.Config{Environment: "test"}), mock
+}
+
+func irisRows(ids ...int) *sqlmock.Rows {
+	rows := sqlmock.NewRows([]string{"id", "last_modified_at", "left_code", "left_mask", "right_code", "right_mask", "version_id"})
+	for _, id := range ids {
+		rows.AddRow(id, nil, nil, nil, nil, nil, 0)
+	}
+	return rows
+}
+
+type testConverter struct{ err error }
+
+func (c testConverter) GetExtension() string { return "bin" }
+func (c testConverter) ConvertSingle(item iris.StoredIris) ([]byte, error) {
+	return []byte(fmt.Sprintf("%d,", item.ID)), c.err
+}
+func (c testConverter) Convert(items []iris.StoredIris) ([]byte, error) {
+	return []byte("converted"), c.err
+}
+
+type testWriter struct {
+	mu         sync.Mutex
+	chunks     map[string]string
+	markers    []string
+	persistErr error
+	streamErr  error
+	markerErr  error
+}
+
+func (w *testWriter) Persist(path string, data []byte) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if strings.Contains(path, "/timestamps/") {
+		w.markers = append(w.markers, path)
+		return w.markerErr
+	}
+	if w.chunks == nil {
+		w.chunks = make(map[string]string)
+	}
+	w.chunks[path] = string(data)
+	return w.persistErr
+}
+
+func (w *testWriter) PersistStream(_ context.Context, path string, input <-chan []byte) error {
+	if w.streamErr != nil {
+		return w.streamErr // Intentionally leaves producers blocked unless the caller drains.
+	}
+	var data []byte
+	for item := range input {
+		data = append(data, item...)
+	}
+	return w.Persist(path, data)
+}
+
+type testReader struct{}
+
+func (testReader) GetTimeOfLastExport(context.Context, string) (*int64, error) {
+	timestamp := int64(123)
+	return &timestamp, nil
+}
+
+func TestCompleteExportFailuresSuppressMarker(t *testing.T) {
+	for _, failure := range []string{"query", "scan", "rows", "converter", "persistence"} {
+		t.Run(failure, func(t *testing.T) {
+			store, mock := exportStore(t, 3)
+			wantErr := errors.New("batch failed")
+			writer := &testWriter{}
+			converter := testConverter{}
+			query := mock.ExpectQuery("SELECT id").WithArgs(1, 3)
+			rows := irisRows(1, 2, 3)
+			switch failure {
+			case "query":
+				query.WillReturnError(wantErr)
+			case "scan":
+				rows = sqlmock.NewRows([]string{"id"}).AddRow("invalid")
+			case "rows":
+				rows.RowError(1, wantErr)
+			case "converter":
+				converter.err = wantErr
+			case "persistence":
+				writer.streamErr = wantErr
+			}
+			if failure != "query" {
+				query.WillReturnRows(rows).RowsWillBeClosed()
+			}
+			err := ExportCommand(context.Background(), CompleteExport, "output", store, converter, writer, testReader{}, 3, 1, 0, 0)
+			require.Error(t, err)
+			if failure != "scan" {
+				require.ErrorIs(t, err, wantErr)
+			}
+			require.Empty(t, writer.markers)
+		})
+	}
+}
+
+func TestExportAllBatchesBeforeMarker(t *testing.T) {
+	for _, failedBatch := range []bool{false, true} {
+		t.Run(fmt.Sprintf("failed_batch_%t", failedBatch), func(t *testing.T) {
+			store, mock := exportStore(t, 5)
+			writer := &testWriter{}
+			wantErr := errors.New("middle batch failed")
+			mock.ExpectQuery("SELECT id").WithArgs(1, 2).WillReturnRows(irisRows(1, 2)).RowsWillBeClosed()
+			middle := mock.ExpectQuery("SELECT id").WithArgs(3, 4)
+			if failedBatch {
+				middle.WillReturnError(wantErr)
+			} else {
+				middle.WillReturnRows(irisRows(3, 4)).RowsWillBeClosed()
+			}
+			mock.ExpectQuery("SELECT id").WithArgs(5, 5).WillReturnRows(irisRows(5)).RowsWillBeClosed()
+			err := ExportCommand(context.Background(), CompleteExport, "output", store, testConverter{}, writer, testReader{}, 2, 3, 0, 0)
+			if failedBatch {
+				require.ErrorIs(t, err, wantErr)
+				require.Empty(t, writer.markers)
+				require.Len(t, writer.chunks, 2)
+			} else {
+				require.NoError(t, err)
+				require.Len(t, writer.markers, 1)
+				require.True(t, strings.HasSuffix(writer.markers[0], "_2_5"))
+				require.Equal(t, map[string]string{"output/1.bin": "1,2,", "output/3.bin": "3,4,", "output/5.bin": "5,"}, writer.chunks)
+			}
+		})
+	}
+}
+
+func TestMarkerFailureIsReturned(t *testing.T) {
+	store, mock := exportStore(t, 1)
+	mock.ExpectQuery("SELECT id").WithArgs(1, 1).WillReturnRows(irisRows(1)).RowsWillBeClosed()
+	wantErr := errors.New("marker failed")
+	writer := &testWriter{markerErr: wantErr}
+	err := ExportCommand(context.Background(), CompleteExport, "output", store, testConverter{}, writer, testReader{}, 1, 1, 0, 0)
+	require.ErrorIs(t, err, wantErr)
+	require.Len(t, writer.markers, 1)
+}
+
+func TestEmptyExportDoesNotAdvanceCheckpoint(t *testing.T) {
+	store, _ := exportStore(t, 0)
+	writer := &testWriter{}
+	require.NoError(t, ExportCommand(context.Background(), CompleteExport, "output", store, testConverter{}, writer, testReader{}, 1, 1, 0, 0))
+	require.Empty(t, writer.chunks)
+	require.Empty(t, writer.markers)
+}
+
+func TestCountFailureSuppressesMarker(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+	wantErr := errors.New("count failed")
+	mock.ExpectQuery(`SELECT count\(\*\)`).WillReturnError(wantErr)
+	store := iris.NewStore(context.Background(), db, config.Config{Environment: "test"})
+	writer := &testWriter{}
+	err = ExportCommand(context.Background(), CompleteExport, "output", *store, testConverter{}, writer, testReader{}, 1, 1, 0, 0)
+	require.ErrorIs(t, err, wantErr)
+	require.Empty(t, writer.markers)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestIncrementalFailuresSuppressMarker(t *testing.T) {
+	for _, failure := range []string{"query", "converter", "persistence"} {
+		t.Run(failure, func(t *testing.T) {
+			store, mock := exportStore(t, 1)
+			wantErr := errors.New("incremental failed")
+			writer := &testWriter{}
+			converter := testConverter{}
+			query := mock.ExpectQuery("SELECT id").WithArgs(1, 1, int64(123))
+			if failure == "query" {
+				query.WillReturnError(wantErr)
+			} else {
+				query.WillReturnRows(irisRows(1)).RowsWillBeClosed()
+				mock.ExpectQuery("SELECT id").WithArgs(1, 1).WillReturnRows(irisRows(1)).RowsWillBeClosed()
+				if failure == "converter" {
+					converter.err = wantErr
+				} else {
+					writer.persistErr = wantErr
+				}
+			}
+			err := ExportCommand(context.Background(), IncrementalExport, "output", store, converter, writer, testReader{}, 1, 1, 0, 0)
+			require.ErrorIs(t, err, wantErr)
+			require.Empty(t, writer.markers)
+		})
+	}
+}

--- a/iris-mpc-db-exporter/src/iris/store.go
+++ b/iris-mpc-db-exporter/src/iris/store.go
@@ -74,6 +74,7 @@ func (s *Store) GetCount(ctx context.Context) (int, error) {
 		o11y.S(ctx).With(zap.Error(err)).Error("Failed to fetch count")
 		return -1, err
 	}
+	defer rows.Close()
 
 	var count int
 	for rows.Next() {
@@ -83,7 +84,7 @@ func (s *Store) GetCount(ctx context.Context) (int, error) {
 		}
 	}
 
-	return count, nil
+	return count, rows.Err()
 }
 
 func (s *Store) GetStoredIrisesByRange(ctx context.Context, startIndex, endIndex int) ([]StoredIris, error) {
@@ -115,38 +116,42 @@ func (s *Store) GetStoredIrisesByRange(ctx context.Context, startIndex, endIndex
 		irises = append(irises, storedIris)
 	}
 
-	return irises, nil
+	return irises, rows.Err()
 }
 
-func (s *Store) StreamStoredIrisesByRange(ctx context.Context, startIndex, endIndex, chanBufferLen int) (<-chan StoredIris, error) {
+func (s *Store) StreamStoredIrisesByRange(ctx context.Context, startIndex, endIndex, chanBufferLen int) (<-chan StoredIris, <-chan error, error) {
 	span, ctx := tracer.StartSpanFromContext(ctx, "pgsql.get_stored_irises_by_range")
 	defer span.Finish()
 
 	span.SetTag("startIndex", startIndex)
 	span.SetTag("endIndex", endIndex)
 	outputChannel := make(chan StoredIris, chanBufferLen)
+	streamError := make(chan error, 1)
 
 	query := storedIrisesByRangeQuery(s.schema)
 	rows, err := s.db.Query(query, startIndex, endIndex)
 	if err != nil {
 		o11y.S(ctx).With(zap.Error(err)).Errorf("Failed to fetch irises in range %d, %d. Error: %v", startIndex, endIndex, err)
-		return nil, err
+		return nil, nil, err
 	}
 
 	go func() {
-		defer rows.Close()
 		defer close(outputChannel)
+		defer close(streamError)
+		defer rows.Close()
 		for rows.Next() {
 			var storedIris StoredIris
 			if err := rows.Scan(&storedIris.ID, &storedIris.LastModifiedAt, &storedIris.LeftCode, &storedIris.LeftMask, &storedIris.RightCode, &storedIris.RightMask, &storedIris.VersionID); err != nil {
 				o11y.S(ctx).With(zap.Error(err)).Error("Failed to populate iris")
+				streamError <- err
 				return
 			}
 			outputChannel <- storedIris
 		}
+		streamError <- rows.Err()
 	}()
 
-	return outputChannel, nil
+	return outputChannel, streamError, nil
 }
 
 func (s *Store) GetStoredIrisesOlderThanByRange(ctx context.Context, lastModifiedAt int64, startIndex, endIndex int) ([]StoredIris, error) {
@@ -177,7 +182,7 @@ func (s *Store) GetStoredIrisesOlderThanByRange(ctx context.Context, lastModifie
 		irises = append(irises, storedIris)
 	}
 
-	return irises, nil
+	return irises, rows.Err()
 }
 
 func (s *Store) InsertIris(ctx context.Context, iris StoredIris) error {

--- a/iris-mpc-db-exporter/src/iris/store_test.go
+++ b/iris-mpc-db-exporter/src/iris/store_test.go
@@ -1,0 +1,71 @@
+package iris
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadFailures(t *testing.T) {
+	ctx := context.Background()
+	for _, method := range []string{"count", "range", "older", "stream"} {
+		for _, failure := range []string{"query", "scan", "rows"} {
+			t.Run(method+"/"+failure, func(t *testing.T) {
+				db, mock, err := sqlmock.New()
+				require.NoError(t, err)
+				t.Cleanup(func() { require.NoError(t, db.Close()) })
+				store := &Store{db: db, schema: "test"}
+				wantErr := errors.New("database read failed")
+				rows := sqlmock.NewRows([]string{"id", "last_modified_at", "left_code", "left_mask", "right_code", "right_mask", "version_id"})
+				if method == "count" {
+					rows = sqlmock.NewRows([]string{"count"})
+					if failure == "scan" {
+						rows.AddRow("invalid count")
+					} else {
+						rows.AddRow(1)
+					}
+				} else if failure == "scan" {
+					rows.AddRow("invalid id", nil, nil, nil, nil, nil, 0)
+				} else {
+					rows.AddRow(1, nil, nil, nil, nil, nil, 0)
+				}
+				query := mock.ExpectQuery("SELECT")
+				if failure == "query" {
+					query.WillReturnError(wantErr)
+				} else {
+					if failure == "rows" {
+						rows.RowError(0, wantErr)
+					}
+					query.WillReturnRows(rows).RowsWillBeClosed()
+				}
+
+				switch method {
+				case "count":
+					_, err = store.GetCount(ctx)
+				case "range":
+					_, err = store.GetStoredIrisesByRange(ctx, 1, 2)
+				case "older":
+					_, err = store.GetStoredIrisesOlderThanByRange(ctx, 123, 1, 2)
+				case "stream":
+					var records <-chan StoredIris
+					var streamError <-chan error
+					records, streamError, err = store.StreamStoredIrisesByRange(ctx, 1, 2, 0)
+					if err == nil {
+						for range records {
+						}
+						err = <-streamError
+					}
+				}
+				require.Error(t, err)
+				if failure != "scan" {
+					require.ErrorIs(t, err, wantErr)
+				}
+				require.NoError(t, mock.ExpectationsWereMet())
+				mock.ExpectClose()
+			})
+		}
+	}
+}

--- a/iris-mpc-db-exporter/src/persistence/filesystem.go
+++ b/iris-mpc-db-exporter/src/persistence/filesystem.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -18,12 +17,12 @@ func (f *FilesystemWriter) Persist(path string, data []byte) error {
 	dir := filepath.Dir(path)
 	err := os.MkdirAll(dir, 0755)
 	if err != nil {
-		log.Fatalf("Failed to create directories: %v", err)
+		return fmt.Errorf("create directories for %s: %w", path, err)
 	}
 
 	err = os.WriteFile(path, data, 0644)
 	if err != nil {
-		log.Fatal(err)
+		return fmt.Errorf("write file %s: %w", path, err)
 	}
 	return nil
 }
@@ -51,7 +50,7 @@ func (f *FilesystemWriter) PersistStream(ctx context.Context, path string, input
 		case item, ok := <-inputChannel:
 			if !ok {
 				// channel closed; we're done receiving data
-				return nil
+				return file.Close()
 			}
 			if _, writeErr := file.Write(item); writeErr != nil {
 				return fmt.Errorf("failed to write to file: %w", writeErr)

--- a/iris-mpc-db-exporter/src/persistence/filesystem_test.go
+++ b/iris-mpc-db-exporter/src/persistence/filesystem_test.go
@@ -1,0 +1,22 @@
+package persistence
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilesystemPersistenceErrors(t *testing.T) {
+	writer := &FilesystemWriter{}
+	file := filepath.Join(t.TempDir(), "existing-file")
+	require.NoError(t, os.WriteFile(file, []byte("existing"), 0600))
+	for _, path := range []string{filepath.Join(file, "child"), t.TempDir()} {
+		require.Error(t, writer.Persist(path, nil))
+		input := make(chan []byte)
+		close(input)
+		require.Error(t, writer.PersistStream(context.Background(), path, input))
+	}
+}

--- a/iris-mpc-db-exporter/src/persistence/s3.go
+++ b/iris-mpc-db-exporter/src/persistence/s3.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -126,7 +125,7 @@ func (s *S3Writer) Persist(path string, data []byte) error {
 		Body:   bytes.NewReader(data),
 	})
 	if err != nil {
-		log.Fatal(err)
+		return fmt.Errorf("put object %s: %w", path, err)
 	}
 	return nil
 }

--- a/iris-mpc-db-exporter/src/persistence/s3_test.go
+++ b/iris-mpc-db-exporter/src/persistence/s3_test.go
@@ -1,0 +1,34 @@
+package persistence
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/stretchr/testify/require"
+)
+
+type failingHTTPClient struct{ err error }
+
+func (c failingHTTPClient) Do(*http.Request) (*http.Response, error) { return nil, c.err }
+
+func TestS3PersistenceErrors(t *testing.T) {
+	wantErr := errors.New("storage unavailable")
+	writer := &S3Writer{
+		Client: s3.NewFromConfig(aws.Config{
+			Region:           "eu-north-1",
+			Credentials:      credentials.NewStaticCredentialsProvider("test", "test", ""),
+			HTTPClient:       failingHTTPClient{wantErr},
+			RetryMaxAttempts: 1,
+		}),
+		Bucket: "test-bucket",
+	}
+	require.ErrorIs(t, writer.Persist("timestamps/test", nil), wantErr)
+	input := make(chan []byte)
+	close(input)
+	require.ErrorIs(t, writer.PersistStream(context.Background(), "chunk", input), wantErr)
+}

--- a/iris-mpc-db-exporter/test/e2e_binary_hdd_export_test.go
+++ b/iris-mpc-db-exporter/test/e2e_binary_hdd_export_test.go
@@ -234,7 +234,9 @@ func TestDBExporting(t *testing.T) {
 	reader = &persistence.FilesystemReader{}
 	writer = &persistence.FilesystemWriter{}
 
-	commands.ExportCommand(ctx, "COMPLETE_EXPORT", "test_output", *store, converter.NewBinaryConverter(cfg.SingleCodeSize, cfg.SingleMaskSize, 4, 2), writer, reader, 503, 2, 0, 200)
+	if err := commands.ExportCommand(ctx, "COMPLETE_EXPORT", "test_output", *store, converter.NewBinaryConverter(cfg.SingleCodeSize, cfg.SingleMaskSize, 4, 2), writer, reader, 503, 2, 0, 200); err != nil {
+		t.Fatalf("export failed: %v", err)
+	}
 
 	files, err := getFilesWithExtension("test_output", ".bin")
 	if err != nil {

--- a/iris-mpc-db-exporter/test/e2e_postgres_store_test.go
+++ b/iris-mpc-db-exporter/test/e2e_postgres_store_test.go
@@ -69,13 +69,14 @@ func TestPostgresRangeReadsAreOrderedByID(t *testing.T) {
 	})
 
 	t.Run("streaming range", func(t *testing.T) {
-		records, err := store.StreamStoredIrisesByRange(ctx, 1, 4, 4)
+		records, streamError, err := store.StreamStoredIrisesByRange(ctx, 1, 4, 4)
 		require.NoError(t, err)
 
 		var ids []int64
 		for record := range records {
 			ids = append(ids, record.ID)
 		}
+		require.NoError(t, <-streamError)
 		require.Equal(t, []int64{1, 2, 3, 4}, ids)
 	})
 }


### PR DESCRIPTION
Database export failures now propagate from row streaming, conversion, and persistence through Cobra. A failed or incomplete export exits non-zero and cannot write the completion marker; an empty export also leaves the checkpoint unchanged.

Adds focused failure-path, marker, race, and exit-code coverage. Tested with `go test -mod=readonly -count=1 -timeout=60s ./src/... .`, `go test -race -count=1 -timeout=60s ./src/... .`, `go vet ./...`, and compile-only e2e packages.

Related: https://linear.app/worldcoin/issue/POP-4319/iris-mpc-db-exporter-evaluate-aurora-reader-instance-for-exports