### PR TITLE
[POP-4319] Preserve exporter snapshots on failure

### DIFF
--- a/iris-mpc-db-exporter/src/commands/exportCommand.go
+++ b/iris-mpc-db-exporter/src/commands/exportCommand.go
@@ -72,7 +72,7 @@ func runCompleteExportCommand(ctx context.Context, mode, outputFolder string, st
 	}
 	// The writer consumes producerStatus after a complete input stream. If it
 	// returned early, the caller owns the remaining status after draining.
-	producerErr, _ := <-producerStatus
+	producerErr := <-producerStatus
 	if err = errors.Join(err, producerErr); err != nil {
 		return fmt.Errorf("export chunk %s: %w", path, err)
 	}

--- a/iris-mpc-db-exporter/src/commands/exportCommand.go
+++ b/iris-mpc-db-exporter/src/commands/exportCommand.go
@@ -40,31 +40,40 @@ func runCompleteExportCommand(ctx context.Context, mode, outputFolder string, st
 	}
 
 	outputChannel := make(chan []byte, chanBufferLen)
-	conversionError := make(chan error, 1)
+	producerStatus := make(chan error, 1)
 	go func() {
 		defer close(outputChannel)
-		defer close(conversionError)
+		defer close(producerStatus)
+		var conversionError error
 		for item := range irisesStream {
 			convertedIrises, err := converter.ConvertSingle(item)
 			if err != nil {
-				conversionError <- fmt.Errorf("convert iris %d: %w", item.ID, err)
+				conversionError = fmt.Errorf("convert iris %d: %w", item.ID, err)
 				// Let the database producer finish even when conversion stops.
 				for range irisesStream {
 				}
-				return
+				break
 			}
 			outputChannel <- convertedIrises
 		}
+		streamErr, ok := <-streamError
+		if !ok {
+			streamErr = errors.New("database stream status channel closed without a value")
+		}
+		producerStatus <- errors.Join(conversionError, streamErr)
 	}()
 
 	path := fmt.Sprintf("%s/%d.%s", outputFolder, startIndex, converter.GetExtension())
 
 	persistStart := time.Now()
-	err = writer.PersistStream(ctx, path, outputChannel)
+	err = writer.PersistStream(ctx, path, outputChannel, producerStatus)
 	// Persistence may return before consuming the stream; unblock the producer.
 	for range outputChannel {
 	}
-	if err = errors.Join(err, <-conversionError, <-streamError); err != nil {
+	// The writer consumes producerStatus after a complete input stream. If it
+	// returned early, the caller owns the remaining status after draining.
+	producerErr, _ := <-producerStatus
+	if err = errors.Join(err, producerErr); err != nil {
 		return fmt.Errorf("export chunk %s: %w", path, err)
 	}
 	elapsedPersist := time.Since(persistStart)

--- a/iris-mpc-db-exporter/src/commands/exportCommand_test.go
+++ b/iris-mpc-db-exporter/src/commands/exportCommand_test.go
@@ -86,13 +86,18 @@ func (w *testWriter) Persist(path string, data []byte) error {
 	return w.persistErr
 }
 
-func (w *testWriter) PersistStream(_ context.Context, path string, input <-chan []byte) error {
+func (w *testWriter) PersistStream(_ context.Context, path string, input <-chan []byte, producerStatus <-chan error) error {
 	if w.streamErr != nil {
 		return w.streamErr // Intentionally leaves producers blocked unless the caller drains.
 	}
 	var data []byte
 	for item := range input {
 		data = append(data, item...)
+	}
+	if err, ok := <-producerStatus; !ok {
+		return errors.New("missing producer status")
+	} else if err != nil {
+		return err
 	}
 	return w.Persist(path, data)
 }
@@ -134,8 +139,25 @@ func TestCompleteExportFailuresSuppressMarker(t *testing.T) {
 				require.ErrorIs(t, err, wantErr)
 			}
 			require.Empty(t, writer.markers)
+			require.Empty(t, writer.chunks)
 		})
 	}
+}
+
+func TestCompleteExportJoinsConversionAndDatabaseStreamErrors(t *testing.T) {
+	store, mock := exportStore(t, 2)
+	conversionErr := errors.New("conversion failed")
+	streamErr := errors.New("database stream failed")
+	rows := irisRows(1, 2)
+	rows.RowError(1, streamErr)
+	mock.ExpectQuery("SELECT id").WithArgs(1, 2).WillReturnRows(rows).RowsWillBeClosed()
+	writer := &testWriter{}
+
+	err := ExportCommand(context.Background(), CompleteExport, "output", store, testConverter{err: conversionErr}, writer, testReader{}, 2, 1, 0, 0)
+	require.ErrorIs(t, err, conversionErr)
+	require.ErrorIs(t, err, streamErr)
+	require.Empty(t, writer.chunks)
+	require.Empty(t, writer.markers)
 }
 
 func TestExportAllBatchesBeforeMarker(t *testing.T) {

--- a/iris-mpc-db-exporter/src/persistence/filesystem.go
+++ b/iris-mpc-db-exporter/src/persistence/filesystem.go
@@ -27,7 +27,7 @@ func (f *FilesystemWriter) Persist(path string, data []byte) error {
 	return nil
 }
 
-func (f *FilesystemWriter) PersistStream(ctx context.Context, path string, inputChannel <-chan []byte) error {
+func (f *FilesystemWriter) PersistStream(ctx context.Context, path string, inputChannel <-chan []byte, producerStatus <-chan error) (resultErr error) {
 	// Ensure the directory exists
 	dir := filepath.Dir(path)
 	err := os.MkdirAll(dir, 0755)
@@ -35,12 +35,25 @@ func (f *FilesystemWriter) PersistStream(ctx context.Context, path string, input
 		return fmt.Errorf("failed to create directories: %w", err)
 	}
 
-	// Open (or create) the file for writing
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	file, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
 	if err != nil {
-		return fmt.Errorf("failed to open file for writing: %w", err)
+		return fmt.Errorf("create temporary file for %s: %w", path, err)
 	}
-	defer file.Close()
+	tempPath := file.Name()
+	fileClosed := false
+	committed := false
+	defer func() {
+		if !fileClosed {
+			if closeErr := file.Close(); closeErr != nil {
+				resultErr = errors.Join(resultErr, fmt.Errorf("close temporary file for %s: %w", path, closeErr))
+			}
+		}
+		if !committed {
+			if removeErr := os.Remove(tempPath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+				resultErr = errors.Join(resultErr, fmt.Errorf("remove temporary file for %s: %w", path, removeErr))
+			}
+		}
+	}()
 
 	// Write chunks as they arrive on the channel
 	for {
@@ -49,8 +62,21 @@ func (f *FilesystemWriter) PersistStream(ctx context.Context, path string, input
 			return ctx.Err() // context canceled or deadline exceeded
 		case item, ok := <-inputChannel:
 			if !ok {
-				// channel closed; we're done receiving data
-				return file.Close()
+				if err := readProducerStatus(producerStatus); err != nil {
+					return fmt.Errorf("producer failed for %s: %w", path, err)
+				}
+				if err := file.Chmod(0644); err != nil {
+					return fmt.Errorf("chmod temporary file for %s: %w", path, err)
+				}
+				if err := file.Close(); err != nil {
+					return fmt.Errorf("close temporary file for %s: %w", path, err)
+				}
+				fileClosed = true
+				if err := os.Rename(tempPath, path); err != nil {
+					return fmt.Errorf("replace file %s: %w", path, err)
+				}
+				committed = true
+				return nil
 			}
 			if _, writeErr := file.Write(item); writeErr != nil {
 				return fmt.Errorf("failed to write to file: %w", writeErr)

--- a/iris-mpc-db-exporter/src/persistence/filesystem.go
+++ b/iris-mpc-db-exporter/src/persistence/filesystem.go
@@ -2,6 +2,8 @@ package persistence
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -11,6 +13,22 @@ import (
 )
 
 type FilesystemWriter struct{}
+
+func createTempFile(dir, base string, mode os.FileMode) (*os.File, error) {
+	for range 100 {
+		var suffix [8]byte
+		if _, err := rand.Read(suffix[:]); err != nil {
+			return nil, fmt.Errorf("generate temporary filename: %w", err)
+		}
+		path := filepath.Join(dir, "."+base+".tmp-"+hex.EncodeToString(suffix[:]))
+		file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, mode)
+		if errors.Is(err, os.ErrExist) {
+			continue
+		}
+		return file, err
+	}
+	return nil, errors.New("failed to allocate a unique temporary filename")
+}
 
 func (f *FilesystemWriter) Persist(path string, data []byte) error {
 	// Ensure the directory exists
@@ -35,7 +53,16 @@ func (f *FilesystemWriter) PersistStream(ctx context.Context, path string, input
 		return fmt.Errorf("failed to create directories: %w", err)
 	}
 
-	file, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	mode := os.FileMode(0644)
+	preserveMode := false
+	if info, statErr := os.Stat(path); statErr == nil {
+		mode = info.Mode().Perm()
+		preserveMode = true
+	} else if !errors.Is(statErr, os.ErrNotExist) {
+		return fmt.Errorf("stat existing file %s: %w", path, statErr)
+	}
+
+	file, err := createTempFile(dir, filepath.Base(path), mode)
 	if err != nil {
 		return fmt.Errorf("create temporary file for %s: %w", path, err)
 	}
@@ -54,6 +81,11 @@ func (f *FilesystemWriter) PersistStream(ctx context.Context, path string, input
 			}
 		}
 	}()
+	if preserveMode {
+		if err := file.Chmod(mode); err != nil {
+			return fmt.Errorf("preserve permissions for %s: %w", path, err)
+		}
+	}
 
 	// Write chunks as they arrive on the channel
 	for {
@@ -64,9 +96,6 @@ func (f *FilesystemWriter) PersistStream(ctx context.Context, path string, input
 			if !ok {
 				if err := readProducerStatus(producerStatus); err != nil {
 					return fmt.Errorf("producer failed for %s: %w", path, err)
-				}
-				if err := file.Chmod(0644); err != nil {
-					return fmt.Errorf("chmod temporary file for %s: %w", path, err)
 				}
 				if err := file.Close(); err != nil {
 					return fmt.Errorf("close temporary file for %s: %w", path, err)

--- a/iris-mpc-db-exporter/src/persistence/filesystem_test.go
+++ b/iris-mpc-db-exporter/src/persistence/filesystem_test.go
@@ -2,6 +2,7 @@ package persistence
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -17,6 +18,59 @@ func TestFilesystemPersistenceErrors(t *testing.T) {
 		require.Error(t, writer.Persist(path, nil))
 		input := make(chan []byte)
 		close(input)
-		require.Error(t, writer.PersistStream(context.Background(), path, input))
+		require.Error(t, writer.PersistStream(context.Background(), path, input, terminalStatus(nil)))
 	}
+}
+
+func TestFilesystemPersistStreamAtomicallyReplacesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "chunk.bin")
+	require.NoError(t, os.WriteFile(path, []byte("old"), 0600))
+
+	writer := &FilesystemWriter{}
+	require.NoError(t, writer.PersistStream(context.Background(), path, streamInput([]byte("new")), terminalStatus(nil)))
+	contents, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, []byte("new"), contents)
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0644), info.Mode().Perm())
+	require.Empty(t, temporaryFiles(t, dir))
+}
+
+func TestFilesystemPersistStreamPreservesPriorFileOnProducerFailure(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "chunk.bin")
+	require.NoError(t, os.WriteFile(path, []byte("old"), 0600))
+	wantErr := errors.New("conversion failed")
+
+	writer := &FilesystemWriter{}
+	err := writer.PersistStream(context.Background(), path, streamInput([]byte("partial")), terminalStatus(wantErr))
+	require.ErrorIs(t, err, wantErr)
+	contents, readErr := os.ReadFile(path)
+	require.NoError(t, readErr)
+	require.Equal(t, []byte("old"), contents)
+	info, statErr := os.Stat(path)
+	require.NoError(t, statErr)
+	require.Equal(t, os.FileMode(0600), info.Mode().Perm())
+	require.Empty(t, temporaryFiles(t, dir))
+}
+
+func TestFilesystemPersistStreamRejectsMissingProducerStatus(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "chunk.bin")
+	missingStatus := make(chan error)
+	close(missingStatus)
+
+	err := (&FilesystemWriter{}).PersistStream(context.Background(), path, streamInput([]byte("partial")), missingStatus)
+	require.ErrorIs(t, err, errMissingProducerStatus)
+	require.NoFileExists(t, path)
+	require.Empty(t, temporaryFiles(t, dir))
+}
+
+func temporaryFiles(t *testing.T, dir string) []string {
+	t.Helper()
+	files, err := filepath.Glob(filepath.Join(dir, ".*.tmp-*"))
+	require.NoError(t, err)
+	return files
 }

--- a/iris-mpc-db-exporter/src/persistence/filesystem_test.go
+++ b/iris-mpc-db-exporter/src/persistence/filesystem_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -34,7 +35,20 @@ func TestFilesystemPersistStreamAtomicallyReplacesFile(t *testing.T) {
 	require.Equal(t, []byte("new"), contents)
 	info, err := os.Stat(path)
 	require.NoError(t, err)
-	require.Equal(t, os.FileMode(0644), info.Mode().Perm())
+	require.Equal(t, os.FileMode(0600), info.Mode().Perm())
+	require.Empty(t, temporaryFiles(t, dir))
+}
+
+func TestFilesystemPersistStreamHonorsUmaskForNewFile(t *testing.T) {
+	oldUmask := syscall.Umask(0077)
+	t.Cleanup(func() { syscall.Umask(oldUmask) })
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "chunk.bin")
+	require.NoError(t, (&FilesystemWriter{}).PersistStream(context.Background(), path, streamInput([]byte("new")), terminalStatus(nil)))
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0600), info.Mode().Perm())
 	require.Empty(t, temporaryFiles(t, dir))
 }
 

--- a/iris-mpc-db-exporter/src/persistence/interface.go
+++ b/iris-mpc-db-exporter/src/persistence/interface.go
@@ -1,6 +1,9 @@
 package persistence
 
-import "context"
+import (
+	"context"
+	"errors"
+)
 
 const (
 	TimestampsFolder = "timestamps"
@@ -8,9 +11,21 @@ const (
 
 type Writer interface {
 	Persist(path string, data []byte) error
-	PersistStream(ctx context.Context, path string, inputChannel <-chan []byte) error
+	// PersistStream receives exactly one buffered terminal producer status after
+	// inputChannel closes. A nil status means the complete stream was produced.
+	PersistStream(ctx context.Context, path string, inputChannel <-chan []byte, producerStatus <-chan error) error
 }
 
 type Reader interface {
 	GetTimeOfLastExport(ctx context.Context, exportPath string) (*int64, error)
+}
+
+var errMissingProducerStatus = errors.New("producer status channel closed without a value")
+
+func readProducerStatus(producerStatus <-chan error) error {
+	err, ok := <-producerStatus
+	if !ok {
+		return errMissingProducerStatus
+	}
+	return err
 }

--- a/iris-mpc-db-exporter/src/persistence/s3.go
+++ b/iris-mpc-db-exporter/src/persistence/s3.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -18,21 +19,50 @@ import (
 	"github.com/worldcoin/iris-mpc-db-exporter/src/o11y"
 )
 
+type s3WriterClient interface {
+	CreateMultipartUpload(context.Context, *s3.CreateMultipartUploadInput, ...func(*s3.Options)) (*s3.CreateMultipartUploadOutput, error)
+	UploadPart(context.Context, *s3.UploadPartInput, ...func(*s3.Options)) (*s3.UploadPartOutput, error)
+	CompleteMultipartUpload(context.Context, *s3.CompleteMultipartUploadInput, ...func(*s3.Options)) (*s3.CompleteMultipartUploadOutput, error)
+	AbortMultipartUpload(context.Context, *s3.AbortMultipartUploadInput, ...func(*s3.Options)) (*s3.AbortMultipartUploadOutput, error)
+	PutObject(context.Context, *s3.PutObjectInput, ...func(*s3.Options)) (*s3.PutObjectOutput, error)
+}
+
 type S3Writer struct {
-	Client                *s3.Client
+	Client                s3WriterClient
 	Bucket                string
 	MaxItemsPerPartUpload int
 }
 
-func (s *S3Writer) PersistStream(ctx context.Context, path string, inputChannel <-chan []byte) error {
+func (s *S3Writer) PersistStream(ctx context.Context, path string, inputChannel <-chan []byte, producerStatus <-chan error) (resultErr error) {
+	if s.MaxItemsPerPartUpload <= 0 {
+		return errors.New("max items per part upload must be positive")
+	}
+
 	input := &s3.CreateMultipartUploadInput{
 		Bucket: &s.Bucket,
 		Key:    &path,
 	}
 	resp, err := s.Client.CreateMultipartUpload(ctx, input)
 	if err != nil {
-		return err
+		return fmt.Errorf("create multipart upload for %s: %w", path, err)
 	}
+	completed := false
+	defer func() {
+		if completed {
+			return
+		}
+
+		abortCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+		defer cancel()
+		_, abortErr := s.Client.AbortMultipartUpload(abortCtx, &s3.AbortMultipartUploadInput{
+			Bucket:   resp.Bucket,
+			Key:      resp.Key,
+			UploadId: resp.UploadId,
+		})
+		if abortErr != nil {
+			resultErr = errors.Join(resultErr, fmt.Errorf("abort multipart upload for %s: %w", path, abortErr))
+		}
+	}()
 
 	o11y.S(ctx).Infof("Created multipart upload with ID %s", *resp.UploadId)
 
@@ -43,10 +73,18 @@ func (s *S3Writer) PersistStream(ctx context.Context, path string, inputChannel 
 	itemIdx := 0
 
 	for {
-		item, ok := <-inputChannel
+		var item []byte
+		var ok bool
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case item, ok = <-inputChannel:
+		}
 		if ok {
 			outputBuffer = append(outputBuffer, item...)
 			itemIdx++
+		} else if err := readProducerStatus(producerStatus); err != nil {
+			return fmt.Errorf("producer failed for %s: %w", path, err)
 		}
 
 		// if we have collected enough items or the channel is closed, upload the part
@@ -60,16 +98,7 @@ func (s *S3Writer) PersistStream(ctx context.Context, path string, inputChannel 
 			}
 			uploadResult, err := s.Client.UploadPart(ctx, partInput)
 			if err != nil {
-				aboInput := &s3.AbortMultipartUploadInput{
-					Bucket:   resp.Bucket,
-					Key:      resp.Key,
-					UploadId: resp.UploadId,
-				}
-				_, aboErr := s.Client.AbortMultipartUpload(ctx, aboInput)
-				if aboErr != nil {
-					return aboErr
-				}
-				return err
+				return fmt.Errorf("upload part %d for %s: %w", partNumber, path, err)
 			}
 			o11y.S(ctx).Infof("Uploaded part %d to path %s", partNumber, path)
 			completedParts = append(completedParts, types.CompletedPart{
@@ -102,18 +131,10 @@ func (s *S3Writer) PersistStream(ctx context.Context, path string, inputChannel 
 	_, err = s.Client.CompleteMultipartUpload(ctx, compInput)
 	if err != nil {
 		o11y.S(ctx).With(zap.Error(err)).Error("Failed to complete multipart upload, aborting")
-		abortInput := &s3.AbortMultipartUploadInput{
-			Bucket:   resp.Bucket,
-			Key:      resp.Key,
-			UploadId: resp.UploadId,
-		}
-		_, abortErr := s.Client.AbortMultipartUpload(ctx, abortInput)
-		if abortErr != nil {
-			return abortErr
-		}
-		return err
+		return fmt.Errorf("complete multipart upload for %s: %w", path, err)
 	}
 
+	completed = true
 	return nil
 }
 

--- a/iris-mpc-db-exporter/src/persistence/s3_test.go
+++ b/iris-mpc-db-exporter/src/persistence/s3_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/credentials"
@@ -16,6 +17,146 @@ type failingHTTPClient struct{ err error }
 
 func (c failingHTTPClient) Do(*http.Request) (*http.Response, error) { return nil, c.err }
 
+type fakeS3WriterClient struct {
+	createErr       error
+	uploadErr       error
+	completeErr     error
+	abortErr        error
+	createCalls     int
+	uploadCalls     int
+	completeCalls   int
+	abortCalls      int
+	putCalls        int
+	abortContextErr error
+	abortDeadline   time.Time
+}
+
+func (c *fakeS3WriterClient) CreateMultipartUpload(_ context.Context, input *s3.CreateMultipartUploadInput, _ ...func(*s3.Options)) (*s3.CreateMultipartUploadOutput, error) {
+	c.createCalls++
+	if c.createErr != nil {
+		return nil, c.createErr
+	}
+	return &s3.CreateMultipartUploadOutput{Bucket: input.Bucket, Key: input.Key, UploadId: aws.String("upload-id")}, nil
+}
+
+func (c *fakeS3WriterClient) UploadPart(_ context.Context, _ *s3.UploadPartInput, _ ...func(*s3.Options)) (*s3.UploadPartOutput, error) {
+	c.uploadCalls++
+	if c.uploadErr != nil {
+		return nil, c.uploadErr
+	}
+	return &s3.UploadPartOutput{ETag: aws.String("etag")}, nil
+}
+
+func (c *fakeS3WriterClient) CompleteMultipartUpload(_ context.Context, _ *s3.CompleteMultipartUploadInput, _ ...func(*s3.Options)) (*s3.CompleteMultipartUploadOutput, error) {
+	c.completeCalls++
+	return &s3.CompleteMultipartUploadOutput{}, c.completeErr
+}
+
+func (c *fakeS3WriterClient) AbortMultipartUpload(ctx context.Context, _ *s3.AbortMultipartUploadInput, _ ...func(*s3.Options)) (*s3.AbortMultipartUploadOutput, error) {
+	c.abortCalls++
+	c.abortContextErr = ctx.Err()
+	c.abortDeadline, _ = ctx.Deadline()
+	return &s3.AbortMultipartUploadOutput{}, c.abortErr
+}
+
+func (c *fakeS3WriterClient) PutObject(_ context.Context, _ *s3.PutObjectInput, _ ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	c.putCalls++
+	return &s3.PutObjectOutput{}, nil
+}
+
+func streamInput(items ...[]byte) <-chan []byte {
+	input := make(chan []byte, len(items))
+	for _, item := range items {
+		input <- item
+	}
+	close(input)
+	return input
+}
+
+func terminalStatus(err error) <-chan error {
+	status := make(chan error, 1)
+	status <- err
+	close(status)
+	return status
+}
+
+func TestS3PersistStreamCompletesOnlyAfterProducerSuccess(t *testing.T) {
+	client := &fakeS3WriterClient{}
+	writer := &S3Writer{Client: client, Bucket: "bucket", MaxItemsPerPartUpload: 3}
+
+	require.NoError(t, writer.PersistStream(context.Background(), "chunk", streamInput([]byte("iris-1"), []byte("iris-2")), terminalStatus(nil)))
+	require.Equal(t, 1, client.createCalls)
+	require.Equal(t, 1, client.uploadCalls)
+	require.Equal(t, 1, client.completeCalls)
+	require.Zero(t, client.abortCalls)
+}
+
+func TestS3PersistStreamAbortsOnProducerFailure(t *testing.T) {
+	wantErr := errors.New("conversion failed")
+	client := &fakeS3WriterClient{}
+	writer := &S3Writer{Client: client, Bucket: "bucket", MaxItemsPerPartUpload: 1}
+
+	err := writer.PersistStream(context.Background(), "chunk", streamInput([]byte("partial")), terminalStatus(wantErr))
+	require.ErrorIs(t, err, wantErr)
+	require.Equal(t, 1, client.uploadCalls)
+	require.Zero(t, client.completeCalls)
+	require.Equal(t, 1, client.abortCalls)
+}
+
+func TestS3PersistStreamRejectsMissingProducerStatus(t *testing.T) {
+	client := &fakeS3WriterClient{}
+	writer := &S3Writer{Client: client, Bucket: "bucket", MaxItemsPerPartUpload: 1}
+	missingStatus := make(chan error)
+	close(missingStatus)
+
+	err := writer.PersistStream(context.Background(), "chunk", streamInput([]byte("partial")), missingStatus)
+	require.ErrorIs(t, err, errMissingProducerStatus)
+	require.Zero(t, client.completeCalls)
+	require.Equal(t, 1, client.abortCalls)
+}
+
+func TestS3PersistStreamJoinsPrimaryAndAbortErrors(t *testing.T) {
+	producerErr := errors.New("database stream failed")
+	abortErr := errors.New("abort failed")
+	client := &fakeS3WriterClient{abortErr: abortErr}
+	writer := &S3Writer{Client: client, Bucket: "bucket", MaxItemsPerPartUpload: 1}
+
+	err := writer.PersistStream(context.Background(), "chunk", streamInput([]byte("partial")), terminalStatus(producerErr))
+	require.ErrorIs(t, err, producerErr)
+	require.ErrorIs(t, err, abortErr)
+	require.Equal(t, 1, client.abortCalls)
+}
+
+func TestS3PersistStreamAbortsWithBoundedUncancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	client := &fakeS3WriterClient{}
+	writer := &S3Writer{Client: client, Bucket: "bucket", MaxItemsPerPartUpload: 1}
+	input := make(chan []byte)
+
+	err := writer.PersistStream(ctx, "chunk", input, terminalStatus(nil))
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, 1, client.abortCalls)
+	require.NoError(t, client.abortContextErr)
+	require.WithinDuration(t, time.Now().Add(10*time.Second), client.abortDeadline, time.Second)
+}
+
+func TestS3PersistStreamAbortsUploadAndCompleteFailures(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		client *fakeS3WriterClient
+	}{
+		{name: "upload", client: &fakeS3WriterClient{uploadErr: errors.New("upload failed")}},
+		{name: "complete", client: &fakeS3WriterClient{completeErr: errors.New("complete failed")}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			writer := &S3Writer{Client: test.client, Bucket: "bucket", MaxItemsPerPartUpload: 1}
+			require.Error(t, writer.PersistStream(context.Background(), "chunk", streamInput([]byte("iris")), terminalStatus(nil)))
+			require.Equal(t, 1, test.client.abortCalls)
+		})
+	}
+}
+
 func TestS3PersistenceErrors(t *testing.T) {
 	wantErr := errors.New("storage unavailable")
 	writer := &S3Writer{
@@ -25,10 +166,9 @@ func TestS3PersistenceErrors(t *testing.T) {
 			HTTPClient:       failingHTTPClient{wantErr},
 			RetryMaxAttempts: 1,
 		}),
-		Bucket: "test-bucket",
+		Bucket:                "test-bucket",
+		MaxItemsPerPartUpload: 1,
 	}
 	require.ErrorIs(t, writer.Persist("timestamps/test", nil), wantErr)
-	input := make(chan []byte)
-	close(input)
-	require.ErrorIs(t, writer.PersistStream(context.Background(), "chunk", input), wantErr)
+	require.ErrorIs(t, writer.PersistStream(context.Background(), "chunk", streamInput(), terminalStatus(nil)), wantErr)
 }


### PR DESCRIPTION
Complete exports now pass their terminal producer status into persistence, so S3 aborts multipart uploads and filesystem writes stay temporary when conversion or database streaming fails. Successful streams keep the existing stable-key layout and only publish after producer success.

Tests cover conversion and row-stream errors, multipart abort/complete behavior, abort failures, missing producer status, and preservation of the previous filesystem snapshot.