### PR TITLE
deploy(stage): roll out POP-4321 retention reaper

### DIFF
--- a/deploy/stage/common-values-ampc-hnsw-anon-stats-retention.yaml
+++ b/deploy/stage/common-values-ampc-hnsw-anon-stats-retention.yaml
@@ -2,7 +2,7 @@
 # worldcoin-foundation/common-cronjob) via wf-cluster-apps, mirroring ampc-hnsw-db-exporter.
 # Per-cluster env (map format) + the attachSecurityGroupPolicy that lets the pod reach the
 # anon-stats Aurora live per-node.
-image: "ghcr.io/worldcoin/retention-reaper:d9a3d33342dfd9e95c7b11e8ef4e4101a3e6ed80"
+image: "ghcr.io/worldcoin/retention-reaper:e021e13dad7710f4dda417c210fadf2c0c43b43a@sha256:70c52f46bef422afae1a706b10b8b82322f1258145465e8953349ec78f7fac82"
 
 # STAGE LIVE: dry-run validated 2026-07-03 → 2026-07-09 (daily runs, all parties, exact
 # delete predicate logged incl. the processed=TRUE guard; 0 rows eligible only because

--- a/deploy/stage/common-values-ampc-hnsw-modifications-retention.yaml
+++ b/deploy/stage/common-values-ampc-hnsw-modifications-retention.yaml
@@ -9,7 +9,7 @@
 # coordination exists or is needed. The GPU MPCV2 DB's copy grows the same way; its
 # reaper instance FOLLOWS SHORTLY (same binary, values + cluster-apps entry only).
 #
-image: "ghcr.io/worldcoin/retention-reaper:v0.32.6@sha256:366cc7dcd9e9132bbfe2b5719332ff8d1f301ed5b487cbfc458fbc97cca92ace"
+image: "ghcr.io/worldcoin/retention-reaper:e021e13dad7710f4dda417c210fadf2c0c43b43a@sha256:70c52f46bef422afae1a706b10b8b82322f1258145465e8953349ec78f7fac82"
 
 # STAGE LIVE: dry-run cleared after clean daily previews (2026-07-09 → 2026-07-20 all
 # "would delete 0"). The reaper now performs the real guarded DELETE. This is a no-op

--- a/deploy/stage/common-values-anon-stats-retention.yaml
+++ b/deploy/stage/common-values-anon-stats-retention.yaml
@@ -1,7 +1,7 @@
 # POP-3905 — anon-stats retention CronJob (stage, smpcv2). Uses the common-cronjob chart
 # (chartVersion 1.11.0, worldcoin-foundation/common-cronjob) via wf-cluster-apps, mirroring
 # iris-mpc-db-exporter. Per-cluster env (RETENTION__*, map format) lives in the per-node values files.
-image: "ghcr.io/worldcoin/retention-reaper:d9a3d33342dfd9e95c7b11e8ef4e4101a3e6ed80"
+image: "ghcr.io/worldcoin/retention-reaper:e021e13dad7710f4dda417c210fadf2c0c43b43a@sha256:70c52f46bef422afae1a706b10b8b82322f1258145465e8953349ec78f7fac82"
 
 # STAGE LIVE: dry-run validated 2026-07-03 → 2026-07-09 (daily runs, all parties, exact
 # delete predicate logged incl. the processed=TRUE guard; 0 rows eligible only because

--- a/deploy/stage/common-values-iris-mpc-modifications-retention.yaml
+++ b/deploy/stage/common-values-iris-mpc-modifications-retention.yaml
@@ -8,7 +8,7 @@
 # Runs in the iris-mpc-db-exporter namespace for its `application` secret
 # (DATABASE_AURORA_URL). NOTE the original "generic nodes reach the Aurora, mirroring
 # iris-mpc-db-exporter" assumption held on prod but NOT on stage — see nodeSelector below.
-image: "ghcr.io/worldcoin/retention-reaper:v0.32.6@sha256:366cc7dcd9e9132bbfe2b5719332ff8d1f301ed5b487cbfc458fbc97cca92ace"
+image: "ghcr.io/worldcoin/retention-reaper:e021e13dad7710f4dda417c210fadf2c0c43b43a@sha256:70c52f46bef422afae1a706b10b8b82322f1258145465e8953349ec78f7fac82"
 
 # STAGE LIVE: dry-run cleared — the reaper now performs the real guarded DELETE against
 # the GPU MPCV2 DB. No-op today by design (created_at backfilled at migration boot + the


### PR DESCRIPTION
Repins the four stage retention reapers to the image built from #2389 (`e021e13dad7710f4dda417c210fadf2c0c43b43a@sha256:70c52f46bef422afae1a706b10b8b82322f1258145465e8953349ec78f7fac82`). After one clean stage run completes and emits the new tuple/autovacuum gauges, the same digest can be promoted in a production follow-up; rollback is `d9a3d33342dfd9e95c7b11e8ef4e4101a3e6ed80` for anon-stats and `v0.32.6@sha256:366cc7dcd9e9132bbfe2b5719332ff8d1f301ed5b487cbfc458fbc97cca92ace` for modifications. Verified with `yq eval` on all four values files and `git diff --check`.