### PR TITLE
[POP-4319] Deploy fail-closed exporter to stage

### DIFF
--- a/deploy/stage/common-values-iris-mpc-db-exporter.yaml
+++ b/deploy/stage/common-values-iris-mpc-db-exporter.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/worldcoin/iris-mpc-database-exporter:v0.31.8@sha256:fd14a8270fd78f285b45f30df551f7be49a42b2f9cd928b5536b35977dfc14ea"
+image: "ghcr.io/worldcoin/iris-mpc-database-exporter:a250ee4ef4ca0727dfaf54f5e0d413db83db837e@sha256:0d839c78027198555ab7c92344520bec06c72bfccf333d278d088c45e32537c4"
 
 replicaCount: 1
 


### PR DESCRIPTION
Deploys iris-mpc-db-exporter commit `a250ee4ef4ca0727dfaf54f5e0d413db83db837e` to stage, pinned to GHCR digest `sha256:0d839c78027198555ab7c92344520bec06c72bfccf333d278d088c45e32537c4`. This contains #2392's fail-closed export behavior; production stays unchanged until we have observed completed scheduled runs in stage.